### PR TITLE
Inventory double click ArrayIndexOutOfBoundsException

### DIFF
--- a/src/main/java/net/minestom/server/inventory/Inventory.java
+++ b/src/main/java/net/minestom/server/inventory/Inventory.java
@@ -405,7 +405,7 @@ public class Inventory implements InventoryModifier, InventoryClickHandler, View
         }
 
         if (isInWindow) {
-                setItemStack(slot, clickResult.getClicked());
+            setItemStack(slot, clickResult.getClicked());
         } else {
             playerInventory.setItemStack(slot, offset, clickResult.getClicked());
         }

--- a/src/main/java/net/minestom/server/inventory/Inventory.java
+++ b/src/main/java/net/minestom/server/inventory/Inventory.java
@@ -405,7 +405,8 @@ public class Inventory implements InventoryModifier, InventoryClickHandler, View
         }
 
         if (isInWindow) {
-            setItemStack(slot, clickResult.getClicked());
+//            if (clickResult.isCancel())
+                setItemStack(slot, clickResult.getClicked());
         } else {
             playerInventory.setItemStack(slot, offset, clickResult.getClicked());
         }
@@ -564,7 +565,7 @@ public class Inventory implements InventoryModifier, InventoryClickHandler, View
     public boolean dragging(@NotNull Player player, int slot, int button) {
         final PlayerInventory playerInventory = player.getInventory();
         final boolean isInWindow = isClickInWindow(slot);
-        final ItemStack clicked = slot != 999 ?
+        final ItemStack clicked = slot != -999 ?
                 (isInWindow ? getItemStack(slot) : playerInventory.getItemStack(slot, offset)) :
                 ItemStack.getAirItem();
         final ItemStack cursor = getCursorItem(player);
@@ -611,13 +612,8 @@ public class Inventory implements InventoryModifier, InventoryClickHandler, View
                 // Looping through player inventory
                 new InventoryClickLoopHandler(0, PlayerInventory.INVENTORY_SIZE - 9, 1,
                         PlayerInventoryUtils::convertToPacketSlot,
-                        index -> playerInventory.getItemStack(index, offset),
-                        (index, itemStack) -> playerInventory.setItemStack(index, offset, itemStack)),
-                // Player hot bar
-                new InventoryClickLoopHandler(0, 9, 1,
-                        PlayerInventoryUtils::convertToPacketSlot,
-                        index -> playerInventory.getItemStack(index, offset),
-                        (index, itemStack) -> playerInventory.setItemStack(index, offset, itemStack)));
+                        index -> playerInventory.getItemStack(index, 9),
+                        (index, itemStack) -> playerInventory.setItemStack(index, 9, itemStack)));
 
         if (clickResult == null)
             return false;

--- a/src/main/java/net/minestom/server/inventory/Inventory.java
+++ b/src/main/java/net/minestom/server/inventory/Inventory.java
@@ -612,7 +612,7 @@ public class Inventory implements InventoryModifier, InventoryClickHandler, View
                 // Looping through player inventory
                 new InventoryClickLoopHandler(0, PlayerInventory.INVENTORY_SIZE - 9, 1,
                         PlayerInventoryUtils::convertToPacketSlot,
-                        index -> playerInventory.getItemStack(index, 9),
+                        index -> playerInventory.getItemStack(index, PlayerInventoryUtils.OFFSET),
                         (index, itemStack) -> playerInventory.setItemStack(index, 9, itemStack)));
 
         if (clickResult == null)

--- a/src/main/java/net/minestom/server/inventory/Inventory.java
+++ b/src/main/java/net/minestom/server/inventory/Inventory.java
@@ -405,7 +405,6 @@ public class Inventory implements InventoryModifier, InventoryClickHandler, View
         }
 
         if (isInWindow) {
-//            if (clickResult.isCancel())
                 setItemStack(slot, clickResult.getClicked());
         } else {
             playerInventory.setItemStack(slot, offset, clickResult.getClicked());

--- a/src/main/java/net/minestom/server/utils/inventory/PlayerInventoryUtils.java
+++ b/src/main/java/net/minestom/server/utils/inventory/PlayerInventoryUtils.java
@@ -49,7 +49,7 @@ public final class PlayerInventoryUtils {
             case 8:
                 return BOOTS_SLOT;
         }
-        //System.out.println("ENTRY: " + slot + " | " + offset);
+        System.out.println("ENTRY: " + slot + " | " + offset);
         final int rowSize = 9;
         slot -= offset;
         if (slot >= rowSize * 3 && slot < rowSize * 4) {
@@ -57,7 +57,7 @@ public final class PlayerInventoryUtils {
         } else {
             slot = slot + rowSize;
         }
-        //System.out.println("CONVERT: " + slot);
+        System.out.println("CONVERT: " + slot);
         return slot;
     }
 
@@ -68,7 +68,7 @@ public final class PlayerInventoryUtils {
      * @return a slot id which can be used for packets
      */
     public static int convertToPacketSlot(int slot) {
-        if (slot > -1 && slot < 9) { // Held bar 0-9
+        if (slot > -1 && slot < 9) { // Held bar 0-8
             slot = slot + 36;
         } else if (slot > 8 && slot < 36) { // Inventory 9-35
             slot = slot;

--- a/src/main/java/net/minestom/server/utils/inventory/PlayerInventoryUtils.java
+++ b/src/main/java/net/minestom/server/utils/inventory/PlayerInventoryUtils.java
@@ -49,7 +49,6 @@ public final class PlayerInventoryUtils {
             case 8:
                 return BOOTS_SLOT;
         }
-        System.out.println("ENTRY: " + slot + " | " + offset);
         final int rowSize = 9;
         slot -= offset;
         if (slot >= rowSize * 3 && slot < rowSize * 4) {
@@ -57,7 +56,6 @@ public final class PlayerInventoryUtils {
         } else {
             slot = slot + rowSize;
         }
-        System.out.println("CONVERT: " + slot);
         return slot;
     }
 


### PR DESCRIPTION
When you double click an item in an inventory it would give an array out of bounds exception because the internal slot it was trying to access computed to -9. 

The fix in this PR is to supply an offset of 9 to `playerInventory.getItemStack` in one of the `InventoryClickLoopHandlers`. In my testing it appears to behave correctly, however I am unsure why it was offset previously. I think it is worth someone with more knowledge doing some testing on their own to make sure this doesnt have other side effects.

In other notes, I removed the hotbar loop handler because the inventory one handles those slots, and changed a comment for accuracy.