### PR TITLE
Fix Armor Stand Metadata

### DIFF
--- a/src/main/java/net/minestom/server/entity/type/decoration/EntityArmorStand.java
+++ b/src/main/java/net/minestom/server/entity/type/decoration/EntityArmorStand.java
@@ -95,13 +95,13 @@ public class EntityArmorStand extends ObjectEntity implements EquipmentHandler {
             packet.writeByte(METADATA_BYTE);
             byte dataValue = 0;
             if (isSmall())
-                dataValue += 1;
+                dataValue |= 0x01;
             if (hasArms)
-                dataValue += 2;
+                dataValue |= 0x04;
             if (hasNoBasePlate())
-                dataValue += 4;
+                dataValue |= 0x08;
             if (hasMarker())
-                dataValue += 8;
+                dataValue |= 0x10;
             packet.writeByte(dataValue);
         } else if (index == 15) {
             packet.writeByte((byte) 15);


### PR DESCRIPTION
Currently, the server sends armor stand metadata incorrectly, and sometimes leads to incorrect results displaying on the client.
For example: when trying to spawn an armor stand with `noArms, noBasePlate, marker` values, it displayed it with the `small, noArms, noBasePlate` values active.

Using the same code as before after applying these changes seems to have fixed it.