### PR TITLE
Fix block placement when close to block

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -201,7 +201,7 @@ public class Player extends LivingEntity implements CommandSender {
         this.username = username;
         this.playerConnection = playerConnection;
 
-        setBoundingBox(0.69f, 1.8f, 0.69f);
+        setBoundingBox(0.6f, 1.8f, 0.6f);
 
         setRespawnPoint(new Position(0, 0, 0));
 


### PR DESCRIPTION
Block placement was being denied when a player was standing too close to a block. This is because the player's bounding box was (correctly) intersecting with the block.

The player size was set to 0.69, which is bigger than the vanilla size of 0.6. This PR sets the size to 0.6, which fixes the above issue.