### PR TITLE
Disable keep alive packet handling when using BungeeCord.

### DIFF
--- a/src/main/java/net/minestom/server/MinecraftServer.java
+++ b/src/main/java/net/minestom/server/MinecraftServer.java
@@ -284,16 +284,18 @@ public class MinecraftServer {
         return tagManager;
     }
 
-    public void start(String address, int port, ResponseDataConsumer responseDataConsumer) {
+    public void start(String address, int port, boolean bungeecordEnabled, ResponseDataConsumer responseDataConsumer) {
         LOGGER.info("Starting Minestom server.");
         MinecraftServer.responseDataConsumer = responseDataConsumer;
-        updateManager.start();
+        updateManager.start(bungeecordEnabled);
         nettyServer.start(address, port);
         LOGGER.info("Minestom server started successfully.");
     }
 
-    public void start(String address, int port) {
-        start(address, port, null);
+    public void start(String address, int port) { start(address, port, false, null); }
+
+    public void start(String address, int port, boolean bungeecordEnabled) {
+        start(address, port, bungeecordEnabled, null);
     }
 
     /**

--- a/src/main/java/net/minestom/server/MinecraftServer.java
+++ b/src/main/java/net/minestom/server/MinecraftServer.java
@@ -298,6 +298,10 @@ public class MinecraftServer {
         start(address, port, null, bungeecordEnabled);
     }
 
+    public void start(String address, int port, ResponseDataConsumer responseDataConsumer) {
+        start(address, port, responseDataConsumer, false);
+    }
+
     /**
      * Stops this server properly (saves if needed, kicking players, etc.)
      */

--- a/src/main/java/net/minestom/server/MinecraftServer.java
+++ b/src/main/java/net/minestom/server/MinecraftServer.java
@@ -284,7 +284,7 @@ public class MinecraftServer {
         return tagManager;
     }
 
-    public void start(String address, int port, boolean bungeecordEnabled, ResponseDataConsumer responseDataConsumer) {
+    public void start(String address, int port, ResponseDataConsumer responseDataConsumer, boolean bungeecordEnabled) {
         LOGGER.info("Starting Minestom server.");
         MinecraftServer.responseDataConsumer = responseDataConsumer;
         updateManager.start(bungeecordEnabled);
@@ -292,10 +292,10 @@ public class MinecraftServer {
         LOGGER.info("Minestom server started successfully.");
     }
 
-    public void start(String address, int port) { start(address, port, false, null); }
+    public void start(String address, int port) { start(address, port, null, false); }
 
     public void start(String address, int port, boolean bungeecordEnabled) {
-        start(address, port, bungeecordEnabled, null);
+        start(address, port, null, bungeecordEnabled);
     }
 
     /**

--- a/src/main/java/net/minestom/server/UpdateManager.java
+++ b/src/main/java/net/minestom/server/UpdateManager.java
@@ -33,7 +33,7 @@ public final class UpdateManager {
     protected UpdateManager() {
     }
 
-    public void start() {
+    public void start(final boolean bungeecordEnabled) {
         mainUpdate.execute(() -> {
 
             final ConnectionManager connectionManager = MinecraftServer.getConnectionManager();
@@ -47,15 +47,17 @@ public final class UpdateManager {
                 currentTime = System.nanoTime();
 
                 // Keep Alive Handling
-                final long time = System.currentTimeMillis();
-                final KeepAlivePacket keepAlivePacket = new KeepAlivePacket(time);
-                for (Player player : connectionManager.getOnlinePlayers()) {
-                    final long lastKeepAlive = time - player.getLastKeepAlive();
-                    if (lastKeepAlive > KEEP_ALIVE_DELAY && player.didAnswerKeepAlive()) {
-                        player.refreshKeepAlive(time);
-                        player.getPlayerConnection().sendPacket(keepAlivePacket);
-                    } else if (lastKeepAlive >= KEEP_ALIVE_KICK) {
-                        player.kick(ColoredText.of(ChatColor.RED + "Timeout"));
+                if(!bungeecordEnabled) {
+                    final long time = System.currentTimeMillis();
+                    final KeepAlivePacket keepAlivePacket = new KeepAlivePacket(time);
+                    for (Player player : connectionManager.getOnlinePlayers()) {
+                        final long lastKeepAlive = time - player.getLastKeepAlive();
+                        if (lastKeepAlive > KEEP_ALIVE_DELAY && player.didAnswerKeepAlive()) {
+                            player.refreshKeepAlive(time);
+                            player.getPlayerConnection().sendPacket(keepAlivePacket);
+                        } else if (lastKeepAlive >= KEEP_ALIVE_KICK) {
+                            player.kick(ColoredText.of(ChatColor.RED + "Timeout"));
+                        }
                     }
                 }
 


### PR DESCRIPTION
Added `bungeecordEnabled` argument to start method of `UpdateManager`. If true it disables keep alive packet handling and player joining with BungeeCord aren't being kicked. It is still possible to use old start methods of `MinecraftServer`:
`public void start(String address, int port, ResponseDataConsumer responseDataConsumer)`
and
`public void start(String address, int port)`