### PR TITLE
Fix missing field bug

### DIFF
--- a/src/main/java/net/minestom/server/extensions/ExtensionManager.java
+++ b/src/main/java/net/minestom/server/extensions/ExtensionManager.java
@@ -193,7 +193,7 @@ public class ExtensionManager {
 
         // Set extension description
         try {
-            Field descriptionField = extensionClass.getSuperclass().getDeclaredField("description");
+            Field descriptionField = Extension.class.getDeclaredField("description");
             descriptionField.setAccessible(true);
             descriptionField.set(extension, extensionDescription);
         } catch (IllegalAccessException e) {
@@ -205,7 +205,7 @@ public class ExtensionManager {
 
         // Set logger
         try {
-            Field loggerField = extensionClass.getSuperclass().getDeclaredField("logger");
+            Field loggerField = Extension.class.getDeclaredField("logger");
             loggerField.setAccessible(true);
             loggerField.set(extension, LoggerFactory.getLogger(extensionClass));
         } catch (IllegalAccessException e) {


### PR DESCRIPTION
This code sets the extension's description and logger instance through reflection, but those fields are private to `Extension`. Consider the following code:

----

    // This class is to give extensions more utilities without merging them into Minestom itself
    public abstract class MiddleMod extends Extension {
    
        public String getName() { // This isn't present on Extension
            return getDescription().getName();
        }

    }

----

    public class AwesomeExtension extends MiddleMod {
    
        @Override
        public void initialize() {
        }

        @Override
        public void terminate() {
        }

    }

----

When starting the server, `ExtensionManager` will throw an exception because `AwesomeExtension` doesn't directly inherit `Extension`, so when `ExtensionManager` attempts to find the declared fields within the extension's parent class, it throws an error because `MiddleMod` doesn't declare those fields, and `Extension`'s private fields are not visible or accessible to `MiddleMod`.

*So*, if the whole point is to set the field of `Extension` then why not reference it directly? You already know from checking earlier that the class extends `Extension`.