### PR TITLE
Set the last location at the end of refreshPosition and at construction

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -151,6 +151,9 @@ public abstract class Entity implements Viewable, EventHandler, DataContainer, P
         this.entityType = entityType;
         this.uuid = uuid;
         this.position = spawnPosition.clone();
+        this.lastX = spawnPosition.getX();
+        this.lastY = spawnPosition.getY();
+        this.lastZ = spawnPosition.getZ();
 
         setBoundingBox(0, 0, 0);
 
@@ -1100,9 +1103,6 @@ public abstract class Entity implements Viewable, EventHandler, DataContainer, P
      * @param z new position Z
      */
     public void refreshPosition(float x, float y, float z) {
-        this.lastX = position.getX();
-        this.lastY = position.getY();
-        this.lastZ = position.getZ();
         position.setX(x);
         position.setY(y);
         position.setZ(z);
@@ -1139,6 +1139,10 @@ public abstract class Entity implements Viewable, EventHandler, DataContainer, P
                 }
             }
         }
+
+        this.lastX = position.getX();
+        this.lastY = position.getY();
+        this.lastZ = position.getZ();
     }
 
     /**


### PR DESCRIPTION
Without this change, in Entity#refreshPosition the lastChunk and the newChunk were always the same.
This issue did not occur while teleporting, as the new location was directly given to the method. For pathfinding the method is called with the current position which leads to this issue.

This issue causes entities to not change their chunk at pathfinding movement, which leads to a memory leak.