### PR TITLE
Event Handler support for Extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ gradle-app.setting
 
 # When compiling we get a docs folder
 /docs
+
+# Mac
+.DS_STORE

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -12,6 +12,7 @@ import net.minestom.server.event.Event;
 import net.minestom.server.event.EventCallback;
 import net.minestom.server.event.entity.*;
 import net.minestom.server.event.handler.EventHandler;
+import net.minestom.server.extensions.Extension;
 import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.InstanceManager;
@@ -119,7 +120,7 @@ public abstract class Entity implements Viewable, EventHandler, DataContainer, P
     private long lastAbsoluteSynchronizationTime;
 
     // Events
-    private final Map<Class<? extends Event>, Collection<EventCallback>> eventCallbacks = new ConcurrentHashMap<>();
+    private final Map<Class<? extends Extension>, Map<Class<? extends Event>, Collection<EventCallback>>> eventCallbacks = new ConcurrentHashMap<>();
 
     // Metadata
     protected boolean onFire;
@@ -650,8 +651,14 @@ public abstract class Entity implements Viewable, EventHandler, DataContainer, P
 
     @NotNull
     @Override
-    public Map<Class<? extends Event>, Collection<EventCallback>> getEventCallbacksMap() {
-        return eventCallbacks;
+    public <V extends Extension> Map<Class<? extends Event>, Collection<EventCallback>> getEventCallbacksMap(Class<V> extensionClass) {
+        eventCallbacks.putIfAbsent(extensionClass, new ConcurrentHashMap<>());
+        return eventCallbacks.get(extensionClass);
+    }
+
+    @Override
+    public <V extends Extension> void clearExtension(Class<V> extensionClass) {
+        eventCallbacks.remove(extensionClass);
     }
 
     /**

--- a/src/main/java/net/minestom/server/event/GlobalEventHandler.java
+++ b/src/main/java/net/minestom/server/event/GlobalEventHandler.java
@@ -1,6 +1,7 @@
 package net.minestom.server.event;
 
 import net.minestom.server.event.handler.EventHandler;
+import net.minestom.server.extensions.Extension;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -13,11 +14,17 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class GlobalEventHandler implements EventHandler {
 
     // Events
-    private final Map<Class<? extends Event>, Collection<EventCallback>> eventCallbacks = new ConcurrentHashMap<>();
+    private final Map<Class<? extends Extension>, Map<Class<? extends Event>, Collection<EventCallback>>> eventCallbacks = new ConcurrentHashMap<>();
 
     @NotNull
     @Override
-    public Map<Class<? extends Event>, Collection<EventCallback>> getEventCallbacksMap() {
-        return eventCallbacks;
+    public <V extends Extension> Map<Class<? extends Event>, Collection<EventCallback>> getEventCallbacksMap(Class<V> extensionClass) {
+        eventCallbacks.putIfAbsent(extensionClass, new ConcurrentHashMap<>());
+        return eventCallbacks.get(extensionClass);
+    }
+
+    @Override
+    public <V extends Extension> void clearExtension(Class<V> extensionClass) {
+        eventCallbacks.remove(extensionClass);
     }
 }

--- a/src/main/java/net/minestom/server/extensions/ExtensionManager.java
+++ b/src/main/java/net/minestom/server/extensions/ExtensionManager.java
@@ -6,6 +6,7 @@ import net.minestom.dependencies.maven.MavenRepository;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.extras.selfmodification.MinestomExtensionClassLoader;
 import net.minestom.server.extras.selfmodification.MinestomRootClassLoader;
+import net.minestom.server.instance.Instance;
 import net.minestom.server.ping.ResponseDataConsumer;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.NotNull;
@@ -513,6 +514,15 @@ public class ExtensionManager {
         ext.terminate();
         ext.postTerminate();
         ext.unload();
+
+        // remove the extension from all known event handlers.
+        MinecraftServer.getGlobalEventHandler().clearExtension(ext.getClass());
+        for (Instance instance : MinecraftServer.getInstanceManager().getInstances()) {
+            instance.clearExtension(ext.getClass());
+        }
+
+        // call GC to try to get rid of extension in event handlers.
+        System.gc();
 
         // remove as dependent of other extensions
         // this avoids issues where a dependent extension fails to reload, and prevents the base extension to reload too


### PR DESCRIPTION
### What would you like added/changed?
We currently have the `addEventCallback()` method implementation in global and instance scope, but we need to add this for Extensions.

### Why do you want this to be added?
A few things are missing in the Extension API and event hooks are one of them, currently, when hooking an event from an extension and reloading the extension, there will not happen any unregister/unhooking of the event. Therefore making an event handler duplication.

### Implementation suggestion
Like we see in the Instance structure, the Instance class has en declared method called `addEventCallback()`, the suggestion is to add the same thing to the Extension.
#### Suggested methods
`EventHandler.addEventCallback(Extension extension, Class<E> eventClass, EventCallback<E> eventCallback)`
`EventHandler.removeEventCallback(Extension extension, Class<E> eventClass, EventCallback<E> eventCallback)`
