### PR TITLE
Added distanceSquared where applicable and changed BlockPosition distance calculation

### DIFF
--- a/src/main/java/net/minestom/server/utils/BlockPosition.java
+++ b/src/main/java/net/minestom/server/utils/BlockPosition.java
@@ -174,16 +174,40 @@ public class BlockPosition {
     }
 
     /**
-     * Gets the distance to another block position.
+     * Gets the manhattan distance to another block position.
      *
      * @param blockPosition the block position to check the distance
      * @return the distance between 'this' and {@code blockPosition}
      */
-    public int getDistance(@NotNull BlockPosition blockPosition) {
+    public int getManhattanDistance(@NotNull BlockPosition blockPosition) {
         return Math.abs(getX() - blockPosition.getX()) +
                 Math.abs(getY() - blockPosition.getY()) +
                 Math.abs(getZ() - blockPosition.getZ());
     }
+
+    /**
+     * Gets the distance to another block position.
+     * In cases where performance matters, {@link #getDistanceSquared(BlockPosition)} should be used
+     * as it does not perform the expensive Math.sqrt method.
+     *
+     * @param blockPosition the block position to check the distance
+     * @return the distance between 'this' and {@code blockPosition}
+     */
+    public double getDistance(@NotNull BlockPosition blockPosition) {
+        return Math.sqrt(getDistanceSquared(blockPosition));
+    }
+
+    /**
+     * Gets the square distance to another block position.
+    *
+    * @param blockPosition the block position to check the distance
+    * @return the distance between 'this' and {@code blockPosition}
+    */
+   public int getDistanceSquared(@NotNull BlockPosition blockPosition) {
+       return MathUtils.square(getX() - blockPosition.getX()) +
+               MathUtils.square(getY() - blockPosition.getY()) +
+               MathUtils.square(getZ() - blockPosition.getZ());
+   }
 
     /**
      * Copies this block position.

--- a/src/main/java/net/minestom/server/utils/Position.java
+++ b/src/main/java/net/minestom/server/utils/Position.java
@@ -72,6 +72,8 @@ public class Position {
 
     /**
      * Gets the distance between 2 positions.
+     *   In cases where performance matters, {@link #getDistanceSquared(Position)} should be used
+     *   as it does not perform the expensive Math.sqrt method.
      *
      * @param position the second position
      * @return the distance between {@code this} and {@code position}
@@ -81,6 +83,18 @@ public class Position {
                 MathUtils.square(position.getY() - getY()) +
                 MathUtils.square(position.getZ() - getZ()));
     }
+
+    /**
+     * Gets the square distance to another position.
+    *
+    * @param position the second position
+    * @return the squared distance between {@code this} and {@code position}
+    */
+   public float getDistanceSquared(Position position) {
+       return MathUtils.square(getX() - position.getX()) +
+               MathUtils.square(getY() - position.getY()) +
+               MathUtils.square(getZ() - position.getZ());
+   }
 
     /**
      * Gets a unit-vector pointing in the direction that this Location is

--- a/src/main/java/net/minestom/server/utils/Vector.java
+++ b/src/main/java/net/minestom/server/utils/Vector.java
@@ -119,6 +119,16 @@ public class Vector {
     }
 
     /**
+     * Gets the squared distance between this vector and another.
+     *
+     * @param o The other vector
+     * @return the squared distance
+     */
+    public double distanceSquared(Vector o) {
+        return MathUtils.square(x - o.x) + MathUtils.square(y - o.y) + MathUtils.square(z - o.z);
+    }
+
+    /**
      * Performs scalar multiplication, multiplying all components with a
      * scalar.
      *


### PR DESCRIPTION
Warning: Breaks current API-Implementation (API-specification remains the same) in a way that BlockPosition#getDistance(BlockPosition) no longer returns the manhattan distance, but the distance according to pythagoras.
However BlockPosition#getManhattanDistance(BlockPosition) was added to replace the old undocumented functionallity.
Reasoning to change the getDistance was that it is implictitly assumed to be based on the c² = x² + y² + z² formula and it's not documented that it actually performs the Manhattan distance.

The distance sqared was added as sometimes the distance is used in hardcoded comparisions, were using the sqared would save the math.sqrt operation, which is fairly expensive