### PR TITLE
Update EntityType To use Namespaced IDs

### DIFF
--- a/src/main/java/net/minestom/server/chat/ChatHoverEvent.java
+++ b/src/main/java/net/minestom/server/chat/ChatHoverEvent.java
@@ -83,7 +83,7 @@ public class ChatHoverEvent {
     public static ChatHoverEvent showEntity(Entity entity) {
         NBTCompound compound = new NBTCompound()
                 .setString("id", entity.getUuid().toString())
-                .setString("type", EntityType.fromId(entity.getEntityType()).getNamespaceID());
+                .setString("type", entity.getEntityType().getNamespaceID());
         return new ChatHoverEvent("show_entity", compound.toSNBT());
     }
 }

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -79,7 +79,7 @@ public abstract class Entity implements Viewable, EventHandler, DataContainer {
     private boolean isActive; // False if entity has only been instanced without being added somewhere
     private boolean shouldRemove;
     private long scheduledRemoveTime;
-    private int entityType;
+    private EntityType entityType;
     private long lastUpdate;
     private Map<Class<? extends Event>, List<EventCallback>> eventCallbacks = new ConcurrentHashMap<>();
     protected long lastVelocityUpdateTime; // Reset velocity to 0 after countdown
@@ -113,7 +113,7 @@ public abstract class Entity implements Viewable, EventHandler, DataContainer {
     private long ticks;
     private final EntityTickEvent tickEvent = new EntityTickEvent(this);
 
-    public Entity(int entityType, Position spawnPosition) {
+    public Entity(EntityType entityType, Position spawnPosition) {
         this.id = generateId();
         this.entityType = entityType;
         this.uuid = UUID.randomUUID();
@@ -131,7 +131,7 @@ public abstract class Entity implements Viewable, EventHandler, DataContainer {
         nextTick.add(callback);
     }
 
-    public Entity(int entityType) {
+    public Entity(EntityType entityType) {
         this(entityType, new Position());
     }
 
@@ -547,7 +547,7 @@ public abstract class Entity implements Viewable, EventHandler, DataContainer {
      *
      * @return the entity type id
      */
-    public int getEntityType() {
+    public EntityType getEntityType() {
         return entityType;
     }
 

--- a/src/main/java/net/minestom/server/entity/EntityCreature.java
+++ b/src/main/java/net/minestom/server/entity/EntityCreature.java
@@ -161,7 +161,7 @@ public abstract class EntityCreature extends LivingEntity {
         SpawnLivingEntityPacket spawnLivingEntityPacket = new SpawnLivingEntityPacket();
         spawnLivingEntityPacket.entityId = getEntityId();
         spawnLivingEntityPacket.entityUuid = getUuid();
-        spawnLivingEntityPacket.entityType = getEntityType();
+        spawnLivingEntityPacket.entityType = getEntityType().getId();
         spawnLivingEntityPacket.position = getPosition();
         spawnLivingEntityPacket.headPitch = 0;
 

--- a/src/main/java/net/minestom/server/entity/ExperienceOrb.java
+++ b/src/main/java/net/minestom/server/entity/ExperienceOrb.java
@@ -8,7 +8,7 @@ public class ExperienceOrb extends Entity {
     private short experienceCount;
 
     public ExperienceOrb(short experienceCount) {
-        super(23);
+        super(EntityType.EXPERIENCE_ORB);
         setGravity(0.02f);
         setBoundingBox(0.5f, 0.5f, 0.5f);
         this.experienceCount = experienceCount;

--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -55,7 +55,7 @@ public abstract class LivingEntity extends Entity implements EquipmentHandler {
     private long fireDamagePeriod = 1000L;
 
     public LivingEntity(EntityType entityType, Position spawnPosition) {
-        super(entityType.getId(), spawnPosition);
+        super(entityType, spawnPosition);
         setupAttributes();
         setGravity(0.02f);
     }
@@ -233,7 +233,7 @@ public abstract class LivingEntity extends Entity implements EquipmentHandler {
             return false;
         }
 
-        EntityDamageEvent entityDamageEvent = new EntityDamageEvent(type, value);
+        EntityDamageEvent entityDamageEvent = new EntityDamageEvent(type, value, this);
         callCancellableEvent(EntityDamageEvent.class, entityDamageEvent, () -> {
             float damage = entityDamageEvent.getDamage();
 

--- a/src/main/java/net/minestom/server/entity/ObjectEntity.java
+++ b/src/main/java/net/minestom/server/entity/ObjectEntity.java
@@ -7,7 +7,7 @@ import net.minestom.server.utils.Position;
 public abstract class ObjectEntity extends Entity {
 
     public ObjectEntity(EntityType entityType, Position spawnPosition) {
-        super(entityType.getId(), spawnPosition);
+        super(entityType, spawnPosition);
         setGravity(0.02f);
     }
 
@@ -40,7 +40,7 @@ public abstract class ObjectEntity extends Entity {
         SpawnEntityPacket spawnEntityPacket = new SpawnEntityPacket();
         spawnEntityPacket.entityId = getEntityId();
         spawnEntityPacket.uuid = getUuid();
-        spawnEntityPacket.type = getEntityType();
+        spawnEntityPacket.type = getEntityType().getId();
         spawnEntityPacket.position = getPosition();
         spawnEntityPacket.data = getObjectData();
         playerConnection.sendPacket(spawnEntityPacket);

--- a/src/main/java/net/minestom/server/event/entity/EntityDamageEvent.java
+++ b/src/main/java/net/minestom/server/event/entity/EntityDamageEvent.java
@@ -1,5 +1,7 @@
 package net.minestom.server.event.entity;
 
+import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.LivingEntity;
 import net.minestom.server.entity.damage.DamageType;
 import net.minestom.server.event.CancellableEvent;
 
@@ -10,10 +12,12 @@ public class EntityDamageEvent extends CancellableEvent {
 
     private DamageType damageType;
     private float damage;
+    private LivingEntity entity;
 
-    public EntityDamageEvent(DamageType damageType, float damage) {
+    public EntityDamageEvent(DamageType damageType, float damage, LivingEntity entity) {
         this.damageType = damageType;
         this.damage = damage;
+        this.entity = entity;
     }
 
     /**
@@ -35,5 +39,9 @@ public class EntityDamageEvent extends CancellableEvent {
      */
     public void setDamage(float damage) {
         this.damage = damage;
+    }
+
+    public LivingEntity getEntity() {
+        return entity;
     }
 }


### PR DESCRIPTION
Allow the use of namespaced IDs for EntityTypes, while still using numerical IDs for packets.