### PR TITLE
Fix block placement inside entities.

### DIFF
--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -42,6 +42,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
 
 /**
@@ -752,8 +753,8 @@ public abstract class Instance implements BlockModifier, EventHandler, DataConta
      */
     @Nullable
     public Chunk getChunkAt(float x, float z) {
-        final int chunkX = ChunkUtils.getChunkCoordinate((int) x);
-        final int chunkZ = ChunkUtils.getChunkCoordinate((int) z);
+        final int chunkX = ChunkUtils.getChunkCoordinate((int) Math.floor(x));
+        final int chunkZ = ChunkUtils.getChunkCoordinate((int) Math.floor(z));
         return getChunk(chunkX, chunkZ);
     }
 
@@ -930,7 +931,8 @@ public abstract class Instance implements BlockModifier, EventHandler, DataConta
             Set<Entity> entities = getEntitiesInChunk(chunkIndex);
             entities.add(entity);
 
-            this.entities.add(entity);
+            boolean added = this.entities.add(entity);
+            System.out.println(added + " " + chunk.toString());
             if (entity instanceof Player) {
                 this.players.add((Player) entity);
             } else if (entity instanceof EntityCreature) {

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -42,7 +42,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
 
 /**
@@ -931,8 +930,7 @@ public abstract class Instance implements BlockModifier, EventHandler, DataConta
             Set<Entity> entities = getEntitiesInChunk(chunkIndex);
             entities.add(entity);
 
-            boolean added = this.entities.add(entity);
-            System.out.println(added + " " + chunk.toString());
+            this.entities.add(entity);
             if (entity instanceof Player) {
                 this.players.add((Player) entity);
             } else if (entity instanceof EntityCreature) {


### PR DESCRIPTION
This changes the rounding method of `Instance#getChunkAt` to `Math#floor` as opposed to casting to an int. Casting a float such as -0.5 to an int will result in 0, as opposed to the desired -1. This means that negative x or z chunk borders were off by one.

As a result, entities were being marked as in different chunks than they actually were and were ignored in collision.