### PR TITLE
Check for removed entity before targeting

### DIFF
--- a/src/main/java/net/minestom/server/entity/ai/target/ClosestEntityTarget.java
+++ b/src/main/java/net/minestom/server/entity/ai/target/ClosestEntityTarget.java
@@ -56,6 +56,11 @@ public class ClosestEntityTarget extends TargetSelector {
                     continue;
                 }
 
+                if (ent.isRemoved()) {
+                    // Entity not valid
+                    return null;
+                }
+
                 // Check if the entity type can be targeted
                 final Class<? extends Entity> clazz = ent.getClass();
                 boolean correct = false;


### PR DESCRIPTION
This makes sure that removed entities won't be targeted by the ClosestEntityTarget.