### PR TITLE
Change ColoredText usages to JsonMessage

### DIFF
--- a/src/main/java/net/minestom/server/advancements/Advancement.java
+++ b/src/main/java/net/minestom/server/advancements/Advancement.java
@@ -1,6 +1,6 @@
 package net.minestom.server.advancements;
 
-import net.minestom.server.chat.ColoredText;
+import net.minestom.server.chat.JsonMessage;
 import net.minestom.server.entity.Player;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
@@ -23,8 +23,8 @@ public class Advancement {
 
     private boolean achieved;
 
-    private ColoredText title;
-    private ColoredText description;
+    private JsonMessage title;
+    private JsonMessage description;
 
     private ItemStack icon;
 
@@ -42,7 +42,7 @@ public class Advancement {
     // Packet
     private AdvancementsPacket.Criteria criteria;
 
-    public Advancement(@NotNull ColoredText title, ColoredText description,
+    public Advancement(@NotNull JsonMessage title, JsonMessage description,
                        @NotNull ItemStack icon, @NotNull FrameType frameType,
                        float x, float y) {
         this.title = title;
@@ -53,7 +53,7 @@ public class Advancement {
         this.y = y;
     }
 
-    public Advancement(@NotNull ColoredText title, @NotNull ColoredText description,
+    public Advancement(@NotNull JsonMessage title, @NotNull JsonMessage description,
                        @NotNull Material icon, @NotNull FrameType frameType,
                        float x, float y) {
         this(title, description, new ItemStack(icon, (byte) 1), frameType, x, y);
@@ -100,7 +100,7 @@ public class Advancement {
      * @return the advancement title
      */
     @NotNull
-    public ColoredText getTitle() {
+    public JsonMessage getTitle() {
         return title;
     }
 
@@ -109,7 +109,7 @@ public class Advancement {
      *
      * @param title the new title
      */
-    public void setTitle(@NotNull ColoredText title) {
+    public void setTitle(@NotNull JsonMessage title) {
         this.title = title;
         update();
     }
@@ -120,7 +120,7 @@ public class Advancement {
      * @return the description title
      */
     @NotNull
-    public ColoredText getDescription() {
+    public JsonMessage getDescription() {
         return description;
     }
 
@@ -129,7 +129,7 @@ public class Advancement {
      *
      * @param description the new description
      */
-    public void setDescription(@NotNull ColoredText description) {
+    public void setDescription(@NotNull JsonMessage description) {
         this.description = description;
         update();
     }

--- a/src/main/java/net/minestom/server/advancements/AdvancementRoot.java
+++ b/src/main/java/net/minestom/server/advancements/AdvancementRoot.java
@@ -1,6 +1,7 @@
 package net.minestom.server.advancements;
 
 import net.minestom.server.chat.ColoredText;
+import net.minestom.server.chat.JsonMessage;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
 import org.jetbrains.annotations.NotNull;
@@ -14,7 +15,7 @@ import org.jetbrains.annotations.Nullable;
  */
 public class AdvancementRoot extends Advancement {
 
-    public AdvancementRoot(@NotNull ColoredText title, @NotNull ColoredText description,
+    public AdvancementRoot(@NotNull JsonMessage title, @NotNull JsonMessage description,
                            @NotNull ItemStack icon, @NotNull FrameType frameType,
                            float x, float y,
                            @Nullable String background) {
@@ -22,7 +23,7 @@ public class AdvancementRoot extends Advancement {
         setBackground(background);
     }
 
-    public AdvancementRoot(@NotNull ColoredText title, @NotNull ColoredText description,
+    public AdvancementRoot(@NotNull JsonMessage title, @NotNull JsonMessage description,
                            @NotNull Material icon, FrameType frameType,
                            float x, float y,
                            @Nullable String background) {

--- a/src/main/java/net/minestom/server/advancements/notifications/Notification.java
+++ b/src/main/java/net/minestom/server/advancements/notifications/Notification.java
@@ -1,7 +1,7 @@
 package net.minestom.server.advancements.notifications;
 
 import net.minestom.server.advancements.FrameType;
-import net.minestom.server.chat.ColoredText;
+import net.minestom.server.chat.JsonMessage;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
 import org.jetbrains.annotations.NotNull;
@@ -11,17 +11,17 @@ import org.jetbrains.annotations.NotNull;
  */
 public class Notification {
 
-    private final ColoredText title;
+    private final JsonMessage title;
     private final FrameType frameType;
     private final ItemStack icon;
 
-    public Notification(@NotNull ColoredText title, @NotNull FrameType frameType, @NotNull ItemStack icon) {
+    public Notification(@NotNull JsonMessage title, @NotNull FrameType frameType, @NotNull ItemStack icon) {
         this.title = title;
         this.frameType = frameType;
         this.icon = icon;
     }
 
-    public Notification(@NotNull ColoredText title, @NotNull FrameType frameType, @NotNull Material icon) {
+    public Notification(@NotNull JsonMessage title, @NotNull FrameType frameType, @NotNull Material icon) {
         this.title = title;
         this.frameType = frameType;
         this.icon = new ItemStack(icon, (byte) 1);
@@ -33,7 +33,7 @@ public class Notification {
      * @return the notification title
      */
     @NotNull
-    public ColoredText getTitle() {
+    public JsonMessage getTitle() {
         return title;
     }
 

--- a/src/main/java/net/minestom/server/bossbar/BossBar.java
+++ b/src/main/java/net/minestom/server/bossbar/BossBar.java
@@ -1,7 +1,7 @@
 package net.minestom.server.bossbar;
 
 import net.minestom.server.Viewable;
-import net.minestom.server.chat.ColoredText;
+import net.minestom.server.chat.JsonMessage;
 import net.minestom.server.entity.Player;
 import net.minestom.server.network.packet.server.play.BossBarPacket;
 import net.minestom.server.utils.MathUtils;
@@ -29,7 +29,7 @@ public class BossBar implements Viewable {
     private final Set<Player> viewers = new CopyOnWriteArraySet<>();
     private final Set<Player> unmodifiableViewers = Collections.unmodifiableSet(viewers);
 
-    private ColoredText title;
+    private JsonMessage title;
     private float progress;
     private BarColor color;
     private BarDivision division;
@@ -42,7 +42,7 @@ public class BossBar implements Viewable {
      * @param color    the boss bar color
      * @param division the boss bar division
      */
-    public BossBar(@NotNull ColoredText title, @NotNull BarColor color, @NotNull BarDivision division) {
+    public BossBar(@NotNull JsonMessage title, @NotNull BarColor color, @NotNull BarDivision division) {
         this.title = title;
         this.color = color;
         this.division = division;
@@ -99,7 +99,7 @@ public class BossBar implements Viewable {
      * @return the current title of the bossbar
      */
     @NotNull
-    public ColoredText getTitle() {
+    public JsonMessage getTitle() {
         return title;
     }
 
@@ -108,7 +108,7 @@ public class BossBar implements Viewable {
      *
      * @param title the new title of the bossbar
      */
-    public void setTitle(@NotNull ColoredText title) {
+    public void setTitle(@NotNull JsonMessage title) {
         this.title = title;
         updateTitle();
     }

--- a/src/main/java/net/minestom/server/chat/ChatHoverEvent.java
+++ b/src/main/java/net/minestom/server/chat/ChatHoverEvent.java
@@ -51,13 +51,13 @@ public class ChatHoverEvent {
     }
 
     /**
-     * Shows a {@link ColoredText} when hovered.
+     * Shows a {@link JsonMessage} when hovered.
      *
      * @param text the text to show
      * @return the chat hover event
      */
     @NotNull
-    public static ChatHoverEvent showText(@NotNull ColoredText text) {
+    public static ChatHoverEvent showText(@NotNull JsonMessage text) {
         return new ChatHoverEvent("show_text", text.getJsonObject());
     }
 

--- a/src/main/java/net/minestom/server/chat/JsonMessage.java
+++ b/src/main/java/net/minestom/server/chat/JsonMessage.java
@@ -1,5 +1,6 @@
 package net.minestom.server.chat;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.jetbrains.annotations.NotNull;
 
@@ -36,6 +37,15 @@ public abstract class JsonMessage {
     }
 
     /**
+     * Gets the content of the message without any formatting or effects.
+     *
+     * @return The message without formatting or effects
+     */
+    public String getRawMessage() {
+        return getTextMessage(getJsonObject()).toString();
+    }
+
+    /**
      * Gets the Json representation.
      * <p>
      * Will check of the current cached compiled json is up-to-date in order to prevent
@@ -54,6 +64,24 @@ public abstract class JsonMessage {
         }
 
         return compiledJson;
+    }
+
+    /**
+     * Recursively collects the 'text' field from the provided object and it's 'extra's.
+     *
+     * @param obj The object to parse
+     * @return The text content of the object and its 'extra's
+     */
+    private StringBuilder getTextMessage(JsonObject obj) {
+        StringBuilder message = new StringBuilder(obj.get("text").getAsString());
+        JsonElement extra = obj.get("extra");
+        if (extra != null && extra.isJsonArray()) {
+            for (JsonElement child : extra.getAsJsonArray()) {
+                if (!child.isJsonObject()) continue;
+                message.append(getTextMessage(child.getAsJsonObject()));
+            }
+        }
+        return message;
     }
 
     public static class RawJsonMessage extends JsonMessage {

--- a/src/main/java/net/minestom/server/command/CommandSender.java
+++ b/src/main/java/net/minestom/server/command/CommandSender.java
@@ -32,16 +32,16 @@ public interface CommandSender extends PermissionHandler {
     }
 
     /**
-     * Sends a {@link ColoredText} message.
+     * Sends a {@link JsonMessage} message.
      * If this is not a {@link Player}, only the content of the message will be sent as a string.
      *
-     * @param text The {@link ColoredText} to send.
+     * @param text The {@link JsonMessage} to send.
      * */
-    default void sendMessage(@NotNull ColoredText text) {
+    default void sendMessage(@NotNull JsonMessage text) {
         if (this instanceof Player) {
             ((Player) this).sendMessage((JsonMessage) text);
         } else {
-            sendMessage(text.getMessage());
+            sendMessage(text.getRawMessage());
         }
     }
 

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity;
 import com.google.common.collect.Queues;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.Viewable;
-import net.minestom.server.chat.ColoredText;
+import net.minestom.server.chat.JsonMessage;
 import net.minestom.server.collision.BoundingBox;
 import net.minestom.server.collision.CollisionUtils;
 import net.minestom.server.data.Data;
@@ -128,7 +128,7 @@ public abstract class Entity implements Viewable, EventHandler, DataContainer, P
     protected boolean glowing;
     protected boolean usingElytra;
     protected int air = 300;
-    protected ColoredText customName;
+    protected JsonMessage customName;
     protected boolean customNameVisible;
     protected boolean silent;
     protected boolean noGravity;
@@ -1019,7 +1019,7 @@ public abstract class Entity implements Viewable, EventHandler, DataContainer, P
      *
      * @return the custom name of the entity, null if there is not
      */
-    public ColoredText getCustomName() {
+    public JsonMessage getCustomName() {
         return customName;
     }
 
@@ -1028,7 +1028,7 @@ public abstract class Entity implements Viewable, EventHandler, DataContainer, P
      *
      * @param customName the custom name of the entity, null to remove it
      */
-    public void setCustomName(ColoredText customName) {
+    public void setCustomName(JsonMessage customName) {
         this.customName = customName;
         sendMetadataIndex(2);
     }

--- a/src/main/java/net/minestom/server/entity/ExperienceOrb.java
+++ b/src/main/java/net/minestom/server/entity/ExperienceOrb.java
@@ -3,18 +3,24 @@ package net.minestom.server.entity;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.network.packet.server.play.SpawnExperienceOrbPacket;
 import net.minestom.server.network.player.PlayerConnection;
+import net.minestom.server.utils.BlockPosition;
 import net.minestom.server.utils.Position;
+import net.minestom.server.utils.Vector;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class ExperienceOrb extends Entity {
 
     private short experienceCount;
+    private Player target;
+    private long lastTargetUpdateTick;
+
 
     public ExperienceOrb(short experienceCount, @NotNull Position spawnPosition) {
         super(EntityType.EXPERIENCE_ORB, spawnPosition);
         setGravity(0.02f, 0.04f, 1.96f);
         setBoundingBox(0.5f, 0.5f, 0.5f);
+        //todo vanilla sets random velocity here?
         this.experienceCount = experienceCount;
     }
 
@@ -28,7 +34,51 @@ public class ExperienceOrb extends Entity {
 
     @Override
     public void update(long time) {
+
         // TODO slide toward nearest player
+
+        //todo water movement
+        if (hasNoGravity()) {
+            setVelocity(getVelocity().add(0, -0.3f, 0));
+        }
+
+        //todo lava
+
+        double d = 8.0;
+        if (lastTargetUpdateTick < time - 20 + getEntityId() % 100) {
+            if (target == null || target.getPosition().getDistanceSquared(getPosition()) > 64) {
+                this.target = getClosestPlayer(this, 8);
+            }
+
+            lastTargetUpdateTick = time;
+        }
+
+        if (target != null && target.getGameMode() == GameMode.SPECTATOR) {
+            target = null;
+        }
+
+        if (target != null) {
+            Position pos = getPosition();
+            Position targetPos = target.getPosition();
+            Vector toTarget = new Vector(targetPos.getX() - pos.getX(), targetPos.getY() + (target.getEyeHeight() / 2) - pos.getY(), targetPos.getZ() - pos.getZ());
+            double e = toTarget.length(); //could really be lengthSquared
+            if (e < 8) {
+                double f = 1 - (e / 8);
+                setVelocity(getVelocity().add(toTarget.normalize().multiply(f * f * 0.1)));
+            }
+        }
+
+        // Move should be called here
+        float g = 0.98f;
+        if (this.onGround) {
+//            g = 2f;
+            g = 0.6f * 0.98f;
+        }
+        // apply slipperiness
+
+        setVelocity(getVelocity().multiply(new Vector(g, 0.98f, g)));
+        if (isOnGround())
+            setVelocity(getVelocity().multiply(new Vector(1, -0.9f, 1)));
     }
 
     @Override
@@ -76,5 +126,16 @@ public class ExperienceOrb extends Entity {
         this.experienceCount = experienceCount;
 
         getViewers().forEach(this::addViewer);
+    }
+
+    private Player getClosestPlayer(Entity entity, float maxDistance) {
+        Player closest = entity.getInstance()
+                .getPlayers()
+                .stream()
+                .min((a, b) -> Float.compare(a.getDistance(entity), b.getDistance(entity)))
+                .orElse(null);
+        if (closest == null) return null;
+        if (closest.getDistance(entity) > maxDistance) return null;
+        return closest;
     }
 }

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -122,7 +122,7 @@ public class Player extends LivingEntity implements CommandSender {
     protected final Set<Entity> viewableEntities = new CopyOnWriteArraySet<>();
 
     private int latency;
-    private ColoredText displayName;
+    private JsonMessage displayName;
     private PlayerSkin skin;
 
     private DimensionType dimensionType;
@@ -500,7 +500,7 @@ public class Player extends LivingEntity implements CommandSender {
     public void kill() {
         if (!isDead()) {
 
-            ColoredText deathText;
+            JsonMessage deathText;
             JsonMessage chatMessage;
 
             // get death screen text to the killed player
@@ -956,7 +956,7 @@ public class Player extends LivingEntity implements CommandSender {
      * @param header the header text, null to set empty
      * @param footer the footer text, null to set empty
      */
-    public void sendHeaderFooter(@Nullable ColoredText header, @Nullable ColoredText footer) {
+    public void sendHeaderFooter(@Nullable JsonMessage header, @Nullable JsonMessage footer) {
         PlayerListHeaderAndFooterPacket playerListHeaderAndFooterPacket = new PlayerListHeaderAndFooterPacket();
         playerListHeaderAndFooterPacket.emptyHeader = header == null;
         playerListHeaderAndFooterPacket.emptyFooter = footer == null;
@@ -973,7 +973,7 @@ public class Player extends LivingEntity implements CommandSender {
      * @param action the action of the title (where to show it)
      * @see #sendTitleTime(int, int, int) to specify the display time
      */
-    private void sendTitle(@NotNull ColoredText text, @NotNull TitlePacket.Action action) {
+    private void sendTitle(@NotNull JsonMessage text, @NotNull TitlePacket.Action action) {
         TitlePacket titlePacket = new TitlePacket();
         titlePacket.action = action;
 
@@ -1001,7 +1001,7 @@ public class Player extends LivingEntity implements CommandSender {
      * @param subtitle the subtitle message
      * @see #sendTitleTime(int, int, int) to specify the display time
      */
-    public void sendTitleSubtitleMessage(@NotNull ColoredText title, @NotNull ColoredText subtitle) {
+    public void sendTitleSubtitleMessage(@NotNull JsonMessage title, @NotNull JsonMessage subtitle) {
         sendTitle(title, TitlePacket.Action.SET_TITLE);
         sendTitle(subtitle, TitlePacket.Action.SET_SUBTITLE);
     }
@@ -1012,7 +1012,7 @@ public class Player extends LivingEntity implements CommandSender {
      * @param title the title message
      * @see #sendTitleTime(int, int, int) to specify the display time
      */
-    public void sendTitleMessage(@NotNull ColoredText title) {
+    public void sendTitleMessage(@NotNull JsonMessage title) {
         sendTitle(title, TitlePacket.Action.SET_TITLE);
     }
 
@@ -1022,7 +1022,7 @@ public class Player extends LivingEntity implements CommandSender {
      * @param subtitle the subtitle message
      * @see #sendTitleTime(int, int, int) to specify the display time
      */
-    public void sendSubtitleMessage(@NotNull ColoredText subtitle) {
+    public void sendSubtitleMessage(@NotNull JsonMessage subtitle) {
         sendTitle(subtitle, TitlePacket.Action.SET_SUBTITLE);
     }
 
@@ -1032,7 +1032,7 @@ public class Player extends LivingEntity implements CommandSender {
      * @param actionBar the action bar message
      * @see #sendTitleTime(int, int, int) to specify the display time
      */
-    public void sendActionBarMessage(@NotNull ColoredText actionBar) {
+    public void sendActionBarMessage(@NotNull JsonMessage actionBar) {
         sendTitle(actionBar, TitlePacket.Action.SET_ACTION_BAR);
     }
 
@@ -1179,7 +1179,7 @@ public class Player extends LivingEntity implements CommandSender {
      * @return the player display name, null means that {@link #getUsername()} is displayed
      */
     @Nullable
-    public ColoredText getDisplayName() {
+    public JsonMessage getDisplayName() {
         return displayName;
     }
 
@@ -1190,7 +1190,7 @@ public class Player extends LivingEntity implements CommandSender {
      *
      * @param displayName the display name, null to display the username
      */
-    public void setDisplayName(@Nullable ColoredText displayName) {
+    public void setDisplayName(@Nullable JsonMessage displayName) {
         this.displayName = displayName;
 
         PlayerInfoPacket infoPacket = new PlayerInfoPacket(PlayerInfoPacket.Action.UPDATE_DISPLAY_NAME);
@@ -1740,7 +1740,7 @@ public class Player extends LivingEntity implements CommandSender {
      *
      * @param text the kick reason
      */
-    public void kick(@NotNull ColoredText text) {
+    public void kick(@NotNull JsonMessage text) {
         DisconnectPacket disconnectPacket = new DisconnectPacket();
         disconnectPacket.message = text;
         playerConnection.sendPacket(disconnectPacket);

--- a/src/main/java/net/minestom/server/entity/damage/DamageType.java
+++ b/src/main/java/net/minestom/server/entity/damage/DamageType.java
@@ -110,7 +110,7 @@ public class DamageType implements DataContainer {
      * @return the death screen text, null to do not send anything
      */
     @Nullable
-    public ColoredText buildDeathScreenText(@NotNull Player killed) {
+    public JsonMessage buildDeathScreenText(@NotNull Player killed) {
         return ColoredText.of("{@death." + identifier + "}");
     }
 

--- a/src/main/java/net/minestom/server/entity/hologram/Hologram.java
+++ b/src/main/java/net/minestom/server/entity/hologram/Hologram.java
@@ -2,6 +2,7 @@ package net.minestom.server.entity.hologram;
 
 import net.minestom.server.Viewable;
 import net.minestom.server.chat.ColoredText;
+import net.minestom.server.chat.JsonMessage;
 import net.minestom.server.entity.Player;
 import net.minestom.server.entity.type.decoration.EntityArmorStand;
 import net.minestom.server.instance.Instance;
@@ -12,7 +13,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Set;
 
 /**
- * Represents an invisible armor stand showing a {@link ColoredText}.
+ * Represents an invisible armor stand showing a {@link JsonMessage}.
  */
 public class Hologram implements Viewable {
 
@@ -21,11 +22,11 @@ public class Hologram implements Viewable {
     private final HologramEntity entity;
 
     private Position position;
-    private ColoredText text;
+    private JsonMessage text;
 
     private boolean removed;
 
-    public Hologram(Instance instance, Position spawnPosition, ColoredText text, boolean autoViewable) {
+    public Hologram(Instance instance, Position spawnPosition, JsonMessage text, boolean autoViewable) {
         this.entity = new HologramEntity(spawnPosition.clone().add(0, OFFSET_Y, 0));
         this.entity.setInstance(instance);
         this.entity.setAutoViewable(autoViewable);
@@ -34,7 +35,7 @@ public class Hologram implements Viewable {
         setText(text);
     }
 
-    public Hologram(Instance instance, Position spawnPosition, ColoredText text) {
+    public Hologram(Instance instance, Position spawnPosition, JsonMessage text) {
         this(instance, spawnPosition, text, true);
     }
 
@@ -64,7 +65,7 @@ public class Hologram implements Viewable {
      *
      * @return the hologram text
      */
-    public ColoredText getText() {
+    public JsonMessage getText() {
         return text;
     }
 
@@ -73,7 +74,7 @@ public class Hologram implements Viewable {
      *
      * @param text the new hologram text
      */
-    public void setText(ColoredText text) {
+    public void setText(JsonMessage text) {
         checkRemoved();
         this.text = text;
         this.entity.setCustomName(text);

--- a/src/main/java/net/minestom/server/event/player/PlayerDeathEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerDeathEvent.java
@@ -12,10 +12,10 @@ import org.jetbrains.annotations.Nullable;
  */
 public class PlayerDeathEvent extends PlayerEvent {
 
-    private ColoredText deathText;
+    private JsonMessage deathText;
     private JsonMessage chatMessage;
 
-    public PlayerDeathEvent(@NotNull Player player, ColoredText deathText, JsonMessage chatMessage) {
+    public PlayerDeathEvent(@NotNull Player player, JsonMessage deathText, JsonMessage chatMessage) {
         super(player);
         this.deathText = deathText;
         this.chatMessage = chatMessage;
@@ -27,7 +27,7 @@ public class PlayerDeathEvent extends PlayerEvent {
      * @return the death text, can be null
      */
     @Nullable
-    public ColoredText getDeathText() {
+    public JsonMessage getDeathText() {
         return deathText;
     }
 
@@ -36,7 +36,7 @@ public class PlayerDeathEvent extends PlayerEvent {
      *
      * @param deathText the death text to display, null to remove
      */
-    public void setDeathText(@Nullable ColoredText deathText) {
+    public void setDeathText(@Nullable JsonMessage deathText) {
         this.deathText = deathText;
     }
 

--- a/src/main/java/net/minestom/server/item/ItemDisplay.java
+++ b/src/main/java/net/minestom/server/item/ItemDisplay.java
@@ -1,13 +1,14 @@
 package net.minestom.server.item;
 
 import net.minestom.server.chat.ColoredText;
+import net.minestom.server.chat.JsonMessage;
 
 public class ItemDisplay {
 
-    private ColoredText displayName;
-    private ColoredText[] lore;
+    private JsonMessage displayName;
+    private JsonMessage[] lore;
 
-    public ItemDisplay(ColoredText displayName, ColoredText[] lore) {
+    public ItemDisplay(JsonMessage displayName, JsonMessage[] lore) {
         this.displayName = displayName;
         this.lore = lore;
     }
@@ -17,7 +18,7 @@ public class ItemDisplay {
      *
      * @return the item display name
      */
-    public ColoredText getDisplayName() {
+    public JsonMessage getDisplayName() {
         return displayName;
     }
 
@@ -26,7 +27,7 @@ public class ItemDisplay {
      *
      * @return the item lore
      */
-    public ColoredText[] getLore() {
+    public JsonMessage[] getLore() {
         return lore;
     }
 }

--- a/src/main/java/net/minestom/server/item/ItemStack.java
+++ b/src/main/java/net/minestom/server/item/ItemStack.java
@@ -1,6 +1,6 @@
 package net.minestom.server.item;
 
-import net.minestom.server.chat.ColoredText;
+import net.minestom.server.chat.JsonMessage;
 import net.minestom.server.data.Data;
 import net.minestom.server.data.DataContainer;
 import net.minestom.server.entity.ItemEntity;
@@ -52,9 +52,9 @@ public class ItemStack implements DataContainer, PublicCloneable<ItemStack> {
     private byte amount;
     private int damage;
 
-    private ColoredText displayName;
+    private JsonMessage displayName;
     private boolean unbreakable;
-    private List<ColoredText> lore;
+    private List<JsonMessage> lore;
 
     private Map<Enchantment, Short> enchantmentMap;
     private List<ItemAttribute> attributes;
@@ -165,7 +165,7 @@ public class ItemStack implements DataContainer, PublicCloneable<ItemStack> {
                 return true;
             }
 
-            final ColoredText itemDisplayName = itemStack.getDisplayName();
+            final JsonMessage itemDisplayName = itemStack.getDisplayName();
             final boolean displayNameCheck = (displayName == null && itemDisplayName == null) ||
                     (displayName != null && displayName.equals(itemDisplayName));
 
@@ -260,7 +260,7 @@ public class ItemStack implements DataContainer, PublicCloneable<ItemStack> {
      * @return the item display name, can be null if not present
      */
     @Nullable
-    public ColoredText getDisplayName() {
+    public JsonMessage getDisplayName() {
         return displayName;
     }
 
@@ -269,7 +269,7 @@ public class ItemStack implements DataContainer, PublicCloneable<ItemStack> {
      *
      * @param displayName the item display name
      */
-    public void setDisplayName(@Nullable ColoredText displayName) {
+    public void setDisplayName(@Nullable JsonMessage displayName) {
         this.displayName = displayName;
     }
 
@@ -288,7 +288,7 @@ public class ItemStack implements DataContainer, PublicCloneable<ItemStack> {
      * @return a modifiable list containing the item lore, can be null if not present
      */
     @Nullable
-    public List<ColoredText> getLore() {
+    public List<JsonMessage> getLore() {
         return lore;
     }
 
@@ -297,7 +297,7 @@ public class ItemStack implements DataContainer, PublicCloneable<ItemStack> {
      *
      * @param lore the item lore, can be null to remove
      */
-    public void setLore(@Nullable List<ColoredText> lore) {
+    public void setLore(@Nullable List<JsonMessage> lore) {
         this.lore = lore;
     }
 

--- a/src/main/java/net/minestom/server/network/ConnectionManager.java
+++ b/src/main/java/net/minestom/server/network/ConnectionManager.java
@@ -46,7 +46,7 @@ public final class ConnectionManager {
     // The consumers to call once a player connect, mostly used to init events
     private final List<Consumer<Player>> playerInitializations = new CopyOnWriteArrayList<>();
 
-    private ColoredText shutdownText = ColoredText.of(ChatColor.RED, "The server is shutting down.");
+    private JsonMessage shutdownText = ColoredText.of(ChatColor.RED, "The server is shutting down.");
 
     /**
      * Gets the {@link Player} linked to a {@link PlayerConnection}.
@@ -295,7 +295,7 @@ public final class ConnectionManager {
      * @return the kick reason in case on a shutdown
      */
     @NotNull
-    public ColoredText getShutdownText() {
+    public JsonMessage getShutdownText() {
         return shutdownText;
     }
 
@@ -305,7 +305,7 @@ public final class ConnectionManager {
      * @param shutdownText the new shutdown kick reason
      * @see #getShutdownText()
      */
-    public void setShutdownText(@NotNull ColoredText shutdownText) {
+    public void setShutdownText(@NotNull JsonMessage shutdownText) {
         this.shutdownText = shutdownText;
     }
 

--- a/src/main/java/net/minestom/server/scoreboard/Sidebar.java
+++ b/src/main/java/net/minestom/server/scoreboard/Sidebar.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Queues;
 import it.unimi.dsi.fastutil.ints.IntLinkedOpenHashSet;
 import net.minestom.server.chat.ChatParser;
 import net.minestom.server.chat.ColoredText;
+import net.minestom.server.chat.JsonMessage;
 import net.minestom.server.entity.Player;
 import net.minestom.server.network.packet.server.play.DisplayScoreboardPacket;
 import net.minestom.server.network.packet.server.play.ScoreboardObjectivePacket;
@@ -29,7 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * and remove him later with {@link #removeViewer(Player)}.
  * <p>
  * Lines can be modified using their respective identifier using
- * {@link #updateLineContent(String, ColoredText)} and {@link #updateLineScore(String, int)}.
+ * {@link #updateLineContent(String, JsonMessage)} and {@link #updateLineScore(String, int)}.
  */
 public class Sidebar implements Scoreboard {
 
@@ -126,7 +127,7 @@ public class Sidebar implements Scoreboard {
      * @param id      The identifier of the {@link ScoreboardLine}
      * @param content The new content for the {@link ScoreboardLine}
      */
-    public void updateLineContent(@NotNull String id, @NotNull ColoredText content) {
+    public void updateLineContent(@NotNull String id, @NotNull JsonMessage content) {
         final ScoreboardLine scoreboardLine = getLine(id);
         if (scoreboardLine != null) {
             scoreboardLine.refreshContent(content);
@@ -240,7 +241,7 @@ public class Sidebar implements Scoreboard {
         /**
          * The content for the line
          */
-        private final ColoredText content;
+        private final JsonMessage content;
         /**
          * The score of the line
          */
@@ -257,7 +258,7 @@ public class Sidebar implements Scoreboard {
          */
         private SidebarTeam sidebarTeam;
 
-        public ScoreboardLine(String id, ColoredText content, int line) {
+        public ScoreboardLine(String id, JsonMessage content, int line) {
             this.id = id;
             this.content = content;
             this.line = line;
@@ -279,7 +280,7 @@ public class Sidebar implements Scoreboard {
          *
          * @return The line content
          */
-        public ColoredText getContent() {
+        public JsonMessage getContent() {
             return sidebarTeam == null ? content : sidebarTeam.getPrefix();
         }
 
@@ -360,7 +361,7 @@ public class Sidebar implements Scoreboard {
          *
          * @param content The new content
          */
-        private void refreshContent(ColoredText content) {
+        private void refreshContent(JsonMessage content) {
             this.sidebarTeam.refreshPrefix(content);
         }
 
@@ -372,10 +373,10 @@ public class Sidebar implements Scoreboard {
     private static class SidebarTeam {
 
         private final String teamName;
-        private ColoredText prefix, suffix;
+        private JsonMessage prefix, suffix;
         private final String entityName;
 
-        private final ColoredText teamDisplayName = ColoredText.of("displaynametest");
+        private final JsonMessage teamDisplayName = ColoredText.of("displaynametest");
         private final byte friendlyFlags = 0x00;
         private final TeamsPacket.NameTagVisibility nameTagVisibility = TeamsPacket.NameTagVisibility.NEVER;
         private final TeamsPacket.CollisionRule collisionRule = TeamsPacket.CollisionRule.NEVER;
@@ -390,7 +391,7 @@ public class Sidebar implements Scoreboard {
          * @param suffix     The team suffix
          * @param entityName The team entity name
          */
-        private SidebarTeam(String teamName, ColoredText prefix, ColoredText suffix, String entityName) {
+        private SidebarTeam(String teamName, JsonMessage prefix, JsonMessage suffix, String entityName) {
             this.teamName = teamName;
             this.prefix = prefix;
             this.suffix = suffix;
@@ -435,7 +436,7 @@ public class Sidebar implements Scoreboard {
          * @param prefix The new prefix
          * @return a {@link TeamsPacket} with the updated prefix
          */
-        private TeamsPacket updatePrefix(ColoredText prefix) {
+        private TeamsPacket updatePrefix(JsonMessage prefix) {
             TeamsPacket teamsPacket = new TeamsPacket();
             teamsPacket.teamName = teamName;
             teamsPacket.action = TeamsPacket.Action.UPDATE_TEAM_INFO;
@@ -463,7 +464,7 @@ public class Sidebar implements Scoreboard {
          *
          * @return the prefix
          */
-        private ColoredText getPrefix() {
+        private JsonMessage getPrefix() {
             return prefix;
         }
 
@@ -472,7 +473,7 @@ public class Sidebar implements Scoreboard {
          *
          * @param prefix The refreshed prefix
          */
-        private void refreshPrefix(ColoredText prefix) {
+        private void refreshPrefix(JsonMessage prefix) {
             this.prefix = prefix;
         }
     }

--- a/src/main/java/net/minestom/server/scoreboard/Team.java
+++ b/src/main/java/net/minestom/server/scoreboard/Team.java
@@ -3,6 +3,7 @@ package net.minestom.server.scoreboard;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.chat.ChatColor;
 import net.minestom.server.chat.ColoredText;
+import net.minestom.server.chat.JsonMessage;
 import net.minestom.server.entity.LivingEntity;
 import net.minestom.server.entity.Player;
 import net.minestom.server.network.ConnectionManager;
@@ -34,7 +35,7 @@ public class Team {
     /**
      * The display name of the team
      */
-    private ColoredText teamDisplayName;
+    private JsonMessage teamDisplayName;
     /**
      * A BitMask
      */
@@ -57,11 +58,11 @@ public class Team {
     /**
      * Shown before the names of the players who belong to this team
      */
-    private ColoredText prefix;
+    private JsonMessage prefix;
     /**
      * Shown after the names of the player who belong to this team
      */
-    private ColoredText suffix;
+    private JsonMessage suffix;
 
     /**
      * Identifiers for the entities in this team
@@ -147,7 +148,7 @@ public class Team {
      *
      * @param teamDisplayName The new display name
      */
-    public void setTeamDisplayName(ColoredText teamDisplayName) {
+    public void setTeamDisplayName(JsonMessage teamDisplayName) {
         this.teamDisplayName = teamDisplayName;
     }
 
@@ -156,7 +157,7 @@ public class Team {
      *
      * @param teamDisplayName The new display name
      */
-    public void updateTeamDisplayName(ColoredText teamDisplayName) {
+    public void updateTeamDisplayName(JsonMessage teamDisplayName) {
         this.setTeamDisplayName(teamDisplayName);
         sendUpdatePacket();
     }
@@ -231,7 +232,7 @@ public class Team {
      *
      * @param prefix The new prefix
      */
-    public void setPrefix(ColoredText prefix) {
+    public void setPrefix(JsonMessage prefix) {
         this.prefix = prefix;
     }
 
@@ -240,7 +241,7 @@ public class Team {
      *
      * @param prefix The new prefix
      */
-    public void updatePrefix(ColoredText prefix) {
+    public void updatePrefix(JsonMessage prefix) {
         this.setPrefix(prefix);
         sendUpdatePacket();
     }
@@ -252,7 +253,7 @@ public class Team {
      *
      * @param suffix The new suffix
      */
-    public void setSuffix(ColoredText suffix) {
+    public void setSuffix(JsonMessage suffix) {
         this.suffix = suffix;
     }
 
@@ -261,7 +262,7 @@ public class Team {
      *
      * @param suffix The new suffix
      */
-    public void updateSuffix(ColoredText suffix) {
+    public void updateSuffix(JsonMessage suffix) {
         this.setSuffix(suffix);
         sendUpdatePacket();
     }
@@ -343,7 +344,7 @@ public class Team {
      *
      * @return the display name
      */
-    public ColoredText getTeamDisplayName() {
+    public JsonMessage getTeamDisplayName() {
         return teamDisplayName;
     }
 
@@ -388,7 +389,7 @@ public class Team {
      *
      * @return the team prefix
      */
-    public ColoredText getPrefix() {
+    public JsonMessage getPrefix() {
         return prefix;
     }
 
@@ -397,7 +398,7 @@ public class Team {
      *
      * @return the suffix team
      */
-    public ColoredText getSuffix() {
+    public JsonMessage getSuffix() {
         return suffix;
     }
 

--- a/src/main/java/net/minestom/server/scoreboard/TeamBuilder.java
+++ b/src/main/java/net/minestom/server/scoreboard/TeamBuilder.java
@@ -2,6 +2,7 @@ package net.minestom.server.scoreboard;
 
 import net.minestom.server.chat.ChatColor;
 import net.minestom.server.chat.ColoredText;
+import net.minestom.server.chat.JsonMessage;
 import net.minestom.server.network.packet.server.play.TeamsPacket.CollisionRule;
 import net.minestom.server.network.packet.server.play.TeamsPacket.NameTagVisibility;
 
@@ -61,7 +62,7 @@ public class TeamBuilder {
      * @param prefix The new prefix
      * @return this builder, for chaining
      */
-    public TeamBuilder updatePrefix(ColoredText prefix) {
+    public TeamBuilder updatePrefix(JsonMessage prefix) {
         this.team.updatePrefix(prefix);
         return this;
     }
@@ -93,7 +94,7 @@ public class TeamBuilder {
      * @param suffix The new suffix
      * @return this builder, for chaining
      */
-    public TeamBuilder updateSuffix(ColoredText suffix) {
+    public TeamBuilder updateSuffix(JsonMessage suffix) {
         this.team.updateSuffix(suffix);
         return this;
     }
@@ -114,7 +115,7 @@ public class TeamBuilder {
      * @param displayName The new display name
      * @return this builder, for chaining
      */
-    public TeamBuilder updateTeamDisplayName(ColoredText displayName) {
+    public TeamBuilder updateTeamDisplayName(JsonMessage displayName) {
         this.team.updateTeamDisplayName(displayName);
         return this;
     }
@@ -190,7 +191,7 @@ public class TeamBuilder {
      * @param prefix The new prefix
      * @return this builder, for chaining
      */
-    public TeamBuilder prefix(ColoredText prefix) {
+    public TeamBuilder prefix(JsonMessage prefix) {
         this.team.setPrefix(prefix);
         return this;
     }
@@ -216,7 +217,7 @@ public class TeamBuilder {
      * @param suffix The new suffix
      * @return this builder, for chaining
      */
-    public TeamBuilder suffix(ColoredText suffix) {
+    public TeamBuilder suffix(JsonMessage suffix) {
         this.team.setSuffix(suffix);
         return this;
     }
@@ -254,7 +255,7 @@ public class TeamBuilder {
      * @param displayName The new display name
      * @return this builder, for chaining
      */
-    public TeamBuilder teamDisplayName(ColoredText displayName) {
+    public TeamBuilder teamDisplayName(JsonMessage displayName) {
         this.team.setTeamDisplayName(displayName);
         return this;
     }

--- a/src/main/java/net/minestom/server/scoreboard/TeamManager.java
+++ b/src/main/java/net/minestom/server/scoreboard/TeamManager.java
@@ -3,6 +3,7 @@ package net.minestom.server.scoreboard;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.chat.ChatColor;
 import net.minestom.server.chat.ColoredText;
+import net.minestom.server.chat.JsonMessage;
 import net.minestom.server.entity.LivingEntity;
 import net.minestom.server.entity.Player;
 import net.minestom.server.network.ConnectionManager;
@@ -98,7 +99,7 @@ public final class TeamManager {
      * @param suffix    The team suffix
      * @return the created {@link Team} with a prefix, teamColor and suffix
      */
-    public Team createTeam(String name, ColoredText prefix, ChatColor teamColor, ColoredText suffix) {
+    public Team createTeam(String name, JsonMessage prefix, ChatColor teamColor, JsonMessage suffix) {
         return this.createBuilder(name).prefix(prefix).teamColor(teamColor).suffix(suffix).updateTeamPacket().build();
     }
 
@@ -112,7 +113,7 @@ public final class TeamManager {
      * @param suffix      The team suffix
      * @return the created {@link Team} with a prefix, teamColor, suffix and the display name
      */
-    public Team createTeam(String name, ColoredText displayName, ColoredText prefix, ChatColor teamColor, ColoredText suffix) {
+    public Team createTeam(String name, JsonMessage displayName, JsonMessage prefix, ChatColor teamColor, JsonMessage suffix) {
         return this.createBuilder(name).teamDisplayName(displayName).prefix(prefix).teamColor(teamColor).suffix(suffix).updateTeamPacket().build();
     }
 

--- a/src/main/java/net/minestom/server/utils/NBTUtils.java
+++ b/src/main/java/net/minestom/server/utils/NBTUtils.java
@@ -5,6 +5,7 @@ import net.minestom.server.attribute.Attribute;
 import net.minestom.server.attribute.AttributeOperation;
 import net.minestom.server.chat.ChatParser;
 import net.minestom.server.chat.ColoredText;
+import net.minestom.server.chat.JsonMessage;
 import net.minestom.server.data.Data;
 import net.minestom.server.data.DataType;
 import net.minestom.server.inventory.Inventory;
@@ -136,7 +137,7 @@ public final class NBTUtils {
             }
             if (display.containsKey("Lore")) {
                 NBTList<NBTString> loreList = display.getList("Lore");
-                List<ColoredText> lore = new ArrayList<>();
+                List<JsonMessage> lore = new ArrayList<>();
                 for (NBTString s : loreList) {
                     lore.add(ChatParser.toColoredText(s.getValue()));
                 }
@@ -266,10 +267,10 @@ public final class NBTUtils {
             }
 
             if (hasLore) {
-                final List<ColoredText> lore = itemStack.getLore();
+                final List<JsonMessage> lore = itemStack.getLore();
 
                 final NBTList<NBTString> loreNBT = new NBTList<>(NBTTypes.TAG_String);
-                for (ColoredText line : lore) {
+                for (JsonMessage line : lore) {
                     loreNBT.add(new NBTString(line.toString()));
                 }
                 displayNBT.set("Lore", loreNBT);

--- a/src/test/java/demo/Main.java
+++ b/src/test/java/demo/Main.java
@@ -40,6 +40,7 @@ public class Main {
         commandManager.register(new TeleportCommand());
         commandManager.register(new PlayersCommand());
         commandManager.register(new PotionCommand());
+        commandManager.register(new TitleCommand());
 
         commandManager.setUnknownCommandCallback((sender, command) -> sender.sendMessage("unknown command"));
 

--- a/src/test/java/demo/commands/TitleCommand.java
+++ b/src/test/java/demo/commands/TitleCommand.java
@@ -1,0 +1,45 @@
+package demo.commands;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
+import net.minestom.server.chat.ColoredText;
+import net.minestom.server.chat.JsonMessage;
+import net.minestom.server.command.CommandSender;
+import net.minestom.server.command.builder.Arguments;
+import net.minestom.server.command.builder.Command;
+import net.minestom.server.command.builder.arguments.Argument;
+import net.minestom.server.command.builder.arguments.ArgumentType;
+import net.minestom.server.entity.Player;
+
+public class TitleCommand extends Command {
+    public TitleCommand() {
+        super("title");
+        setDefaultExecutor((source, args) -> {
+            source.sendMessage("Unknown syntax (note: title must be quoted)");
+        });
+
+        Argument content = ArgumentType.String("content");
+
+        addSyntax(this::handleTitle, content);
+    }
+
+    private void handleTitle(CommandSender source, Arguments args) {
+        if (!source.isPlayer()) {
+            source.sendMessage("Only players can run this command!");
+            return;
+        }
+
+        Player player = source.asPlayer();
+        String titleContent = args.getString("content");
+
+        player.sendTitleTime(10, 100, 10);
+        try {
+            JsonElement parsed = JsonParser.parseString(titleContent);
+            JsonMessage message = new JsonMessage.RawJsonMessage(parsed.getAsJsonObject());
+            player.sendTitleMessage(message);
+        } catch (JsonParseException | IllegalStateException ignored) {
+            player.sendTitleMessage(ColoredText.of(titleContent));
+        }
+    }
+}


### PR DESCRIPTION
ColoredText was rather restrictive, and the client will accept any valid json message in places where some tags (such as `hoverEvent` in an actionbar message) are not supported.

This branch also adds a `title` command to the demo project which will send a title to the sender either as text or any valid json message.