### PR TITLE
Handle goal functions inside EntityCreature instead of GoalSelector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ gradle-app.setting
 
 # When running the demo we generate the extensions folder
 /extensions/
+
+# Ignore docs during compile
+/docs

--- a/src/main/java/net/minestom/server/entity/EntityCreature.java
+++ b/src/main/java/net/minestom/server/entity/EntityCreature.java
@@ -84,7 +84,7 @@ public abstract class EntityCreature extends LivingEntity implements NavigableEn
             // (null if not found)
             final Supplier<GoalSelector> goalSelectorSupplier = () -> {
                 for (GoalSelector goalSelector : goalSelectors) {
-                    final boolean start = goalSelector.shouldStart();
+                    final boolean start = goalSelector.shouldStart(this);
                     if (start) {
                         return goalSelector;
                     }
@@ -100,10 +100,10 @@ public abstract class EntityCreature extends LivingEntity implements NavigableEn
                 this.currentGoalSelector = goalSelectorSupplier.get();
                 newGoalSelector = currentGoalSelector != null;
             } else {
-                final boolean stop = currentGoalSelector.shouldEnd();
+                final boolean stop = currentGoalSelector.shouldEnd(this);
                 if (stop) {
                     // The current goal selector stopped, find a new one
-                    this.currentGoalSelector.end();
+                    this.currentGoalSelector.end(this);
                     this.currentGoalSelector = goalSelectorSupplier.get();
                     newGoalSelector = currentGoalSelector != null;
                 }
@@ -111,12 +111,12 @@ public abstract class EntityCreature extends LivingEntity implements NavigableEn
 
             // Start the new goal selector
             if (newGoalSelector) {
-                this.currentGoalSelector.start();
+                this.currentGoalSelector.start(this);
             }
 
             // Execute tick for the current goal selector
             if (currentGoalSelector != null) {
-                currentGoalSelector.tick(time);
+                currentGoalSelector.tick(this, time);
             }
         }
 

--- a/src/main/java/net/minestom/server/entity/ai/GoalSelector.java
+++ b/src/main/java/net/minestom/server/entity/ai/GoalSelector.java
@@ -7,10 +7,8 @@ import org.jetbrains.annotations.Nullable;
 
 public abstract class GoalSelector {
 
-    protected EntityCreature entityCreature;
+    public GoalSelector() {
 
-    public GoalSelector(@NotNull EntityCreature entityCreature) {
-        this.entityCreature = entityCreature;
     }
 
     /**
@@ -18,31 +16,31 @@ public abstract class GoalSelector {
      *
      * @return true to start
      */
-    public abstract boolean shouldStart();
+    public abstract boolean shouldStart(@NotNull EntityCreature entityCreature);
 
     /**
      * Starts this {@link GoalSelector}.
      */
-    public abstract void start();
+    public abstract void start(@NotNull EntityCreature entityCreature);
 
     /**
      * Called every tick when this {@link GoalSelector} is running.
      *
      * @param time the time of the update in milliseconds
      */
-    public abstract void tick(long time);
+    public abstract void tick(@NotNull EntityCreature entityCreature, long time);
 
     /**
      * Whether or not this {@link GoalSelector} should end.
      *
      * @return true to end
      */
-    public abstract boolean shouldEnd();
+    public abstract boolean shouldEnd(@NotNull EntityCreature entityCreature);
 
     /**
      * Ends this {@link GoalSelector}.
      */
-    public abstract void end();
+    public abstract void end(@NotNull EntityCreature entityCreature);
 
     /**
      * Finds a target based on the entity {@link TargetSelector}.
@@ -50,7 +48,7 @@ public abstract class GoalSelector {
      * @return the target entity, null if not found
      */
     @Nullable
-    public Entity findTarget() {
+    public Entity findTarget(@NotNull EntityCreature entityCreature) {
         for (TargetSelector targetSelector : entityCreature.getTargetSelectors()) {
             final Entity entity = targetSelector.findTarget();
             if (entity != null) {
@@ -58,28 +56,5 @@ public abstract class GoalSelector {
             }
         }
         return null;
-    }
-
-    /**
-     * Gets the entity behind the goal selector.
-     *
-     * @return the entity
-     */
-    @NotNull
-    public EntityCreature getEntityCreature() {
-        return entityCreature;
-    }
-
-    /**
-     * Changes the entity affected by the goal selector.
-     * <p>
-     * WARNING: this does not add the goal selector to {@code entityCreature},
-     * this only change the internal entity field. Be sure to remove the goal from
-     * the previous entity and add it to the new one using {@link EntityCreature#getGoalSelectors()}.
-     *
-     * @param entityCreature the new affected entity
-     */
-    public void setEntityCreature(@NotNull EntityCreature entityCreature) {
-        this.entityCreature = entityCreature;
     }
 }

--- a/src/main/java/net/minestom/server/entity/ai/goal/DoNothingGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/DoNothingGoal.java
@@ -1,8 +1,10 @@
 package net.minestom.server.entity.ai.goal;
 
+import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.EntityCreature;
 import net.minestom.server.entity.ai.GoalSelector;
 import net.minestom.server.utils.MathUtils;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Random;
 
@@ -17,38 +19,36 @@ public class DoNothingGoal extends GoalSelector {
     /**
      * Create a DoNothing goal
      *
-     * @param entityCreature the entity
      * @param time           the time in milliseconds where nothing happen
      * @param chance         the chance to do nothing (0-1)
      */
-    public DoNothingGoal(EntityCreature entityCreature, long time, float chance) {
-        super(entityCreature);
+    public DoNothingGoal(long time, float chance) {
         this.time = time;
         this.chance = MathUtils.clampFloat(chance, 0, 1);
     }
 
     @Override
-    public void end() {
+    public void end(@NotNull EntityCreature entityCreature) {
         this.startTime = 0;
     }
 
     @Override
-    public boolean shouldEnd() {
+    public boolean shouldEnd(@NotNull EntityCreature entityCreature) {
         return System.currentTimeMillis() - startTime >= time;
     }
 
     @Override
-    public boolean shouldStart() {
+    public boolean shouldStart(@NotNull EntityCreature entityCreature) {
         return RANDOM.nextFloat() <= chance;
     }
 
     @Override
-    public void start() {
+    public void start(@NotNull EntityCreature entityCreature) {
         this.startTime = System.currentTimeMillis();
     }
 
     @Override
-    public void tick(long time) {
+    public void tick(@NotNull EntityCreature entityCreature, long time) {
 
     }
 }

--- a/src/main/java/net/minestom/server/entity/ai/goal/EatBlockGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/EatBlockGoal.java
@@ -17,24 +17,21 @@ public class EatBlockGoal extends GoalSelector {
     private int eatAnimationTick;
 
     /**
-     * @param entityCreature Creature that should eat a block.
      * @param eatInMap       Map containing the block IDs that the entity can eat (when inside the block) and the block ID of the replacement block.
      * @param eatBelowMap    Map containing block IDs that the entity can eat (when above the block) and the block ID of the replacement block.
      * @param chancePerTick  The chance (per tick) that the entity eats. Settings this to N would mean there is a 1 in N chance.
      */
     public EatBlockGoal(
-            @NotNull EntityCreature entityCreature,
             @NotNull Map<Short, Short> eatInMap,
             @NotNull Map<Short, Short> eatBelowMap,
             int chancePerTick) {
-        super(entityCreature);
         this.eatInMap = eatInMap;
         this.eatBelowMap = eatBelowMap;
         this.chancePerTick = chancePerTick;
     }
 
     @Override
-    public boolean shouldStart() {
+    public boolean shouldStart(@NotNull EntityCreature entityCreature) {
         // TODO: is Baby
         if (RANDOM.nextInt(chancePerTick) != 0) {
             return false;
@@ -48,7 +45,7 @@ public class EatBlockGoal extends GoalSelector {
     }
 
     @Override
-    public void start() {
+    public void start(@NotNull EntityCreature entityCreature) {
         this.eatAnimationTick = 40;
         // TODO: EatBlockEvent call here.
         // Stop moving
@@ -56,7 +53,7 @@ public class EatBlockGoal extends GoalSelector {
     }
 
     @Override
-    public void tick(long time) {
+    public void tick(@NotNull EntityCreature entityCreature, long time) {
         this.eatAnimationTick = Math.max(0, this.eatAnimationTick - 1);
         if (this.eatAnimationTick != 4) {
             return;
@@ -76,12 +73,12 @@ public class EatBlockGoal extends GoalSelector {
     }
 
     @Override
-    public boolean shouldEnd() {
+    public boolean shouldEnd(@NotNull EntityCreature entityCreature) {
         return eatAnimationTick <= 0;
     }
 
     @Override
-    public void end() {
+    public void end(@NotNull EntityCreature entityCreature) {
         this.eatAnimationTick = 0;
     }
 }

--- a/src/main/java/net/minestom/server/entity/ai/goal/FollowTargetGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/FollowTargetGoal.java
@@ -18,22 +18,20 @@ public class FollowTargetGoal extends GoalSelector {
     /**
      * Creates a follow target goal object.
      *
-     * @param entityCreature   the entity
      * @param pathUpdateOption the time between each path update (to check if the target moved)
      */
-    public FollowTargetGoal(@NotNull EntityCreature entityCreature, @NotNull UpdateOption pathUpdateOption) {
-        super(entityCreature);
+    public FollowTargetGoal(@NotNull UpdateOption pathUpdateOption) {
         this.pathUpdateOption = pathUpdateOption;
     }
 
     @Override
-    public boolean shouldStart() {
+    public boolean shouldStart(@NotNull EntityCreature entityCreature) {
         return entityCreature.getTarget() != null &&
                 getDistance(entityCreature.getTarget().getPosition(), entityCreature.getPosition()) >= 2;
     }
 
     @Override
-    public void start() {
+    public void start(@NotNull EntityCreature entityCreature) {
         lastUpdateTime = 0;
         forceEnd = false;
         lastTargetPos = null;
@@ -57,7 +55,7 @@ public class FollowTargetGoal extends GoalSelector {
     }
 
     @Override
-    public void tick(long time) {
+    public void tick(@NotNull EntityCreature entityCreature, long time) {
         if (forceEnd ||
                 pathUpdateOption.getValue() == 0 ||
                 pathUpdateOption.getTimeUnit().toMilliseconds(pathUpdateOption.getValue()) + lastUpdateTime > time) {
@@ -72,14 +70,14 @@ public class FollowTargetGoal extends GoalSelector {
     }
 
     @Override
-    public boolean shouldEnd() {
+    public boolean shouldEnd(@NotNull EntityCreature entityCreature) {
         return forceEnd ||
                 entityCreature.getTarget() == null ||
                 getDistance(entityCreature.getTarget().getPosition(), entityCreature.getPosition()) < 2;
     }
 
     @Override
-    public void end() {
+    public void end(@NotNull EntityCreature entityCreature) {
         entityCreature.setPathTo(null);
     }
 

--- a/src/main/java/net/minestom/server/entity/ai/goal/MeleeAttackGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/MeleeAttackGoal.java
@@ -24,32 +24,30 @@ public class MeleeAttackGoal extends GoalSelector {
     private boolean stop;
 
     /**
-     * @param entityCreature the entity to add the goal to
      * @param delay          the delay between each attacks
      * @param timeUnit       the unit of the delay
      */
-    public MeleeAttackGoal(@NotNull EntityCreature entityCreature, int delay, @NotNull TimeUnit timeUnit) {
-        super(entityCreature);
+    public MeleeAttackGoal(int delay, @NotNull TimeUnit timeUnit) {
         this.delay = delay;
         this.timeUnit = timeUnit;
     }
 
     @Override
-    public boolean shouldStart() {
-        return getTarget() != null;
+    public boolean shouldStart(@NotNull EntityCreature entityCreature) {
+        return getTarget(entityCreature) != null;
     }
 
     @Override
-    public void start() {
-        final Entity target = getTarget();
+    public void start(@NotNull EntityCreature entityCreature) {
+        final Entity target = getTarget(entityCreature);
         Check.notNull(target, "The target is not expected to be null!");
         final Position targetPosition = target.getPosition();
         entityCreature.setPathTo(targetPosition);
     }
 
     @Override
-    public void tick(long time) {
-        final Entity target = getTarget();
+    public void tick(@NotNull EntityCreature entityCreature, long time) {
+        final Entity target = getTarget(entityCreature);
 
         this.stop = target == null;
 
@@ -74,12 +72,12 @@ public class MeleeAttackGoal extends GoalSelector {
     }
 
     @Override
-    public boolean shouldEnd() {
+    public boolean shouldEnd(@NotNull EntityCreature entityCreature) {
         return stop;
     }
 
     @Override
-    public void end() {
+    public void end(@NotNull EntityCreature entityCreature) {
         // Stop following the target
         entityCreature.setPathTo(null);
     }
@@ -91,8 +89,8 @@ public class MeleeAttackGoal extends GoalSelector {
      * @return the target of the entity
      */
     @Nullable
-    private Entity getTarget() {
+    private Entity getTarget(@NotNull EntityCreature entityCreature) {
         final Entity target = entityCreature.getTarget();
-        return target == null ? findTarget() : target;
+        return target == null ? findTarget(entityCreature) : target;
     }
 }

--- a/src/main/java/net/minestom/server/entity/ai/goal/RandomLookAroundGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/RandomLookAroundGoal.java
@@ -17,8 +17,8 @@ public class RandomLookAroundGoal extends GoalSelector {
     private Vector lookDirection;
     private int lookTime = 0;
 
-    public RandomLookAroundGoal(EntityCreature entityCreature, int chancePerTick) {
-        this(entityCreature, chancePerTick,
+    public RandomLookAroundGoal(int chancePerTick) {
+        this(chancePerTick,
                 // These two functions act similarily enough to how MC randomly looks around.
 
                 // Look in one direction for at most 40 ticks and at minimum 20 ticks.
@@ -35,25 +35,22 @@ public class RandomLookAroundGoal extends GoalSelector {
     }
 
     /**
-     * @param entityCreature          Creature that should randomly look around.
      * @param chancePerTick           The chance (per tick) that the entity looks around. Setting this to N would mean there is a 1 in N chance.
      * @param minimalLookTimeSupplier A supplier that returns the minimal amount of time an entity looks in a direction.
      * @param randomDirectionFunction A function that returns a random vector that the entity will look in/at.
      */
     public RandomLookAroundGoal(
-            EntityCreature entityCreature,
             int chancePerTick,
             @NotNull Supplier<Integer> minimalLookTimeSupplier,
             @NotNull Function<EntityCreature, Vector> randomDirectionFunction
     ) {
-        super(entityCreature);
         this.chancePerTick = chancePerTick;
         this.minimalLookTimeSupplier = minimalLookTimeSupplier;
         this.randomDirectionFunction = randomDirectionFunction;
     }
 
     @Override
-    public boolean shouldStart() {
+    public boolean shouldStart(@NotNull EntityCreature entityCreature) {
         if (RANDOM.nextInt(chancePerTick) != 0) {
             return false;
         }
@@ -61,24 +58,24 @@ public class RandomLookAroundGoal extends GoalSelector {
     }
 
     @Override
-    public void start() {
+    public void start(@NotNull EntityCreature entityCreature) {
         lookTime = minimalLookTimeSupplier.get();
         lookDirection = randomDirectionFunction.apply(entityCreature);
     }
 
     @Override
-    public void tick(long time) {
+    public void tick(@NotNull EntityCreature entityCreature, long time) {
         --lookTime;
         entityCreature.setView(entityCreature.getPosition().copy().setDirection(lookDirection));
     }
 
     @Override
-    public boolean shouldEnd() {
+    public boolean shouldEnd(@NotNull EntityCreature entityCreature) {
         return this.lookTime < 0;
     }
 
     @Override
-    public void end() {
+    public void end(@NotNull EntityCreature entityCreature) {
 
     }
 }

--- a/src/main/java/net/minestom/server/entity/ai/goal/RandomStrollGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/RandomStrollGoal.java
@@ -18,20 +18,20 @@ public class RandomStrollGoal extends GoalSelector {
 
     private long lastStroll;
 
-    public RandomStrollGoal(@NotNull EntityCreature entityCreature, int radius) {
-        super(entityCreature);
+    public RandomStrollGoal(int radius) {
+        super();
         this.radius = radius;
 
         this.closePositions = getNearbyBlocks(radius);
     }
 
     @Override
-    public boolean shouldStart() {
+    public boolean shouldStart(@NotNull EntityCreature entityCreature) {
         return System.currentTimeMillis() - lastStroll >= DELAY;
     }
 
     @Override
-    public void start() {
+    public void start(@NotNull EntityCreature entityCreature) {
         Collections.shuffle(closePositions);
 
         for (Position position : closePositions) {
@@ -45,17 +45,17 @@ public class RandomStrollGoal extends GoalSelector {
     }
 
     @Override
-    public void tick(long time) {
+    public void tick(@NotNull EntityCreature entityCreature, long time) {
 
     }
 
     @Override
-    public boolean shouldEnd() {
+    public boolean shouldEnd(@NotNull EntityCreature entityCreature) {
         return true;
     }
 
     @Override
-    public void end() {
+    public void end(@NotNull EntityCreature entityCreature) {
         this.lastStroll = System.currentTimeMillis();
     }
 

--- a/src/test/java/demo/entity/ChickenCreature.java
+++ b/src/test/java/demo/entity/ChickenCreature.java
@@ -16,7 +16,7 @@ public class ChickenCreature extends EntityChicken {
 
         //goalSelectors.add(new DoNothingGoal(this, 500, 0.1f));
         //goalSelectors.add(new MeleeAttackGoal(this, 500, TimeUnit.MILLISECOND));
-        goalSelectors.add(new RandomStrollGoal(this, 2));
+        goalSelectors.add(new RandomStrollGoal(2));
         /*goalSelectors.add(new EatBlockGoal(this,
                 new HashMap<>() {
                     {

--- a/src/test/java/demo/entity/ZombieCreature.java
+++ b/src/test/java/demo/entity/ZombieCreature.java
@@ -8,6 +8,6 @@ public class ZombieCreature extends EntityZombie {
 
     public ZombieCreature(Position spawnPosition) {
         super(spawnPosition);
-        goalSelectors.add(new RandomLookAroundGoal(this, 20));
+        goalSelectors.add(new RandomLookAroundGoal(20));
     }
 }


### PR DESCRIPTION
This is a demo for goals that don't need entitycreature as a parameter, allowing its functions to be called later, passing the same data. This allows for easier goal duplication and having goals for later usage. 