### PR TITLE
Function in CommandSender to send ColoredText

### DIFF
--- a/src/main/java/net/minestom/server/command/CommandSender.java
+++ b/src/main/java/net/minestom/server/command/CommandSender.java
@@ -1,5 +1,7 @@
 package net.minestom.server.command;
 
+import net.minestom.server.chat.ColoredText;
+import net.minestom.server.chat.JsonMessage;
 import net.minestom.server.entity.Player;
 import net.minestom.server.permission.PermissionHandler;
 import org.jetbrains.annotations.NotNull;
@@ -27,6 +29,11 @@ public interface CommandSender extends PermissionHandler {
         for (String message : messages) {
             sendMessage(message);
         }
+    }
+
+    default void sendMessage(@NotNull ColoredText message) {
+        if (this instanceof ConsoleSender) sendMessage(message.getMessage());
+        else if (this instanceof Player) ((Player) this).sendMessage((JsonMessage) message);
     }
 
     /**

--- a/src/main/java/net/minestom/server/command/CommandSender.java
+++ b/src/main/java/net/minestom/server/command/CommandSender.java
@@ -32,6 +32,13 @@ public interface CommandSender extends PermissionHandler {
         }
     }
 
+    /**
+     * Sends a {@link ColoredText} message.
+     *
+     *  If this is not a {@link Player}, only the content of the message will be sent as a string.
+     *
+     * @param text The {@link ColoredText} to send.
+     * */
     default void sendMessage(@NotNull ColoredText text) {
         if (this instanceof Player) ((Player) this).sendMessage((JsonMessage) text);
         else sendMessage(text.getMessage());

--- a/src/main/java/net/minestom/server/command/CommandSender.java
+++ b/src/main/java/net/minestom/server/command/CommandSender.java
@@ -2,6 +2,7 @@ package net.minestom.server.command;
 
 import net.minestom.server.chat.ColoredText;
 import net.minestom.server.chat.JsonMessage;
+import net.minestom.server.chat.RichMessage;
 import net.minestom.server.entity.Player;
 import net.minestom.server.permission.PermissionHandler;
 import org.jetbrains.annotations.NotNull;
@@ -31,9 +32,9 @@ public interface CommandSender extends PermissionHandler {
         }
     }
 
-    default void sendMessage(@NotNull ColoredText message) {
-        if (this instanceof ConsoleSender) sendMessage(message.getMessage());
-        else if (this instanceof Player) ((Player) this).sendMessage((JsonMessage) message);
+    default void sendMessage(@NotNull ColoredText text) {
+        if (this instanceof Player) ((Player) this).sendMessage((JsonMessage) text);
+        else sendMessage(text.getMessage());
     }
 
     /**


### PR DESCRIPTION
This PR adds a default function in CommandSender which allows you to send ColoredText instead of a string. Since at this time only Players can render ColoredText, the function checks for the type of CommandSender, and if it isn't Player it just sends the message content as a string. If it is a Player, the ColoredText will be sent using Player's implementation of `sendMessage(JsonMessage message)`

This is just a small convenience function so that one doesn't need to check for a player every time they want to send ColoredText in, say, an error message. 