### PR TITLE
Changed DEFAULT_STACKING_RULE's maxSize from 127 to 64

### DIFF
--- a/src/main/java/net/minestom/server/item/ItemStack.java
+++ b/src/main/java/net/minestom/server/item/ItemStack.java
@@ -34,7 +34,7 @@ import java.util.*;
  */
 public class ItemStack implements DataContainer {
 
-    private static final StackingRule DEFAULT_STACKING_RULE = new VanillaStackingRule(127);
+    private static final StackingRule DEFAULT_STACKING_RULE = new VanillaStackingRule(64);
 
     private Material material;
 


### PR DESCRIPTION
I understand that this is a very small change, but after some experimentation I have found that Minecraft behaves very unpredictably when an ItemStack's amount is higher than 64, so therefore I propose that the default rule should have a maxSize of 64.