### PR TITLE
Fix encoding with Player ChatEvent

### DIFF
--- a/src/main/java/net/minestom/server/event/player/PlayerChatEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerChatEvent.java
@@ -4,6 +4,8 @@ import net.minestom.server.chat.RichMessage;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.CancellableEvent;
 
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.function.Function;
@@ -22,7 +24,7 @@ public class PlayerChatEvent extends CancellableEvent {
     public PlayerChatEvent(Player sender, Collection<Player> recipients, String message) {
         this.sender = sender;
         this.recipients = new ArrayList<>(recipients);
-        this.message = message;
+        this.message = new String(message.getBytes(), StandardCharsets.UTF_8);
     }
 
     /**


### PR DESCRIPTION
Not sure if this would break anything else or if there is a better way to do this, but I fixed non-Latin characters [showing up incorrectly](https://cdn.discordapp.com/attachments/706186227493109860/740166375837925416/unknown.png). This seems to only occur on systems not using UTF-8 encoding.