### PR TITLE
Expose ArgumentWord "restrictions" arg as protected

### DIFF
--- a/src/main/java/net/minestom/server/command/builder/arguments/ArgumentWord.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/ArgumentWord.java
@@ -16,7 +16,7 @@ public class ArgumentWord extends Argument<String> {
     public static final int SPACE_ERROR = 1;
     public static final int RESTRICTION_ERROR = 2;
 
-    private String[] restrictions;
+    protected String[] restrictions;
 
     public ArgumentWord(String id) {
         super(id, false);


### PR DESCRIPTION
This is to allow modification of it from a subclass of ArgumentWord.