### PR TITLE
Fix removePlayer in ConnectionManager

### DIFF
--- a/src/main/java/net/minestom/server/network/ConnectionManager.java
+++ b/src/main/java/net/minestom/server/network/ConnectionManager.java
@@ -247,6 +247,6 @@ public final class ConnectionManager {
             return;
 
         this.players.remove(player);
-        this.connectionPlayerMap.remove(player);
+        this.connectionPlayerMap.remove(connection);
     }
 }


### PR DESCRIPTION
Previously, you were trying to remove the player (a Player object) from a map in which keys are PlayerConnection.