### PR TITLE
Ignore kotlin to allow stdlib and reflect to be accessed by extensions.

### DIFF
--- a/src/main/java/net/minestom/server/extras/selfmodification/MinestomRootClassLoader.java
+++ b/src/main/java/net/minestom/server/extras/selfmodification/MinestomRootClassLoader.java
@@ -48,6 +48,7 @@ public class MinestomRootClassLoader extends HierarchyClassLoader {
             add("org.spongepowered");
             add("net.minestom.server.extras.selfmodification");
             add("org.jboss.shrinkwrap.resolver");
+            add("kotlin");
         }
     };
     /**


### PR DESCRIPTION
This allows kotlin-reflect to work in extensions instead of just the server jar.