### PR TITLE
Allow EntityCreature in GoalSelector to be null

### DIFF
--- a/src/main/java/net/minestom/server/entity/ai/GoalSelector.java
+++ b/src/main/java/net/minestom/server/entity/ai/GoalSelector.java
@@ -9,12 +9,8 @@ public abstract class GoalSelector {
 
     protected EntityCreature entityCreature;
 
-    public GoalSelector(@Nullable EntityCreature entityCreature) {
+    public GoalSelector(@NotNull EntityCreature entityCreature) {
         this.entityCreature = entityCreature;
-    }
-
-    public GoalSelector() {
-        this.entityCreature = null;
     }
 
     /**
@@ -69,7 +65,7 @@ public abstract class GoalSelector {
      *
      * @return the entity
      */
-    @Nullable
+    @NotNull
     public EntityCreature getEntityCreature() {
         return entityCreature;
     }
@@ -81,12 +77,9 @@ public abstract class GoalSelector {
      * this only change the internal entity field. Be sure to remove the goal from
      * the previous entity and add it to the new one using {@link EntityCreature#getGoalSelectors()}.
      *
-     * WARNING: If the EntityCreature is null when goals are running, the goal will not run properly.
-     * Setting it to null is an unsafe operation.
-     *
      * @param entityCreature the new affected entity
      */
-    public void setEntityCreature(@Nullable EntityCreature entityCreature) {
+    public void setEntityCreature(@NotNull EntityCreature entityCreature) {
         this.entityCreature = entityCreature;
     }
 }

--- a/src/main/java/net/minestom/server/entity/ai/GoalSelector.java
+++ b/src/main/java/net/minestom/server/entity/ai/GoalSelector.java
@@ -9,8 +9,12 @@ public abstract class GoalSelector {
 
     protected EntityCreature entityCreature;
 
-    public GoalSelector(@NotNull EntityCreature entityCreature) {
+    public GoalSelector(@Nullable EntityCreature entityCreature) {
         this.entityCreature = entityCreature;
+    }
+
+    public GoalSelector() {
+        this.entityCreature = null;
     }
 
     /**
@@ -65,7 +69,7 @@ public abstract class GoalSelector {
      *
      * @return the entity
      */
-    @NotNull
+    @Nullable
     public EntityCreature getEntityCreature() {
         return entityCreature;
     }
@@ -77,9 +81,12 @@ public abstract class GoalSelector {
      * this only change the internal entity field. Be sure to remove the goal from
      * the previous entity and add it to the new one using {@link EntityCreature#getGoalSelectors()}.
      *
+     * WARNING: If the EntityCreature is null when goals are running, the goal will not run properly.
+     * Setting it to null is an unsafe operation.
+     *
      * @param entityCreature the new affected entity
      */
-    public void setEntityCreature(@NotNull EntityCreature entityCreature) {
+    public void setEntityCreature(@Nullable EntityCreature entityCreature) {
         this.entityCreature = entityCreature;
     }
 }

--- a/src/main/java/net/minestom/server/entity/ai/GoalSelector.java
+++ b/src/main/java/net/minestom/server/entity/ai/GoalSelector.java
@@ -9,7 +9,7 @@ public abstract class GoalSelector {
 
     protected EntityCreature entityCreature;
 
-    public GoalSelector(@NotNull EntityCreature entityCreature) {
+    public GoalSelector(@Nullable EntityCreature entityCreature) {
         this.entityCreature = entityCreature;
     }
 
@@ -65,7 +65,7 @@ public abstract class GoalSelector {
      *
      * @return the entity
      */
-    @NotNull
+    @Nullable
     public EntityCreature getEntityCreature() {
         return entityCreature;
     }
@@ -79,7 +79,7 @@ public abstract class GoalSelector {
      *
      * @param entityCreature the new affected entity
      */
-    public void setEntityCreature(@NotNull EntityCreature entityCreature) {
+    public void setEntityCreature(@Nullable EntityCreature entityCreature) {
         this.entityCreature = entityCreature;
     }
 }

--- a/src/main/java/net/minestom/server/entity/ai/goal/DoNothingGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/DoNothingGoal.java
@@ -15,7 +15,7 @@ public class DoNothingGoal extends GoalSelector {
     private long startTime;
 
     /**
-     * Create a DoNothing goal.
+     * Create a DoNothing goal
      *
      * @param entityCreature the entity
      * @param time           the time in milliseconds where nothing happen
@@ -28,7 +28,7 @@ public class DoNothingGoal extends GoalSelector {
     }
 
     /**
-     * Create a DoNothing goal with no applicable creature (unsafe).
+     * Create a DoNothing goal with no applicable creature (unsafe)
      *
      * @param time           the time in milliseconds where nothing happen
      * @param chance         the chance to do nothing (0-1)

--- a/src/main/java/net/minestom/server/entity/ai/goal/DoNothingGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/DoNothingGoal.java
@@ -27,18 +27,6 @@ public class DoNothingGoal extends GoalSelector {
         this.chance = MathUtils.clampFloat(chance, 0, 1);
     }
 
-    /**
-     * Create a DoNothing goal with no applicable creature (unsafe)
-     *
-     * @param time           the time in milliseconds where nothing happen
-     * @param chance         the chance to do nothing (0-1)
-     */
-    public DoNothingGoal(long time, float chance) {
-        super();
-        this.time = time;
-        this.chance = MathUtils.clampFloat(chance, 0, 1);
-    }
-
     @Override
     public void end() {
         this.startTime = 0;

--- a/src/main/java/net/minestom/server/entity/ai/goal/DoNothingGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/DoNothingGoal.java
@@ -27,6 +27,18 @@ public class DoNothingGoal extends GoalSelector {
         this.chance = MathUtils.clampFloat(chance, 0, 1);
     }
 
+    /**
+     * Create a DoNothing goal with no applicable creature (unsafe)
+     *
+     * @param time           the time in milliseconds where nothing happen
+     * @param chance         the chance to do nothing (0-1)
+     */
+    public DoNothingGoal(long time, float chance) {
+        super();
+        this.time = time;
+        this.chance = MathUtils.clampFloat(chance, 0, 1);
+    }
+
     @Override
     public void end() {
         this.startTime = 0;

--- a/src/main/java/net/minestom/server/entity/ai/goal/DoNothingGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/DoNothingGoal.java
@@ -3,6 +3,7 @@ package net.minestom.server.entity.ai.goal;
 import net.minestom.server.entity.EntityCreature;
 import net.minestom.server.entity.ai.GoalSelector;
 import net.minestom.server.utils.MathUtils;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Random;
 
@@ -21,7 +22,7 @@ public class DoNothingGoal extends GoalSelector {
      * @param time           the time in milliseconds where nothing happen
      * @param chance         the chance to do nothing (0-1)
      */
-    public DoNothingGoal(EntityCreature entityCreature, long time, float chance) {
+    public DoNothingGoal(@Nullable EntityCreature entityCreature, long time, float chance) {
         super(entityCreature);
         this.time = time;
         this.chance = MathUtils.clampFloat(chance, 0, 1);

--- a/src/main/java/net/minestom/server/entity/ai/goal/DoNothingGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/DoNothingGoal.java
@@ -15,7 +15,7 @@ public class DoNothingGoal extends GoalSelector {
     private long startTime;
 
     /**
-     * Create a DoNothing goal
+     * Create a DoNothing goal.
      *
      * @param entityCreature the entity
      * @param time           the time in milliseconds where nothing happen
@@ -28,7 +28,7 @@ public class DoNothingGoal extends GoalSelector {
     }
 
     /**
-     * Create a DoNothing goal with no applicable creature (unsafe)
+     * Create a DoNothing goal with no applicable creature (unsafe).
      *
      * @param time           the time in milliseconds where nothing happen
      * @param chance         the chance to do nothing (0-1)

--- a/src/main/java/net/minestom/server/entity/ai/goal/EatBlockGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/EatBlockGoal.java
@@ -5,6 +5,7 @@ import net.minestom.server.entity.ai.GoalSelector;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.utils.BlockPosition;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 import java.util.Random;
@@ -23,7 +24,7 @@ public class EatBlockGoal extends GoalSelector {
      * @param chancePerTick  The chance (per tick) that the entity eats. Settings this to N would mean there is a 1 in N chance.
      */
     public EatBlockGoal(
-            @NotNull EntityCreature entityCreature,
+            @Nullable EntityCreature entityCreature,
             @NotNull Map<Short, Short> eatInMap,
             @NotNull Map<Short, Short> eatBelowMap,
             int chancePerTick) {

--- a/src/main/java/net/minestom/server/entity/ai/goal/EatBlockGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/EatBlockGoal.java
@@ -5,6 +5,7 @@ import net.minestom.server.entity.ai.GoalSelector;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.utils.BlockPosition;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 import java.util.Random;
@@ -17,17 +18,37 @@ public class EatBlockGoal extends GoalSelector {
     private int eatAnimationTick;
 
     /**
+     * Create an EatBlockGoal goal
+     *
      * @param entityCreature Creature that should eat a block.
      * @param eatInMap       Map containing the block IDs that the entity can eat (when inside the block) and the block ID of the replacement block.
      * @param eatBelowMap    Map containing block IDs that the entity can eat (when above the block) and the block ID of the replacement block.
      * @param chancePerTick  The chance (per tick) that the entity eats. Settings this to N would mean there is a 1 in N chance.
      */
     public EatBlockGoal(
-            @NotNull EntityCreature entityCreature,
+            @Nullable EntityCreature entityCreature,
             @NotNull Map<Short, Short> eatInMap,
             @NotNull Map<Short, Short> eatBelowMap,
             int chancePerTick) {
         super(entityCreature);
+        this.eatInMap = eatInMap;
+        this.eatBelowMap = eatBelowMap;
+        this.chancePerTick = chancePerTick;
+    }
+
+    /**
+     *
+     * Create an EatBlockGoal goal with no applicable creature (unsafe)
+     *
+     * @param eatInMap       Map containing the block IDs that the entity can eat (when inside the block) and the block ID of the replacement block.
+     * @param eatBelowMap    Map containing block IDs that the entity can eat (when above the block) and the block ID of the replacement block.
+     * @param chancePerTick  The chance (per tick) that the entity eats. Settings this to N would mean there is a 1 in N chance.
+     */
+    public EatBlockGoal(
+            @NotNull Map<Short, Short> eatInMap,
+            @NotNull Map<Short, Short> eatBelowMap,
+            int chancePerTick) {
+        super();
         this.eatInMap = eatInMap;
         this.eatBelowMap = eatBelowMap;
         this.chancePerTick = chancePerTick;

--- a/src/main/java/net/minestom/server/entity/ai/goal/EatBlockGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/EatBlockGoal.java
@@ -19,7 +19,6 @@ public class EatBlockGoal extends GoalSelector {
 
     /**
      * Create an EatBlockGoal goal
-     *
      * @param entityCreature Creature that should eat a block.
      * @param eatInMap       Map containing the block IDs that the entity can eat (when inside the block) and the block ID of the replacement block.
      * @param eatBelowMap    Map containing block IDs that the entity can eat (when above the block) and the block ID of the replacement block.
@@ -37,9 +36,7 @@ public class EatBlockGoal extends GoalSelector {
     }
 
     /**
-     *
      * Create an EatBlockGoal goal with no applicable creature (unsafe)
-     *
      * @param eatInMap       Map containing the block IDs that the entity can eat (when inside the block) and the block ID of the replacement block.
      * @param eatBelowMap    Map containing block IDs that the entity can eat (when above the block) and the block ID of the replacement block.
      * @param chancePerTick  The chance (per tick) that the entity eats. Settings this to N would mean there is a 1 in N chance.

--- a/src/main/java/net/minestom/server/entity/ai/goal/EatBlockGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/EatBlockGoal.java
@@ -19,6 +19,7 @@ public class EatBlockGoal extends GoalSelector {
 
     /**
      * Create an EatBlockGoal goal
+     *
      * @param entityCreature Creature that should eat a block.
      * @param eatInMap       Map containing the block IDs that the entity can eat (when inside the block) and the block ID of the replacement block.
      * @param eatBelowMap    Map containing block IDs that the entity can eat (when above the block) and the block ID of the replacement block.
@@ -36,7 +37,9 @@ public class EatBlockGoal extends GoalSelector {
     }
 
     /**
+     *
      * Create an EatBlockGoal goal with no applicable creature (unsafe)
+     *
      * @param eatInMap       Map containing the block IDs that the entity can eat (when inside the block) and the block ID of the replacement block.
      * @param eatBelowMap    Map containing block IDs that the entity can eat (when above the block) and the block ID of the replacement block.
      * @param chancePerTick  The chance (per tick) that the entity eats. Settings this to N would mean there is a 1 in N chance.

--- a/src/main/java/net/minestom/server/entity/ai/goal/EatBlockGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/EatBlockGoal.java
@@ -5,7 +5,6 @@ import net.minestom.server.entity.ai.GoalSelector;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.utils.BlockPosition;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 import java.util.Random;
@@ -18,37 +17,17 @@ public class EatBlockGoal extends GoalSelector {
     private int eatAnimationTick;
 
     /**
-     * Create an EatBlockGoal goal
-     *
      * @param entityCreature Creature that should eat a block.
      * @param eatInMap       Map containing the block IDs that the entity can eat (when inside the block) and the block ID of the replacement block.
      * @param eatBelowMap    Map containing block IDs that the entity can eat (when above the block) and the block ID of the replacement block.
      * @param chancePerTick  The chance (per tick) that the entity eats. Settings this to N would mean there is a 1 in N chance.
      */
     public EatBlockGoal(
-            @Nullable EntityCreature entityCreature,
+            @NotNull EntityCreature entityCreature,
             @NotNull Map<Short, Short> eatInMap,
             @NotNull Map<Short, Short> eatBelowMap,
             int chancePerTick) {
         super(entityCreature);
-        this.eatInMap = eatInMap;
-        this.eatBelowMap = eatBelowMap;
-        this.chancePerTick = chancePerTick;
-    }
-
-    /**
-     *
-     * Create an EatBlockGoal goal with no applicable creature (unsafe)
-     *
-     * @param eatInMap       Map containing the block IDs that the entity can eat (when inside the block) and the block ID of the replacement block.
-     * @param eatBelowMap    Map containing block IDs that the entity can eat (when above the block) and the block ID of the replacement block.
-     * @param chancePerTick  The chance (per tick) that the entity eats. Settings this to N would mean there is a 1 in N chance.
-     */
-    public EatBlockGoal(
-            @NotNull Map<Short, Short> eatInMap,
-            @NotNull Map<Short, Short> eatBelowMap,
-            int chancePerTick) {
-        super();
         this.eatInMap = eatInMap;
         this.eatBelowMap = eatBelowMap;
         this.chancePerTick = chancePerTick;

--- a/src/main/java/net/minestom/server/entity/ai/goal/FollowTargetGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/FollowTargetGoal.java
@@ -18,6 +18,7 @@ public class FollowTargetGoal extends GoalSelector {
 
     /**
      * Creates a follow target goal object.
+     *
      * @param entityCreature   the entity
      * @param pathUpdateOption the time between each path update (to check if the target moved)
      */
@@ -28,6 +29,7 @@ public class FollowTargetGoal extends GoalSelector {
 
     /**
      * Creates a follow target goal object.
+     *
      * @param pathUpdateOption the time between each path update (to check if the target moved)
      */
     public FollowTargetGoal(@NotNull UpdateOption pathUpdateOption) {

--- a/src/main/java/net/minestom/server/entity/ai/goal/FollowTargetGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/FollowTargetGoal.java
@@ -7,7 +7,6 @@ import net.minestom.server.utils.MathUtils;
 import net.minestom.server.utils.Position;
 import net.minestom.server.utils.time.UpdateOption;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public class FollowTargetGoal extends GoalSelector {
 
@@ -22,18 +21,8 @@ public class FollowTargetGoal extends GoalSelector {
      * @param entityCreature   the entity
      * @param pathUpdateOption the time between each path update (to check if the target moved)
      */
-    public FollowTargetGoal(@Nullable EntityCreature entityCreature, @NotNull UpdateOption pathUpdateOption) {
+    public FollowTargetGoal(@NotNull EntityCreature entityCreature, @NotNull UpdateOption pathUpdateOption) {
         super(entityCreature);
-        this.pathUpdateOption = pathUpdateOption;
-    }
-
-    /**
-     * Creates a follow target goal object.
-     *
-     * @param pathUpdateOption the time between each path update (to check if the target moved)
-     */
-    public FollowTargetGoal(@NotNull UpdateOption pathUpdateOption) {
-        super();
         this.pathUpdateOption = pathUpdateOption;
     }
 

--- a/src/main/java/net/minestom/server/entity/ai/goal/FollowTargetGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/FollowTargetGoal.java
@@ -7,6 +7,7 @@ import net.minestom.server.utils.MathUtils;
 import net.minestom.server.utils.Position;
 import net.minestom.server.utils.time.UpdateOption;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class FollowTargetGoal extends GoalSelector {
 
@@ -21,7 +22,7 @@ public class FollowTargetGoal extends GoalSelector {
      * @param entityCreature   the entity
      * @param pathUpdateOption the time between each path update (to check if the target moved)
      */
-    public FollowTargetGoal(@NotNull EntityCreature entityCreature, @NotNull UpdateOption pathUpdateOption) {
+    public FollowTargetGoal(@Nullable EntityCreature entityCreature, @NotNull UpdateOption pathUpdateOption) {
         super(entityCreature);
         this.pathUpdateOption = pathUpdateOption;
     }

--- a/src/main/java/net/minestom/server/entity/ai/goal/FollowTargetGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/FollowTargetGoal.java
@@ -18,7 +18,6 @@ public class FollowTargetGoal extends GoalSelector {
 
     /**
      * Creates a follow target goal object.
-     *
      * @param entityCreature   the entity
      * @param pathUpdateOption the time between each path update (to check if the target moved)
      */
@@ -29,7 +28,6 @@ public class FollowTargetGoal extends GoalSelector {
 
     /**
      * Creates a follow target goal object.
-     *
      * @param pathUpdateOption the time between each path update (to check if the target moved)
      */
     public FollowTargetGoal(@NotNull UpdateOption pathUpdateOption) {

--- a/src/main/java/net/minestom/server/entity/ai/goal/FollowTargetGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/FollowTargetGoal.java
@@ -7,6 +7,7 @@ import net.minestom.server.utils.MathUtils;
 import net.minestom.server.utils.Position;
 import net.minestom.server.utils.time.UpdateOption;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class FollowTargetGoal extends GoalSelector {
 
@@ -21,8 +22,18 @@ public class FollowTargetGoal extends GoalSelector {
      * @param entityCreature   the entity
      * @param pathUpdateOption the time between each path update (to check if the target moved)
      */
-    public FollowTargetGoal(@NotNull EntityCreature entityCreature, @NotNull UpdateOption pathUpdateOption) {
+    public FollowTargetGoal(@Nullable EntityCreature entityCreature, @NotNull UpdateOption pathUpdateOption) {
         super(entityCreature);
+        this.pathUpdateOption = pathUpdateOption;
+    }
+
+    /**
+     * Creates a follow target goal object.
+     *
+     * @param pathUpdateOption the time between each path update (to check if the target moved)
+     */
+    public FollowTargetGoal(@NotNull UpdateOption pathUpdateOption) {
+        super();
         this.pathUpdateOption = pathUpdateOption;
     }
 

--- a/src/main/java/net/minestom/server/entity/ai/goal/MeleeAttackGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/MeleeAttackGoal.java
@@ -28,8 +28,18 @@ public class MeleeAttackGoal extends GoalSelector {
      * @param delay          the delay between each attacks
      * @param timeUnit       the unit of the delay
      */
-    public MeleeAttackGoal(@NotNull EntityCreature entityCreature, int delay, @NotNull TimeUnit timeUnit) {
+    public MeleeAttackGoal(@Nullable EntityCreature entityCreature, int delay, @NotNull TimeUnit timeUnit) {
         super(entityCreature);
+        this.delay = delay;
+        this.timeUnit = timeUnit;
+    }
+
+    /**
+     * @param delay          the delay between each attacks
+     * @param timeUnit       the unit of the delay
+     */
+    public MeleeAttackGoal(int delay, @NotNull TimeUnit timeUnit) {
+        super();
         this.delay = delay;
         this.timeUnit = timeUnit;
     }

--- a/src/main/java/net/minestom/server/entity/ai/goal/MeleeAttackGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/MeleeAttackGoal.java
@@ -28,7 +28,7 @@ public class MeleeAttackGoal extends GoalSelector {
      * @param delay          the delay between each attacks
      * @param timeUnit       the unit of the delay
      */
-    public MeleeAttackGoal(@NotNull EntityCreature entityCreature, int delay, @NotNull TimeUnit timeUnit) {
+    public MeleeAttackGoal(@Nullable EntityCreature entityCreature, int delay, @NotNull TimeUnit timeUnit) {
         super(entityCreature);
         this.delay = delay;
         this.timeUnit = timeUnit;

--- a/src/main/java/net/minestom/server/entity/ai/goal/MeleeAttackGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/MeleeAttackGoal.java
@@ -28,18 +28,8 @@ public class MeleeAttackGoal extends GoalSelector {
      * @param delay          the delay between each attacks
      * @param timeUnit       the unit of the delay
      */
-    public MeleeAttackGoal(@Nullable EntityCreature entityCreature, int delay, @NotNull TimeUnit timeUnit) {
+    public MeleeAttackGoal(@NotNull EntityCreature entityCreature, int delay, @NotNull TimeUnit timeUnit) {
         super(entityCreature);
-        this.delay = delay;
-        this.timeUnit = timeUnit;
-    }
-
-    /**
-     * @param delay          the delay between each attacks
-     * @param timeUnit       the unit of the delay
-     */
-    public MeleeAttackGoal(int delay, @NotNull TimeUnit timeUnit) {
-        super();
         this.delay = delay;
         this.timeUnit = timeUnit;
     }

--- a/src/main/java/net/minestom/server/entity/ai/goal/RandomLookAroundGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/RandomLookAroundGoal.java
@@ -62,8 +62,7 @@ public class RandomLookAroundGoal extends GoalSelector {
             @Nullable EntityCreature entityCreature,
             int chancePerTick,
             @NotNull Supplier<Integer> minimalLookTimeSupplier,
-            @NotNull Function<EntityCreature, Vector> randomDirectionFunction
-    ) {
+            @NotNull Function<EntityCreature, Vector> randomDirectionFunction) {
         super(entityCreature);
         this.chancePerTick = chancePerTick;
         this.minimalLookTimeSupplier = minimalLookTimeSupplier;
@@ -78,8 +77,7 @@ public class RandomLookAroundGoal extends GoalSelector {
     public RandomLookAroundGoal(
             int chancePerTick,
             @NotNull Supplier<Integer> minimalLookTimeSupplier,
-            @NotNull Function<EntityCreature, Vector> randomDirectionFunction
-    ) {
+            @NotNull Function<EntityCreature, Vector> randomDirectionFunction) {
         super();
         this.chancePerTick = chancePerTick;
         this.minimalLookTimeSupplier = minimalLookTimeSupplier;

--- a/src/main/java/net/minestom/server/entity/ai/goal/RandomLookAroundGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/RandomLookAroundGoal.java
@@ -62,7 +62,8 @@ public class RandomLookAroundGoal extends GoalSelector {
             @Nullable EntityCreature entityCreature,
             int chancePerTick,
             @NotNull Supplier<Integer> minimalLookTimeSupplier,
-            @NotNull Function<EntityCreature, Vector> randomDirectionFunction) {
+            @NotNull Function<EntityCreature, Vector> randomDirectionFunction
+    ) {
         super(entityCreature);
         this.chancePerTick = chancePerTick;
         this.minimalLookTimeSupplier = minimalLookTimeSupplier;
@@ -77,7 +78,8 @@ public class RandomLookAroundGoal extends GoalSelector {
     public RandomLookAroundGoal(
             int chancePerTick,
             @NotNull Supplier<Integer> minimalLookTimeSupplier,
-            @NotNull Function<EntityCreature, Vector> randomDirectionFunction) {
+            @NotNull Function<EntityCreature, Vector> randomDirectionFunction
+    ) {
         super();
         this.chancePerTick = chancePerTick;
         this.minimalLookTimeSupplier = minimalLookTimeSupplier;

--- a/src/main/java/net/minestom/server/entity/ai/goal/RandomLookAroundGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/RandomLookAroundGoal.java
@@ -4,7 +4,6 @@ import net.minestom.server.entity.EntityCreature;
 import net.minestom.server.entity.ai.GoalSelector;
 import net.minestom.server.utils.Vector;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Random;
 import java.util.function.Function;
@@ -18,25 +17,8 @@ public class RandomLookAroundGoal extends GoalSelector {
     private Vector lookDirection;
     private int lookTime = 0;
 
-    public RandomLookAroundGoal(@Nullable EntityCreature entityCreature, int chancePerTick) {
+    public RandomLookAroundGoal(EntityCreature entityCreature, int chancePerTick) {
         this(entityCreature, chancePerTick,
-                // These two functions act similarily enough to how MC randomly looks around.
-
-                // Look in one direction for at most 40 ticks and at minimum 20 ticks.
-                () -> 20 + RANDOM.nextInt(20),
-                // Look at a random block
-                (creature) -> {
-                    final double n = Math.PI * 2 * RANDOM.nextDouble();
-                    return new Vector(
-                            (float) Math.cos(n),
-                            0,
-                            (float) Math.sin(n)
-                    );
-                });
-    }
-
-    public RandomLookAroundGoal(int chancePerTick) {
-        this(chancePerTick,
                 // These two functions act similarily enough to how MC randomly looks around.
 
                 // Look in one direction for at most 40 ticks and at minimum 20 ticks.
@@ -59,28 +41,12 @@ public class RandomLookAroundGoal extends GoalSelector {
      * @param randomDirectionFunction A function that returns a random vector that the entity will look in/at.
      */
     public RandomLookAroundGoal(
-            @Nullable EntityCreature entityCreature,
+            EntityCreature entityCreature,
             int chancePerTick,
             @NotNull Supplier<Integer> minimalLookTimeSupplier,
             @NotNull Function<EntityCreature, Vector> randomDirectionFunction
     ) {
         super(entityCreature);
-        this.chancePerTick = chancePerTick;
-        this.minimalLookTimeSupplier = minimalLookTimeSupplier;
-        this.randomDirectionFunction = randomDirectionFunction;
-    }
-
-    /**
-     * @param chancePerTick           The chance (per tick) that the entity looks around. Setting this to N would mean there is a 1 in N chance.
-     * @param minimalLookTimeSupplier A supplier that returns the minimal amount of time an entity looks in a direction.
-     * @param randomDirectionFunction A function that returns a random vector that the entity will look in/at.
-     */
-    public RandomLookAroundGoal(
-            int chancePerTick,
-            @NotNull Supplier<Integer> minimalLookTimeSupplier,
-            @NotNull Function<EntityCreature, Vector> randomDirectionFunction
-    ) {
-        super();
         this.chancePerTick = chancePerTick;
         this.minimalLookTimeSupplier = minimalLookTimeSupplier;
         this.randomDirectionFunction = randomDirectionFunction;

--- a/src/main/java/net/minestom/server/entity/ai/goal/RandomLookAroundGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/RandomLookAroundGoal.java
@@ -4,6 +4,7 @@ import net.minestom.server.entity.EntityCreature;
 import net.minestom.server.entity.ai.GoalSelector;
 import net.minestom.server.utils.Vector;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Random;
 import java.util.function.Function;
@@ -17,8 +18,25 @@ public class RandomLookAroundGoal extends GoalSelector {
     private Vector lookDirection;
     private int lookTime = 0;
 
-    public RandomLookAroundGoal(EntityCreature entityCreature, int chancePerTick) {
+    public RandomLookAroundGoal(@Nullable EntityCreature entityCreature, int chancePerTick) {
         this(entityCreature, chancePerTick,
+                // These two functions act similarily enough to how MC randomly looks around.
+
+                // Look in one direction for at most 40 ticks and at minimum 20 ticks.
+                () -> 20 + RANDOM.nextInt(20),
+                // Look at a random block
+                (creature) -> {
+                    final double n = Math.PI * 2 * RANDOM.nextDouble();
+                    return new Vector(
+                            (float) Math.cos(n),
+                            0,
+                            (float) Math.sin(n)
+                    );
+                });
+    }
+
+    public RandomLookAroundGoal(int chancePerTick) {
+        this(chancePerTick,
                 // These two functions act similarily enough to how MC randomly looks around.
 
                 // Look in one direction for at most 40 ticks and at minimum 20 ticks.
@@ -41,12 +59,28 @@ public class RandomLookAroundGoal extends GoalSelector {
      * @param randomDirectionFunction A function that returns a random vector that the entity will look in/at.
      */
     public RandomLookAroundGoal(
-            EntityCreature entityCreature,
+            @Nullable EntityCreature entityCreature,
             int chancePerTick,
             @NotNull Supplier<Integer> minimalLookTimeSupplier,
             @NotNull Function<EntityCreature, Vector> randomDirectionFunction
     ) {
         super(entityCreature);
+        this.chancePerTick = chancePerTick;
+        this.minimalLookTimeSupplier = minimalLookTimeSupplier;
+        this.randomDirectionFunction = randomDirectionFunction;
+    }
+
+    /**
+     * @param chancePerTick           The chance (per tick) that the entity looks around. Setting this to N would mean there is a 1 in N chance.
+     * @param minimalLookTimeSupplier A supplier that returns the minimal amount of time an entity looks in a direction.
+     * @param randomDirectionFunction A function that returns a random vector that the entity will look in/at.
+     */
+    public RandomLookAroundGoal(
+            int chancePerTick,
+            @NotNull Supplier<Integer> minimalLookTimeSupplier,
+            @NotNull Function<EntityCreature, Vector> randomDirectionFunction
+    ) {
+        super();
         this.chancePerTick = chancePerTick;
         this.minimalLookTimeSupplier = minimalLookTimeSupplier;
         this.randomDirectionFunction = randomDirectionFunction;

--- a/src/main/java/net/minestom/server/entity/ai/goal/RandomLookAroundGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/RandomLookAroundGoal.java
@@ -4,6 +4,7 @@ import net.minestom.server.entity.EntityCreature;
 import net.minestom.server.entity.ai.GoalSelector;
 import net.minestom.server.utils.Vector;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Random;
 import java.util.function.Function;
@@ -17,7 +18,7 @@ public class RandomLookAroundGoal extends GoalSelector {
     private Vector lookDirection;
     private int lookTime = 0;
 
-    public RandomLookAroundGoal(EntityCreature entityCreature, int chancePerTick) {
+    public RandomLookAroundGoal(@Nullable EntityCreature entityCreature, int chancePerTick) {
         this(entityCreature, chancePerTick,
                 // These two functions act similarily enough to how MC randomly looks around.
 
@@ -41,7 +42,7 @@ public class RandomLookAroundGoal extends GoalSelector {
      * @param randomDirectionFunction A function that returns a random vector that the entity will look in/at.
      */
     public RandomLookAroundGoal(
-            EntityCreature entityCreature,
+            @Nullable EntityCreature entityCreature,
             int chancePerTick,
             @NotNull Supplier<Integer> minimalLookTimeSupplier,
             @NotNull Function<EntityCreature, Vector> randomDirectionFunction

--- a/src/main/java/net/minestom/server/entity/ai/goal/RandomStrollGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/RandomStrollGoal.java
@@ -4,7 +4,6 @@ import net.minestom.server.entity.EntityCreature;
 import net.minestom.server.entity.ai.GoalSelector;
 import net.minestom.server.utils.Position;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -19,15 +18,8 @@ public class RandomStrollGoal extends GoalSelector {
 
     private long lastStroll;
 
-    public RandomStrollGoal(@Nullable EntityCreature entityCreature, int radius) {
+    public RandomStrollGoal(@NotNull EntityCreature entityCreature, int radius) {
         super(entityCreature);
-        this.radius = radius;
-
-        this.closePositions = getNearbyBlocks(radius);
-    }
-
-    public RandomStrollGoal(int radius) {
-        super();
         this.radius = radius;
 
         this.closePositions = getNearbyBlocks(radius);

--- a/src/main/java/net/minestom/server/entity/ai/goal/RandomStrollGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/RandomStrollGoal.java
@@ -4,6 +4,7 @@ import net.minestom.server.entity.EntityCreature;
 import net.minestom.server.entity.ai.GoalSelector;
 import net.minestom.server.utils.Position;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -18,7 +19,7 @@ public class RandomStrollGoal extends GoalSelector {
 
     private long lastStroll;
 
-    public RandomStrollGoal(@NotNull EntityCreature entityCreature, int radius) {
+    public RandomStrollGoal(@Nullable EntityCreature entityCreature, int radius) {
         super(entityCreature);
         this.radius = radius;
 

--- a/src/main/java/net/minestom/server/entity/ai/goal/RandomStrollGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/RandomStrollGoal.java
@@ -4,6 +4,7 @@ import net.minestom.server.entity.EntityCreature;
 import net.minestom.server.entity.ai.GoalSelector;
 import net.minestom.server.utils.Position;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -18,8 +19,15 @@ public class RandomStrollGoal extends GoalSelector {
 
     private long lastStroll;
 
-    public RandomStrollGoal(@NotNull EntityCreature entityCreature, int radius) {
+    public RandomStrollGoal(@Nullable EntityCreature entityCreature, int radius) {
         super(entityCreature);
+        this.radius = radius;
+
+        this.closePositions = getNearbyBlocks(radius);
+    }
+
+    public RandomStrollGoal(int radius) {
+        super();
         this.radius = radius;
 
         this.closePositions = getNearbyBlocks(radius);

--- a/src/main/java/net/minestom/server/extras/selfmodification/MinestomRootClassLoader.java
+++ b/src/main/java/net/minestom/server/extras/selfmodification/MinestomRootClassLoader.java
@@ -48,6 +48,7 @@ public class MinestomRootClassLoader extends HierarchyClassLoader {
             add("org.spongepowered");
             add("net.minestom.server.extras.selfmodification");
             add("org.jboss.shrinkwrap.resolver");
+            add("kotlin.reflect");
         }
     };
     /**

--- a/src/main/java/net/minestom/server/extras/selfmodification/MinestomRootClassLoader.java
+++ b/src/main/java/net/minestom/server/extras/selfmodification/MinestomRootClassLoader.java
@@ -48,7 +48,7 @@ public class MinestomRootClassLoader extends HierarchyClassLoader {
             add("org.spongepowered");
             add("net.minestom.server.extras.selfmodification");
             add("org.jboss.shrinkwrap.resolver");
-            add("kotlin.reflect");
+            add("kotlin");
         }
     };
     /**


### PR DESCRIPTION
This allows an unsafe operation that allows an EntityCreature to be passed in a constructor as null, or not passed at all, and can be null wherever during the object. If handled improperly, it may lead to unexpected behavior.