### PR TITLE
Check home directory for Minecraft files on Linux

### DIFF
--- a/src/main/java/net/minestom/server/registry/ResourceGatherer.java
+++ b/src/main/java/net/minestom/server/registry/ResourceGatherer.java
@@ -165,6 +165,6 @@ public class ResourceGatherer {
             return new File(user + "/Library/Application Support/minecraft");
         }
 
-        return new File("~/.minecraft");
+        return new File(System.getProperty("user.home") + "/.minecraft");
     }
 }


### PR DESCRIPTION
Problem: Minestom tries find the Minecraft directory at "~/.minecraft". This directory does not exist because Java does not do shell expansion.
Solution: Look for .minecraft/ in the user's home directory.