### PR TITLE
Implement Cloneable whereever Applicable

### DIFF
--- a/src/main/java/net/minestom/server/collision/CollisionUtils.java
+++ b/src/main/java/net/minestom/server/collision/CollisionUtils.java
@@ -83,7 +83,7 @@ public class CollisionUtils {
         BlockPosition[] cornerPositions = new BlockPosition[corners.length];
         Vector[] cornersCopy = new Vector[corners.length];
         for (int i = 0; i < corners.length; i++) {
-            cornersCopy[i] = corners[i].copy();
+            cornersCopy[i] = corners[i].clone();
             cornerPositions[i] = new BlockPosition(corners[i]);
         }
 

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -129,7 +129,7 @@ public abstract class Entity implements Viewable, EventHandler, DataContainer {
         this.id = generateId();
         this.entityType = entityType;
         this.uuid = UUID.randomUUID();
-        this.position = spawnPosition.copy();
+        this.position = spawnPosition.clone();
 
         setBoundingBox(0, 0, 0);
 

--- a/src/main/java/net/minestom/server/entity/EntityCreature.java
+++ b/src/main/java/net/minestom/server/entity/EntityCreature.java
@@ -386,7 +386,7 @@ public abstract class EntityCreature extends LivingEntity {
             return false;
         }
 
-        final Position targetPosition = position.copy();
+        final Position targetPosition = position.clone();
 
         this.path = pathFinder.initiatePathTo(position.getX(), position.getY(), position.getZ());
         this.pathLock.unlock();

--- a/src/main/java/net/minestom/server/entity/ItemEntity.java
+++ b/src/main/java/net/minestom/server/entity/ItemEntity.java
@@ -111,7 +111,7 @@ public class ItemEntity extends ObjectEntity {
                     if (!canApply)
                         continue;
 
-                    final ItemStack result = stackingRule.apply(itemStack.copy(), totalAmount);
+                    final ItemStack result = stackingRule.apply(itemStack.clone(), totalAmount);
 
                     EntityItemMergeEvent entityItemMergeEvent = new EntityItemMergeEvent(this, itemEntity, result);
                     callCancellableEvent(EntityItemMergeEvent.class, entityItemMergeEvent, () -> {

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -1861,7 +1861,7 @@ public class Player extends LivingEntity implements CommandSender {
      */
     protected void updatePlayerPosition() {
         PlayerPositionAndLookPacket positionAndLookPacket = new PlayerPositionAndLookPacket();
-        positionAndLookPacket.position = position.copy(); // clone needed to prevent synchronization issue
+        positionAndLookPacket.position = position.clone(); // clone needed to prevent synchronization issue
         positionAndLookPacket.flags = 0x00;
         positionAndLookPacket.teleportId = teleportId.incrementAndGet();
         playerConnection.sendPacket(positionAndLookPacket);

--- a/src/main/java/net/minestom/server/entity/ai/goal/EatBlockGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/EatBlockGoal.java
@@ -41,8 +41,8 @@ public class EatBlockGoal extends GoalSelector {
         }
         final Instance instance = entityCreature.getInstance();
         final BlockPosition blockPosition = entityCreature.getPosition().toBlockPosition();
-        final short blockStateIdIn = instance.getBlockStateId(blockPosition.copy().subtract(0, 1, 0));
-        final short blockStateIdBelow = instance.getBlockStateId(blockPosition.copy().subtract(0, 2, 0));
+        final short blockStateIdIn = instance.getBlockStateId(blockPosition.clone().subtract(0, 1, 0));
+        final short blockStateIdBelow = instance.getBlockStateId(blockPosition.clone().subtract(0, 2, 0));
 
         return eatInMap.containsKey(blockStateIdIn) || eatBelowMap.containsKey(blockStateIdBelow);
     }
@@ -62,8 +62,8 @@ public class EatBlockGoal extends GoalSelector {
             return;
         }
         Instance instance = entityCreature.getInstance();
-        final BlockPosition currentPosition = entityCreature.getPosition().toBlockPosition().copy().subtract(0, 1, 0);
-        final BlockPosition belowPosition = currentPosition.copy().subtract(0, 1, 0);
+        final BlockPosition currentPosition = entityCreature.getPosition().toBlockPosition().clone().subtract(0, 1, 0);
+        final BlockPosition belowPosition = currentPosition.clone().subtract(0, 1, 0);
 
         final short blockStateIdIn = instance.getBlockStateId(currentPosition);
         final short blockStateIdBelow = instance.getBlockStateId(belowPosition);

--- a/src/main/java/net/minestom/server/entity/ai/goal/RandomLookAroundGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/RandomLookAroundGoal.java
@@ -69,7 +69,7 @@ public class RandomLookAroundGoal extends GoalSelector {
     @Override
     public void tick(long time) {
         --lookTime;
-        entityCreature.setView(entityCreature.getPosition().copy().setDirection(lookDirection));
+        entityCreature.setView(entityCreature.getPosition().clone().setDirection(lookDirection));
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/ai/goal/RandomStrollGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/RandomStrollGoal.java
@@ -35,7 +35,7 @@ public class RandomStrollGoal extends GoalSelector {
         Collections.shuffle(closePositions);
 
         for (Position position : closePositions) {
-            final Position target = position.copy().add(entityCreature.getPosition());
+            final Position target = position.clone().add(entityCreature.getPosition());
             final boolean result = entityCreature.setPathTo(target);
             if (result) {
                 break;

--- a/src/main/java/net/minestom/server/entity/hologram/Hologram.java
+++ b/src/main/java/net/minestom/server/entity/hologram/Hologram.java
@@ -26,7 +26,7 @@ public class Hologram implements Viewable {
     private boolean removed;
 
     public Hologram(Instance instance, Position spawnPosition, ColoredText text, boolean autoViewable) {
-        this.entity = new HologramEntity(spawnPosition.copy().add(0, OFFSET_Y, 0));
+        this.entity = new HologramEntity(spawnPosition.clone().add(0, OFFSET_Y, 0));
         this.entity.setInstance(instance);
         this.entity.setAutoViewable(autoViewable);
 

--- a/src/main/java/net/minestom/server/inventory/click/InventoryClickProcessor.java
+++ b/src/main/java/net/minestom/server/inventory/click/InventoryClickProcessor.java
@@ -96,18 +96,18 @@ public class InventoryClickProcessor {
         } else {
             if (cursor.isAir()) {
                 final int amount = (int) Math.ceil((double) clicked.getAmount() / 2d);
-                resultCursor = clicked.copy();
+                resultCursor = clicked.clone();
                 resultCursor = cursorRule.apply(resultCursor, amount);
 
-                resultClicked = clicked.copy();
+                resultClicked = clicked.clone();
                 resultClicked = clickedRule.apply(resultClicked, clicked.getAmount() / 2);
             } else {
                 if (clicked.isAir()) {
                     final int amount = cursor.getAmount();
-                    resultCursor = cursor.copy();
+                    resultCursor = cursor.clone();
                     resultCursor = cursorRule.apply(resultCursor, amount - 1);
 
-                    resultClicked = cursor.copy();
+                    resultClicked = cursor.clone();
                     resultClicked = clickedRule.apply(resultClicked, 1);
                 } else {
                     resultCursor = clicked;
@@ -181,7 +181,7 @@ public class InventoryClickProcessor {
         final StackingRule clickedRule = clicked.getStackingRule();
 
         boolean filled = false;
-        ItemStack resultClicked = clicked.copy();
+        ItemStack resultClicked = clicked.clone();
 
         for (InventoryClickLoopHandler loopHandler : loopHandlers) {
             final Int2IntFunction indexModifier = loopHandler.getIndexModifier();
@@ -278,7 +278,7 @@ public class InventoryClickProcessor {
                 int finalCursorAmount = cursorAmount;
 
                 for (Integer s : slots) {
-                    final ItemStack draggedItem = cursor.copy();
+                    final ItemStack draggedItem = cursor.clone();
                     ItemStack slotItem = itemGetter.apply(s);
 
                     clickResult = startCondition(clickResult, inventory, player, s, ClickType.DRAGGING, slotItem, cursor);
@@ -318,7 +318,7 @@ public class InventoryClickProcessor {
                 if (size > cursorAmount)
                     return null;
                 for (Integer s : slots) {
-                    ItemStack draggedItem = cursor.copy();
+                    ItemStack draggedItem = cursor.clone();
                     ItemStack slotItem = itemGetter.apply(s);
 
                     clickResult = startCondition(clickResult, inventory, player, s, ClickType.DRAGGING, slotItem, cursor);
@@ -435,8 +435,8 @@ public class InventoryClickProcessor {
         final StackingRule clickedRule = clicked == null ? null : clicked.getStackingRule();
         final StackingRule cursorRule = cursor.getStackingRule();
 
-        ItemStack resultClicked = clicked == null ? null : clicked.copy();
-        ItemStack resultCursor = cursor.copy();
+        ItemStack resultClicked = clicked == null ? null : clicked.clone();
+        ItemStack resultCursor = cursor.clone();
 
 
         if (slot == -999) {
@@ -444,7 +444,7 @@ public class InventoryClickProcessor {
             if (button == 0) {
                 // Left (drop all)
                 final int amount = cursorRule.getAmount(resultCursor);
-                final ItemStack dropItem = cursorRule.apply(resultCursor.copy(), amount);
+                final ItemStack dropItem = cursorRule.apply(resultCursor.clone(), amount);
                 final boolean dropResult = player.dropItem(dropItem);
                 clickResult.setCancel(!dropResult);
                 if (dropResult) {
@@ -452,7 +452,7 @@ public class InventoryClickProcessor {
                 }
             } else if (button == 1) {
                 // Right (drop 1)
-                final ItemStack dropItem = cursorRule.apply(resultCursor.copy(), 1);
+                final ItemStack dropItem = cursorRule.apply(resultCursor.clone(), 1);
                 final boolean dropResult = player.dropItem(dropItem);
                 clickResult.setCancel(!dropResult);
                 if (dropResult) {
@@ -465,7 +465,7 @@ public class InventoryClickProcessor {
         } else if (mode == 4) {
             if (button == 0) {
                 // Drop key Q (drop 1)
-                final ItemStack dropItem = cursorRule.apply(resultClicked.copy(), 1);
+                final ItemStack dropItem = cursorRule.apply(resultClicked.clone(), 1);
                 final boolean dropResult = player.dropItem(dropItem);
                 clickResult.setCancel(!dropResult);
                 if (dropResult) {
@@ -476,7 +476,7 @@ public class InventoryClickProcessor {
             } else if (button == 1) {
                 // Ctrl + Drop key Q (drop all)
                 final int amount = cursorRule.getAmount(resultClicked);
-                final ItemStack dropItem = clickedRule.apply(resultClicked.copy(), amount);
+                final ItemStack dropItem = clickedRule.apply(resultClicked.clone(), amount);
                 final boolean dropResult = player.dropItem(dropItem);
                 clickResult.setCancel(!dropResult);
                 if (dropResult) {

--- a/src/main/java/net/minestom/server/item/ItemStack.java
+++ b/src/main/java/net/minestom/server/item/ItemStack.java
@@ -34,7 +34,7 @@ import java.util.*;
  * Here a non-exhaustive list of what you can do to update the item:
  * {@link PlayerInventory#refreshSlot(short)}, {@link Inventory#refreshSlot(short)} or a raw {@link SetSlotPacket}.
  */
-public class ItemStack implements DataContainer {
+public class ItemStack implements DataContainer, Cloneable {
 
     private static final StackingRule DEFAULT_STACKING_RULE = new VanillaStackingRule(64);
 
@@ -529,11 +529,13 @@ public class ItemStack implements DataContainer {
     }
 
     /**
+     * @deprecated use {@link #clone()} instead.
      * Copies this item stack.
      *
      * @return a cloned item stack
      */
     @NotNull
+    @Deprecated
     public synchronized ItemStack copy() {
         ItemStack itemStack = new ItemStack(material, amount, damage);
         itemStack.setDisplayName(displayName);
@@ -558,6 +560,40 @@ public class ItemStack implements DataContainer {
         if (data != null)
             itemStack.setData(data.copy());
         return itemStack;
+    }
+
+    /**
+     * Clones this item stack.
+     * This copies all metadata to the new Itemstack.
+     *
+     * @return a cloned item stack
+     */
+    @NotNull
+    @Override
+    public synchronized ItemStack clone() {
+        ItemStack clone = new ItemStack(material, amount, damage);
+        clone.setDisplayName(displayName);
+        clone.setUnbreakable(unbreakable);
+        if (lore != null) {
+            clone.setLore(new ArrayList<>(lore));
+        }
+        if (stackingRule != null) {
+            clone.setStackingRule(stackingRule);
+        }
+
+        clone.enchantmentMap = new HashMap<>(enchantmentMap);
+        clone.attributes = new ArrayList<>(attributes);
+
+        clone.hideFlag = hideFlag;
+        clone.customModelData = customModelData;
+
+        if (itemMeta != null)
+            clone.itemMeta = itemMeta.copy();
+
+        final Data data = getData();
+        if (data != null)
+            clone.setData(data.copy());
+        return clone;
     }
 
     @Override

--- a/src/main/java/net/minestom/server/item/metadata/CrossbowMeta.java
+++ b/src/main/java/net/minestom/server/item/metadata/CrossbowMeta.java
@@ -183,9 +183,9 @@ public class CrossbowMeta implements ItemMeta {
     public ItemMeta copy() {
         CrossbowMeta crossbowMeta = new CrossbowMeta();
         crossbowMeta.triple = triple;
-        crossbowMeta.projectile1 = projectile1 == null ? null : projectile1.copy();
-        crossbowMeta.projectile2 = projectile2 == null ? null : projectile2.copy();
-        crossbowMeta.projectile3 = projectile3 == null ? null : projectile3.copy();
+        crossbowMeta.projectile1 = projectile1 == null ? null : projectile1.clone();
+        crossbowMeta.projectile2 = projectile2 == null ? null : projectile2.clone();
+        crossbowMeta.projectile3 = projectile3 == null ? null : projectile3.clone();
 
         crossbowMeta.charged = charged;
 

--- a/src/main/java/net/minestom/server/listener/PlayerDiggingListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerDiggingListener.java
@@ -92,12 +92,12 @@ public class PlayerDiggingListener {
                 }
                 break;
             case DROP_ITEM_STACK:
-                final ItemStack droppedItemStack = player.getInventory().getItemInMainHand().copy();
+                final ItemStack droppedItemStack = player.getInventory().getItemInMainHand().clone();
                 dropItem(player, droppedItemStack, ItemStack.getAirItem());
                 break;
             case DROP_ITEM:
-                ItemStack handItem = player.getInventory().getItemInMainHand().copy();
-                ItemStack droppedItemStack2 = handItem.copy();
+                ItemStack handItem = player.getInventory().getItemInMainHand().clone();
+                ItemStack droppedItemStack2 = handItem.clone();
                 final StackingRule handStackingRule = handItem.getStackingRule();
 
                 droppedItemStack2 = handStackingRule.apply(droppedItemStack2, 1);
@@ -119,7 +119,7 @@ public class PlayerDiggingListener {
 
                 break;
             case SWAP_ITEM_HAND:
-                PlayerSwapItemEvent swapItemEvent = new PlayerSwapItemEvent(player, offHand.copy(), mainHand.copy());
+                PlayerSwapItemEvent swapItemEvent = new PlayerSwapItemEvent(player, offHand.clone(), mainHand.clone());
                 player.callCancellableEvent(PlayerSwapItemEvent.class, swapItemEvent, () -> {
                     synchronized (playerInventory) {
                         playerInventory.setItemInMainHand(swapItemEvent.getMainHandItem());

--- a/src/main/java/net/minestom/server/listener/PlayerPositionListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerPositionListener.java
@@ -56,9 +56,9 @@ public class PlayerPositionListener {
             return;
         }
 
-        final Position currentPosition = player.getPosition().copy();
+        final Position currentPosition = player.getPosition().clone();
         Position newPosition = new Position(x, y, z, yaw, pitch);
-        final Position cachedPosition = newPosition.copy();
+        final Position cachedPosition = newPosition.clone();
 
         PlayerMoveEvent playerMoveEvent = new PlayerMoveEvent(player, newPosition);
         player.callEvent(PlayerMoveEvent.class, playerMoveEvent);

--- a/src/main/java/net/minestom/server/utils/BlockPosition.java
+++ b/src/main/java/net/minestom/server/utils/BlockPosition.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 /**
  * Represents the position of a block, so with integers instead of floating numbers.
  */
-public class BlockPosition {
+public class BlockPosition implements Cloneable {
 
     private int x, y, z;
 
@@ -210,12 +210,25 @@ public class BlockPosition {
    }
 
     /**
+     * @deprecated Use {@link #clone()} instead.
      * Copies this block position.
      *
      * @return the cloned block position
      */
     @NotNull
+    @Deprecated
     public BlockPosition copy() {
+        return clone();
+    }
+
+    /**
+     * Clones this block position.
+     * 
+     * @return the cloned block position
+     */
+    @NotNull
+    @Override
+    public BlockPosition clone() {
         return new BlockPosition(x, y, z);
     }
 

--- a/src/main/java/net/minestom/server/utils/Position.java
+++ b/src/main/java/net/minestom/server/utils/Position.java
@@ -2,11 +2,13 @@ package net.minestom.server.utils;
 
 import java.util.Objects;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Represents a position.
  * The instance is not contained.
  */
-public class Position {
+public class Position implements Cloneable {
 
     private float x, y, z;
     private float yaw, pitch;
@@ -177,14 +179,27 @@ public class Position {
     }
 
     /**
+     * @deprecated Use {@link #clone()} instead.
      * Copies this position object with the same values.
      *
      * @return a new {@link Position} object with the same coordinates
      */
+    @Deprecated
     public Position copy() {
         return new Position(getX(), getY(), getZ(), getYaw(), getPitch());
     }
 
+    /**
+     * Clones this position object with the same values.
+     *
+     * @return a new {@link Position} object with the same coordinates and pitch/yaw
+     */
+    @NotNull
+    @Override
+    public Position clone() {
+        return new Position(getX(), getY(), getZ(), getYaw(), getPitch());
+    }
+    
     /**
      * Gets if the two objects are position and have the same values.
      *

--- a/src/main/java/net/minestom/server/utils/Vector.java
+++ b/src/main/java/net/minestom/server/utils/Vector.java
@@ -1,6 +1,6 @@
 package net.minestom.server.utils;
 
-public class Vector {
+public class Vector implements Cloneable {
 
     private static final double epsilon = 0.000001;
 
@@ -79,10 +79,10 @@ public class Vector {
     }
 
     /**
-     * Copies another vector
+     * Copies another vector into the current vector
      *
      * @param vec The other vector
-     * @return the same vector
+     * @return the current vector instance
      */
     public Vector copy(Vector vec) {
         x = vec.x;
@@ -233,11 +233,24 @@ public class Vector {
     }
 
     /**
+     * @deprecated Use {@link #clone()} instead.
      * Gets a new vector.
      *
      * @return vector
      */
+    @Deprecated
     public Vector copy() {
+        return new Vector(x, y, z);
+    }
+
+    /**
+     * Clones the current vector to return a new vector that is similar to the current one.
+     * The new vector has the same properties as the current one
+     *
+     * @return vector The cloned vector
+     */
+    @Override
+    public Vector clone() {
         return new Vector(x, y, z);
     }
 

--- a/src/test/java/demo/PlayerInit.java
+++ b/src/test/java/demo/PlayerInit.java
@@ -90,13 +90,13 @@ public class PlayerInit {
                 if (entity instanceof EntityCreature) {
                     EntityCreature creature = (EntityCreature) entity;
                     creature.damage(DamageType.fromPlayer(player), -1);
-                    Vector velocity = player.getPosition().copy().getDirection().multiply(6);
+                    Vector velocity = player.getPosition().clone().getDirection().multiply(6);
                     velocity.setY(4f);
                     entity.setVelocity(velocity);
                     player.sendMessage("You attacked an entity!");
                 } else if (entity instanceof Player) {
                     Player target = (Player) entity;
-                    Vector velocity = player.getPosition().copy().getDirection().multiply(4);
+                    Vector velocity = player.getPosition().clone().getDirection().multiply(4);
                     velocity.setY(3.5f);
                     target.setVelocity(velocity);
                     target.damage(DamageType.fromPlayer(player), 5);
@@ -137,11 +137,11 @@ public class PlayerInit {
             player.addEventCallback(ItemDropEvent.class, event -> {
                 ItemStack droppedItem = event.getItemStack();
 
-                Position position = player.getPosition().copy().add(0, 1.5f, 0);
+                Position position = player.getPosition().clone().add(0, 1.5f, 0);
                 ItemEntity itemEntity = new ItemEntity(droppedItem, position);
                 itemEntity.setPickupDelay(500, TimeUnit.MILLISECOND);
                 itemEntity.setInstance(player.getInstance());
-                Vector velocity = player.getPosition().copy().getDirection().multiply(6);
+                Vector velocity = player.getPosition().clone().getDirection().multiply(6);
                 itemEntity.setVelocity(velocity);
 
                 EntityZombie entityZombie = new EntityZombie(player.getPosition());

--- a/src/test/java/demo/blocks/StoneBlock.java
+++ b/src/test/java/demo/blocks/StoneBlock.java
@@ -23,7 +23,7 @@ public class StoneBlock extends CustomBlock {
 
     @Override
     public void onDestroy(@NotNull Instance instance, @NotNull BlockPosition blockPosition, Data data) {
-        BlockPosition above = blockPosition.copy().add(0, 1, 0);
+        BlockPosition above = blockPosition.clone().add(0, 1, 0);
         CustomBlock blockAbove = instance.getCustomBlock(above);
         if (blockAbove == this) {
             instance.setBlock(above, Block.AIR);

--- a/src/test/java/demo/entity/ChickenCreature.java
+++ b/src/test/java/demo/entity/ChickenCreature.java
@@ -42,7 +42,7 @@ public class ChickenCreature extends EntityChicken {
         addEventCallback(EntityAttackEvent.class, event -> {
             //System.out.println("CALL ATTACK");
             LivingEntity entity = (LivingEntity) event.getTarget();
-            Vector velocity = getPosition().copy().getDirection().multiply(6);
+            Vector velocity = getPosition().clone().getDirection().multiply(6);
             velocity.setY(4f);
             entity.damage(DamageType.fromEntity(this), -1);
             entity.setVelocity(velocity);

--- a/src/test/java/demo/generator/Structure.java
+++ b/src/test/java/demo/generator/Structure.java
@@ -20,7 +20,7 @@ public class Structure {
 				return;
 			if (bPos.getZ() + pos.getZ() >= Chunk.CHUNK_SIZE_Z || bPos.getZ() + pos.getZ() < 0)
 				return;
-			batch.setBlock(bPos.copy().add(pos), block);
+			batch.setBlock(bPos.clone().add(pos), block);
 		});
 	}
 


### PR DESCRIPTION
I didn't change the ItemMeta#copy() function as that is more API-breaking than the rest of the changes. The old Copy methods were deprecated.

My Reasoning behind using Cloneable (and then overriding Object#clone()) is that Cloneable is a relatively widely-accepted API to signify that the Object may be cloned. It is also may weaken some of the ambiguity beween Position#copy(Vector) or Position#copy(Position) and Position#clone() for example.