### PR TITLE
Methods to read ServerPackets and write ClientPackets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,7 +140,7 @@ dependencies {
     api 'org.apache.logging.log4j:log4j-slf4j-impl:2.14.0'
 
     // Guava 21.0+ required for Mixin, but Authlib imports 17.0
-    api 'com.google.guava:guava:21.0'
+    api 'com.google.guava:guava:30.1-jre'
     api 'com.mojang:authlib:1.5.21'
 
     // Code modification

--- a/src/main/java/net/minestom/server/command/CommandManager.java
+++ b/src/main/java/net/minestom/server/command/CommandManager.java
@@ -17,6 +17,7 @@ import net.minestom.server.entity.Player;
 import net.minestom.server.event.player.PlayerCommandEvent;
 import net.minestom.server.network.packet.server.play.DeclareCommandsPacket;
 import net.minestom.server.utils.ArrayUtils;
+import net.minestom.server.utils.binary.BinaryWriter;
 import net.minestom.server.utils.callback.CommandCallback;
 import net.minestom.server.utils.validate.Check;
 import org.apache.commons.lang3.StringUtils;
@@ -379,7 +380,7 @@ public final class CommandManager {
                         true, false, tracking);
                 tabNode.name = tracking ? "tab_completion" : "args";
                 tabNode.parser = "brigadier:string";
-                tabNode.properties = packetWriter -> packetWriter.writeVarInt(2); // Greedy phrase
+                tabNode.properties = BinaryWriter.makeArray(packetWriter -> packetWriter.writeVarInt(2)); // Greedy phrase
                 tabNode.children = new int[0];
                 if (tracking) {
                     tabNode.suggestionsType = "minecraft:ask_server";
@@ -597,7 +598,6 @@ public final class CommandManager {
 
         literalNode.children = ArrayUtils.toArray(cmdChildren);
         return literalNode;
-
     }
 
     @NotNull

--- a/src/main/java/net/minestom/server/command/builder/arguments/ArgumentDynamicStringArray.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/ArgumentDynamicStringArray.java
@@ -5,6 +5,7 @@ import net.minestom.server.command.builder.NodeMaker;
 import net.minestom.server.command.builder.exception.ArgumentSyntaxException;
 import net.minestom.server.command.builder.suggestion.SuggestionCallback;
 import net.minestom.server.network.packet.server.play.DeclareCommandsPacket;
+import net.minestom.server.utils.binary.BinaryWriter;
 import net.minestom.server.utils.callback.validator.StringArrayValidator;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -47,9 +48,9 @@ public class ArgumentDynamicStringArray extends Argument<String[]> {
         DeclareCommandsPacket.Node argumentNode = simpleArgumentNode(this, executable, false, true);
 
         argumentNode.parser = "brigadier:string";
-        argumentNode.properties = packetWriter -> {
+        argumentNode.properties = BinaryWriter.makeArray(packetWriter -> {
             packetWriter.writeVarInt(2); // Greedy phrase
-        };
+        });
         argumentNode.suggestionsType = "minecraft:ask_server";
 
         nodeMaker.addNodes(new DeclareCommandsPacket.Node[]{argumentNode});

--- a/src/main/java/net/minestom/server/command/builder/arguments/ArgumentDynamicWord.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/ArgumentDynamicWord.java
@@ -6,6 +6,7 @@ import net.minestom.server.command.builder.arguments.minecraft.SuggestionType;
 import net.minestom.server.command.builder.exception.ArgumentSyntaxException;
 import net.minestom.server.command.builder.suggestion.SuggestionCallback;
 import net.minestom.server.network.packet.server.play.DeclareCommandsPacket;
+import net.minestom.server.utils.binary.BinaryWriter;
 import net.minestom.server.utils.callback.validator.StringValidator;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -56,9 +57,9 @@ public class ArgumentDynamicWord extends Argument<String> {
         final SuggestionType suggestionType = this.getSuggestionType();
 
         argumentNode.parser = "brigadier:string";
-        argumentNode.properties = packetWriter -> {
+        argumentNode.properties = BinaryWriter.makeArray(packetWriter -> {
             packetWriter.writeVarInt(0); // Single word
-        };
+        });
         argumentNode.suggestionsType = suggestionType.getIdentifier();
 
         nodeMaker.addNodes(new DeclareCommandsPacket.Node[]{argumentNode});

--- a/src/main/java/net/minestom/server/command/builder/arguments/ArgumentString.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/ArgumentString.java
@@ -4,6 +4,7 @@ import io.netty.util.internal.StringUtil;
 import net.minestom.server.command.builder.NodeMaker;
 import net.minestom.server.command.builder.exception.ArgumentSyntaxException;
 import net.minestom.server.network.packet.server.play.DeclareCommandsPacket;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.apache.commons.text.StringEscapeUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -35,9 +36,9 @@ public class ArgumentString extends Argument<String> {
         DeclareCommandsPacket.Node argumentNode = simpleArgumentNode(this, executable, false, false);
 
         argumentNode.parser = "brigadier:string";
-        argumentNode.properties = packetWriter -> {
+        argumentNode.properties = BinaryWriter.makeArray(packetWriter -> {
             packetWriter.writeVarInt(1); // Quotable phrase
-        };
+        });
 
         nodeMaker.addNodes(new DeclareCommandsPacket.Node[]{argumentNode});
     }

--- a/src/main/java/net/minestom/server/command/builder/arguments/ArgumentStringArray.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/ArgumentStringArray.java
@@ -2,6 +2,7 @@ package net.minestom.server.command.builder.arguments;
 
 import net.minestom.server.command.builder.NodeMaker;
 import net.minestom.server.network.packet.server.play.DeclareCommandsPacket;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -29,9 +30,9 @@ public class ArgumentStringArray extends Argument<String[]> {
         DeclareCommandsPacket.Node argumentNode = simpleArgumentNode(this, executable, false, false);
 
         argumentNode.parser = "brigadier:string";
-        argumentNode.properties = packetWriter -> {
+        argumentNode.properties = BinaryWriter.makeArray(packetWriter -> {
             packetWriter.writeVarInt(2); // Greedy phrase
-        };
+        });
 
         nodeMaker.addNodes(new DeclareCommandsPacket.Node[]{argumentNode});
     }

--- a/src/main/java/net/minestom/server/command/builder/arguments/ArgumentWord.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/ArgumentWord.java
@@ -3,6 +3,7 @@ package net.minestom.server.command.builder.arguments;
 import net.minestom.server.command.builder.NodeMaker;
 import net.minestom.server.command.builder.exception.ArgumentSyntaxException;
 import net.minestom.server.network.packet.server.play.DeclareCommandsPacket;
+import net.minestom.server.utils.binary.BinaryWriter;
 import net.minestom.server.utils.validate.Check;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -90,9 +91,9 @@ public class ArgumentWord extends Argument<String> {
             // Can be any word, add only one argument node
             DeclareCommandsPacket.Node argumentNode = simpleArgumentNode(this, executable, false, false);
             argumentNode.parser = "brigadier:string";
-            argumentNode.properties = packetWriter -> {
+            argumentNode.properties = BinaryWriter.makeArray(packetWriter -> {
                 packetWriter.writeVarInt(0); // Single word
-            };
+            });
             nodeMaker.addNodes(new DeclareCommandsPacket.Node[]{argumentNode});
         }
     }

--- a/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentEntity.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentEntity.java
@@ -7,6 +7,7 @@ import net.minestom.server.entity.EntityType;
 import net.minestom.server.entity.GameMode;
 import net.minestom.server.network.packet.server.play.DeclareCommandsPacket;
 import net.minestom.server.registry.Registries;
+import net.minestom.server.utils.binary.BinaryWriter;
 import net.minestom.server.utils.entity.EntityFinder;
 import net.minestom.server.utils.math.IntRange;
 import org.apache.commons.lang3.StringUtils;
@@ -75,7 +76,7 @@ public class ArgumentEntity extends Argument<EntityFinder> {
     public void processNodes(@NotNull NodeMaker nodeMaker, boolean executable) {
         DeclareCommandsPacket.Node argumentNode = simpleArgumentNode(this, executable, false, false);
         argumentNode.parser = "minecraft:entity";
-        argumentNode.properties = packetWriter -> {
+        argumentNode.properties = BinaryWriter.makeArray(packetWriter -> {
             byte mask = 0;
             if (this.isOnlySingleEntity()) {
                 mask += 1;
@@ -84,7 +85,7 @@ public class ArgumentEntity extends Argument<EntityFinder> {
                 mask += 2;
             }
             packetWriter.writeByte(mask);
-        };
+        });
 
         nodeMaker.addNodes(new DeclareCommandsPacket.Node[]{argumentNode});
     }

--- a/src/main/java/net/minestom/server/command/builder/arguments/number/ArgumentDouble.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/number/ArgumentDouble.java
@@ -3,6 +3,7 @@ package net.minestom.server.command.builder.arguments.number;
 import net.minestom.server.command.builder.NodeMaker;
 import net.minestom.server.command.builder.exception.ArgumentSyntaxException;
 import net.minestom.server.network.packet.server.play.DeclareCommandsPacket;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ArgumentDouble extends ArgumentNumber<Double> {
@@ -45,13 +46,13 @@ public class ArgumentDouble extends ArgumentNumber<Double> {
         DeclareCommandsPacket.Node argumentNode = simpleArgumentNode(this, executable, false, false);
 
         argumentNode.parser = "brigadier:double";
-        argumentNode.properties = packetWriter -> {
+        argumentNode.properties = BinaryWriter.makeArray(packetWriter -> {
             packetWriter.writeByte(getNumberProperties());
             if (this.hasMin())
                 packetWriter.writeDouble(this.getMin());
             if (this.hasMax())
                 packetWriter.writeDouble(this.getMax());
-        };
+        });
 
         nodeMaker.addNodes(new DeclareCommandsPacket.Node[]{argumentNode});
     }

--- a/src/main/java/net/minestom/server/command/builder/arguments/number/ArgumentFloat.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/number/ArgumentFloat.java
@@ -3,6 +3,7 @@ package net.minestom.server.command.builder.arguments.number;
 import net.minestom.server.command.builder.NodeMaker;
 import net.minestom.server.command.builder.exception.ArgumentSyntaxException;
 import net.minestom.server.network.packet.server.play.DeclareCommandsPacket;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ArgumentFloat extends ArgumentNumber<Float> {
@@ -45,13 +46,13 @@ public class ArgumentFloat extends ArgumentNumber<Float> {
         DeclareCommandsPacket.Node argumentNode = simpleArgumentNode(this, executable, false, false);
 
         argumentNode.parser = "brigadier:float";
-        argumentNode.properties = packetWriter -> {
+        argumentNode.properties = BinaryWriter.makeArray(packetWriter -> {
             packetWriter.writeByte(getNumberProperties());
             if (this.hasMin())
                 packetWriter.writeFloat(this.getMin());
             if (this.hasMax())
                 packetWriter.writeFloat(this.getMax());
-        };
+        });
 
         nodeMaker.addNodes(new DeclareCommandsPacket.Node[]{argumentNode});
     }

--- a/src/main/java/net/minestom/server/command/builder/arguments/number/ArgumentInteger.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/number/ArgumentInteger.java
@@ -3,6 +3,7 @@ package net.minestom.server.command.builder.arguments.number;
 import net.minestom.server.command.builder.NodeMaker;
 import net.minestom.server.command.builder.exception.ArgumentSyntaxException;
 import net.minestom.server.network.packet.server.play.DeclareCommandsPacket;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ArgumentInteger extends ArgumentNumber<Integer> {
@@ -36,13 +37,13 @@ public class ArgumentInteger extends ArgumentNumber<Integer> {
         DeclareCommandsPacket.Node argumentNode = simpleArgumentNode(this, executable, false, false);
 
         argumentNode.parser = "brigadier:integer";
-        argumentNode.properties = packetWriter -> {
+        argumentNode.properties = BinaryWriter.makeArray(packetWriter -> {
             packetWriter.writeByte(getNumberProperties());
             if (this.hasMin())
                 packetWriter.writeInt(this.getMin());
             if (this.hasMax())
                 packetWriter.writeInt(this.getMax());
-        };
+        });
 
         nodeMaker.addNodes(new DeclareCommandsPacket.Node[]{argumentNode});
     }

--- a/src/main/java/net/minestom/server/command/builder/arguments/number/ArgumentLong.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/number/ArgumentLong.java
@@ -3,6 +3,7 @@ package net.minestom.server.command.builder.arguments.number;
 import net.minestom.server.command.builder.NodeMaker;
 import net.minestom.server.command.builder.exception.ArgumentSyntaxException;
 import net.minestom.server.network.packet.server.play.DeclareCommandsPacket;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ArgumentLong extends ArgumentNumber<Long> {
@@ -38,13 +39,13 @@ public class ArgumentLong extends ArgumentNumber<Long> {
         // TODO maybe use ArgumentLiteral/ArgumentWord and impose long restriction server side?
 
         argumentNode.parser = "brigadier:integer";
-        argumentNode.properties = packetWriter -> {
+        argumentNode.properties = BinaryWriter.makeArray(packetWriter -> {
             packetWriter.writeByte(getNumberProperties());
             if (this.hasMin())
                 packetWriter.writeInt(this.getMin().intValue());
             if (this.hasMax())
                 packetWriter.writeInt(this.getMax().intValue());
-        };
+        });
 
         nodeMaker.addNodes(new DeclareCommandsPacket.Node[]{argumentNode});
     }

--- a/src/main/java/net/minestom/server/data/type/InventoryData.java
+++ b/src/main/java/net/minestom/server/data/type/InventoryData.java
@@ -35,7 +35,7 @@ public class InventoryData extends DataType<Inventory> {
 
         // Read all item stacks
         for (int i = 0; i < size; i++) {
-            inventory.setItemStack(i, reader.readSlot());
+            inventory.setItemStack(i, reader.readItemStack());
         }
 
         return inventory;

--- a/src/main/java/net/minestom/server/data/type/ItemStackData.java
+++ b/src/main/java/net/minestom/server/data/type/ItemStackData.java
@@ -15,6 +15,6 @@ public class ItemStackData extends DataType<ItemStack> {
     @NotNull
     @Override
     public ItemStack decode(@NotNull BinaryReader reader) {
-        return reader.readSlot();
+        return reader.readItemStack();
     }
 }

--- a/src/main/java/net/minestom/server/data/type/array/ItemStackArrayData.java
+++ b/src/main/java/net/minestom/server/data/type/array/ItemStackArrayData.java
@@ -20,7 +20,7 @@ public class ItemStackArrayData extends DataType<ItemStack[]> {
     public ItemStack[] decode(@NotNull BinaryReader reader) {
         ItemStack[] items = new ItemStack[reader.readVarInt()];
         for (int i = 0; i < items.length; i++) {
-            items[i] = reader.readSlot();
+            items[i] = reader.readItemStack();
         }
         return items;
     }

--- a/src/main/java/net/minestom/server/entity/Metadata.java
+++ b/src/main/java/net/minestom/server/entity/Metadata.java
@@ -2,45 +2,54 @@ package net.minestom.server.entity;
 
 import net.kyori.adventure.text.Component;
 import net.minestom.server.adventure.AdventureSerializer;
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.chat.ColoredText;
 import net.minestom.server.chat.JsonMessage;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.network.packet.server.play.EntityMetaDataPacket;
 import net.minestom.server.utils.BlockPosition;
 import net.minestom.server.utils.Direction;
+import net.minestom.server.utils.Position;
 import net.minestom.server.utils.Vector;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
+import net.minestom.server.utils.binary.Readable;
 import net.minestom.server.utils.binary.Writeable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jglrxavpok.hephaistos.nbt.NBT;
+import org.jglrxavpok.hephaistos.nbt.NBTEnd;
+import org.jglrxavpok.hephaistos.nbt.NBTException;
 
 import java.util.*;
+import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 public class Metadata {
 
     // METADATA TYPES
 
     public static Value<Byte> Byte(byte value) {
-        return new Value<>(TYPE_BYTE, value, writer -> writer.writeByte(value));
+        return new Value<>(TYPE_BYTE, value, writer -> writer.writeByte(value), BinaryReader::readByte);
     }
 
     public static Value<Integer> VarInt(int value) {
-        return new Value<>(TYPE_VARINT, value, writer -> writer.writeVarInt(value));
+        return new Value<>(TYPE_VARINT, value, writer -> writer.writeVarInt(value), BinaryReader::readVarInt);
     }
 
     public static Value<Float> Float(float value) {
-        return new Value<>(TYPE_FLOAT, value, writer -> writer.writeFloat(value));
+        return new Value<>(TYPE_FLOAT, value, writer -> writer.writeFloat(value), BinaryReader::readFloat);
     }
 
     public static Value<String> String(@NotNull String value) {
-        return new Value<>(TYPE_STRING, value, writer -> writer.writeSizedString(value));
+        return new Value<>(TYPE_STRING, value, writer -> writer.writeSizedString(value), reader -> reader.readSizedString(Integer.MAX_VALUE));
     }
 
     @Deprecated
     public static Value<JsonMessage> Chat(@NotNull JsonMessage value) {
-        return new Value<>(TYPE_CHAT, value, writer -> writer.writeSizedString(value.toString()));
+        return new Value<>(TYPE_CHAT, value, writer -> writer.writeSizedString(value.toString()), reader -> reader.readJsonMessage(Integer.MAX_VALUE));
     }
 
     @Deprecated
@@ -51,11 +60,19 @@ public class Metadata {
             if (present) {
                 writer.writeSizedString(value.toString());
             }
+        },
+        reader -> {
+            boolean present = reader.readBoolean();
+            if(present) {
+                return reader.readJsonMessage(Integer.MAX_VALUE);
+            } else {
+                return null;
+            }
         });
     }
 
     public static Value<Component> Chat(@NotNull Component value) {
-        return new Value<>(TYPE_CHAT, value, writer -> writer.writeSizedString(AdventureSerializer.serialize(value)));
+        return new Value<>(TYPE_CHAT, value, writer -> writer.writeSizedString(AdventureSerializer.serialize(value)), reader -> reader.readComponent(Integer.MAX_VALUE));
     }
 
     public static Value<Component> OptChat(@Nullable Component value) {
@@ -65,15 +82,21 @@ public class Metadata {
             if (present) {
                 writer.writeSizedString(AdventureSerializer.serialize(value));
             }
+        }, reader -> {
+            boolean present = reader.readBoolean();
+            if(present) {
+                return reader.readComponent(Integer.MAX_VALUE);
+            }
+            return null;
         });
     }
 
     public static Value<ItemStack> Slot(@NotNull ItemStack value) {
-        return new Value<>(TYPE_SLOT, value, writer -> writer.writeItemStack(value));
+        return new Value<>(TYPE_SLOT, value, writer -> writer.writeItemStack(value), BinaryReader::readItemStack);
     }
 
     public static Value<Boolean> Boolean(boolean value) {
-        return new Value<>(TYPE_BOOLEAN, value, writer -> writer.writeBoolean(value));
+        return new Value<>(TYPE_BOOLEAN, value, writer -> writer.writeBoolean(value), BinaryReader::readBoolean);
     }
 
     public static Value<Vector> Rotation(@NotNull Vector value) {
@@ -81,11 +104,11 @@ public class Metadata {
             writer.writeFloat((float) value.getX());
             writer.writeFloat((float) value.getY());
             writer.writeFloat((float) value.getZ());
-        });
+        }, reader -> new Vector(reader.readFloat(), reader.readFloat(), reader.readFloat()));
     }
 
     public static Value<BlockPosition> Position(@NotNull BlockPosition value) {
-        return new Value<>(TYPE_POSITION, value, writer -> writer.writeBlockPosition(value));
+        return new Value<>(TYPE_POSITION, value, writer -> writer.writeBlockPosition(value), BinaryReader::readBlockPosition);
     }
 
     public static Value<BlockPosition> OptPosition(@Nullable BlockPosition value) {
@@ -95,11 +118,18 @@ public class Metadata {
             if (present) {
                 writer.writeBlockPosition(value);
             }
+        }, reader -> {
+            boolean present = reader.readBoolean();
+            if(present) {
+                return reader.readBlockPosition();
+            } else {
+                return null;
+            }
         });
     }
 
     public static Value<Direction> Direction(@NotNull Direction value) {
-        return new Value<>(TYPE_DIRECTION, value, writer -> writer.writeVarInt(value.ordinal()));
+        return new Value<>(TYPE_DIRECTION, value, writer -> writer.writeVarInt(value.ordinal()), reader -> Direction.values()[reader.readVarInt()]);
     }
 
     public static Value<UUID> OptUUID(@Nullable UUID value) {
@@ -109,6 +139,13 @@ public class Metadata {
             if (present) {
                 writer.writeUuid(value);
             }
+        }, reader -> {
+            boolean present = reader.readBoolean();
+            if(present) {
+                return reader.readUuid();
+            } else {
+                return null;
+            }
         });
     }
 
@@ -116,11 +153,27 @@ public class Metadata {
         return new Value<>(TYPE_OPTBLOCKID, value, writer -> {
             final boolean present = value != null;
             writer.writeVarInt(present ? value : 0);
+        }, reader -> {
+            boolean present = reader.readBoolean();
+            if(present) {
+                return reader.readVarInt();
+            } else {
+                return null;
+            }
         });
     }
 
     public static Value<NBT> NBT(@NotNull NBT nbt) {
-        return new Value<>(TYPE_NBT, nbt, writer -> writer.writeNBT("", nbt));
+        return new Value<>(TYPE_NBT, nbt, writer -> {
+            writer.writeNBT("", nbt);
+        }, reader -> {
+            try {
+                return reader.readTag();
+            } catch (IOException | NBTException e) {
+                MinecraftServer.getExceptionManager().handleException(e);
+                return null;
+            }
+        });
     }
 
     public static Value<int[]> VillagerData(int villagerType,
@@ -130,6 +183,10 @@ public class Metadata {
             writer.writeVarInt(villagerType);
             writer.writeVarInt(villagerProfession);
             writer.writeVarInt(level);
+        }, reader -> new int[] {
+                reader.readVarInt(),
+                reader.readVarInt(),
+                reader.readVarInt()
         });
     }
 
@@ -137,11 +194,18 @@ public class Metadata {
         return new Value<>(TYPE_OPTVARINT, value, writer -> {
             final boolean present = value != null;
             writer.writeVarInt(present ? value + 1 : 0);
+        }, reader -> {
+            boolean present = reader.readBoolean();
+            if(present) {
+                return reader.readVarInt();
+            } else {
+                return null;
+            }
         });
     }
 
     public static Value<Entity.Pose> Pose(@NotNull Entity.Pose value) {
-        return new Value<>(TYPE_POSE, value, writer -> writer.writeVarInt(value.ordinal()));
+        return new Value<>(TYPE_POSE, value, writer -> writer.writeVarInt(value.ordinal()), reader -> Entity.Pose.values()[reader.readVarInt()]);
     }
 
     public static final byte TYPE_BYTE = 0;
@@ -236,12 +300,18 @@ public class Metadata {
 
     public static class Entry<T> implements Writeable {
 
-        protected final byte index;
-        protected final Value<T> value;
+        protected byte index;
+        protected Value<T> value;
 
         public Entry(byte index, @NotNull Value<T> value) {
             this.index = index;
             this.value = value;
+        }
+
+        public Entry(BinaryReader reader) {
+            this.index = reader.readByte();
+            int type = reader.readVarInt();
+            value = Metadata.read(type, reader);
         }
 
         @Override
@@ -260,22 +330,82 @@ public class Metadata {
         }
     }
 
-    public static class Value<T> implements Writeable {
+    private static <T> Value<T> getCorrespondingNewEmptyValue(int type) {
+        switch(type) {
+            case TYPE_BYTE:
+                return (Value<T>) Byte((byte) 0);
+            case TYPE_VARINT:
+                return (Value<T>) VarInt(0);
+            case TYPE_FLOAT:
+                return (Value<T>) Float(0);
+            case TYPE_STRING:
+                return (Value<T>) String("");
+            case TYPE_CHAT:
+                return (Value<T>) Chat(ColoredText.of(""));
+            case TYPE_OPTCHAT:
+                return (Value<T>) OptChat((Component) null);
+            case TYPE_SLOT:
+                return (Value<T>) Slot(ItemStack.getAirItem());
+            case TYPE_BOOLEAN:
+                return (Value<T>) Boolean(false);
+            case TYPE_ROTATION:
+                return (Value<T>) Rotation(new Vector());
+            case TYPE_POSITION:
+                return (Value<T>) Position(new BlockPosition(0,0,0));
+            case TYPE_OPTPOSITION:
+                return (Value<T>) OptPosition(null);
+            case TYPE_DIRECTION:
+                return (Value<T>) Direction(Direction.DOWN);
+            case TYPE_OPTUUID:
+                return (Value<T>) OptUUID(null);
+            case TYPE_OPTBLOCKID:
+                return (Value<T>) OptBlockID(null);
+            case TYPE_NBT:
+                return (Value<T>) NBT(new NBTEnd());
+            case TYPE_PARTICLE:
+                throw new UnsupportedOperationException();
+            case TYPE_VILLAGERDATA:
+                return (Value<T>) VillagerData(0,0,0);
+            case TYPE_OPTVARINT:
+                return (Value<T>) OptVarInt(null);
+            case TYPE_POSE:
+                return (Value<T>) Pose(Entity.Pose.STANDING);
+
+            default:
+                throw new UnsupportedOperationException();
+        }
+    }
+
+    private static <T> Value<T> read(int type, BinaryReader reader) {
+        Value<T> value = getCorrespondingNewEmptyValue(type);
+        value.read(reader);
+        return value;
+    }
+
+    public static class Value<T> implements Writeable, Readable {
 
         protected final int type;
-        protected final T value;
+        protected T value;
         protected final Consumer<BinaryWriter> valueWriter;
+        protected final Function<BinaryReader, T> readingFunction;
 
-        public Value(int type, T value, @NotNull Consumer<BinaryWriter> valueWriter) {
+        public Value(int type, T value, @NotNull Consumer<BinaryWriter> valueWriter, @NotNull Function<BinaryReader, T> readingFunction) {
             this.type = type;
             this.value = value;
             this.valueWriter = valueWriter;
+            this.readingFunction = readingFunction;
         }
 
         @Override
         public void write(@NotNull BinaryWriter writer) {
             writer.writeVarInt(type);
             this.valueWriter.accept(writer);
+        }
+
+        @Override
+        public void read(@NotNull BinaryReader reader) {
+            // skip type, will be read somewhere else
+            value = readingFunction.apply(reader);
         }
 
         public int getType() {

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -1986,10 +1986,9 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
                 return;
             }
 
-            OpenWindowPacket openWindowPacket = new OpenWindowPacket();
+            OpenWindowPacket openWindowPacket = new OpenWindowPacket(newInventory.getTitle());
             openWindowPacket.windowId = newInventory.getWindowId();
             openWindowPacket.windowType = newInventory.getInventoryType().getWindowType();
-            openWindowPacket.title = newInventory.getTitle();
             playerConnection.sendPacket(openWindowPacket);
             newInventory.addViewer(this);
             this.openInventory = newInventory;

--- a/src/main/java/net/minestom/server/entity/fakeplayer/FakePlayerController.java
+++ b/src/main/java/net/minestom/server/entity/fakeplayer/FakePlayerController.java
@@ -71,7 +71,7 @@ public class FakePlayerController {
     public void closeWindow() {
         Inventory openInventory = fakePlayer.getOpenInventory();
 
-        ClientCloseWindow closeWindow = new ClientCloseWindow();
+        ClientCloseWindowPacket closeWindow = new ClientCloseWindowPacket();
         closeWindow.windowId = openInventory == null ? 0 : openInventory.getWindowId();
         addToQueue(closeWindow);
     }

--- a/src/main/java/net/minestom/server/gamedata/tags/Tag.java
+++ b/src/main/java/net/minestom/server/gamedata/tags/Tag.java
@@ -19,11 +19,20 @@ public class Tag {
     private Set<NamespaceID> values;
 
     /**
-     * Creates a new empty tag
+     * Creates a new empty tag. This does not cache the tag.
      */
     public Tag(NamespaceID name) {
         this.name = name;
         values = new HashSet<>();
+        lockValues();
+    }
+
+    /**
+     * Creates a new tag with the given values. This does not cache the tag.
+     */
+    public Tag(NamespaceID name, Set<NamespaceID> values) {
+        this.name = name;
+        this.values = new HashSet<>(values);
         lockValues();
     }
 

--- a/src/main/java/net/minestom/server/instance/palette/PaletteStorage.java
+++ b/src/main/java/net/minestom/server/instance/palette/PaletteStorage.java
@@ -10,6 +10,8 @@ import net.minestom.server.utils.clone.PublicCloneable;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Arrays;
+
 import static net.minestom.server.instance.Chunk.CHUNK_SECTION_COUNT;
 import static net.minestom.server.instance.Chunk.CHUNK_SECTION_SIZE;
 

--- a/src/main/java/net/minestom/server/instance/palette/Section.java
+++ b/src/main/java/net/minestom/server/instance/palette/Section.java
@@ -121,7 +121,7 @@ public class Section implements PublicCloneable<Section> {
      *
      * @param newBitsPerEntry the new bits per entry count
      */
-    private void resize(int newBitsPerEntry) {
+    public void resize(int newBitsPerEntry) {
         newBitsPerEntry = fixBitsPerEntry(newBitsPerEntry);
 
         Section section = new Section(newBitsPerEntry, bitsIncrement);

--- a/src/main/java/net/minestom/server/inventory/Inventory.java
+++ b/src/main/java/net/minestom/server/inventory/Inventory.java
@@ -118,11 +118,10 @@ public class Inventory implements InventoryModifier, InventoryClickHandler, View
     public void setTitle(@NotNull String title) {
         this.title = title;
 
-        OpenWindowPacket packet = new OpenWindowPacket();
+        OpenWindowPacket packet = new OpenWindowPacket(title);
 
         packet.windowId = getWindowId();
         packet.windowType = getInventoryType().getWindowType();
-        packet.title = title;
 
         // Re-open the inventory
         sendPacketToViewers(packet);

--- a/src/main/java/net/minestom/server/listener/WindowListener.java
+++ b/src/main/java/net/minestom/server/listener/WindowListener.java
@@ -7,7 +7,7 @@ import net.minestom.server.inventory.InventoryClickHandler;
 import net.minestom.server.inventory.PlayerInventory;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.network.packet.client.play.ClientClickWindowPacket;
-import net.minestom.server.network.packet.client.play.ClientCloseWindow;
+import net.minestom.server.network.packet.client.play.ClientCloseWindowPacket;
 import net.minestom.server.network.packet.client.play.ClientWindowConfirmationPacket;
 import net.minestom.server.network.packet.server.play.SetSlotPacket;
 import net.minestom.server.network.packet.server.play.WindowConfirmationPacket;
@@ -96,7 +96,7 @@ public class WindowListener {
         player.getPlayerConnection().sendPacket(windowConfirmationPacket);
     }
 
-    public static void closeWindowListener(ClientCloseWindow packet, Player player) {
+    public static void closeWindowListener(ClientCloseWindowPacket packet, Player player) {
         // if windowId == 0 then it is player's inventory, meaning that they hadn't been any open inventory packet
         InventoryCloseEvent inventoryCloseEvent = new InventoryCloseEvent(player.getOpenInventory(), player);
         player.callEvent(InventoryCloseEvent.class, inventoryCloseEvent);

--- a/src/main/java/net/minestom/server/listener/manager/PacketListenerManager.java
+++ b/src/main/java/net/minestom/server/listener/manager/PacketListenerManager.java
@@ -27,7 +27,7 @@ public final class PacketListenerManager {
         setListener(ClientKeepAlivePacket.class, KeepAliveListener::listener);
         setListener(ClientChatMessagePacket.class, ChatMessageListener::listener);
         setListener(ClientClickWindowPacket.class, WindowListener::clickWindowListener);
-        setListener(ClientCloseWindow.class, WindowListener::closeWindowListener);
+        setListener(ClientCloseWindowPacket.class, WindowListener::closeWindowListener);
         setListener(ClientWindowConfirmationPacket.class, WindowListener::windowConfirmationListener);
         setListener(ClientEntityActionPacket.class, EntityActionListener::listener);
         setListener(ClientHeldItemChangePacket.class, PlayerHeldListener::heldListener);

--- a/src/main/java/net/minestom/server/network/packet/client/ClientPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/ClientPacket.java
@@ -1,10 +1,18 @@
 package net.minestom.server.network.packet.client;
 
+import net.minestom.server.utils.binary.BinaryWriter;
 import net.minestom.server.utils.binary.Readable;
+import net.minestom.server.utils.binary.Writeable;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a packet received from a client.
  */
-public interface ClientPacket extends Readable {
+public interface ClientPacket extends Readable, Writeable {
 
+    @Override
+    default void write(@NotNull BinaryWriter writer) {
+        // FIXME: remove when all packets are written and read properly
+        throw new UnsupportedOperationException("WIP: This packet is not setup to be written from Minestom code at the moment.");
+    }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/handler/ClientPlayPacketsHandler.java
+++ b/src/main/java/net/minestom/server/network/packet/client/handler/ClientPlayPacketsHandler.java
@@ -14,7 +14,7 @@ public class ClientPlayPacketsHandler extends ClientPacketsHandler {
         register(0x07, ClientWindowConfirmationPacket::new);
         register(0x08, ClientClickWindowButtonPacket::new);
         register(0x09, ClientClickWindowPacket::new);
-        register(0x0A, ClientCloseWindow::new);
+        register(0x0A, ClientCloseWindowPacket::new);
         register(0x0B, ClientPluginMessagePacket::new);
         register(0x0C, ClientEditBookPacket::new);
         register(0x0D, ClientQueryEntityNbtPacket::new);

--- a/src/main/java/net/minestom/server/network/packet/client/handshake/HandshakePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/handshake/HandshakePacket.java
@@ -11,6 +11,7 @@ import net.minestom.server.network.packet.server.login.LoginDisconnectPacket;
 import net.minestom.server.network.player.NettyPlayerConnection;
 import net.minestom.server.network.player.PlayerConnection;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 import java.net.SocketAddress;
@@ -25,7 +26,7 @@ public class HandshakePacket implements ClientPreplayPacket {
     private static final Component INVALID_BUNGEE_FORWARDING = Component.text("If you wish to use IP forwarding, please enable it in your BungeeCord config as well!", NamedTextColor.RED);
 
     private int protocolVersion;
-    private String serverAddress;
+    private String serverAddress = "";
     private int serverPort;
     private int nextState;
 
@@ -35,6 +36,18 @@ public class HandshakePacket implements ClientPreplayPacket {
         this.serverAddress = reader.readSizedString(BungeeCordProxy.isEnabled() ? Short.MAX_VALUE : 255);
         this.serverPort = reader.readUnsignedShort();
         this.nextState = reader.readVarInt();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(protocolVersion);
+        int maxLength = BungeeCordProxy.isEnabled() ? Short.MAX_VALUE : 255;
+        if(serverAddress.length() > maxLength) {
+            throw new IllegalArgumentException("serverAddress is "+serverAddress.length()+" characters long, maximum allowed is "+maxLength);
+        }
+        writer.writeSizedString(serverAddress);
+        writer.writeUnsignedShort(serverPort);
+        writer.writeVarInt(nextState);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/client/login/EncryptionResponsePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/login/EncryptionResponsePacket.java
@@ -11,6 +11,7 @@ import net.minestom.server.network.player.NettyPlayerConnection;
 import net.minestom.server.network.player.PlayerConnection;
 import net.minestom.server.utils.async.AsyncUtils;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 import javax.crypto.SecretKey;
@@ -21,6 +22,11 @@ public class EncryptionResponsePacket implements ClientPreplayPacket {
 
     private byte[] sharedSecret;
     private byte[] verifyToken;
+
+    public EncryptionResponsePacket() {
+        sharedSecret = new byte[0];
+        verifyToken = new byte[0];
+    }
 
     @Override
     public void process(@NotNull PlayerConnection connection) {
@@ -66,6 +72,12 @@ public class EncryptionResponsePacket implements ClientPreplayPacket {
     public void read(@NotNull BinaryReader reader) {
         sharedSecret = ByteArrayData.decodeByteArray(reader);
         verifyToken = ByteArrayData.decodeByteArray(reader);
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        ByteArrayData.encodeByteArray(writer, sharedSecret);
+        ByteArrayData.encodeByteArray(writer, verifyToken);
     }
 
     public SecretKey getSecretKey() {

--- a/src/main/java/net/minestom/server/network/packet/client/login/LoginPluginResponsePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/login/LoginPluginResponsePacket.java
@@ -12,6 +12,7 @@ import net.minestom.server.network.packet.server.login.LoginDisconnectPacket;
 import net.minestom.server.network.player.NettyPlayerConnection;
 import net.minestom.server.network.player.PlayerConnection;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 import java.net.InetAddress;
@@ -27,7 +28,7 @@ public class LoginPluginResponsePacket implements ClientPreplayPacket {
 
     public int messageId;
     public boolean successful;
-    public byte[] data;
+    public byte[] data = new byte[0];
 
     @Override
     public void process(@NotNull PlayerConnection connection) {
@@ -93,7 +94,17 @@ public class LoginPluginResponsePacket implements ClientPreplayPacket {
         this.messageId = reader.readVarInt();
         this.successful = reader.readBoolean();
         if (successful) {
-            this.data = reader.getRemainingBytes();
+            this.data = reader.readRemainingBytes();
+        }
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(messageId);
+        writer.writeBoolean(successful);
+
+        if(successful) {
+            writer.writeBytes(data);
         }
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/login/LoginStartPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/login/LoginStartPacket.java
@@ -15,6 +15,7 @@ import net.minestom.server.network.packet.server.login.LoginPluginRequestPacket;
 import net.minestom.server.network.player.NettyPlayerConnection;
 import net.minestom.server.network.player.PlayerConnection;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
@@ -24,7 +25,7 @@ public class LoginStartPacket implements ClientPreplayPacket {
 
     private static final Component ALREADY_CONNECTED = Component.text("You are already on this server", NamedTextColor.RED);
 
-    public String username;
+    public String username = "";
 
     @Override
     public void process(@NotNull PlayerConnection connection) {
@@ -101,4 +102,10 @@ public class LoginStartPacket implements ClientPreplayPacket {
         this.username = reader.readSizedString(16);
     }
 
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        if(username.length() > 16)
+            throw new IllegalArgumentException("Username is not allowed to be longer than 16 characters");
+        writer.writeSizedString(username);
+    }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientAdvancementTabPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientAdvancementTabPacket.java
@@ -3,12 +3,13 @@ package net.minestom.server.network.packet.client.play;
 import net.minestom.server.advancements.AdvancementAction;
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientAdvancementTabPacket extends ClientPlayPacket {
 
-    public AdvancementAction action;
-    public String tabIdentifier;
+    public AdvancementAction action = AdvancementAction.OPENED_TAB;
+    public String tabIdentifier = "";
 
     @Override
     public void read(@NotNull BinaryReader reader) {
@@ -19,4 +20,15 @@ public class ClientAdvancementTabPacket extends ClientPlayPacket {
         }
     }
 
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(action.ordinal());
+
+        if(action == AdvancementAction.OPENED_TAB) {
+            if(tabIdentifier.length() > 256) {
+                throw new IllegalArgumentException("Tab identifier cannot be longer than 256 characters.");
+            }
+            writer.writeSizedString(tabIdentifier);
+        }
+    }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientAnimationPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientAnimationPacket.java
@@ -3,14 +3,20 @@ package net.minestom.server.network.packet.client.play;
 import net.minestom.server.entity.Player;
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientAnimationPacket extends ClientPlayPacket {
 
-    public Player.Hand hand;
+    public Player.Hand hand = Player.Hand.MAIN;
 
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.hand = Player.Hand.values()[reader.readVarInt()];
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(hand.ordinal());
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientChatMessagePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientChatMessagePacket.java
@@ -2,14 +2,23 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientChatMessagePacket extends ClientPlayPacket {
 
-    public String message;
+    public String message = "";
 
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.message = reader.readSizedString(256);
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        if(message.length() > 256) {
+            throw new IllegalArgumentException("Message cannot be more than 256 characters long.");
+        }
+        writer.writeSizedString(message);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientClickWindowButtonPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientClickWindowButtonPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientClickWindowButtonPacket extends ClientPlayPacket {
@@ -13,5 +14,11 @@ public class ClientClickWindowButtonPacket extends ClientPlayPacket {
     public void read(@NotNull BinaryReader reader) {
         this.windowId = reader.readByte();
         this.buttonId = reader.readByte();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeByte(windowId);
+        writer.writeByte(buttonId);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientClickWindowPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientClickWindowPacket.java
@@ -3,6 +3,7 @@ package net.minestom.server.network.packet.client.play;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientClickWindowPacket extends ClientPlayPacket {
@@ -12,7 +13,7 @@ public class ClientClickWindowPacket extends ClientPlayPacket {
     public byte button;
     public short actionNumber;
     public int mode;
-    public ItemStack item;
+    public ItemStack item = ItemStack.getAirItem();
 
     @Override
     public void read(@NotNull BinaryReader reader) {
@@ -22,5 +23,15 @@ public class ClientClickWindowPacket extends ClientPlayPacket {
         this.actionNumber = reader.readShort();
         this.mode = reader.readVarInt();
         this.item = reader.readItemStack();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeByte(windowId);
+        writer.writeShort(slot);
+        writer.writeByte(button);
+        writer.writeShort(actionNumber);
+        writer.writeVarInt(mode);
+        writer.writeItemStack(item);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientClickWindowPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientClickWindowPacket.java
@@ -21,6 +21,6 @@ public class ClientClickWindowPacket extends ClientPlayPacket {
         this.button = reader.readByte();
         this.actionNumber = reader.readShort();
         this.mode = reader.readVarInt();
-        this.item = reader.readSlot();
+        this.item = reader.readItemStack();
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientCloseWindowPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientCloseWindowPacket.java
@@ -2,14 +2,20 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
-public class ClientCloseWindow extends ClientPlayPacket {
+public class ClientCloseWindowPacket extends ClientPlayPacket {
 
     public int windowId;
 
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.windowId = reader.readVarInt();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(windowId);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientCraftRecipeRequest.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientCraftRecipeRequest.java
@@ -2,12 +2,13 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientCraftRecipeRequest extends ClientPlayPacket {
 
     public byte windowId;
-    public String recipe;
+    public String recipe = "";
     public boolean makeAll;
 
     @Override
@@ -15,5 +16,15 @@ public class ClientCraftRecipeRequest extends ClientPlayPacket {
         this.windowId = reader.readByte();
         this.recipe = reader.readSizedString(256);
         this.makeAll = reader.readBoolean();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeByte(windowId);
+        if(recipe.length() > 256) {
+            throw new IllegalArgumentException("'recipe' cannot be longer than 256 characters.");
+        }
+        writer.writeSizedString(recipe);
+        writer.writeBoolean(makeAll);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientCreativeInventoryActionPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientCreativeInventoryActionPacket.java
@@ -3,16 +3,23 @@ package net.minestom.server.network.packet.client.play;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientCreativeInventoryActionPacket extends ClientPlayPacket {
 
     public short slot;
-    public ItemStack item;
+    public ItemStack item = ItemStack.getAirItem();
 
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.slot = reader.readShort();
         this.item = reader.readItemStack();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeShort(slot);
+        writer.writeItemStack(item);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientCreativeInventoryActionPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientCreativeInventoryActionPacket.java
@@ -13,6 +13,6 @@ public class ClientCreativeInventoryActionPacket extends ClientPlayPacket {
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.slot = reader.readShort();
-        this.item = reader.readSlot();
+        this.item = reader.readItemStack();
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientEditBookPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientEditBookPacket.java
@@ -14,7 +14,7 @@ public class ClientEditBookPacket extends ClientPlayPacket {
 
     @Override
     public void read(@NotNull BinaryReader reader) {
-        this.book = reader.readSlot();
+        this.book = reader.readItemStack();
         this.isSigning = reader.readBoolean();
         this.hand = Player.Hand.values()[reader.readVarInt()];
     }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientEditBookPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientEditBookPacket.java
@@ -4,18 +4,26 @@ import net.minestom.server.entity.Player;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientEditBookPacket extends ClientPlayPacket {
 
-    public ItemStack book;
+    public ItemStack book = ItemStack.getAirItem();
     public boolean isSigning;
-    public Player.Hand hand;
+    public Player.Hand hand = Player.Hand.MAIN;
 
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.book = reader.readItemStack();
         this.isSigning = reader.readBoolean();
         this.hand = Player.Hand.values()[reader.readVarInt()];
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeItemStack(book);
+        writer.writeBoolean(isSigning);
+        writer.writeVarInt(hand.ordinal());
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientEntityActionPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientEntityActionPacket.java
@@ -2,12 +2,13 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientEntityActionPacket extends ClientPlayPacket {
 
     public int playerId;
-    public Action action;
+    public Action action = Action.START_SNEAKING;
     public int horseJumpBoost;
 
     @Override
@@ -15,6 +16,13 @@ public class ClientEntityActionPacket extends ClientPlayPacket {
         this.playerId = reader.readVarInt();
         this.action = Action.values()[reader.readVarInt()];
         this.horseJumpBoost = reader.readVarInt();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(playerId);
+        writer.writeVarInt(action.ordinal());
+        writer.writeVarInt(horseJumpBoost);
     }
 
     public enum Action {

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientGenerateStructurePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientGenerateStructurePacket.java
@@ -3,11 +3,12 @@ package net.minestom.server.network.packet.client.play;
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.BlockPosition;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientGenerateStructurePacket extends ClientPlayPacket {
 
-    public BlockPosition blockPosition;
+    public BlockPosition blockPosition = new BlockPosition(0,0,0);
     public int level;
     public boolean keepJigsaws;
 
@@ -16,5 +17,12 @@ public class ClientGenerateStructurePacket extends ClientPlayPacket {
         this.blockPosition = reader.readBlockPosition();
         this.level = reader.readVarInt();
         this.keepJigsaws = reader.readBoolean();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeBlockPosition(blockPosition);
+        writer.writeVarInt(level);
+        writer.writeBoolean(keepJigsaws);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientHeldItemChangePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientHeldItemChangePacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientHeldItemChangePacket extends ClientPlayPacket {
@@ -11,5 +12,10 @@ public class ClientHeldItemChangePacket extends ClientPlayPacket {
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.slot = reader.readShort();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeShort(slot);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientInteractEntityPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientInteractEntityPacket.java
@@ -3,16 +3,17 @@ package net.minestom.server.network.packet.client.play;
 import net.minestom.server.entity.Player;
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientInteractEntityPacket extends ClientPlayPacket {
 
     public int targetId;
-    public Type type;
+    public Type type = Type.INTERACT;
     public float x;
     public float y;
     public float z;
-    public Player.Hand hand;
+    public Player.Hand hand = Player.Hand.MAIN;
     public boolean sneaking;
 
     @Override
@@ -34,6 +35,27 @@ public class ClientInteractEntityPacket extends ClientPlayPacket {
                 break;
         }
         this.sneaking = reader.readBoolean();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(targetId);
+        writer.writeVarInt(type.ordinal());
+
+        switch (type) {
+            case INTERACT:
+                writer.writeVarInt(hand.ordinal());
+                break;
+            case ATTACK:
+                break;
+            case INTERACT_AT:
+                writer.writeFloat(x);
+                writer.writeFloat(y);
+                writer.writeFloat(z);
+                writer.writeVarInt(hand.ordinal());
+                break;
+        }
+        writer.writeBoolean(sneaking);
     }
 
     public enum Type {

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientKeepAlivePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientKeepAlivePacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientKeepAlivePacket extends ClientPlayPacket {
@@ -11,5 +12,10 @@ public class ClientKeepAlivePacket extends ClientPlayPacket {
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.id = reader.readLong();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeLong(id);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientNameItemPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientNameItemPacket.java
@@ -2,14 +2,23 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientNameItemPacket extends ClientPlayPacket {
 
-    public String itemName;
+    public String itemName = "";
 
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.itemName = reader.readSizedString(Short.MAX_VALUE);
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        if(itemName.length() > Short.MAX_VALUE) {
+            throw new IllegalArgumentException("Item name cannot be longer than Short.MAX_VALUE characters!");
+        }
+        writer.writeSizedString(itemName);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPickItemPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPickItemPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientPickItemPacket extends ClientPlayPacket {
@@ -11,5 +12,10 @@ public class ClientPickItemPacket extends ClientPlayPacket {
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.slotToUse = reader.readVarInt();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(slotToUse);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerAbilitiesPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerAbilitiesPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientPlayerAbilitiesPacket extends ClientPlayPacket {
@@ -11,5 +12,10 @@ public class ClientPlayerAbilitiesPacket extends ClientPlayPacket {
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.flags = reader.readByte();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeByte(flags);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerBlockPlacementPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerBlockPlacementPacket.java
@@ -5,13 +5,14 @@ import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.BlockPosition;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientPlayerBlockPlacementPacket extends ClientPlayPacket {
 
-    public Player.Hand hand;
-    public BlockPosition blockPosition;
-    public BlockFace blockFace;
+    public Player.Hand hand = Player.Hand.MAIN;
+    public BlockPosition blockPosition = new BlockPosition(0,0,0);
+    public BlockFace blockFace = BlockFace.TOP;
     public float cursorPositionX, cursorPositionY, cursorPositionZ;
     public boolean insideBlock;
 
@@ -26,4 +27,14 @@ public class ClientPlayerBlockPlacementPacket extends ClientPlayPacket {
         this.insideBlock = reader.readBoolean();
     }
 
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(hand.ordinal());
+        writer.writeBlockPosition(blockPosition);
+        writer.writeVarInt(blockFace.ordinal());
+        writer.writeFloat(cursorPositionX);
+        writer.writeFloat(cursorPositionY);
+        writer.writeFloat(cursorPositionZ);
+        writer.writeBoolean(insideBlock);
+    }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerDiggingPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerDiggingPacket.java
@@ -4,19 +4,27 @@ import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.BlockPosition;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientPlayerDiggingPacket extends ClientPlayPacket {
 
-    public Status status;
-    public BlockPosition blockPosition;
-    public BlockFace blockFace;
+    public Status status = Status.SWAP_ITEM_HAND;
+    public BlockPosition blockPosition = new BlockPosition(0,0,0);
+    public BlockFace blockFace = BlockFace.TOP;
 
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.status = Status.values()[reader.readVarInt()];
         this.blockPosition = reader.readBlockPosition();
         this.blockFace = BlockFace.values()[reader.readByte()];
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(status.ordinal());
+        writer.writeBlockPosition(blockPosition);
+        writer.writeByte((byte) blockFace.ordinal());
     }
 
     public enum Status {

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientPlayerPacket extends ClientPlayPacket {
@@ -11,5 +12,10 @@ public class ClientPlayerPacket extends ClientPlayPacket {
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.onGround = reader.readBoolean();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeBoolean(onGround);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerPositionAndRotationPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerPositionAndRotationPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientPlayerPositionAndRotationPacket extends ClientPlayPacket {
@@ -20,5 +21,17 @@ public class ClientPlayerPositionAndRotationPacket extends ClientPlayPacket {
         this.pitch = reader.readFloat();
 
         this.onGround = reader.readBoolean();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeDouble(x);
+        writer.writeDouble(y);
+        writer.writeDouble(z);
+
+        writer.writeFloat(yaw);
+        writer.writeFloat(pitch);
+
+        writer.writeBoolean(onGround);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerPositionPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerPositionPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientPlayerPositionPacket extends ClientPlayPacket {
@@ -16,5 +17,14 @@ public class ClientPlayerPositionPacket extends ClientPlayPacket {
         this.z = reader.readDouble();
 
         this.onGround = reader.readBoolean();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeDouble(x);
+        writer.writeDouble(y);
+        writer.writeDouble(z);
+
+        writer.writeBoolean(onGround);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerRotationPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerRotationPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientPlayerRotationPacket extends ClientPlayPacket {
@@ -14,5 +15,12 @@ public class ClientPlayerRotationPacket extends ClientPlayPacket {
         this.yaw = reader.readFloat();
         this.pitch = reader.readFloat();
         this.onGround = reader.readBoolean();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeFloat(yaw);
+        writer.writeFloat(pitch);
+        writer.writeBoolean(onGround);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPluginMessagePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPluginMessagePacket.java
@@ -2,16 +2,25 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientPluginMessagePacket extends ClientPlayPacket {
 
-    public String channel;
-    public byte[] data;
+    public String channel = "";
+    public byte[] data = new byte[0];
 
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.channel = reader.readSizedString(256);
-        this.data = reader.getRemainingBytes();
+        this.data = reader.readRemainingBytes();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        if(channel.length() > 256)
+            throw new IllegalArgumentException("Channel cannot be more than 256 characters long");
+        writer.writeSizedString(channel);
+        writer.writeBytes(data);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientQueryBlockNbtPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientQueryBlockNbtPacket.java
@@ -3,16 +3,23 @@ package net.minestom.server.network.packet.client.play;
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.BlockPosition;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientQueryBlockNbtPacket extends ClientPlayPacket {
 
     public int transactionId;
-    public BlockPosition blockPosition;
+    public BlockPosition blockPosition = new BlockPosition(0,0,0);
 
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.transactionId = reader.readVarInt();
         this.blockPosition = reader.readBlockPosition();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(transactionId);
+        writer.writeBlockPosition(blockPosition);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientQueryEntityNbtPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientQueryEntityNbtPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientQueryEntityNbtPacket extends ClientPlayPacket {
@@ -13,5 +14,11 @@ public class ClientQueryEntityNbtPacket extends ClientPlayPacket {
     public void read(@NotNull BinaryReader reader) {
         this.transactionId = reader.readVarInt();
         this.entityId = reader.readVarInt();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(transactionId);
+        writer.writeVarInt(entityId);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientRecipeBookData.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientRecipeBookData.java
@@ -2,13 +2,14 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientRecipeBookData extends ClientPlayPacket {
 
     public int type;
 
-    public String recipeId;
+    public String recipeId = "";
 
     public boolean craftingRecipeBookOpen;
     public boolean craftingRecipeFilterActive;
@@ -36,6 +37,30 @@ public class ClientRecipeBookData extends ClientPlayPacket {
                 this.blastingRecipeFilterActive = reader.readBoolean();
                 this.smokingRecipeBookOpen = reader.readBoolean();
                 this.smokingRecipeFilterActive = reader.readBoolean();
+                break;
+        }
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(type);
+
+        switch (type) {
+            case 0:
+                if(recipeId.length() > 256)
+                    throw new IllegalArgumentException("recipeId must be less than 256 bytes");
+                writer.writeSizedString(recipeId);
+                break;
+
+            case 1:
+                writer.writeBoolean(this.craftingRecipeBookOpen);
+                writer.writeBoolean(this.craftingRecipeFilterActive);
+                writer.writeBoolean(this.smeltingRecipeBookOpen);
+                writer.writeBoolean(this.smeltingRecipeFilterActive);
+                writer.writeBoolean(this.blastingRecipeBookOpen);
+                writer.writeBoolean(this.blastingRecipeFilterActive);
+                writer.writeBoolean(this.smokingRecipeBookOpen);
+                writer.writeBoolean(this.smokingRecipeFilterActive);
                 break;
         }
     }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientResourcePackStatusPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientResourcePackStatusPacket.java
@@ -3,15 +3,20 @@ package net.minestom.server.network.packet.client.play;
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.resourcepack.ResourcePackStatus;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientResourcePackStatusPacket extends ClientPlayPacket {
 
-    public ResourcePackStatus result;
+    public ResourcePackStatus result = ResourcePackStatus.SUCCESS;
 
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.result = ResourcePackStatus.values()[reader.readVarInt()];
     }
 
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(result.ordinal());
+    }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientSelectTradePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientSelectTradePacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientSelectTradePacket extends ClientPlayPacket {
@@ -11,5 +12,10 @@ public class ClientSelectTradePacket extends ClientPlayPacket {
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.selectedSlot = reader.readVarInt();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(selectedSlot);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientSetBeaconEffectPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientSetBeaconEffectPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientSetBeaconEffectPacket extends ClientPlayPacket {
@@ -13,5 +14,11 @@ public class ClientSetBeaconEffectPacket extends ClientPlayPacket {
     public void read(@NotNull BinaryReader reader) {
         this.primaryEffect = reader.readVarInt();
         this.secondaryEffect = reader.readVarInt();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(primaryEffect);
+        writer.writeVarInt(secondaryEffect);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientSettingsPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientSettingsPacket.java
@@ -3,16 +3,17 @@ package net.minestom.server.network.packet.client.play;
 import net.minestom.server.entity.Player;
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientSettingsPacket extends ClientPlayPacket {
 
-    public String locale;
+    public String locale = "";
     public byte viewDistance;
-    public Player.ChatMode chatMode;
+    public Player.ChatMode chatMode = Player.ChatMode.ENABLED;
     public boolean chatColors;
     public byte displayedSkinParts;
-    public Player.MainHand mainHand;
+    public Player.MainHand mainHand = Player.MainHand.RIGHT;
 
     @Override
     public void read(@NotNull BinaryReader reader) {
@@ -22,5 +23,17 @@ public class ClientSettingsPacket extends ClientPlayPacket {
         this.chatColors = reader.readBoolean();
         this.displayedSkinParts = reader.readByte();
         this.mainHand = Player.MainHand.values()[reader.readVarInt()];
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        if(locale.length() > 128)
+            throw new IllegalArgumentException("Locale cannot be longer than 128 characters.");
+        writer.writeSizedString(locale);
+        writer.writeByte(viewDistance);
+        writer.writeVarInt(chatMode.ordinal());
+        writer.writeBoolean(chatColors);
+        writer.writeByte(displayedSkinParts);
+        writer.writeVarInt(mainHand.ordinal());
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientSpectatePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientSpectatePacket.java
@@ -2,16 +2,22 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
 public class ClientSpectatePacket extends ClientPlayPacket {
 
-    public UUID targetUuid;
+    public UUID targetUuid = new UUID(0,0);
 
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.targetUuid = reader.readUuid();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeUuid(targetUuid);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientStatusPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientStatusPacket.java
@@ -2,15 +2,25 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientStatusPacket extends ClientPlayPacket {
 
     public Action action;
 
+    public ClientStatusPacket() {
+        action = Action.REQUEST_STATS;
+    }
+
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.action = Action.values()[reader.readVarInt()];
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(action.ordinal());
     }
 
     public enum Action {

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientSteerBoatPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientSteerBoatPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientSteerBoatPacket extends ClientPlayPacket {
@@ -13,5 +14,11 @@ public class ClientSteerBoatPacket extends ClientPlayPacket {
     public void read(@NotNull BinaryReader reader) {
         this.leftPaddleTurning = reader.readBoolean();
         this.rightPaddleTurning = reader.readBoolean();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeBoolean(leftPaddleTurning);
+        writer.writeBoolean(rightPaddleTurning);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientSteerVehiclePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientSteerVehiclePacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientSteerVehiclePacket extends ClientPlayPacket {
@@ -15,5 +16,12 @@ public class ClientSteerVehiclePacket extends ClientPlayPacket {
         this.sideways = reader.readFloat();
         this.forward = reader.readFloat();
         this.flags = reader.readByte();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeFloat(sideways);
+        writer.writeFloat(forward);
+        writer.writeByte(flags);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientTabCompletePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientTabCompletePacket.java
@@ -2,16 +2,23 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientTabCompletePacket extends ClientPlayPacket {
 
     public int transactionId;
-    public String text;
+    public String text = "";
 
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.transactionId = reader.readVarInt();
         this.text = reader.readSizedString(Short.MAX_VALUE);
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(transactionId);
+        writer.writeSizedString(text);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientTeleportConfirmPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientTeleportConfirmPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientTeleportConfirmPacket extends ClientPlayPacket {
@@ -11,5 +12,10 @@ public class ClientTeleportConfirmPacket extends ClientPlayPacket {
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.teleportId = reader.readVarInt();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(teleportId);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientUpdateCommandBlockMinecartPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientUpdateCommandBlockMinecartPacket.java
@@ -2,12 +2,13 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientUpdateCommandBlockMinecartPacket extends ClientPlayPacket {
 
     public int entityId;
-    public String command;
+    public String command = "";
     public boolean trackOutput;
 
     @Override
@@ -15,5 +16,12 @@ public class ClientUpdateCommandBlockMinecartPacket extends ClientPlayPacket {
         this.entityId = reader.readVarInt();
         this.command = reader.readSizedString(Short.MAX_VALUE);
         this.trackOutput = reader.readBoolean();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(entityId);
+        writer.writeSizedString(command);
+        writer.writeBoolean(trackOutput);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientUpdateCommandBlockPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientUpdateCommandBlockPacket.java
@@ -3,6 +3,7 @@ package net.minestom.server.network.packet.client.play;
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.BlockPosition;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientUpdateCommandBlockPacket extends ClientPlayPacket {
@@ -12,12 +13,26 @@ public class ClientUpdateCommandBlockPacket extends ClientPlayPacket {
     public Mode mode;
     public byte flags;
 
+    public ClientUpdateCommandBlockPacket() {
+        blockPosition = new BlockPosition(0,0,0);
+        command = "";
+        mode = Mode.REDSTONE;
+    }
+
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.blockPosition = reader.readBlockPosition();
         this.command = reader.readSizedString(Short.MAX_VALUE);
         this.mode = Mode.values()[reader.readVarInt()];
         this.flags = reader.readByte();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeBlockPosition(blockPosition);
+        writer.writeSizedString(command);
+        writer.writeVarInt(mode.ordinal());
+        writer.writeByte(flags);
     }
 
     public enum Mode {

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientUpdateSignPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientUpdateSignPacket.java
@@ -3,15 +3,16 @@ package net.minestom.server.network.packet.client.play;
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.BlockPosition;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientUpdateSignPacket extends ClientPlayPacket {
 
-    public BlockPosition blockPosition;
-    public String line1;
-    public String line2;
-    public String line3;
-    public String line4;
+    public BlockPosition blockPosition = new BlockPosition(0,0,0);
+    public String line1 = "";
+    public String line2 = "";
+    public String line3 = "";
+    public String line4 = "";
 
     @Override
     public void read(@NotNull BinaryReader reader) {
@@ -20,6 +21,22 @@ public class ClientUpdateSignPacket extends ClientPlayPacket {
         this.line2 = reader.readSizedString(384);
         this.line3 = reader.readSizedString(384);
         this.line4 = reader.readSizedString(384);
+    }
 
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeBlockPosition(blockPosition);
+        if(line1.length() > 384)
+            throw new IllegalArgumentException("line1 is too long! Signs allow a maximum of 384 characters per line.");
+        if(line2.length() > 384)
+            throw new IllegalArgumentException("line2 is too long! Signs allow a maximum of 384 characters per line.");
+        if(line3.length() > 384)
+            throw new IllegalArgumentException("line3 is too long! Signs allow a maximum of 384 characters per line.");
+        if(line4.length() > 384)
+            throw new IllegalArgumentException("line4 is too long! Signs allow a maximum of 384 characters per line.");
+        writer.writeSizedString(line1);
+        writer.writeSizedString(line2);
+        writer.writeSizedString(line3);
+        writer.writeSizedString(line4);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientUseItemPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientUseItemPacket.java
@@ -3,14 +3,20 @@ package net.minestom.server.network.packet.client.play;
 import net.minestom.server.entity.Player;
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientUseItemPacket extends ClientPlayPacket {
 
-    public Player.Hand hand;
+    public Player.Hand hand = Player.Hand.MAIN;
 
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.hand = Player.Hand.values()[reader.readVarInt()];
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeVarInt(hand.ordinal());
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientVehicleMovePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientVehicleMovePacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientVehicleMovePacket extends ClientPlayPacket {
@@ -17,5 +18,14 @@ public class ClientVehicleMovePacket extends ClientPlayPacket {
 
         this.yaw = reader.readFloat();
         this.pitch = reader.readFloat();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeDouble(x);
+        writer.writeDouble(y);
+        writer.writeDouble(z);
+        writer.writeFloat(yaw);
+        writer.writeFloat(pitch);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientWindowConfirmationPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientWindowConfirmationPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.client.play;
 
 import net.minestom.server.network.packet.client.ClientPlayPacket;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ClientWindowConfirmationPacket extends ClientPlayPacket {
@@ -15,5 +16,12 @@ public class ClientWindowConfirmationPacket extends ClientPlayPacket {
         this.windowId = reader.readByte();
         this.actionNumber = reader.readShort();
         this.accepted = reader.readBoolean();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeByte(windowId);
+        writer.writeShort(actionNumber);
+        writer.writeBoolean(accepted);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/status/LegacyServerListPingPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/status/LegacyServerListPingPacket.java
@@ -3,6 +3,7 @@ package net.minestom.server.network.packet.client.status;
 import net.minestom.server.network.packet.client.ClientPreplayPacket;
 import net.minestom.server.network.player.PlayerConnection;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class LegacyServerListPingPacket implements ClientPreplayPacket {
@@ -17,5 +18,10 @@ public class LegacyServerListPingPacket implements ClientPreplayPacket {
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.payload = reader.readByte();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeByte(payload);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/status/PingPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/status/PingPacket.java
@@ -4,11 +4,14 @@ import net.minestom.server.network.packet.client.ClientPreplayPacket;
 import net.minestom.server.network.packet.server.status.PongPacket;
 import net.minestom.server.network.player.PlayerConnection;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class PingPacket implements ClientPreplayPacket {
 
     private long number;
+
+    public PingPacket() {}
 
     @Override
     public void process(@NotNull PlayerConnection connection) {
@@ -20,5 +23,10 @@ public class PingPacket implements ClientPreplayPacket {
     @Override
     public void read(@NotNull BinaryReader reader) {
         this.number = reader.readLong();
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
+        writer.writeLong(number);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/status/StatusRequestPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/status/StatusRequestPacket.java
@@ -7,6 +7,7 @@ import net.minestom.server.network.player.PlayerConnection;
 import net.minestom.server.ping.ResponseData;
 import net.minestom.server.ping.ResponseDataConsumer;
 import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class StatusRequestPacket implements ClientPreplayPacket {
@@ -35,6 +36,11 @@ public class StatusRequestPacket implements ClientPreplayPacket {
 
     @Override
     public void read(@NotNull BinaryReader reader) {
+        // Empty
+    }
+
+    @Override
+    public void write(@NotNull BinaryWriter writer) {
         // Empty
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/server/ServerPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/ServerPacket.java
@@ -1,21 +1,23 @@
 package net.minestom.server.network.packet.server;
 
 import net.minestom.server.network.player.PlayerConnection;
-import net.minestom.server.utils.binary.BinaryWriter;
+import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.Readable;
 import net.minestom.server.utils.binary.Writeable;
 import org.jetbrains.annotations.NotNull;
+
+import java.nio.CharBuffer;
 
 /**
  * Represents a packet which can be sent to a player using {@link PlayerConnection#sendPacket(ServerPacket)}.
  */
-public interface ServerPacket extends Writeable {
+public interface ServerPacket extends Readable, Writeable {
 
-    /**
-     * Writes the packet to a {@link BinaryWriter}.
-     *
-     * @param writer the writer to write the packet to.
-     */
-    void write(@NotNull BinaryWriter writer);
+    @Override
+    default void read(@NotNull BinaryReader reader) {
+        // FIXME: remove when all packets are written and read properly
+        throw new UnsupportedOperationException("WIP: This packet is not set up to be read from Minestom code at the moment.");
+    }
 
     /**
      * Gets the id of this packet.

--- a/src/main/java/net/minestom/server/network/packet/server/handshake/ResponsePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/handshake/ResponsePacket.java
@@ -1,16 +1,22 @@
 package net.minestom.server.network.packet.server.handshake;
 
 import net.minestom.server.network.packet.server.ServerPacket;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ResponsePacket implements ServerPacket {
 
-    public String jsonResponse;
+    public String jsonResponse = "";
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeSizedString(jsonResponse);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        jsonResponse = reader.readSizedString(Integer.MAX_VALUE);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/login/EncryptionRequestPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/login/EncryptionRequestPacket.java
@@ -5,6 +5,7 @@ import net.minestom.server.extras.MojangAuth;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.network.player.NettyPlayerConnection;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -20,12 +21,28 @@ public class EncryptionRequestPacket implements ServerPacket {
         connection.setNonce(nonce);
     }
 
+    /**
+     * Only for testing purposes. DO NOT USE
+     */
+    private EncryptionRequestPacket() {
+        MojangAuth.init();
+        publicKey = new byte[0];
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeSizedString("");
         final byte[] publicKey = MojangAuth.getKeyPair().getPublic().getEncoded();
         ByteArrayData.encodeByteArray(writer, publicKey);
         ByteArrayData.encodeByteArray(writer, nonce);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        reader.readSizedString(Integer.MAX_VALUE); // server id, apparently empty
+
+        publicKey = ByteArrayData.decodeByteArray(reader);
+        nonce = ByteArrayData.decodeByteArray(reader);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/login/LoginDisconnectPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/login/LoginDisconnectPacket.java
@@ -4,6 +4,7 @@ import net.kyori.adventure.text.Component;
 import net.minestom.server.chat.JsonMessage;
 import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -13,6 +14,10 @@ import java.util.function.UnaryOperator;
 
 public class LoginDisconnectPacket implements ComponentHoldingServerPacket {
     public Component kickMessage;
+
+    private LoginDisconnectPacket() {
+        this(Component.text("This constructor should not be used, tell your server devs."));
+    }
 
     public LoginDisconnectPacket(@NotNull Component kickMessage) {
         this.kickMessage = kickMessage;
@@ -29,6 +34,11 @@ public class LoginDisconnectPacket implements ComponentHoldingServerPacket {
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeComponent(kickMessage);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        kickMessage = reader.readComponent(Integer.MAX_VALUE);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/login/LoginPluginRequestPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/login/LoginPluginRequestPacket.java
@@ -2,13 +2,14 @@ package net.minestom.server.network.packet.server.login;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class LoginPluginRequestPacket implements ServerPacket {
 
     public int messageId;
-    public String channel;
+    public String channel = "none";
     public byte[] data;
 
     @Override
@@ -18,6 +19,13 @@ public class LoginPluginRequestPacket implements ServerPacket {
         if (data != null && data.length > 0) {
             writer.writeBytes(data);
         }
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        messageId = reader.readVarInt();
+        channel = reader.readSizedString(Integer.MAX_VALUE);
+        data = reader.readRemainingBytes();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/login/LoginSuccessPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/login/LoginSuccessPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.login;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,6 +13,13 @@ public class LoginSuccessPacket implements ServerPacket {
     public UUID uuid;
     public String username;
 
+    /**
+     * DO NOT USE.
+     */
+    private LoginSuccessPacket() {
+        this(new UUID(0,0), "");
+    }
+
     public LoginSuccessPacket(@NotNull UUID uuid, @NotNull String username) {
         this.uuid = uuid;
         this.username = username;
@@ -21,6 +29,12 @@ public class LoginSuccessPacket implements ServerPacket {
     public void write(@NotNull BinaryWriter writer) {
         writer.writeUuid(uuid);
         writer.writeSizedString(username);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        uuid = reader.readUuid();
+        username = reader.readSizedString(Integer.MAX_VALUE);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/login/SetCompressionPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/login/SetCompressionPacket.java
@@ -2,12 +2,20 @@ package net.minestom.server.network.packet.server.login;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class SetCompressionPacket implements ServerPacket {
 
     public int threshold;
+
+    /**
+     * DO NOT USE
+     */
+    private SetCompressionPacket() {
+        threshold = 256;
+    }
 
     public SetCompressionPacket(int threshold) {
         this.threshold = threshold;
@@ -16,6 +24,11 @@ public class SetCompressionPacket implements ServerPacket {
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(threshold);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        threshold = reader.readVarInt();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/AcknowledgePlayerDiggingPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/AcknowledgePlayerDiggingPacket.java
@@ -4,15 +4,18 @@ import net.minestom.server.network.packet.client.play.ClientPlayerDiggingPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.BlockPosition;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class AcknowledgePlayerDiggingPacket implements ServerPacket {
 
-    public BlockPosition blockPosition;
+    public BlockPosition blockPosition = new BlockPosition(0,0,0);
     public int blockStateId;
-    public ClientPlayerDiggingPacket.Status status;
+    public ClientPlayerDiggingPacket.Status status = ClientPlayerDiggingPacket.Status.STARTED_DIGGING;
     public boolean successful;
+
+    public AcknowledgePlayerDiggingPacket() {}
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -20,6 +23,14 @@ public class AcknowledgePlayerDiggingPacket implements ServerPacket {
         writer.writeVarInt(blockStateId);
         writer.writeVarInt(status.ordinal());
         writer.writeBoolean(successful);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        blockPosition = reader.readBlockPosition();
+        blockStateId = reader.readVarInt();
+        status = ClientPlayerDiggingPacket.Status.values()[reader.readVarInt()];
+        successful = reader.readBoolean();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/AdvancementsPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/AdvancementsPacket.java
@@ -2,11 +2,15 @@ package net.minestom.server.network.packet.server.play;
 
 import net.kyori.adventure.text.Component;
 import net.minestom.server.advancements.FrameType;
+import net.minestom.server.chat.ColoredText;
+import net.minestom.server.chat.JsonMessage;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
+import net.minestom.server.utils.binary.Readable;
 import net.minestom.server.utils.binary.Writeable;
 import org.jetbrains.annotations.NotNull;
 
@@ -19,9 +23,11 @@ import java.util.function.UnaryOperator;
 public class AdvancementsPacket implements ComponentHoldingServerPacket {
 
     public boolean resetAdvancements;
-    public AdvancementMapping[] advancementMappings;
-    public String[] identifiersToRemove;
-    public ProgressMapping[] progressMappings;
+    public AdvancementMapping[] advancementMappings = new AdvancementMapping[0];
+    public String[] identifiersToRemove = new String[0];
+    public ProgressMapping[] progressMappings = new ProgressMapping[0];
+
+    public AdvancementsPacket() {}
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -36,6 +42,27 @@ public class AdvancementsPacket implements ComponentHoldingServerPacket {
         writer.writeVarInt(progressMappings.length);
         for (ProgressMapping progressMapping : progressMappings) {
             progressMapping.write(writer);
+        }
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        resetAdvancements = reader.readBoolean();
+
+        int mappingCount = reader.readVarInt();
+        advancementMappings = new AdvancementMapping[mappingCount];
+        for (int i = 0; i < mappingCount; i++) {
+            advancementMappings[i] = new AdvancementMapping();
+            advancementMappings[i].read(reader);
+        }
+
+        identifiersToRemove = reader.readSizedStringArray(Integer.MAX_VALUE);
+
+        int progressCount = reader.readVarInt();
+        progressMappings = new ProgressMapping[progressCount];
+        for (int i = 0; i < progressCount; i++) {
+            progressMappings[i] = new ProgressMapping();
+            progressMappings[i].read(reader);
         }
     }
 
@@ -73,7 +100,7 @@ public class AdvancementsPacket implements ComponentHoldingServerPacket {
     /**
      * AdvancementMapping maps the namespaced ID to the Advancement.
      */
-    public static class AdvancementMapping implements Writeable {
+    public static class AdvancementMapping implements Writeable, Readable {
 
         public String key;
         public Advancement value;
@@ -84,13 +111,19 @@ public class AdvancementsPacket implements ComponentHoldingServerPacket {
             value.write(writer);
         }
 
+        @Override
+        public void read(@NotNull BinaryReader reader) {
+            key = reader.readSizedString(Integer.MAX_VALUE);
+            value = new Advancement();
+            value.read(reader);
+        }
     }
 
-    public static class Advancement implements Writeable {
+    public static class Advancement implements Writeable, Readable {
         public String parentIdentifier;
         public DisplayData displayData;
-        public String[] criterions;
-        public Requirement[] requirements;
+        public String[] criterions = new String[0];
+        public Requirement[] requirements = new Requirement[0];
 
         @Override
         public void write(@NotNull BinaryWriter writer) {
@@ -114,15 +147,42 @@ public class AdvancementsPacket implements ComponentHoldingServerPacket {
                 requirement.write(writer);
             }
         }
+
+        @Override
+        public void read(@NotNull BinaryReader reader) {
+            boolean hasParent = reader.readBoolean();
+            if(hasParent) {
+                parentIdentifier = reader.readSizedString(Integer.MAX_VALUE);
+            } else {
+                parentIdentifier = null;
+            }
+
+            boolean hasDisplay = reader.readBoolean();
+            if(hasDisplay) {
+                displayData = new DisplayData();
+                displayData.read(reader);
+            } else {
+                displayData = null;
+            }
+
+            criterions = reader.readSizedStringArray(Integer.MAX_VALUE);
+
+            int requirementCount = reader.readVarInt();
+            requirements = new Requirement[requirementCount];
+            for (int i = 0; i < requirementCount; i++) {
+                requirements[i] = new Requirement();
+                requirements[i].read(reader);
+            }
+        }
     }
 
-    public static class DisplayData implements Writeable {
-        public Component title; // Only text
-        public Component description; // Only text
-        public ItemStack icon;
-        public FrameType frameType;
+    public static class DisplayData implements Writeable, Readable {
+        public Component title = Component.empty(); // Only text
+        public Component description = Component.empty(); // Only text
+        public ItemStack icon = ItemStack.getAirItem();
+        public FrameType frameType = FrameType.TASK;
         public int flags;
-        public String backgroundTexture;
+        public String backgroundTexture = "";
         public float x;
         public float y;
 
@@ -140,34 +200,58 @@ public class AdvancementsPacket implements ComponentHoldingServerPacket {
             writer.writeFloat(y);
         }
 
-    }
-
-    public static class Requirement implements Writeable {
-
-        public String[] requirements;
-
         @Override
-        public void write(@NotNull BinaryWriter writer) {
-            writer.writeVarInt(requirements.length);
-            for (String requirement : requirements) {
-                writer.writeSizedString(requirement);
+        public void read(@NotNull BinaryReader reader) {
+            title = reader.readComponent(Integer.MAX_VALUE);
+            description = reader.readComponent(Integer.MAX_VALUE);
+            icon = reader.readItemStack();
+            frameType = FrameType.values()[reader.readVarInt()];
+            flags = reader.readInt();
+            if((flags & 0x1) != 0) {
+                backgroundTexture = reader.readSizedString(Integer.MAX_VALUE);
+            } else {
+                backgroundTexture = null;
             }
+            x = reader.readFloat();
+            y = reader.readFloat();
         }
     }
 
-    public static class ProgressMapping implements Writeable {
-        public String key;
-        public AdvancementProgress value;
+    public static class Requirement implements Writeable, Readable {
+
+        public String[] requirements = new String[0];
+
+        @Override
+        public void write(@NotNull BinaryWriter writer) {
+            writer.writeStringArray(requirements);
+        }
+
+        @Override
+        public void read(@NotNull BinaryReader reader) {
+            requirements = reader.readSizedStringArray(Integer.MAX_VALUE);
+        }
+    }
+
+    public static class ProgressMapping implements Writeable, Readable {
+        public String key = "";
+        public AdvancementProgress value = new AdvancementProgress();
 
         @Override
         public void write(@NotNull BinaryWriter writer) {
             writer.writeSizedString(key);
             value.write(writer);
         }
+
+        @Override
+        public void read(@NotNull BinaryReader reader) {
+            key = reader.readSizedString(Integer.MAX_VALUE);
+            value = new AdvancementProgress();
+            value.read(reader);
+        }
     }
 
-    public static class AdvancementProgress implements Writeable {
-        public Criteria[] criteria;
+    public static class AdvancementProgress implements Writeable, Readable {
+        public Criteria[] criteria = new Criteria[0];
 
         @Override
         public void write(@NotNull BinaryWriter writer) {
@@ -176,11 +260,21 @@ public class AdvancementsPacket implements ComponentHoldingServerPacket {
                 criterion.write(writer);
             }
         }
+
+        @Override
+        public void read(@NotNull BinaryReader reader) {
+            int count = reader.readVarInt();
+            criteria = new Criteria[count];
+            for (int i = 0; i < count; i++) {
+                criteria[i] = new Criteria();
+                criteria[i].read(reader);
+            }
+        }
     }
 
-    public static class Criteria implements Writeable {
-        public String criterionIdentifier;
-        public CriterionProgress criterionProgress;
+    public static class Criteria implements Writeable, Readable {
+        public String criterionIdentifier = "";
+        public CriterionProgress criterionProgress = new CriterionProgress();
 
         @Override
         public void write(@NotNull BinaryWriter writer) {
@@ -188,19 +282,32 @@ public class AdvancementsPacket implements ComponentHoldingServerPacket {
             criterionProgress.write(writer);
         }
 
+        @Override
+        public void read(@NotNull BinaryReader reader) {
+            criterionIdentifier = reader.readSizedString(Integer.MAX_VALUE);
+            criterionProgress = new CriterionProgress();
+            criterionProgress.read(reader);
+        }
     }
 
-    public static class CriterionProgress implements Writeable {
+    public static class CriterionProgress implements Writeable, Readable {
         public boolean achieved;
         public long dateOfAchieving;
 
         @Override
         public void write(@NotNull BinaryWriter writer) {
             writer.writeBoolean(achieved);
-            if (dateOfAchieving != 0)
+            if (achieved)
                 writer.writeLong(dateOfAchieving);
         }
 
+        @Override
+        public void read(@NotNull BinaryReader reader) {
+            achieved = reader.readBoolean();
+            if(achieved) {
+                dateOfAchieving = reader.readLong();
+            }
+        }
     }
 
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/AttachEntityPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/AttachEntityPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,10 +11,18 @@ public class AttachEntityPacket implements ServerPacket {
     public int attachedEntityId;
     public int holdingEntityId; // Or -1 to detach
 
+    public AttachEntityPacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeInt(attachedEntityId);
         writer.writeInt(holdingEntityId);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        attachedEntityId = reader.readInt();
+        holdingEntityId = reader.readInt();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/BlockActionPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/BlockActionPacket.java
@@ -3,6 +3,7 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.BlockPosition;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -13,12 +14,24 @@ public class BlockActionPacket implements ServerPacket {
     public byte actionParam;
     public int blockId;
 
+    public BlockActionPacket() {
+        blockPosition = new BlockPosition(0,0,0);
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeBlockPosition(blockPosition);
         writer.writeByte(actionId);
         writer.writeByte(actionParam);
         writer.writeVarInt(blockId);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        blockPosition = reader.readBlockPosition();
+        actionId = reader.readByte();
+        actionParam = reader.readByte();
+        blockId = reader.readVarInt();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/BlockBreakAnimationPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/BlockBreakAnimationPacket.java
@@ -3,6 +3,7 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.BlockPosition;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -13,7 +14,7 @@ public class BlockBreakAnimationPacket implements ServerPacket {
     public byte destroyStage;
 
     public BlockBreakAnimationPacket() {
-
+        blockPosition = new BlockPosition(0,0,0);
     }
 
     public BlockBreakAnimationPacket(int entityId, BlockPosition blockPosition, byte destroyStage) {
@@ -27,6 +28,13 @@ public class BlockBreakAnimationPacket implements ServerPacket {
         writer.writeVarInt(entityId);
         writer.writeBlockPosition(blockPosition);
         writer.writeByte(destroyStage);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readVarInt();
+        blockPosition = reader.readBlockPosition();
+        destroyStage = reader.readByte();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/BlockChangePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/BlockChangePacket.java
@@ -3,6 +3,7 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.BlockPosition;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,10 +12,20 @@ public class BlockChangePacket implements ServerPacket {
     public BlockPosition blockPosition;
     public int blockStateId;
 
+    public BlockChangePacket() {
+        blockPosition = new BlockPosition(0,0,0);
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeBlockPosition(blockPosition);
         writer.writeVarInt(blockStateId);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        blockPosition = reader.readBlockPosition();
+        blockStateId = reader.readVarInt();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/BlockEntityDataPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/BlockEntityDataPacket.java
@@ -1,17 +1,27 @@
 package net.minestom.server.network.packet.server.play;
 
+import net.minestom.server.MinecraftServer;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.BlockPosition;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
+import org.jglrxavpok.hephaistos.nbt.NBT;
 import org.jglrxavpok.hephaistos.nbt.NBTCompound;
+import org.jglrxavpok.hephaistos.nbt.NBTException;
+
+import java.io.IOException;
 
 public class BlockEntityDataPacket implements ServerPacket {
 
     public BlockPosition blockPosition;
     public byte action;
     public NBTCompound nbtCompound;
+
+    public BlockEntityDataPacket() {
+        blockPosition = new BlockPosition(0,0,0);
+    }
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -22,6 +32,20 @@ public class BlockEntityDataPacket implements ServerPacket {
         } else {
             // TAG_End
             writer.writeByte((byte) 0x00);
+        }
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        blockPosition = reader.readBlockPosition();;
+        action = reader.readByte();
+        try {
+            NBT tag = reader.readTag();
+            if(tag instanceof NBTCompound) {
+                nbtCompound = (NBTCompound) tag;
+            }
+        } catch (IOException | NBTException e) {
+            MinecraftServer.getExceptionManager().handleException(e);
         }
     }
 

--- a/src/main/java/net/minestom/server/network/packet/server/play/BossBarPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/BossBarPacket.java
@@ -6,6 +6,7 @@ import net.minestom.server.adventure.AdventurePacketConvertor;
 import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -16,14 +17,16 @@ import java.util.function.UnaryOperator;
 
 public class BossBarPacket implements ComponentHoldingServerPacket {
 
-    public UUID uuid;
-    public Action action;
+    public UUID uuid = new UUID(0, 0);
+    public Action action = Action.ADD;
 
-    public Component title; // Only text
+    public Component title = Component.empty(); // Only text
     public float health;
-    public BossBar.Color color;
-    public BossBar.Overlay overlay;
+    public BossBar.Color color = BossBar.Color.BLUE;
+    public BossBar.Overlay overlay = BossBar.Overlay.PROGRESS;
     public byte flags;
+
+    public BossBarPacket() {}
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -53,6 +56,38 @@ public class BossBarPacket implements ComponentHoldingServerPacket {
                 break;
             case UPDATE_FLAGS:
                 writer.writeByte(flags);
+                break;
+        }
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        uuid = reader.readUuid();
+        action = Action.values()[reader.readVarInt()];
+
+        switch (action) {
+            case ADD:
+                title = reader.readComponent(Integer.MAX_VALUE);
+                health = reader.readFloat();
+                color = BossBar.Color.values()[reader.readVarInt()];
+                overlay = BossBar.Overlay.values()[reader.readVarInt()];
+                flags = reader.readByte();
+                break;
+            case REMOVE:
+
+                break;
+            case UPDATE_HEALTH:
+                health = reader.readFloat();
+                break;
+            case UPDATE_TITLE:
+                title = reader.readComponent(Integer.MAX_VALUE);
+                break;
+            case UPDATE_STYLE:
+                color = BossBar.Color.values()[reader.readVarInt()];
+                overlay = BossBar.Overlay.values()[reader.readVarInt()];
+                break;
+            case UPDATE_FLAGS:
+                flags = reader.readByte();
                 break;
         }
     }

--- a/src/main/java/net/minestom/server/network/packet/server/play/CameraPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/CameraPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -9,9 +10,16 @@ public class CameraPacket implements ServerPacket {
 
     public int cameraId;
 
+    public CameraPacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(cameraId);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        cameraId = reader.readVarInt();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/ChangeGameStatePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/ChangeGameStatePacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,10 +11,20 @@ public class ChangeGameStatePacket implements ServerPacket {
     public Reason reason;
     public float value;
 
+    public ChangeGameStatePacket() {
+        reason = Reason.NO_RESPAWN_BLOCK;
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeByte((byte) reason.ordinal());
         writer.writeFloat(value);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        reason = Reason.values()[reader.readByte()];
+        value = reader.readFloat();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/ChatMessagePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/ChatMessagePacket.java
@@ -5,6 +5,7 @@ import net.kyori.adventure.text.Component;
 import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -24,6 +25,10 @@ public class ChatMessagePacket implements ComponentHoldingServerPacket {
     public Position position;
     public UUID uuid;
 
+    public ChatMessagePacket() {
+        this(Component.empty(), Position.CHAT);
+    }
+
     public ChatMessagePacket(Component message, Position position, UUID uuid) {
         this.message = message;
         this.position = position;
@@ -39,6 +44,13 @@ public class ChatMessagePacket implements ComponentHoldingServerPacket {
         writer.writeComponent(message);
         writer.writeByte((byte) position.ordinal());
         writer.writeUuid(uuid);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        message = reader.readComponent(Integer.MAX_VALUE);
+        position = Position.values()[reader.readByte()];
+        uuid = reader.readUuid();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/ChunkDataPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/ChunkDataPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import io.netty.buffer.ByteBuf;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.data.Data;
@@ -14,6 +15,7 @@ import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.BlockPosition;
 import net.minestom.server.utils.BufUtils;
 import net.minestom.server.utils.Utils;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import net.minestom.server.utils.cache.CacheablePacket;
 import net.minestom.server.utils.cache.TemporaryCache;
@@ -22,8 +24,11 @@ import net.minestom.server.utils.chunk.ChunkUtils;
 import net.minestom.server.world.biomes.Biome;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jglrxavpok.hephaistos.nbt.NBT;
 import org.jglrxavpok.hephaistos.nbt.NBTCompound;
+import org.jglrxavpok.hephaistos.nbt.NBTException;
 
+import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -52,6 +57,10 @@ public class ChunkDataPacket implements ServerPacket, CacheablePacket {
     // Cacheable data
     private final UUID identifier;
     private final long timestamp;
+
+    private ChunkDataPacket() {
+        this(new UUID(0, 0), 0);
+    }
 
     public ChunkDataPacket(@Nullable UUID identifier, long timestamp) {
         this.identifier = identifier;
@@ -82,6 +91,7 @@ public class ChunkDataPacket implements ServerPacket, CacheablePacket {
 
         writer.writeVarInt(mask);
 
+        // TODO: don't hardcode heightmaps
         // Heightmap
         int[] motionBlocking = new int[16 * 16];
         int[] worldSurface = new int[16 * 16];
@@ -114,25 +124,67 @@ public class ChunkDataPacket implements ServerPacket, CacheablePacket {
         blocks.release();
 
         // Block entities
-        writer.writeVarInt(blockEntities.size());
+        if(blockEntities == null) {
+            writer.writeVarInt(0);
+        } else {
+            writer.writeVarInt(blockEntities.size());
 
-        for (int index : blockEntities) {
-            final BlockPosition blockPosition = ChunkUtils.getBlockPosition(index, chunkX, chunkZ);
+            for (int index : blockEntities) {
+                final BlockPosition blockPosition = ChunkUtils.getBlockPosition(index, chunkX, chunkZ);
 
-            NBTCompound nbt = new NBTCompound()
-                    .setInt("x", blockPosition.getX())
-                    .setInt("y", blockPosition.getY())
-                    .setInt("z", blockPosition.getZ());
+                NBTCompound nbt = new NBTCompound()
+                        .setInt("x", blockPosition.getX())
+                        .setInt("y", blockPosition.getY())
+                        .setInt("z", blockPosition.getZ());
 
-            if (customBlockPaletteStorage != null) {
-                final short customBlockId = customBlockPaletteStorage.getBlockAt(blockPosition.getX(), blockPosition.getY(), blockPosition.getZ());
-                final CustomBlock customBlock = BLOCK_MANAGER.getCustomBlock(customBlockId);
-                if (customBlock != null) {
-                    final Data data = blocksData.get(index);
-                    customBlock.writeBlockEntity(blockPosition, data, nbt);
+                if (customBlockPaletteStorage != null) {
+                    final short customBlockId = customBlockPaletteStorage.getBlockAt(blockPosition.getX(), blockPosition.getY(), blockPosition.getZ());
+                    final CustomBlock customBlock = BLOCK_MANAGER.getCustomBlock(customBlockId);
+                    if (customBlock != null) {
+                        final Data data = blocksData.get(index);
+                        customBlock.writeBlockEntity(blockPosition, data, nbt);
+                    }
+                }
+                writer.writeNBT("", nbt);
+            }
+        }
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        chunkX = reader.readInt();
+        chunkZ = reader.readInt();
+        fullChunk = reader.readBoolean();
+
+        int mask = reader.readVarInt();
+        try {
+            // TODO: Use heightmaps
+            // unused at the moment
+            NBT heightmaps = reader.readTag();
+
+            if(fullChunk) {
+                int[] biomesIds = reader.readVarIntArray();
+                biomes = new Biome[biomesIds.length];
+                for (int i = 0; i < biomesIds.length; i++) {
+                    biomes[i] = MinecraftServer.getBiomeManager().getById(biomesIds[i]);
                 }
             }
-            writer.writeNBT("", nbt);
+
+            int blockArrayLength = reader.readVarInt();
+            byte[] blockArray = reader.readBytes(blockArrayLength);
+            // TODO: read blocks
+
+            int blockEntityCount = reader.readVarInt();
+            blockEntities = new IntOpenHashSet();
+            for (int i = 0; i < blockEntityCount; i++) {
+                NBTCompound tag = (NBTCompound) reader.readTag();
+
+            }
+
+            // TODO
+        } catch (IOException | NBTException e) {
+            MinecraftServer.getExceptionManager().handleException(e);
+            // TODO: should we throw to avoid an invalid packet?
         }
     }
 

--- a/src/main/java/net/minestom/server/network/packet/server/play/ChunkDataPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/ChunkDataPacket.java
@@ -172,7 +172,6 @@ public class ChunkDataPacket implements ServerPacket, CacheablePacket {
             }
 
             // Data
-            // TODO don't hardcode bitsPerEntry (use packet field instead)
             this.paletteStorage = new PaletteStorage(8, 1);
             int blockArrayLength = reader.readVarInt();
             for (int section = 0; section < CHUNK_SECTION_COUNT; section++) {
@@ -181,6 +180,13 @@ public class ChunkDataPacket implements ServerPacket, CacheablePacket {
                     continue;
                 short blockCount = reader.readShort();
                 byte bitsPerEntry = reader.readByte();
+
+                // Resize palette if necessary
+                if (bitsPerEntry > paletteStorage.getSections()[section].getBitsPerEntry()) {
+                    paletteStorage.getSections()[section].resize(bitsPerEntry);
+                }
+
+                // Retrieve palette values
                 if (bitsPerEntry < 9) {
                     int paletteSize = reader.readVarInt();
                     for (int i = 0; i < paletteSize; i++) {
@@ -190,8 +196,8 @@ public class ChunkDataPacket implements ServerPacket, CacheablePacket {
                     }
                 }
 
+                // Read blocks
                 int dataLength = reader.readVarInt();
-                paletteStorage.getSections()[section].resize(bitsPerEntry);
                 long[] data = paletteStorage.getSections()[section].getBlocks();
                 for (int i = 0; i < dataLength; i++) {
                     data[i] = reader.readLong();

--- a/src/main/java/net/minestom/server/network/packet/server/play/ChunkDataPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/ChunkDataPacket.java
@@ -48,7 +48,7 @@ public class ChunkDataPacket implements ServerPacket, CacheablePacket {
     public IntSet blockEntities;
     public Int2ObjectMap<Data> blocksData;
 
-    public int[] sections;
+    public int[] sections = new int[0];
 
     private static final byte CHUNK_SECTION_COUNT = 16;
     private static final int MAX_BITS_PER_ENTRY = 16;
@@ -57,6 +57,17 @@ public class ChunkDataPacket implements ServerPacket, CacheablePacket {
     // Cacheable data
     private final UUID identifier;
     private final long timestamp;
+
+    /**
+     * Block entities NBT, as read from raw packet data.
+     * Only filled by #read, and unused at the moment.
+     */
+    public NBTCompound[] blockEntitiesNBT = new NBTCompound[0];
+    /**
+     * Heightmaps NBT, as read from raw packet data.
+     * Only filled by #read, and unused at the moment.
+     */
+    public NBTCompound heightmapsNBT;
 
     private ChunkDataPacket() {
         this(new UUID(0, 0), 0);
@@ -160,7 +171,7 @@ public class ChunkDataPacket implements ServerPacket, CacheablePacket {
         try {
             // TODO: Use heightmaps
             // unused at the moment
-            NBT heightmaps = reader.readTag();
+            heightmapsNBT = (NBTCompound) reader.readTag();
 
             // Biomes
             if (fullChunk) {
@@ -207,9 +218,10 @@ public class ChunkDataPacket implements ServerPacket, CacheablePacket {
             // Block entities
             int blockEntityCount = reader.readVarInt();
             blockEntities = new IntOpenHashSet();
+            blockEntitiesNBT = new NBTCompound[blockEntityCount];
             for (int i = 0; i < blockEntityCount; i++) {
                 NBTCompound tag = (NBTCompound) reader.readTag();
-                // TODO
+                blockEntitiesNBT[i] = tag;
             }
         } catch (IOException | NBTException e) {
             MinecraftServer.getExceptionManager().handleException(e);

--- a/src/main/java/net/minestom/server/network/packet/server/play/CloseWindowPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/CloseWindowPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -9,9 +10,16 @@ public class CloseWindowPacket implements ServerPacket {
 
     public byte windowId;
 
+    public CloseWindowPacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeByte(windowId);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        windowId = reader.readByte();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/CollectItemPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/CollectItemPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,11 +12,20 @@ public class CollectItemPacket implements ServerPacket {
     public int collectorEntityId;
     public int pickupItemCount;
 
+    public CollectItemPacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(collectedEntityId);
         writer.writeVarInt(collectorEntityId);
         writer.writeVarInt(pickupItemCount);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        collectedEntityId = reader.readVarInt();
+        collectorEntityId = reader.readVarInt();
+        pickupItemCount = reader.readVarInt();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/CombatEventPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/CombatEventPacket.java
@@ -6,6 +6,7 @@ import net.minestom.server.entity.Player;
 import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -19,7 +20,7 @@ import java.util.function.UnaryOperator;
  */
 public class CombatEventPacket implements ComponentHoldingServerPacket {
 
-    private EventType type;
+    private EventType type = EventType.ENTER_COMBAT;
     private int duration;
     private int opponent;
     private int playerID;
@@ -68,6 +69,27 @@ public class CombatEventPacket implements ComponentHoldingServerPacket {
                 writer.writeVarInt(playerID);
                 writer.writeInt(opponent);
                 writer.writeComponent(deathMessage);
+                break;
+        }
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        type = EventType.values()[reader.readVarInt()];
+        switch (type) {
+            case ENTER_COMBAT:
+                // nothing to add
+                break;
+
+            case END_COMBAT:
+                duration = reader.readVarInt();
+                opponent = reader.readInt();
+                break;
+
+            case DEATH:
+                playerID = reader.readVarInt();
+                opponent = reader.readInt();
+                deathMessage = reader.readComponent(Integer.MAX_VALUE);
                 break;
         }
     }

--- a/src/main/java/net/minestom/server/network/packet/server/play/CraftRecipeResponse.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/CraftRecipeResponse.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,10 +11,20 @@ public class CraftRecipeResponse implements ServerPacket {
     public byte windowId;
     public String recipe;
 
+    public CraftRecipeResponse() {
+        recipe = "";
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeByte(windowId);
         writer.writeSizedString(recipe);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        windowId = reader.readByte();
+        recipe = reader.readSizedString(Integer.MAX_VALUE);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/DeclareCommandsPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/DeclareCommandsPacket.java
@@ -2,7 +2,9 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
+import net.minestom.server.utils.binary.Readable;
 import net.minestom.server.utils.binary.Writeable;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,7 +12,7 @@ import java.util.function.Consumer;
 
 public class DeclareCommandsPacket implements ServerPacket {
 
-    public Node[] nodes;
+    public Node[] nodes = new Node[0];
     public int rootIndex;
 
     @Override
@@ -23,19 +25,30 @@ public class DeclareCommandsPacket implements ServerPacket {
     }
 
     @Override
+    public void read(@NotNull BinaryReader reader) {
+        int nodeCount = reader.readVarInt();
+        nodes = new Node[nodeCount];
+        for (int i = 0; i < nodeCount; i++) {
+            nodes[i] = new Node();
+            nodes[i].read(reader);
+        }
+        rootIndex = reader.readVarInt();
+    }
+
+    @Override
     public int getId() {
         return ServerPacketIdentifier.DECLARE_COMMANDS;
     }
 
-    public static class Node implements Writeable {
+    public static class Node implements Writeable, Readable {
 
         public byte flags;
-        public int[] children;
+        public int[] children = new int[0];
         public int redirectedNode; // Only if flags & 0x08
-        public String name; // Only for literal and argument
-        public String parser; // Only for argument
-        public Consumer<BinaryWriter> properties; // Only for argument
-        public String suggestionsType; // Only if flags 0x10
+        public String name = ""; // Only for literal and argument
+        public String parser = ""; // Only for argument
+        public byte[] properties; // Only for argument
+        public String suggestionsType = ""; // Only if flags 0x10
 
         @Override
         public void write(@NotNull BinaryWriter writer) {
@@ -54,14 +67,74 @@ public class DeclareCommandsPacket implements ServerPacket {
             if (isArgument()) {
                 writer.writeSizedString(parser);
                 if (properties != null) {
-                    properties.accept(writer);
+                    writer.writeBytes(properties);
                 }
             }
 
             if ((flags & 0x10) != 0) {
                 writer.writeSizedString(suggestionsType);
             }
+        }
 
+        @Override
+        public void read(@NotNull BinaryReader reader) {
+            flags = reader.readByte();
+            children = reader.readVarIntArray();
+            if ((flags & 0x08) != 0) {
+                redirectedNode = reader.readVarInt();
+            }
+
+            if (isLiteral() || isArgument()) {
+                name = reader.readSizedString(Integer.MAX_VALUE);
+            }
+
+            if(isArgument()) {
+                parser = reader.readSizedString(Integer.MAX_VALUE);
+                properties = getProperties(reader, parser);
+            }
+
+            if ((flags & 0x10) != 0) {
+                suggestionsType = reader.readSizedString(Integer.MAX_VALUE);
+            }
+        }
+
+        private byte[] getProperties(BinaryReader reader, String parser) {
+            switch (parser) {
+                case "brigadier:double":
+                    return reader.extractBytes(() -> {
+                        byte flags = reader.readByte();
+                        if((flags & 0x01) == 0x01) {
+                            reader.readDouble(); // min
+                        }
+                        if((flags & 0x02) == 0x02) {
+                            reader.readDouble(); // max
+                        }
+                    });
+
+                case "brigadier:integer":
+                    return reader.extractBytes(() -> {
+                        byte flags = reader.readByte();
+                        if((flags & 0x01) == 0x01) {
+                            reader.readInt(); // min
+                        }
+                        if((flags & 0x02) == 0x02) {
+                            reader.readInt(); // max
+                        }
+                    });
+
+                case "brigadier:string":
+                    return reader.extractBytes(reader::readVarInt);
+
+                case "brigadier:entity":
+                case "brigadier:score_holder":
+                    return reader.extractBytes(reader::readByte);
+
+                case "brigadier:range":
+                    return reader.extractBytes(reader::readBoolean); // https://wiki.vg/Command_Data#minecraft:range, looks fishy
+
+                default:
+                    return new byte[0]; // unknown
+            }
         }
 
         private boolean isLiteral() {

--- a/src/main/java/net/minestom/server/network/packet/server/play/DestroyEntitiesPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/DestroyEntitiesPacket.java
@@ -2,16 +2,24 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class DestroyEntitiesPacket implements ServerPacket {
 
-    public int[] entityIds;
+    public int[] entityIds = new int[0];
+
+    public DestroyEntitiesPacket() {}
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarIntArray(entityIds);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityIds = reader.readVarIntArray();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/DisconnectPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/DisconnectPacket.java
@@ -4,6 +4,7 @@ import net.kyori.adventure.text.Component;
 import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -22,9 +23,18 @@ public class DisconnectPacket implements ComponentHoldingServerPacket {
         this.message = message;
     }
 
+    private DisconnectPacket() {
+        this(Component.text("Disconnected."));
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeComponent(message);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        message = reader.readComponent(Integer.MAX_VALUE);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/DisplayScoreboardPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/DisplayScoreboardPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,10 +11,20 @@ public class DisplayScoreboardPacket implements ServerPacket {
     public byte position;
     public String scoreName;
 
+    public DisplayScoreboardPacket() {
+        scoreName = "";
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeByte(position);
         writer.writeSizedString(scoreName);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        position = reader.readByte();
+        scoreName = reader.readSizedString(Integer.MAX_VALUE);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/EffectPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EffectPacket.java
@@ -3,6 +3,7 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.BlockPosition;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -13,12 +14,24 @@ public class EffectPacket implements ServerPacket {
     public int data;
     public boolean disableRelativeVolume;
 
+    public EffectPacket() {
+        position = new BlockPosition(0,0,0);
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeInt(effectId);
         writer.writeBlockPosition(position);
         writer.writeInt(data);
         writer.writeBoolean(disableRelativeVolume);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        effectId = reader.readInt();
+        position = reader.readBlockPosition();
+        data = reader.readInt();
+        disableRelativeVolume = reader.readBoolean();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityAnimationPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityAnimationPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,10 +11,20 @@ public class EntityAnimationPacket implements ServerPacket {
     public int entityId;
     public Animation animation;
 
+    public EntityAnimationPacket() {
+        animation = Animation.SWING_MAIN_ARM;
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(entityId);
         writer.writeByte((byte) animation.ordinal());
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readVarInt();
+        animation = Animation.values()[reader.readByte()];
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityEffectPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityEffectPacket.java
@@ -3,6 +3,8 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.potion.Potion;
+import net.minestom.server.potion.PotionEffect;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,6 +13,10 @@ public class EntityEffectPacket implements ServerPacket {
     public int entityId;
     public Potion potion;
 
+    public EntityEffectPacket() {
+        potion = new Potion(PotionEffect.ABSORPTION, (byte) 0, 0);
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(entityId);
@@ -18,6 +24,20 @@ public class EntityEffectPacket implements ServerPacket {
         writer.writeByte(potion.getAmplifier());
         writer.writeVarInt(potion.getDuration());
         writer.writeByte(potion.getFlags());
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readVarInt();
+        byte potionEffectID = reader.readByte();
+        byte amplifier = reader.readByte();
+        int duration = reader.readVarInt();
+        byte flags = reader.readByte();
+        boolean ambient = (flags & 0x01) == 0x01;
+        boolean particles = (flags & 0x02) == 0x02;
+        boolean icon = (flags & 0x04) == 0x04;
+
+        potion = new Potion(PotionEffect.fromId(potionEffectID), amplifier, duration, particles, icon, ambient);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityEquipmentPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityEquipmentPacket.java
@@ -4,14 +4,20 @@ import net.minestom.server.event.item.ArmorEquipEvent;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.LinkedList;
+import java.util.List;
 
 public class EntityEquipmentPacket implements ServerPacket {
 
     public int entityId;
     public Slot[] slots;
     public ItemStack[] itemStacks;
+
+    public EntityEquipmentPacket() {}
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -38,6 +44,25 @@ public class EntityEquipmentPacket implements ServerPacket {
             writer.writeByte(slotEnum);
             writer.writeItemStack(itemStack);
         }
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readVarInt();
+
+        boolean hasRemaining = true;
+        List<Slot> slots = new LinkedList<>();
+        List<ItemStack> stacks = new LinkedList<>();
+        while(hasRemaining) {
+            byte slotEnum = reader.readByte();
+            hasRemaining = (slotEnum & 0x80) == 0x80;
+
+            slots.add(Slot.values()[slotEnum & 0x7F]);
+            stacks.add(reader.readItemStack());
+        }
+
+        this.slots = slots.toArray(new Slot[0]);
+        this.itemStacks = stacks.toArray(new ItemStack[0]);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityHeadLookPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityHeadLookPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,10 +11,18 @@ public class EntityHeadLookPacket implements ServerPacket {
     public int entityId;
     public float yaw;
 
+    public EntityHeadLookPacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(entityId);
         writer.writeByte((byte) (this.yaw * 256 / 360));
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readVarInt();
+        yaw = reader.readByte() * 360f / 256f;
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityMetaDataPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityMetaDataPacket.java
@@ -3,26 +3,48 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.entity.Metadata;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
+import java.util.LinkedList;
 
 public class EntityMetaDataPacket implements ServerPacket {
 
     public int entityId;
     public Collection<Metadata.Entry<?>> entries;
 
+    public EntityMetaDataPacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(entityId);
 
-        // Write all the fields
-        for (Metadata.Entry<?> entry : entries) {
-            entry.write(writer);
+        if(entries != null) {
+            // Write all the fields
+            for (Metadata.Entry<?> entry : entries) {
+                entry.write(writer);
+            }
         }
 
         writer.writeByte((byte) 0xFF); // End
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readVarInt();
+
+        entries = new LinkedList<>();
+        while(true) {
+            byte index = reader.readByte();
+
+            if(index == (byte) 0xFF) { // reached the end
+                break;
+            }
+
+            entries.add(new Metadata.Entry<Object>(reader));
+        }
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityMovementPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityMovementPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -9,9 +10,16 @@ public class EntityMovementPacket implements ServerPacket {
 
     public int entityId;
 
+    public EntityMovementPacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(entityId);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readVarInt();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityPositionAndRotationPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityPositionAndRotationPacket.java
@@ -3,6 +3,7 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.Position;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,6 +13,8 @@ public class EntityPositionAndRotationPacket implements ServerPacket {
     public short deltaX, deltaY, deltaZ;
     public float yaw, pitch;
     public boolean onGround;
+
+    public EntityPositionAndRotationPacket() {}
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -24,6 +27,16 @@ public class EntityPositionAndRotationPacket implements ServerPacket {
         writer.writeBoolean(onGround);
     }
 
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readVarInt();
+        deltaX = reader.readShort();
+        deltaY = reader.readShort();
+        deltaZ = reader.readShort();
+        yaw = reader.readByte() * 360f / 256f;
+        pitch = reader.readByte() * 360f / 256f;
+        onGround = reader.readBoolean();
+    }
 
     @Override
     public int getId() {

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityPositionPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityPositionPacket.java
@@ -3,6 +3,7 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.Position;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,6 +13,8 @@ public class EntityPositionPacket implements ServerPacket {
     public short deltaX, deltaY, deltaZ;
     public boolean onGround;
 
+    public EntityPositionPacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(entityId);
@@ -19,6 +22,15 @@ public class EntityPositionPacket implements ServerPacket {
         writer.writeShort(deltaY);
         writer.writeShort(deltaZ);
         writer.writeBoolean(onGround);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readVarInt();
+        deltaX = reader.readShort();
+        deltaY = reader.readShort();
+        deltaZ = reader.readShort();
+        onGround = reader.readBoolean();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityPropertiesPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityPropertiesPacket.java
@@ -3,9 +3,13 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.attribute.Attribute;
 import net.minestom.server.attribute.AttributeInstance;
 import net.minestom.server.attribute.AttributeModifier;
+import net.minestom.server.attribute.AttributeOperation;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
+import net.minestom.server.utils.binary.Readable;
+import net.minestom.server.utils.binary.Writeable;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -13,8 +17,9 @@ import java.util.Collection;
 public class EntityPropertiesPacket implements ServerPacket {
 
     public int entityId;
-    public Property[] properties;
+    public Property[] properties = new Property[0];
 
+    public EntityPropertiesPacket() {}
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -26,17 +31,28 @@ public class EntityPropertiesPacket implements ServerPacket {
     }
 
     @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readVarInt();
+        int propertyCount = reader.readInt();
+        properties = new Property[propertyCount];
+        for (int i = 0; i < propertyCount; i++) {
+            properties[i] = new Property();
+            properties[i].read(reader);
+        }
+    }
+
+    @Override
     public int getId() {
         return ServerPacketIdentifier.ENTITY_PROPERTIES;
     }
 
-    public static class Property {
+    public static class Property implements Writeable, Readable {
 
         public Attribute attribute;
         public double value;
         public AttributeInstance instance;
 
-        private void write(BinaryWriter writer) {
+        public void write(BinaryWriter writer) {
             float maxValue = attribute.getMaxValue();
 
             // Bypass vanilla limit client-side if needed (by sending the max value allowed)
@@ -54,6 +70,21 @@ public class EntityPropertiesPacket implements ServerPacket {
                     writer.writeDouble(modifier.getAmount());
                     writer.writeByte((byte) modifier.getOperation().getId());
                 }
+            }
+        }
+
+        @Override
+        public void read(@NotNull BinaryReader reader) {
+            String key = reader.readSizedString(Integer.MAX_VALUE);
+            attribute = Attribute.fromKey(key);
+
+            value = reader.readDouble();
+
+            int modifierCount = reader.readVarInt();
+            instance = new AttributeInstance(attribute, null);
+            for (int i = 0; i < modifierCount; i++) {
+                AttributeModifier modifier = new AttributeModifier(reader.readUuid(), "", (float) reader.readDouble(), AttributeOperation.fromId(reader.readByte()));
+                instance.addModifier(modifier);
             }
         }
     }

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityRotationPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityRotationPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,12 +12,22 @@ public class EntityRotationPacket implements ServerPacket {
     public float yaw, pitch;
     public boolean onGround;
 
+    public EntityRotationPacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(entityId);
         writer.writeByte((byte) (yaw * 256 / 360));
         writer.writeByte((byte) (pitch * 256 / 360));
         writer.writeBoolean(onGround);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readVarInt();
+        yaw = reader.readByte() * 360f / 256f;
+        pitch = reader.readByte() * 360f / 256f;
+        onGround = reader.readBoolean();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntitySoundEffectPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntitySoundEffectPacket.java
@@ -4,6 +4,8 @@ import net.kyori.adventure.sound.Sound;
 import net.minestom.server.adventure.AdventurePacketConvertor;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.sound.SoundCategory;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -15,6 +17,10 @@ public class EntitySoundEffectPacket implements ServerPacket {
     public float volume;
     public float pitch;
 
+    public EntitySoundEffectPacket() {
+        soundSource = Sound.Source.NEUTRAL;
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(soundId);
@@ -22,6 +28,15 @@ public class EntitySoundEffectPacket implements ServerPacket {
         writer.writeVarInt(entityId);
         writer.writeFloat(volume);
         writer.writeFloat(pitch);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        soundId = reader.readVarInt();
+        soundSource = Sound.Source.values()[reader.readVarInt()];
+        entityId = reader.readVarInt();
+        volume = reader.readFloat();
+        pitch = reader.readFloat();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityStatusPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityStatusPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,10 +11,18 @@ public class EntityStatusPacket implements ServerPacket {
     public int entityId;
     public byte status;
 
+    public EntityStatusPacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeInt(entityId);
         writer.writeByte(status);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readInt();
+        status = reader.readByte();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityTeleportPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityTeleportPacket.java
@@ -3,6 +3,7 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.Position;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,6 +12,10 @@ public class EntityTeleportPacket implements ServerPacket {
     public int entityId;
     public Position position;
     public boolean onGround;
+
+    public EntityTeleportPacket() {
+        position = new Position();
+    }
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -21,6 +26,19 @@ public class EntityTeleportPacket implements ServerPacket {
         writer.writeByte((byte) (position.getYaw() * 256f / 360f));
         writer.writeByte((byte) (position.getPitch() * 256f / 360f));
         writer.writeBoolean(onGround);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readVarInt();
+        position = new Position(
+                reader.readDouble(),
+                reader.readDouble(),
+                reader.readDouble(),
+                reader.readByte() * 360f / 256f,
+                reader.readByte() * 360f / 256f
+                );
+        onGround = reader.readBoolean();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityVelocityPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityVelocityPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,12 +11,22 @@ public class EntityVelocityPacket implements ServerPacket {
     public int entityId;
     public short velocityX, velocityY, velocityZ;
 
+    public EntityVelocityPacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(entityId);
         writer.writeShort(velocityX);
         writer.writeShort(velocityY);
         writer.writeShort(velocityZ);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readVarInt();
+        velocityX = reader.readShort();
+        velocityY = reader.readShort();
+        velocityZ = reader.readShort();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/ExplosionPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/ExplosionPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -9,8 +10,10 @@ public class ExplosionPacket implements ServerPacket {
 
     public float x, y, z;
     public float radius; // UNUSED
-    public byte[] records;
+    public byte[] records = new byte[0];
     public float playerMotionX, playerMotionY, playerMotionZ;
+
+    public ExplosionPacket() {}
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -24,6 +27,19 @@ public class ExplosionPacket implements ServerPacket {
         writer.writeFloat(playerMotionX);
         writer.writeFloat(playerMotionY);
         writer.writeFloat(playerMotionZ);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        x = reader.readFloat();
+        y = reader.readFloat();
+        z = reader.readFloat();
+        radius = reader.readFloat();
+        int recordCount = reader.readInt() * 3;
+        records = reader.readBytes(recordCount);
+        playerMotionX = reader.readFloat();
+        playerMotionY = reader.readFloat();
+        playerMotionZ = reader.readFloat();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/FacePlayerPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/FacePlayerPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,6 +13,10 @@ public class FacePlayerPacket implements ServerPacket {
     public int entityId;
     public FacePosition entityFacePosition;
 
+    public FacePlayerPacket() {
+        facePosition = FacePosition.EYES;
+        entityFacePosition = FacePosition.EYES;
+    }
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -25,6 +30,22 @@ public class FacePlayerPacket implements ServerPacket {
         if (isEntity) {
             writer.writeVarInt(entityId);
             writer.writeVarInt(entityFacePosition.ordinal());
+        }
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        facePosition = FacePosition.values()[reader.readVarInt()];
+        targetX = reader.readDouble();
+        targetY = reader.readDouble();
+        targetZ = reader.readDouble();
+
+        boolean isEntity = reader.readBoolean();
+        if(isEntity) {
+            entityId = reader.readVarInt();
+            entityFacePosition = FacePosition.values()[reader.readVarInt()];
+        } else {
+            entityId = 0;
         }
     }
 

--- a/src/main/java/net/minestom/server/network/packet/server/play/HeldItemChangePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/HeldItemChangePacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -9,9 +10,16 @@ public class HeldItemChangePacket implements ServerPacket {
 
     public byte slot;
 
+    public HeldItemChangePacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeByte(slot);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        slot = reader.readByte();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/JoinGamePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/JoinGamePacket.java
@@ -4,15 +4,22 @@ import net.minestom.server.MinecraftServer;
 import net.minestom.server.entity.GameMode;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
+import net.minestom.server.utils.validate.Check;
 import net.minestom.server.world.DimensionType;
 import org.jetbrains.annotations.NotNull;
 import org.jglrxavpok.hephaistos.nbt.NBTCompound;
+import org.jglrxavpok.hephaistos.nbt.NBTException;
+
+import java.io.IOException;
 
 public class JoinGamePacket implements ServerPacket {
 
     public int entityId;
+    public boolean hardcore;
     public GameMode gameMode;
+    public GameMode previousGameMode;
     public DimensionType dimensionType;
     public long hashedSeed;
     public int maxPlayers = 0; // Unused
@@ -22,13 +29,22 @@ public class JoinGamePacket implements ServerPacket {
     public boolean isDebug = false;
     public boolean isFlat = false;
 
+    public JoinGamePacket() {
+        gameMode = GameMode.SURVIVAL;
+        dimensionType = DimensionType.OVERWORLD;
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeInt(entityId);
-        writer.writeBoolean(gameMode.isHardcore());
+        writer.writeBoolean(hardcore);
         writer.writeByte(gameMode.getId());
-        //Previous Gamemode
-        writer.writeByte(gameMode.getId());
+
+        if(previousGameMode == null) {
+            writer.writeByte(gameMode.getId());
+        } else {
+            writer.writeByte(previousGameMode.getId());
+        }
 
         //array of worlds
         writer.writeVarInt(1);
@@ -53,6 +69,35 @@ public class JoinGamePacket implements ServerPacket {
         writer.writeBoolean(isDebug);
         //is flat
         writer.writeBoolean(isFlat);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readInt();
+        hardcore = reader.readBoolean();
+        gameMode = GameMode.fromId(reader.readByte());
+        previousGameMode = GameMode.fromId(reader.readByte());
+        int worldCount = reader.readVarInt();
+        Check.stateCondition(worldCount != 1, "Only 1 world is supported per JoinGamePacket by Minestom for the moment.");
+        //for (int i = 0; i < worldCount; i++) {
+            String worldName = reader.readSizedString(Integer.MAX_VALUE);
+            try {
+                NBTCompound dimensionCodec = (NBTCompound) reader.readTag();
+                dimensionType = DimensionType.fromNBT((NBTCompound) reader.readTag());
+
+                String dimensionName = reader.readSizedString(Integer.MAX_VALUE);
+                hashedSeed = reader.readLong();
+                maxPlayers = reader.readVarInt();
+                viewDistance = reader.readVarInt();
+                reducedDebugInfo = reader.readBoolean();
+                enableRespawnScreen = reader.readBoolean();
+                isDebug = reader.readBoolean();
+                isFlat = reader.readBoolean();
+            } catch (IOException | NBTException e) {
+                MinecraftServer.getExceptionManager().handleException(e);
+                // TODO: should we throw as the packet is invalid?
+            }
+        //}
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/KeepAlivePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/KeepAlivePacket.java
@@ -2,12 +2,15 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class KeepAlivePacket implements ServerPacket {
 
     public long id;
+
+    KeepAlivePacket() {}
 
     public KeepAlivePacket(long id) {
         this.id = id;
@@ -16,6 +19,11 @@ public class KeepAlivePacket implements ServerPacket {
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeLong(id);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        id = reader.readLong();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/MapDataPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/MapDataPacket.java
@@ -4,7 +4,10 @@ import net.kyori.adventure.text.Component;
 import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
+import net.minestom.server.utils.binary.Readable;
+import net.minestom.server.utils.binary.Writeable;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -17,13 +20,15 @@ public class MapDataPacket implements ComponentHoldingServerPacket {
     public boolean trackingPosition;
     public boolean locked;
 
-    public Icon[] icons;
+    public Icon[] icons = new Icon[0];
 
     public short columns;
     public short rows;
     public byte x;
     public byte z;
-    public byte[] data;
+    public byte[] data = new byte[0];
+
+    public MapDataPacket() {}
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -56,6 +61,32 @@ public class MapDataPacket implements ComponentHoldingServerPacket {
             writer.writeVarInt(0);
         }
 
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        mapId = reader.readVarInt();
+        scale = reader.readByte();
+        trackingPosition = reader.readBoolean();
+        locked = reader.readBoolean();
+
+        int iconCount = reader.readVarInt();
+        icons = new Icon[iconCount];
+        for (int i = 0; i < iconCount; i++) {
+            icons[i] = new Icon();
+            icons[i].read(reader);
+        }
+
+        columns = reader.readByte();
+        if(columns <= 0) {
+            return;
+        }
+
+        rows = reader.readByte();
+        x = reader.readByte();
+        z = reader.readByte();
+        int dataLength = reader.readVarInt();
+        data = reader.readBytes(dataLength);
     }
 
     @Override
@@ -101,13 +132,13 @@ public class MapDataPacket implements ComponentHoldingServerPacket {
         }
     }
 
-    public static class Icon {
+    public static class Icon implements Writeable, Readable {
         public int type;
         public byte x, z;
         public byte direction;
         public Component displayName;
 
-        private void write(BinaryWriter writer) {
+        public void write(BinaryWriter writer) {
             writer.writeVarInt(type);
             writer.writeByte(x);
             writer.writeByte(z);
@@ -120,6 +151,20 @@ public class MapDataPacket implements ComponentHoldingServerPacket {
             }
         }
 
+        @Override
+        public void read(@NotNull BinaryReader reader) {
+            type = reader.readVarInt();
+            x = reader.readByte();
+            z = reader.readByte();
+            direction = reader.readByte();
+
+            boolean hasDisplayName = reader.readBoolean();
+            if(hasDisplayName) {
+                displayName = reader.readComponent(Integer.MAX_VALUE);
+            } else {
+                displayName = null;
+            }
+        }
     }
 
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/NamedSoundEffectPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/NamedSoundEffectPacket.java
@@ -4,6 +4,8 @@ import net.kyori.adventure.sound.Sound.Source;
 import net.minestom.server.adventure.AdventurePacketConvertor;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.sound.SoundCategory;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -15,6 +17,11 @@ public class NamedSoundEffectPacket implements ServerPacket {
     public float volume;
     public float pitch;
 
+    public NamedSoundEffectPacket() {
+        soundName = "";
+        soundSource = Source.AMBIENT;
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeSizedString(soundName);
@@ -24,6 +31,17 @@ public class NamedSoundEffectPacket implements ServerPacket {
         writer.writeInt(z * 8);
         writer.writeFloat(volume);
         writer.writeFloat(pitch);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        soundName = reader.readSizedString(Integer.MAX_VALUE);
+        soundSource = Source.values()[reader.readVarInt()];
+        x = reader.readInt() / 8;
+        y = reader.readInt() / 8;
+        z = reader.readInt() / 8;
+        volume = reader.readFloat();
+        pitch = reader.readFloat();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/NbtQueryResponsePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/NbtQueryResponsePacket.java
@@ -1,15 +1,24 @@
 package net.minestom.server.network.packet.server.play;
 
+import net.minestom.server.MinecraftServer;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
+import org.jglrxavpok.hephaistos.nbt.NBT;
 import org.jglrxavpok.hephaistos.nbt.NBTCompound;
+import org.jglrxavpok.hephaistos.nbt.NBTEnd;
+import org.jglrxavpok.hephaistos.nbt.NBTException;
+
+import java.io.IOException;
 
 public class NbtQueryResponsePacket implements ServerPacket {
 
     public int transactionId;
     public NBTCompound nbtCompound;
+
+    public NbtQueryResponsePacket() {}
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -19,6 +28,23 @@ public class NbtQueryResponsePacket implements ServerPacket {
         } else {
             // TAG_End
             writer.writeByte((byte) 0x00);
+        }
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        transactionId = reader.readVarInt();
+        try {
+            NBT nbt = reader.readTag();
+
+            if (nbt instanceof NBTEnd) {
+                return;
+            }
+
+            nbtCompound = (NBTCompound) nbt;
+        } catch (IOException | NBTException e) {
+            MinecraftServer.getExceptionManager().handleException(e);
+            // TODO: should we throw? the packet is not valid
         }
     }
 

--- a/src/main/java/net/minestom/server/network/packet/server/play/OpenBookPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/OpenBookPacket.java
@@ -3,16 +3,24 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.entity.Player;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class OpenBookPacket implements ServerPacket {
 
-    public Player.Hand hand;
+    public Player.Hand hand = Player.Hand.MAIN;
+
+    public OpenBookPacket() {}
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(hand.ordinal());
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        hand = Player.Hand.values()[reader.readVarInt()];
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/OpenHorseWindowPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/OpenHorseWindowPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -16,6 +17,13 @@ public class OpenHorseWindowPacket implements ServerPacket {
         writer.writeByte(windowId);
         writer.writeVarInt(slotCount);
         writer.writeInt(entityId);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        windowId = reader.readByte();
+        slotCount = reader.readVarInt();
+        entityId = reader.readInt();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/OpenSignEditorPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/OpenSignEditorPacket.java
@@ -3,17 +3,30 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.BlockPosition;
+import net.minestom.server.utils.Position;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class OpenSignEditorPacket implements ServerPacket {
 
-    // WARNING: There must be a sign in this location (you can send a BlockChangePacket beforehand)
+    /**
+     * WARNING: There must be a sign in this location (you can send a BlockChangePacket beforehand)
+      */
     public BlockPosition signPosition;
+
+    public OpenSignEditorPacket() {
+        signPosition = new BlockPosition(0,0,0);
+    }
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeBlockPosition(signPosition);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        signPosition = reader.readBlockPosition();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/OpenWindowPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/OpenWindowPacket.java
@@ -1,7 +1,10 @@
 package net.minestom.server.network.packet.server.play;
 
+import net.minestom.server.chat.ColoredText;
+import net.minestom.server.chat.JsonMessage;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -9,13 +12,26 @@ public class OpenWindowPacket implements ServerPacket {
 
     public int windowId;
     public int windowType;
-    public String title;
+    public JsonMessage title = ColoredText.of("");
+
+    public OpenWindowPacket() {}
+
+    public OpenWindowPacket(String title) {
+        this.title = ColoredText.of(title);
+    }
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(windowId);
         writer.writeVarInt(windowType);
-        writer.writeSizedString("{\"text\": \"" + title + " \"}");
+        writer.writeJsonMessage(title);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        windowId = reader.readVarInt();
+        windowType = reader.readVarInt();
+        title = reader.readJsonMessage(Integer.MAX_VALUE);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/ParticlePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/ParticlePacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -16,7 +17,11 @@ public class ParticlePacket implements ServerPacket {
     public float particleData;
     public int particleCount;
 
-    public Consumer<BinaryWriter> dataConsumer;
+    public byte[] data;
+
+    public ParticlePacket() {
+        data = new byte[0];
+    }
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -31,9 +36,23 @@ public class ParticlePacket implements ServerPacket {
         writer.writeFloat(particleData);
         writer.writeInt(particleCount);
 
-        if (dataConsumer != null) {
-            dataConsumer.accept(writer);
-        }
+        writer.writeBytes(data);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        particleId = reader.readInt();
+        longDistance = reader.readBoolean();
+        x = reader.readDouble();
+        y = reader.readDouble();
+        z = reader.readDouble();
+        offsetX = reader.readFloat();
+        offsetY = reader.readFloat();
+        offsetZ = reader.readFloat();
+        particleData = reader.readFloat();
+        particleCount = reader.readInt();
+
+        data = reader.readRemainingBytes();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/PlayerAbilitiesPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/PlayerAbilitiesPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -32,6 +33,18 @@ public class PlayerAbilitiesPacket implements ServerPacket {
         writer.writeByte(flags);
         writer.writeFloat(flyingSpeed);
         writer.writeFloat(fieldViewModifier);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        byte flags = reader.readByte();
+        invulnerable = (flags & 1) == 1;
+        flying = (flags & 2) == 2;
+        allowFlying = (flags & 4) == 4;
+        instantBreak = (flags & 8) == 8;
+
+        flyingSpeed = reader.readFloat();
+        fieldViewModifier = reader.readFloat();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/PlayerInfoPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/PlayerInfoPacket.java
@@ -6,6 +6,7 @@ import net.minestom.server.entity.GameMode;
 import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -17,6 +18,10 @@ public class PlayerInfoPacket implements ComponentHoldingServerPacket {
 
     public Action action;
     public List<PlayerInfo> playerInfos;
+
+    PlayerInfoPacket() {
+        this(Action.UPDATE_DISPLAY_NAME);
+    }
 
     public PlayerInfoPacket(Action action) {
         this.action = action;
@@ -32,6 +37,41 @@ public class PlayerInfoPacket implements ComponentHoldingServerPacket {
             if (!playerInfo.getClass().equals(action.getClazz())) continue;
             writer.writeUuid(playerInfo.uuid);
             playerInfo.write(writer);
+        }
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        action = Action.values()[reader.readVarInt()];
+        int playerInfoCount = reader.readVarInt();
+
+        playerInfos = new ArrayList<>(playerInfoCount);
+
+        for (int i = 0; i < playerInfoCount; i++) {
+            UUID uuid = reader.readUuid();
+            PlayerInfo info;
+            switch (action) {
+                case ADD_PLAYER:
+                    info = new AddPlayer(uuid, reader);
+                    break;
+                case UPDATE_GAMEMODE:
+                    info = new UpdateGamemode(uuid, reader);
+                    break;
+                case UPDATE_LATENCY:
+                    info = new UpdateLatency(uuid, reader);
+                    break;
+                case UPDATE_DISPLAY_NAME:
+                    info = new UpdateDisplayName(uuid, reader);
+                    break;
+                case REMOVE_PLAYER:
+                    info = new RemovePlayer(uuid);
+                    break;
+
+                default:
+                    throw new IllegalArgumentException("Unsupported action encountered: "+action.name());
+            }
+
+            playerInfos.set(i, info);
         }
     }
 
@@ -121,6 +161,27 @@ public class PlayerInfoPacket implements ComponentHoldingServerPacket {
             this.ping = ping;
         }
 
+        AddPlayer(UUID uuid, BinaryReader reader) {
+            super(uuid);
+            name = reader.readSizedString(Integer.MAX_VALUE);
+            int propertyCount = reader.readVarInt();
+
+            properties = new ArrayList<>(propertyCount);
+            for (int i = 0; i < propertyCount; i++) {
+                properties.set(i, new Property(reader));
+            }
+
+            gameMode = GameMode.fromId((byte) reader.readVarInt());
+            ping = reader.readVarInt();
+            boolean hasDisplayName = reader.readBoolean();
+
+            if(hasDisplayName) {
+                displayName = reader.readComponent(Integer.MAX_VALUE);
+            } else {
+                displayName = null;
+            }
+        }
+
         @Override
         public void write(BinaryWriter writer) {
             writer.writeSizedString(name);
@@ -173,6 +234,16 @@ public class PlayerInfoPacket implements ComponentHoldingServerPacket {
                 this(name, value, null);
             }
 
+            Property(BinaryReader reader) {
+                name = reader.readSizedString(Integer.MAX_VALUE);
+                value = reader.readSizedString(Integer.MAX_VALUE);
+                boolean hasSignature = reader.readBoolean();
+
+                if(hasSignature) {
+                    signature = reader.readSizedString(Integer.MAX_VALUE);
+                }
+            }
+
             public void write(BinaryWriter writer) {
                 writer.writeSizedString(name);
                 writer.writeSizedString(value);
@@ -194,6 +265,11 @@ public class PlayerInfoPacket implements ComponentHoldingServerPacket {
             this.gameMode = gameMode;
         }
 
+        UpdateGamemode(UUID uuid, BinaryReader reader) {
+            super(uuid);
+            gameMode = GameMode.fromId((byte) reader.readVarInt());
+        }
+
         @Override
         public void write(BinaryWriter writer) {
             writer.writeVarInt(gameMode.getId());
@@ -209,6 +285,11 @@ public class PlayerInfoPacket implements ComponentHoldingServerPacket {
             this.ping = ping;
         }
 
+        UpdateLatency(UUID uuid, BinaryReader reader) {
+            super(uuid);
+            ping = reader.readVarInt();
+        }
+
         @Override
         public void write(BinaryWriter writer) {
             writer.writeVarInt(ping);
@@ -222,6 +303,16 @@ public class PlayerInfoPacket implements ComponentHoldingServerPacket {
         public UpdateDisplayName(UUID uuid, Component displayName) {
             super(uuid);
             this.displayName = displayName;
+        }
+
+        UpdateDisplayName(UUID uuid, BinaryReader reader) {
+            super(uuid);
+            boolean hasDisplayName = reader.readBoolean();
+            if(hasDisplayName) {
+                displayName = reader.readComponent(Integer.MAX_VALUE);
+            } else {
+                displayName = null;
+            }
         }
 
         @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/PlayerListHeaderAndFooterPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/PlayerListHeaderAndFooterPacket.java
@@ -4,6 +4,7 @@ import net.kyori.adventure.text.Component;
 import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -18,6 +19,10 @@ public class PlayerListHeaderAndFooterPacket implements ComponentHoldingServerPa
     public Component header;
     public Component footer;
 
+    public PlayerListHeaderAndFooterPacket() {
+        this(null, null);
+    }
+
     public PlayerListHeaderAndFooterPacket(@Nullable Component header, @Nullable Component footer) {
         this.header = header;
         this.footer = footer;
@@ -27,11 +32,6 @@ public class PlayerListHeaderAndFooterPacket implements ComponentHoldingServerPa
     public void write(@NotNull BinaryWriter writer) {
         writer.writeComponent(Objects.requireNonNullElseGet(header, Component::empty));
         writer.writeComponent(Objects.requireNonNullElseGet(footer, Component::empty));
-    }
-
-    @Override
-    public int getId() {
-        return ServerPacketIdentifier.PLAYER_LIST_HEADER_AND_FOOTER;
     }
 
     @Override
@@ -49,5 +49,15 @@ public class PlayerListHeaderAndFooterPacket implements ComponentHoldingServerPa
     @Override
     public @NotNull ServerPacket copyWithOperator(@NotNull UnaryOperator<Component> operator) {
         return new PlayerListHeaderAndFooterPacket(header == null ? null : operator.apply(header), footer == null ? null : operator.apply(footer));
+    }
+
+    public void read(@NotNull BinaryReader reader) {
+        header = reader.readComponent(Integer.MAX_VALUE);
+        footer = reader.readComponent(Integer.MAX_VALUE);
+    }
+
+    @Override
+    public int getId() {
+        return ServerPacketIdentifier.PLAYER_LIST_HEADER_AND_FOOTER;
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/PlayerPositionAndLookPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/PlayerPositionAndLookPacket.java
@@ -3,6 +3,7 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.Position;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,6 +13,9 @@ public class PlayerPositionAndLookPacket implements ServerPacket {
     public byte flags;
     public int teleportId;
 
+    public PlayerPositionAndLookPacket() {
+        position = new Position();
+    }
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -24,6 +28,14 @@ public class PlayerPositionAndLookPacket implements ServerPacket {
 
         writer.writeByte(flags);
         writer.writeVarInt(teleportId);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        position = new Position(reader.readDouble(), reader.readDouble(), reader.readDouble(), reader.readFloat(), reader.readFloat());
+
+        flags = reader.readByte();
+        teleportId = reader.readVarInt();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/PluginMessagePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/PluginMessagePacket.java
@@ -3,18 +3,27 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.IOException;
+
 public class PluginMessagePacket implements ServerPacket {
 
-    public String channel;
-    public byte[] data;
+    public String channel = "none";
+    public byte[] data = new byte[0];
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeSizedString(channel);
         writer.writeBytes(data);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        channel = reader.readSizedString(Integer.MAX_VALUE);
+        data = reader.getRemainingBytes();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/RemoveEntityEffectPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/RemoveEntityEffectPacket.java
@@ -3,18 +3,27 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.potion.PotionEffect;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class RemoveEntityEffectPacket implements ServerPacket {
 
     public int entityId;
-    public PotionEffect effect;
+    public PotionEffect effect = PotionEffect.ABSORPTION;
+
+    public RemoveEntityEffectPacket() {}
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(entityId);
         writer.writeByte((byte) effect.getId());
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readVarInt();
+        effect = PotionEffect.fromId(reader.readByte());
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/ResourcePackSendPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/ResourcePackSendPacket.java
@@ -2,18 +2,27 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class ResourcePackSendPacket implements ServerPacket {
 
-    public String url;
-    public String hash; // Size 40
+    public String url = "";
+    public String hash = "0000000000000000000000000000000000000000"; // Size 40
+
+    public ResourcePackSendPacket() {}
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeSizedString(url);
         writer.writeSizedString(hash);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        url = reader.readSizedString(Integer.MAX_VALUE);
+        hash = reader.readSizedString(Integer.MAX_VALUE);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/RespawnPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/RespawnPacket.java
@@ -3,9 +3,14 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.entity.GameMode;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import net.minestom.server.world.DimensionType;
 import org.jetbrains.annotations.NotNull;
+import org.jglrxavpok.hephaistos.nbt.NBTCompound;
+import org.jglrxavpok.hephaistos.nbt.NBTException;
+
+import java.io.IOException;
 
 public class RespawnPacket implements ServerPacket {
 
@@ -15,6 +20,11 @@ public class RespawnPacket implements ServerPacket {
     public boolean isDebug = false;
     public boolean isFlat = true;
     public boolean copyMeta = true;
+
+    public RespawnPacket() {
+        dimensionType = DimensionType.OVERWORLD;
+        gameMode = GameMode.SURVIVAL;
+    }
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -29,6 +39,27 @@ public class RespawnPacket implements ServerPacket {
         writer.writeBoolean(isDebug);
         writer.writeBoolean(isFlat);
         writer.writeBoolean(copyMeta);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        try {
+            dimensionType = DimensionType.fromNBT((NBTCompound) reader.readTag());
+
+            // dimension type name
+            reader.readSizedString(Integer.MAX_VALUE);
+
+            hashedSeed = reader.readLong();
+            gameMode = GameMode.values()[reader.readByte()];
+            // TODO: hardcore flag
+            reader.readByte();
+            isDebug = reader.readBoolean();
+            isFlat = reader.readBoolean();
+            copyMeta = reader.readBoolean();
+        } catch (IOException | NBTException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Failed to read DimensionType inside RespawnPacket", e);
+        }
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/ScoreboardObjectivePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/ScoreboardObjectivePacket.java
@@ -4,6 +4,7 @@ import net.kyori.adventure.text.Component;
 import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -32,6 +33,12 @@ public class ScoreboardObjectivePacket implements ComponentHoldingServerPacket {
      */
     public Type type;
 
+    public ScoreboardObjectivePacket() {
+        objectiveName = "";
+        objectiveValue = Component.empty();
+        type = Type.INTEGER;
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeSizedString(objectiveName);
@@ -40,6 +47,17 @@ public class ScoreboardObjectivePacket implements ComponentHoldingServerPacket {
         if (mode == 0 || mode == 2) {
             writer.writeComponent(objectiveValue);
             writer.writeVarInt(type.ordinal());
+        }
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        objectiveName = reader.readSizedString(Integer.MAX_VALUE);
+        mode = reader.readByte();
+
+        if(mode == 0 || mode == 2) {
+            objectiveValue = reader.readComponent(Integer.MAX_VALUE);
+            type = Type.values()[reader.readVarInt()];
         }
     }
 

--- a/src/main/java/net/minestom/server/network/packet/server/play/SelectAdvancementTabPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/SelectAdvancementTabPacket.java
@@ -2,12 +2,17 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class SelectAdvancementTabPacket implements ServerPacket {
 
+    @Nullable
     public String identifier;
+
+    public SelectAdvancementTabPacket() {}
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -16,6 +21,16 @@ public class SelectAdvancementTabPacket implements ServerPacket {
         writer.writeBoolean(hasId);
         if (hasId) {
             writer.writeSizedString(identifier);
+        }
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        boolean hasID = reader.readBoolean();
+        if(hasID) {
+            identifier = reader.readSizedString(Integer.MAX_VALUE);
+        } else {
+            identifier = null;
         }
     }
 

--- a/src/main/java/net/minestom/server/network/packet/server/play/ServerDifficultyPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/ServerDifficultyPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import net.minestom.server.world.Difficulty;
 import org.jetbrains.annotations.NotNull;
@@ -11,10 +12,20 @@ public class ServerDifficultyPacket implements ServerPacket {
     public Difficulty difficulty;
     public boolean locked;
 
+    public ServerDifficultyPacket() {
+        difficulty = Difficulty.NORMAL;
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeByte((byte) difficulty.ordinal());
         writer.writeBoolean(locked);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        difficulty = Difficulty.values()[reader.readByte()];
+        locked = reader.readBoolean();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/SetCooldownPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/SetCooldownPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,10 +11,18 @@ public class SetCooldownPacket implements ServerPacket {
     public int itemId;
     public int cooldownTicks;
 
+    public SetCooldownPacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(itemId);
         writer.writeVarInt(cooldownTicks);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        itemId = reader.readVarInt();
+        cooldownTicks = reader.readVarInt();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/SetExperiencePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/SetExperiencePacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,11 +12,20 @@ public class SetExperiencePacket implements ServerPacket {
     public int level;
     public int totalExperience;
 
+    public SetExperiencePacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeFloat(percentage);
         writer.writeVarInt(level);
         writer.writeVarInt(totalExperience);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        percentage = reader.readFloat();
+        level = reader.readVarInt();
+        totalExperience = reader.readVarInt();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/SetPassengersPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/SetPassengersPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,10 +11,20 @@ public class SetPassengersPacket implements ServerPacket {
     public int vehicleEntityId;
     public int[] passengersId;
 
+    public SetPassengersPacket() {
+        passengersId = new int[0];
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(vehicleEntityId);
         writer.writeVarIntArray(passengersId);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        vehicleEntityId = reader.readVarInt();
+        passengersId = reader.readVarIntArray();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/SetSlotPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/SetSlotPacket.java
@@ -3,6 +3,7 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,11 +13,22 @@ public class SetSlotPacket implements ServerPacket {
     public short slot;
     public ItemStack itemStack;
 
+    public SetSlotPacket() {
+        itemStack = ItemStack.getAirItem();
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeByte(windowId);
         writer.writeShort(slot);
         writer.writeItemStack(itemStack);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        windowId = reader.readByte();
+        slot = reader.readShort();
+        itemStack = reader.readItemStack();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/SoundEffectPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/SoundEffectPacket.java
@@ -6,6 +6,7 @@ import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.sound.SoundEvent;
 import net.minestom.server.utils.Position;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -16,6 +17,10 @@ public class SoundEffectPacket implements ServerPacket {
     public int x, y, z;
     public float volume;
     public float pitch;
+
+    public SoundEffectPacket() {
+        soundSource = Source.AMBIENT;
+    }
 
     @NotNull
     public static SoundEffectPacket create(Source category, SoundEvent sound, Position position, float volume, float pitch) {
@@ -39,6 +44,17 @@ public class SoundEffectPacket implements ServerPacket {
         writer.writeInt(z * 8);
         writer.writeFloat(volume);
         writer.writeFloat(pitch);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        soundId = reader.readVarInt();
+        soundSource = Source.values()[reader.readVarInt()];
+        x = reader.readInt()/8;
+        y = reader.readInt()/8;
+        z = reader.readInt()/8;
+        volume = reader.readFloat();
+        pitch = reader.readFloat();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/SpawnEntityPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/SpawnEntityPacket.java
@@ -3,6 +3,7 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.Position;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -16,6 +17,11 @@ public class SpawnEntityPacket implements ServerPacket {
     public Position position;
     public int data;
     public short velocityX, velocityY, velocityZ;
+
+    public SpawnEntityPacket() {
+        uuid = new UUID(0, 0);
+        position = new Position();
+    }
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -35,6 +41,24 @@ public class SpawnEntityPacket implements ServerPacket {
         writer.writeShort(velocityX);
         writer.writeShort(velocityY);
         writer.writeShort(velocityZ);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readVarInt();
+        uuid = reader.readUuid();
+        type = reader.readVarInt();
+
+        position = new Position(reader.readDouble(), reader.readDouble(), reader.readDouble());
+
+        position.setYaw(reader.readByte() * 360f / 256f);
+        position.setPitch(reader.readByte() * 360f / 256f);
+
+        data = reader.readInt();
+
+        velocityX = reader.readShort();
+        velocityY = reader.readShort();
+        velocityZ = reader.readShort();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/SpawnExperienceOrbPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/SpawnExperienceOrbPacket.java
@@ -3,6 +3,7 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.Position;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,6 +13,10 @@ public class SpawnExperienceOrbPacket implements ServerPacket {
     public Position position;
     public short expCount;
 
+    public SpawnExperienceOrbPacket() {
+        position = new Position();
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(entityId);
@@ -19,6 +24,13 @@ public class SpawnExperienceOrbPacket implements ServerPacket {
         writer.writeDouble(position.getY());
         writer.writeDouble(position.getZ());
         writer.writeShort(expCount);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readVarInt();
+        position = new Position(reader.readDouble(), reader.readDouble(), reader.readDouble());
+        expCount = reader.readShort();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/SpawnLivingEntityPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/SpawnLivingEntityPacket.java
@@ -3,6 +3,7 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.Position;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -16,6 +17,11 @@ public class SpawnLivingEntityPacket implements ServerPacket {
     public Position position;
     public float headPitch;
     public short velocityX, velocityY, velocityZ;
+
+    public SpawnLivingEntityPacket() {
+        entityUuid = new UUID(0, 0);
+        position = new Position();
+    }
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -34,7 +40,23 @@ public class SpawnLivingEntityPacket implements ServerPacket {
         writer.writeShort(velocityX);
         writer.writeShort(velocityY);
         writer.writeShort(velocityZ);
+    }
 
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readVarInt();
+        entityUuid = reader.readUuid();
+        entityType = reader.readVarInt();
+
+        position = new Position(reader.readDouble(), reader.readDouble(), reader.readDouble());
+
+        position.setYaw(reader.readByte() * 360f / 256f);
+        position.setPitch(reader.readByte() * 360f / 256f);
+        headPitch = reader.readByte() * 360f / 256f;
+
+        velocityX = reader.readShort();
+        velocityY = reader.readShort();
+        velocityZ = reader.readShort();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/SpawnPaintingPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/SpawnPaintingPacket.java
@@ -3,6 +3,7 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.BlockPosition;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -16,6 +17,11 @@ public class SpawnPaintingPacket implements ServerPacket {
     public BlockPosition position;
     public byte direction;
 
+    public SpawnPaintingPacket() {
+        entityUuid = new UUID(0, 0);
+        position = new BlockPosition(0, 0, 0);
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(entityId);
@@ -23,6 +29,15 @@ public class SpawnPaintingPacket implements ServerPacket {
         writer.writeVarInt(motive);
         writer.writeBlockPosition(position);
         writer.writeByte(direction);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readVarInt();
+        entityUuid = reader.readUuid();
+        motive = reader.readVarInt();
+        position = reader.readBlockPosition();
+        direction = reader.readByte();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/SpawnPlayerPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/SpawnPlayerPacket.java
@@ -2,7 +2,9 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.BlockPosition;
 import net.minestom.server.utils.Position;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -14,6 +16,11 @@ public class SpawnPlayerPacket implements ServerPacket {
     public UUID playerUuid;
     public Position position;
 
+    public SpawnPlayerPacket() {
+        playerUuid = new UUID(0,0);
+        position = new Position();
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(entityId);
@@ -23,6 +30,15 @@ public class SpawnPlayerPacket implements ServerPacket {
         writer.writeDouble(position.getZ());
         writer.writeByte((byte) (position.getYaw() * 256f / 360f));
         writer.writeByte((byte) (position.getPitch() * 256f / 360f));
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityId = reader.readVarInt();
+        playerUuid = reader.readUuid();
+        position = new Position(reader.readDouble(), reader.readDouble(), reader.readDouble());
+        position.setYaw((reader.readByte() * 360f) / 256f);
+        position.setPitch((reader.readByte() * 360f) / 256f);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/SpawnPositionPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/SpawnPositionPacket.java
@@ -2,6 +2,8 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.BlockPosition;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -9,9 +11,19 @@ public class SpawnPositionPacket implements ServerPacket {
 
     public int x, y, z;
 
+    public SpawnPositionPacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeBlockPosition(x, y, z);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        BlockPosition pos = reader.readBlockPosition();
+        x = pos.getX();
+        y = pos.getY();
+        z = pos.getZ();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/StatisticsPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/StatisticsPacket.java
@@ -3,12 +3,19 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.stat.StatisticCategory;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
+import net.minestom.server.utils.binary.Readable;
+import net.minestom.server.utils.binary.Writeable;
 import org.jetbrains.annotations.NotNull;
 
 public class StatisticsPacket implements ServerPacket {
 
     public Statistic[] statistics;
+
+    public StatisticsPacket() {
+        statistics = new Statistic[0];
+    }
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -19,20 +26,38 @@ public class StatisticsPacket implements ServerPacket {
     }
 
     @Override
+    public void read(@NotNull BinaryReader reader) {
+        int length = reader.readVarInt();
+        statistics = new Statistic[length];
+        for (int i = 0; i < length; i++) {
+            statistics[i] = new Statistic();
+            statistics[i].read(reader);
+        }
+    }
+
+    @Override
     public int getId() {
         return ServerPacketIdentifier.STATISTICS;
     }
 
-    public static class Statistic {
+    public static class Statistic implements Writeable, Readable {
 
         public StatisticCategory category;
         public int statisticId;
         public int value;
 
-        private void write(BinaryWriter writer) {
+        @Override
+        public void write(BinaryWriter writer) {
             writer.writeVarInt(category.ordinal());
             writer.writeVarInt(statisticId);
             writer.writeVarInt(value);
+        }
+
+        @Override
+        public void read(@NotNull BinaryReader reader) {
+            category = StatisticCategory.values()[reader.readVarInt()];
+            statisticId = reader.readVarInt();
+            value = reader.readVarInt();
         }
     }
 

--- a/src/main/java/net/minestom/server/network/packet/server/play/StopSoundPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/StopSoundPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,6 +12,10 @@ public class StopSoundPacket implements ServerPacket {
     public int source;
     public String sound;
 
+    public StopSoundPacket() {
+        sound = "";
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeByte(flags);
@@ -18,6 +23,17 @@ public class StopSoundPacket implements ServerPacket {
             writer.writeVarInt(source);
         if (flags == 2 || flags == 3)
             writer.writeSizedString(sound);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        flags = reader.readByte();
+        if(flags == 3 || flags == 1) {
+            source = reader.readVarInt();
+        }
+        if(flags == 2 || flags == 3) {
+            sound = reader.readSizedString(Integer.MAX_VALUE);
+        }
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/TabCompletePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/TabCompletePacket.java
@@ -52,9 +52,9 @@ public class TabCompletePacket implements ComponentHoldingServerPacket {
         for (int i = 0; i < matchCount; i++) {
             String match = reader.readSizedString(Integer.MAX_VALUE);
             boolean hasTooltip = reader.readBoolean();
-            JsonMessage tooltip = null;
+            Component tooltip = null;
             if(hasTooltip) {
-                tooltip = reader.readJsonMessage(Integer.MAX_VALUE);
+                tooltip = reader.readComponent(Integer.MAX_VALUE);
             }
             Match newMatch = new Match();
             newMatch.match = match;

--- a/src/main/java/net/minestom/server/network/packet/server/play/TabCompletePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/TabCompletePacket.java
@@ -5,6 +5,7 @@ import net.minestom.server.adventure.ComponentHolder;
 import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -21,6 +22,10 @@ public class TabCompletePacket implements ComponentHoldingServerPacket {
     public int length;
     public Match[] matches;
 
+    public TabCompletePacket() {
+        matches = new Match[0];
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(transactionId);
@@ -33,6 +38,29 @@ public class TabCompletePacket implements ComponentHoldingServerPacket {
             writer.writeBoolean(match.hasTooltip);
             if (match.hasTooltip)
                 writer.writeComponent(match.tooltip);
+        }
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        transactionId = reader.readVarInt();
+        start = reader.readVarInt();
+        length = reader.readVarInt();
+
+        int matchCount = reader.readVarInt();
+        matches = new Match[matchCount];
+        for (int i = 0; i < matchCount; i++) {
+            String match = reader.readSizedString(Integer.MAX_VALUE);
+            boolean hasTooltip = reader.readBoolean();
+            JsonMessage tooltip = null;
+            if(hasTooltip) {
+                tooltip = reader.readJsonMessage(Integer.MAX_VALUE);
+            }
+            Match newMatch = new Match();
+            newMatch.match = match;
+            newMatch.hasTooltip = hasTooltip;
+            newMatch.tooltip = tooltip;
+            matches[i] = newMatch;
         }
     }
 

--- a/src/main/java/net/minestom/server/network/packet/server/play/TagsPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/TagsPacket.java
@@ -1,14 +1,20 @@
 package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.MinecraftServer;
+import net.minestom.server.entity.EntityType;
+import net.minestom.server.fluids.Fluid;
 import net.minestom.server.gamedata.tags.Tag;
+import net.minestom.server.instance.block.Block;
+import net.minestom.server.item.Material;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.registry.Registries;
 import net.minestom.server.utils.NamespaceID;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -27,12 +33,25 @@ public class TagsPacket implements ServerPacket {
         MinecraftServer.getTagManager().addRequiredTagsToPacket(REQUIRED_TAGS_PACKET);
     }
 
+    /**
+     * Default constructor, required for reflection operations.
+     */
+    public TagsPacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writeTags(writer, blockTags, name -> Registries.getBlock(name).ordinal());
         writeTags(writer, itemTags, name -> Registries.getMaterial(name).ordinal());
         writeTags(writer, fluidTags, name -> Registries.getFluid(name).ordinal());
         writeTags(writer, entityTags, name -> Registries.getEntityType(name).ordinal());
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        readTags(reader, blockTags, id -> NamespaceID.from("minecraft", Block.values()[id].getName()));
+        readTags(reader, itemTags, id -> NamespaceID.from("minecraft", Material.values()[id].getName()));
+        readTags(reader, fluidTags, id -> NamespaceID.from(Fluid.values()[id].getNamespaceID()));
+        readTags(reader, entityTags, id -> NamespaceID.from(EntityType.values()[id].getNamespaceID()));
     }
 
     private void writeTags(BinaryWriter writer, List<Tag> tags, Function<NamespaceID, Integer> idSupplier) {
@@ -48,6 +67,23 @@ public class TagsPacket implements ServerPacket {
             for (NamespaceID name : values) {
                 writer.writeVarInt(idSupplier.apply(name));
             }
+        }
+    }
+
+    public void readTags(BinaryReader reader, List<Tag> output, Function<Integer, NamespaceID> idSupplier) {
+        output.clear();
+        int length = reader.readVarInt();
+        for (int i = 0; i < length; i++) {
+            String name = reader.readSizedString(Integer.MAX_VALUE);
+
+            int count = reader.readVarInt();
+            Set<NamespaceID> values = new HashSet<>();
+            for (int j = 0; j < count; j++) {
+                int protocolID = reader.readVarInt();
+                values.add(idSupplier.apply(protocolID));
+            }
+
+            output.add(new Tag(NamespaceID.from(name), values));
         }
     }
 

--- a/src/main/java/net/minestom/server/network/packet/server/play/TeamsPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/TeamsPacket.java
@@ -113,13 +113,13 @@ public class TeamsPacket implements ComponentHoldingServerPacket {
         switch (action) {
             case CREATE_TEAM:
             case UPDATE_TEAM_INFO:
-                this.teamDisplayName = reader.readJsonMessage(Integer.MAX_VALUE);
+                this.teamDisplayName = reader.readComponent(Integer.MAX_VALUE);
                 this.friendlyFlags = reader.readByte();
                 nameTagVisibility = NameTagVisibility.fromIdentifier(reader.readSizedString(Integer.MAX_VALUE));
                 collisionRule = CollisionRule.fromIdentifier(reader.readSizedString(Integer.MAX_VALUE));
-                this.teamColor = reader.readVarInt();
-                this.teamPrefix = reader.readJsonMessage(Integer.MAX_VALUE);
-                this.teamSuffix = reader.readJsonMessage(Integer.MAX_VALUE);
+                this.teamColor = NamedTextColor.ofExact(reader.readVarInt());
+                this.teamPrefix = reader.readComponent(Integer.MAX_VALUE);
+                this.teamSuffix = reader.readComponent(Integer.MAX_VALUE);
                 break;
             case REMOVE_TEAM:
 

--- a/src/main/java/net/minestom/server/network/packet/server/play/TimeUpdatePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/TimeUpdatePacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,10 +11,21 @@ public class TimeUpdatePacket implements ServerPacket {
     public long worldAge;
     public long timeOfDay;
 
+    /**
+     * Default constructor, required for reflection operations.
+     */
+    public TimeUpdatePacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeLong(worldAge);
         writer.writeLong(timeOfDay);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        worldAge = reader.readLong();
+        timeOfDay = reader.readLong();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/TitlePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/TitlePacket.java
@@ -6,6 +6,7 @@ import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.TickUtils;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.apache.commons.lang3.Validate;
 import org.jetbrains.annotations.NotNull;
@@ -67,6 +68,10 @@ public class TitlePacket implements ComponentHoldingServerPacket {
         this.fadeOut = fadeOut;
     }
 
+    public TitlePacket() {
+        this(SET_TITLE, Component.empty());
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(action.ordinal());
@@ -82,6 +87,27 @@ public class TitlePacket implements ComponentHoldingServerPacket {
                 writer.writeInt(stay);
                 writer.writeInt(fadeOut);
                 break;
+            case HIDE:
+            case RESET:
+                break;
+        }
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        action = Action.values()[reader.readVarInt()];
+        switch (action) {
+            case SET_TITLE:
+            case SET_SUBTITLE:
+            case SET_ACTION_BAR:
+                payload = reader.readComponent(Integer.MAX_VALUE);
+                break;
+
+            case SET_TIMES_AND_DISPLAY:
+                fadeIn = reader.readInt();
+                stay = reader.readInt();
+                fadeOut = reader.readInt();
+
             case HIDE:
             case RESET:
                 break;

--- a/src/main/java/net/minestom/server/network/packet/server/play/TradeListPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/TradeListPacket.java
@@ -3,7 +3,10 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
+import net.minestom.server.utils.binary.Readable;
+import net.minestom.server.utils.binary.Writeable;
 import org.jetbrains.annotations.NotNull;
 
 public class TradeListPacket implements ServerPacket {
@@ -14,6 +17,13 @@ public class TradeListPacket implements ServerPacket {
     public int experience;
     public boolean regularVillager;
     public boolean canRestock;
+
+    /**
+     * Default constructor, required for reflection operations.
+     */
+    public TradeListPacket() {
+        trades = new Trade[0];
+    }
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -29,11 +39,27 @@ public class TradeListPacket implements ServerPacket {
     }
 
     @Override
+    public void read(@NotNull BinaryReader reader) {
+        windowId = reader.readVarInt();
+        byte tradeCount = reader.readByte();
+
+        trades = new Trade[tradeCount];
+        for (int i = 0; i < tradeCount; i++) {
+            trades[i] = new Trade();
+            trades[i].read(reader);
+        }
+        villagerLevel = reader.readVarInt();
+        experience = reader.readVarInt();
+        regularVillager = reader.readBoolean();
+        canRestock = reader.readBoolean();
+    }
+
+    @Override
     public int getId() {
         return ServerPacketIdentifier.TRADE_LIST;
     }
 
-    public static class Trade {
+    public static class Trade implements Writeable, Readable {
 
         public ItemStack inputItem1;
         public ItemStack result;
@@ -46,8 +72,8 @@ public class TradeListPacket implements ServerPacket {
         public float priceMultiplier;
         public int demand;
 
-
-        private void write(BinaryWriter writer) {
+        @Override
+        public void write(BinaryWriter writer) {
             boolean hasSecondItem = inputItem2 != null;
 
             writer.writeItemStack(inputItem1);
@@ -64,6 +90,26 @@ public class TradeListPacket implements ServerPacket {
             writer.writeInt(demand);
         }
 
+        @Override
+        public void read(@NotNull BinaryReader reader) {
+            inputItem1 = reader.readItemStack();
+            result = reader.readItemStack();
+
+            boolean hasSecondItem = reader.readBoolean();
+            if(hasSecondItem) {
+                inputItem2 = reader.readItemStack();
+            } else {
+                inputItem2 = null;
+            }
+
+            tradeDisabled = reader.readBoolean();
+            tradeUsesNumber = reader.readInt();
+            maxTradeUsesNumber = reader.readInt();
+            exp = reader.readInt();
+            specialPrice = reader.readInt();
+            priceMultiplier = reader.readFloat();
+            demand = reader.readInt();
+        }
     }
 
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/UnloadChunkPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/UnloadChunkPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -9,10 +10,21 @@ public class UnloadChunkPacket implements ServerPacket {
 
     public int chunkX, chunkZ;
 
+    /**
+     * Default constructor, required for reflection operations.
+     */
+    public UnloadChunkPacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeInt(chunkX);
         writer.writeInt(chunkZ);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        chunkX = reader.readInt();
+        chunkZ = reader.readInt();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/UnlockRecipesPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/UnlockRecipesPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -18,6 +19,14 @@ public class UnlockRecipesPacket implements ServerPacket {
 
     // Only if mode = 0
     public String[] initRecipesId;
+
+    /**
+     * Default constructor, required for reflection operations.
+     */
+    public UnlockRecipesPacket() {
+        recipesId = new String[0];
+        initRecipesId = new String[0];
+    }
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -37,6 +46,30 @@ public class UnlockRecipesPacket implements ServerPacket {
             writer.writeVarInt(initRecipesId.length);
             for (String string : initRecipesId) {
                 writer.writeSizedString(string);
+            }
+        }
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        mode = reader.readVarInt();
+
+        craftingRecipeBookOpen = reader.readBoolean();
+        craftingRecipeBookFilterActive = reader.readBoolean();
+        smeltingRecipeBookOpen = reader.readBoolean();
+        smeltingRecipeBookFilterActive = reader.readBoolean();
+
+        int length = reader.readVarInt();
+        recipesId = new String[length];
+        for (int i = 0; i < length; i++) {
+            recipesId[i] = reader.readSizedString(Integer.MAX_VALUE);
+        }
+
+        if(mode == 0) {
+            int initRecipesLength = reader.readVarInt();
+            initRecipesId = new String[initRecipesLength];
+            for (int i = 0; i < length; i++) {
+                initRecipesId[i] = reader.readSizedString(Integer.MAX_VALUE);
             }
         }
     }

--- a/src/main/java/net/minestom/server/network/packet/server/play/UpdateHealthPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/UpdateHealthPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,11 +12,23 @@ public class UpdateHealthPacket implements ServerPacket {
     public int food;
     public float foodSaturation;
 
+    /**
+     * Default constructor, required for reflection operations.
+     */
+    public UpdateHealthPacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeFloat(health);
         writer.writeVarInt(food);
         writer.writeFloat(foodSaturation);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        health = reader.readFloat();
+        food = reader.readVarInt();
+        foodSaturation = reader.readFloat();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/UpdateLightPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/UpdateLightPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import net.minestom.server.utils.cache.CacheablePacket;
 import net.minestom.server.utils.cache.TemporaryCache;
@@ -9,6 +10,8 @@ import net.minestom.server.utils.cache.TimedBuffer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -36,9 +39,25 @@ public class UpdateLightPacket implements ServerPacket, CacheablePacket {
     private final UUID identifier;
     private final long timestamp;
 
+    /**
+     * Default constructor, required for reflection operations.
+     * This one will make a packet that is not meant to be cached
+     */
+    public UpdateLightPacket() {
+        this(UUID.randomUUID(), Long.MAX_VALUE);
+        for (int i = 0; i < 14; i++) {
+            skyLight.add(new byte[2048]);
+        }
+        for (int i = 0; i < 6; i++) {
+            blockLight.add(new byte[2048]);
+        }
+    }
+
     public UpdateLightPacket(@Nullable UUID identifier, long timestamp) {
         this.identifier = identifier;
         this.timestamp = timestamp;
+        skyLight = new ArrayList<>(14);
+        blockLight = new ArrayList<>(6);
     }
 
     @Override
@@ -64,6 +83,44 @@ public class UpdateLightPacket implements ServerPacket, CacheablePacket {
         for (byte[] bytes : blockLight) {
             writer.writeVarInt(2048); // Always 2048 length
             writer.writeBytes(bytes);
+        }
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        chunkX = reader.readVarInt();
+        chunkZ = reader.readVarInt();
+
+        trustEdges = reader.readBoolean();
+
+        skyLightMask = reader.readVarInt();
+        blockLightMask = reader.readVarInt();
+
+        emptySkyLightMask = reader.readVarInt();
+        emptyBlockLightMask = reader.readVarInt();
+
+        // sky light
+        skyLight.clear();
+        for (int i = 0; i < 14; i++) {
+            int length = reader.readVarInt();
+            if(length != 2048) {
+                throw new IllegalStateException("Length must be 2048.");
+            }
+
+            byte[] bytes = reader.readBytes(length);
+            skyLight.add(bytes);
+        }
+
+        // block light
+        blockLight.clear();
+        for (int i = 0; i < 6; i++) {
+            int length = reader.readVarInt();
+            if(length != 2048) {
+                throw new IllegalStateException("Length must be 2048.");
+            }
+
+            byte[] bytes = reader.readBytes(length);
+            blockLight.add(bytes);
         }
     }
 

--- a/src/main/java/net/minestom/server/network/packet/server/play/UpdateScorePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/UpdateScorePacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,6 +13,14 @@ public class UpdateScorePacket implements ServerPacket {
     public String objectiveName;
     public int value;
 
+    /**
+     * Default constructor, required for reflection operations.
+     */
+    public UpdateScorePacket() {
+        entityName = "";
+        objectiveName = "";
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeSizedString(entityName);
@@ -19,6 +28,16 @@ public class UpdateScorePacket implements ServerPacket {
         writer.writeSizedString(objectiveName);
         if (action != 1) {
             writer.writeVarInt(value);
+        }
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        entityName = reader.readSizedString(Integer.MAX_VALUE);
+        action = reader.readByte();
+        objectiveName = reader.readSizedString(Integer.MAX_VALUE);
+        if(action != 1) {
+            value = reader.readVarInt();
         }
     }
 

--- a/src/main/java/net/minestom/server/network/packet/server/play/UpdateViewDistancePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/UpdateViewDistancePacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -9,9 +10,19 @@ public class UpdateViewDistancePacket implements ServerPacket {
 
     public int viewDistance;
 
+    /**
+     * Default constructor, required for reflection operations.
+     */
+    public UpdateViewDistancePacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(viewDistance);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        viewDistance = reader.readVarInt();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/UpdateViewPositionPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/UpdateViewPositionPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -9,10 +10,21 @@ public class UpdateViewPositionPacket implements ServerPacket {
 
     public int chunkX, chunkZ;
 
+    /**
+     * Default constructor, required for reflection operations.
+     */
+    public UpdateViewPositionPacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(chunkX);
         writer.writeVarInt(chunkZ);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        chunkX = reader.readVarInt();
+        chunkZ = reader.readVarInt();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/VehicleMovePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/VehicleMovePacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,6 +11,11 @@ public class VehicleMovePacket implements ServerPacket {
     public double x, y, z;
     public float yaw, pitch;
 
+    /**
+     * Default constructor, required for reflection operations.
+     */
+    public VehicleMovePacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeDouble(x);
@@ -17,6 +23,15 @@ public class VehicleMovePacket implements ServerPacket {
         writer.writeDouble(z);
         writer.writeFloat(yaw);
         writer.writeFloat(pitch);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        x = reader.readDouble();
+        y = reader.readDouble();
+        z = reader.readDouble();
+        yaw = reader.readFloat();
+        pitch = reader.readFloat();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/WindowConfirmationPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/WindowConfirmationPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,11 +12,23 @@ public class WindowConfirmationPacket implements ServerPacket {
     public short actionNumber;
     public boolean accepted;
 
+    /**
+     * Default constructor, required for reflection operations.
+     */
+    public WindowConfirmationPacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeByte(windowId);
         writer.writeShort(actionNumber);
         writer.writeBoolean(accepted);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        windowId = reader.readByte();
+        actionNumber = reader.readShort();
+        accepted = reader.readBoolean();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/WindowItemsPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/WindowItemsPacket.java
@@ -3,6 +3,7 @@ package net.minestom.server.network.packet.server.play;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,6 +11,11 @@ public class WindowItemsPacket implements ServerPacket {
 
     public byte windowId;
     public ItemStack[] items;
+
+    /**
+     * Default constructor, required for reflection operations.
+     */
+    public WindowItemsPacket() {}
 
     @Override
     public void write(@NotNull BinaryWriter writer) {
@@ -23,6 +29,17 @@ public class WindowItemsPacket implements ServerPacket {
         writer.writeShort((short) items.length);
         for (ItemStack item : items) {
             writer.writeItemStack(item);
+        }
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        windowId = reader.readByte();
+
+        short length = reader.readShort();
+        items = new ItemStack[length];
+        for (int i = 0; i < length; i++) {
+            items[i] = reader.readItemStack();
         }
     }
 

--- a/src/main/java/net/minestom/server/network/packet/server/play/WindowPropertyPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/WindowPropertyPacket.java
@@ -2,6 +2,7 @@ package net.minestom.server.network.packet.server.play;
 
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,11 +12,23 @@ public class WindowPropertyPacket implements ServerPacket {
     public short property;
     public short value;
 
+    /**
+     * Default constructor, required for reflection operations.
+     */
+    public WindowPropertyPacket() {}
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeByte(windowId);
         writer.writeShort(property);
         writer.writeShort(value);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        windowId = reader.readByte();
+        property = reader.readShort();
+        value = reader.readShort();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/WorldBorderPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/WorldBorderPacket.java
@@ -10,6 +10,16 @@ public class WorldBorderPacket implements ServerPacket {
     public Action action;
     public WBAction wbAction;
 
+    private static final WBAction DEFAULT_ACTION = new WBSetSize(0.0);
+
+    /**
+     * Default constructor, required for reflection operations.
+     */
+    public WorldBorderPacket() {
+        action = Action.SET_SIZE;
+        wbAction = DEFAULT_ACTION;
+    }
+
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeVarInt(action.ordinal());

--- a/src/main/java/net/minestom/server/network/packet/server/status/PongPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/status/PongPacket.java
@@ -1,12 +1,18 @@
 package net.minestom.server.network.packet.server.status;
 
 import net.minestom.server.network.packet.server.ServerPacket;
+import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class PongPacket implements ServerPacket {
 
     public long number;
+
+    /**
+     * Default constructor, required for reflection operations.
+     */
+    public PongPacket() {}
 
     public PongPacket(long number) {
         this.number = number;
@@ -15,6 +21,11 @@ public class PongPacket implements ServerPacket {
     @Override
     public void write(@NotNull BinaryWriter writer) {
         writer.writeLong(number);
+    }
+
+    @Override
+    public void read(@NotNull BinaryReader reader) {
+        number = reader.readLong();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/particle/ParticleCreator.java
+++ b/src/main/java/net/minestom/server/particle/ParticleCreator.java
@@ -2,6 +2,7 @@ package net.minestom.server.particle;
 
 import net.minestom.server.network.packet.server.play.ParticlePacket;
 import net.minestom.server.utils.binary.BinaryWriter;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Consumer;
 
@@ -13,7 +14,7 @@ public class ParticleCreator {
     public static ParticlePacket createParticlePacket(Particle particleType, boolean distance,
                                                       double x, double y, double z,
                                                       float offsetX, float offsetY, float offsetZ,
-                                                      float particleData, int count, Consumer<BinaryWriter> dataWriter) {
+                                                      float particleData, int count, @Nullable Consumer<BinaryWriter> dataWriter) {
         ParticlePacket particlePacket = new ParticlePacket();
         particlePacket.particleId = particleType.getId();
         particlePacket.longDistance = distance;
@@ -28,7 +29,14 @@ public class ParticleCreator {
 
         particlePacket.particleData = particleData;
         particlePacket.particleCount = count;
-        particlePacket.dataConsumer = dataWriter;
+
+        if(dataWriter != null) {
+            BinaryWriter writer = new BinaryWriter();
+            dataWriter.accept(writer);
+            particlePacket.data = writer.toByteArray();
+        } else {
+            particlePacket.data = new byte[0];
+        }
 
         return particlePacket;
     }

--- a/src/main/java/net/minestom/server/utils/Utils.java
+++ b/src/main/java/net/minestom/server/utils/Utils.java
@@ -88,6 +88,24 @@ public final class Utils {
         return result;
     }
 
+    public static long readVarLong(ByteBuf buffer) {
+        int numRead = 0;
+        long result = 0;
+        byte read;
+        do {
+            read = buffer.readByte();
+            long value = (read & 0b01111111);
+            result |= (value << (7 * numRead));
+
+            numRead++;
+            if (numRead > 10) {
+                throw new RuntimeException("VarLong is too big");
+            }
+        } while ((read & 0b10000000) != 0);
+
+        return result;
+    }
+
     public static void writeVarLong(BinaryWriter writer, long value) {
         do {
             byte temp = (byte) (value & 0b01111111);

--- a/src/main/java/net/minestom/server/utils/binary/BinaryReader.java
+++ b/src/main/java/net/minestom/server/utils/binary/BinaryReader.java
@@ -43,6 +43,10 @@ public class BinaryReader extends InputStream {
         return Utils.readVarInt(buffer);
     }
 
+    public long readVarLong() {
+        return Utils.readVarLong(buffer);
+    }
+
     public boolean readBoolean() {
         return buffer.readBoolean();
     }

--- a/src/main/java/net/minestom/server/utils/binary/BinaryReader.java
+++ b/src/main/java/net/minestom/server/utils/binary/BinaryReader.java
@@ -63,7 +63,17 @@ public class BinaryReader extends InputStream {
         return buffer.readUnsignedShort();
     }
 
+    /**
+     * Same as readInt
+     */
     public int readInteger() {
+        return buffer.readInt();
+    }
+
+    /**
+     * Same as readInteger, created for parity with BinaryWriter
+     */
+    public int readInt() {
         return buffer.readInt();
     }
 
@@ -143,10 +153,18 @@ public class BinaryReader extends InputStream {
      * @return the read item
      * @throws NullPointerException if the item could not get read
      */
-    public ItemStack readSlot() {
+    public ItemStack readItemStack() {
         final ItemStack itemStack = NBTUtils.readItemStack(this);
         Check.notNull(itemStack, "#readSlot returned null, probably because the buffer was corrupted");
         return itemStack;
+    }
+
+    /**
+     * Same as readItemStack
+     */
+    @Deprecated
+    public ItemStack readSlot() {
+        return readItemStack();
     }
 
     /**

--- a/src/main/java/net/minestom/server/utils/binary/BinaryReader.java
+++ b/src/main/java/net/minestom/server/utils/binary/BinaryReader.java
@@ -136,7 +136,15 @@ public class BinaryReader extends InputStream {
         return array;
     }
 
+    /**
+     * @deprecated Use {@link #readRemainingBytes()} (same semantics, but more consistent naming)
+     */
+    @Deprecated
     public byte[] getRemainingBytes() {
+        return readRemainingBytes();
+    }
+
+    public byte[] readRemainingBytes() {
         return readBytes(buffer.readableBytes());
     }
 

--- a/src/main/java/net/minestom/server/utils/binary/BinaryReader.java
+++ b/src/main/java/net/minestom/server/utils/binary/BinaryReader.java
@@ -195,6 +195,34 @@ public class BinaryReader extends InputStream {
         return GsonComponentSerializer.gson().deserialize(jsonObject);
     }
 
+    /**
+     * Creates a new object from the given supplier and calls its {@link Readable#read(BinaryReader)} method with this reader
+     * @param supplier supplier to create new instances of your object
+     * @param <T>
+     * @return the read object
+     */
+    public <T extends Readable> T read(Supplier<T> supplier) {
+        T result = supplier.get();
+        result.read(this);
+        return result;
+    }
+
+    /**
+     * Reads the length of the array to read as a varint, creates the array to contain the readable objects and call
+     * their respective {@link Readable#read(BinaryReader)} methods.
+     * @param supplier supplier to create new instances of your object
+     * @param <T>
+     * @return the read objects
+     */
+    public <T extends Readable> T[] readArray(Supplier<T> supplier) {
+        T[] result = (T[]) new Object[readVarInt()];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = supplier.get();
+            result[i].read(this);
+        }
+        return result;
+    }
+
     public ByteBuf getBuffer() {
         return buffer;
     }

--- a/src/main/java/net/minestom/server/utils/binary/BinaryReader.java
+++ b/src/main/java/net/minestom/server/utils/binary/BinaryReader.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 /**
  * Class used to read from a byte array.
@@ -209,5 +211,20 @@ public class BinaryReader extends InputStream {
 
     public NBT readTag() throws IOException, NBTException {
         return nbtReader.read();
+    }
+
+    /**
+     * Records the current position, runs the given Runnable, and then returns the bytes between the position before
+     * running the runnable and the position after.
+     * Can be used to extract a subsection of this reader's buffer with complex data
+     * @param extractor the extraction code, simply call the reader's read* methods here.
+     */
+    public byte[] extractBytes(Runnable extractor) {
+        int startingPosition = getBuffer().readerIndex();
+        extractor.run();
+        int endingPosition = getBuffer().readerIndex();
+        byte[] output = new byte[endingPosition-startingPosition];
+        getBuffer().getBytes(startingPosition, output);
+        return output;
     }
 }

--- a/src/main/java/net/minestom/server/utils/binary/BinaryWriter.java
+++ b/src/main/java/net/minestom/server/utils/binary/BinaryWriter.java
@@ -6,6 +6,7 @@ import io.netty.buffer.Unpooled;
 import net.kyori.adventure.text.Component;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.adventure.AdventureSerializer;
+import net.minestom.server.chat.JsonMessage;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.utils.BlockPosition;
 import net.minestom.server.utils.NBTUtils;
@@ -177,6 +178,15 @@ public class BinaryWriter extends OutputStream {
     }
 
     /**
+     * Writes a JsonMessage to the buffer.
+     * Simply a writeSizedString with message.toString()
+     * @param message
+     */
+    public void writeJsonMessage(JsonMessage message) {
+        writeSizedString(message.toString());
+    }
+
+    /**
      * Writes a var-int array to the buffer.
      * <p>
      * It is sized by another var-int at the beginning.
@@ -326,5 +336,9 @@ public class BinaryWriter extends OutputStream {
     @Override
     public void write(int b) {
         writeByte((byte) b);
+    }
+
+    public void writeUnsignedShort(int yourShort) {
+        buffer.writeShort(yourShort & 0xFFFF);
     }
 }

--- a/src/main/java/net/minestom/server/utils/binary/BinaryWriter.java
+++ b/src/main/java/net/minestom/server/utils/binary/BinaryWriter.java
@@ -276,6 +276,26 @@ public class BinaryWriter extends OutputStream {
     }
 
     /**
+     * Writes the given writeable object into this writer.
+     * @param writeable the object to write
+     */
+    public void write(Writeable writeable) {
+        writeable.write(this);
+    }
+
+    /**
+     * Writes an array of writeable objects to this writer. Will prepend the binary stream with a var int to denote the
+     * length of the array.
+     * @param writeables the array of writeables to write
+     */
+    public void writeArray(Writeable[] writeables) {
+        writeVarInt(writeables.length);
+        for(Writeable w : writeables) {
+            write(w);
+        }
+    }
+
+    /**
      * Converts the internal buffer to a byte array.
      *
      * @return the byte array containing all the {@link BinaryWriter} data

--- a/src/main/java/net/minestom/server/utils/binary/BinaryWriter.java
+++ b/src/main/java/net/minestom/server/utils/binary/BinaryWriter.java
@@ -341,4 +341,13 @@ public class BinaryWriter extends OutputStream {
     public void writeUnsignedShort(int yourShort) {
         buffer.writeShort(yourShort & 0xFFFF);
     }
+
+    /**
+     * Returns a byte[] with the contents written via BinaryWriter
+     */
+    public static byte[] makeArray(Consumer<BinaryWriter> writing) {
+        BinaryWriter writer = new BinaryWriter();
+        writing.accept(writer);
+        return writer.toByteArray();
+    }
 }

--- a/src/main/java/net/minestom/server/utils/chunk/ChunkUtils.java
+++ b/src/main/java/net/minestom/server/utils/chunk/ChunkUtils.java
@@ -296,4 +296,24 @@ public final class ChunkUtils {
         return (byte) (index >> 12 & 0xF);
     }
 
+    /**
+     * Returns the section, from a chunk index encoded with {@link #getChunkIndexWithSection(int, int, int)}
+     */
+    public static int getSectionFromChunkIndexWithSection(long index) {
+        return (int) (index & 1048575L);
+    }
+
+    /**
+     * Returns the chunk X, from a chunk index encoded with {@link #getChunkIndexWithSection(int, int, int)}
+     */
+    public static int getChunkXFromChunkIndexWithSection(long index) {
+        return (int) ((index >> 42) & 4194303L);
+    }
+
+    /**
+     * Returns the chunk Z, from a chunk index encoded with {@link #getChunkIndexWithSection(int, int, int)}
+     */
+    public static int getChunkZFromChunkIndexWithSection(long index) {
+        return (int) ((index >> 20) & 4194303L);
+    }
 }

--- a/src/main/java/net/minestom/server/utils/validate/Check.java
+++ b/src/main/java/net/minestom/server/utils/validate/Check.java
@@ -37,6 +37,11 @@ public final class Check {
         }
     }
 
+    @Contract("_ -> fail")
+    public static void fail(@NotNull String reason) {
+        throw new IllegalArgumentException(reason);
+    }
+
     @Contract("true, _ -> fail")
     public static void stateCondition(boolean condition, @NotNull String reason) {
         if (condition) {

--- a/src/main/java/net/minestom/server/world/DimensionType.java
+++ b/src/main/java/net/minestom/server/world/DimensionType.java
@@ -82,6 +82,24 @@ public class DimensionType {
         return new DimensionTypeBuilder();
     }
 
+    public static DimensionType fromNBT(NBTCompound nbt) {
+        return DimensionType.builder(NamespaceID.from(nbt.getString("name")))
+                .ambientLight(nbt.getFloat("ambient_light"))
+                .infiniburn(NamespaceID.from(nbt.getString("infiniburn")))
+                .natural(nbt.getByte("natural") != 0)
+                .ceilingEnabled(nbt.getByte("has_ceiling") != 0)
+                .skylightEnabled(nbt.getByte("has_skylight") != 0)
+                .ultrawarm(nbt.getByte("ultrawarm") != 0)
+                .raidCapable(nbt.getByte("has_raids") != 0)
+                .respawnAnchorSafe(nbt.getByte("respawn_anchor_works") != 0)
+                .bedSafe(nbt.getByte("bed_works") != 0)
+                .effects(nbt.getString("effects"))
+                .piglinSafe(nbt.getByte("piglin_safe") != 0)
+                .logicalHeight(nbt.getInt("logical_height"))
+                .coordinateScale(nbt.getInt("coordinate_scale"))
+                .build();
+    }
+
     @NotNull
     public NBTCompound toIndexedNBT() {
         NBTCompound nbt = new NBTCompound();

--- a/src/test/java/readwritepackets/ReadWritePackets.java
+++ b/src/test/java/readwritepackets/ReadWritePackets.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -55,7 +56,9 @@ public class ReadWritePackets {
                         MinecraftServer.init();
 
                         BinaryWriter writer = new BinaryWriter();
-                        T packet = (T) clazz.getConstructor().newInstance();
+                        Constructor<?> constructor = clazz.getDeclaredConstructor();
+                        constructor.setAccessible(true);
+                        T packet = (T) constructor.newInstance();
 
                         // write packet
                         packet.write(writer);

--- a/src/test/java/readwritepackets/ReadWritePackets.java
+++ b/src/test/java/readwritepackets/ReadWritePackets.java
@@ -1,0 +1,86 @@
+package readwritepackets;
+
+import com.google.common.reflect.ClassPath;
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.network.packet.client.ClientPacket;
+import net.minestom.server.network.packet.server.ServerPacket;
+import net.minestom.server.utils.binary.BinaryReader;
+import net.minestom.server.utils.binary.BinaryWriter;
+import net.minestom.server.utils.binary.Readable;
+import net.minestom.server.utils.binary.Writeable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * If you are using IntelliJ, set it up so that tests are run through IntelliJ and not Gradle for this collection of tests
+ */
+public class ReadWritePackets {
+
+    /**
+     * Test that all read operations on ServerPacket subclasses are implemented, and use the correct amount of memory.
+     * This is by no means a perfect test as some packets have variable length and content has to be validated
+     */
+    @TestFactory
+    public Collection<DynamicTest> checkServerImplementationPresence() throws IOException {
+        return checkImplementationPresence(ServerPacket.class);
+    }
+
+    /**
+     * Test that all write operations on ClientPacket subclasses are implemented, and use the correct amount of memory.
+     * This is by no means a perfect test as some packets have variable length and content has to be validated
+     */
+    @TestFactory
+    public Collection<DynamicTest> checkClientImplementationPresence() throws IOException {
+        return checkImplementationPresence(ClientPacket.class);
+    }
+
+    private <T extends Readable & Writeable> Collection<DynamicTest> checkImplementationPresence(Class<T> packetClass) throws IOException {
+        ClassPath cp = ClassPath.from(ClassLoader.getSystemClassLoader());
+        List<DynamicTest> allTests = new LinkedList<>();
+        for(ClassPath.ClassInfo classInfo : cp.getAllClasses()) {
+            if(!classInfo.getPackageName().startsWith("net.minestom.server.network.packet"))
+                continue;
+            try {
+                Class<?> clazz = classInfo.load();
+                if(packetClass.isAssignableFrom(clazz) && !clazz.isInterface() && ((clazz.getModifiers() & Modifier.ABSTRACT) != Modifier.ABSTRACT)) {
+                    allTests.add(DynamicTest.dynamicTest("WriteThenRead "+clazz.getSimpleName(), () -> {
+                        // required for managers to be loaded
+                        MinecraftServer.init();
+
+                        BinaryWriter writer = new BinaryWriter();
+                        T packet = (T) clazz.getConstructor().newInstance();
+
+                        // write packet
+                        packet.write(writer);
+
+                        // re-read packet
+                        byte[] originalBytes = writer.toByteArray();
+                        BinaryReader reader = new BinaryReader(originalBytes);
+                        packet.read(reader);
+
+                        Assertions.assertEquals(0, reader.getRemainingBytes().length, "Packet did not read all available data");
+
+                        // re-write to ensure packet contents are the same
+                        BinaryWriter secondWriter = new BinaryWriter();
+                        packet.write(secondWriter);
+
+                        // check that contents are the same than before read
+                        Assertions.assertArrayEquals(originalBytes, secondWriter.toByteArray());
+                    }));
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+                throw e;
+            }
+        }
+
+        return allTests;
+    }
+}

--- a/src/test/java/readwritepackets/ReadWritePackets.java
+++ b/src/test/java/readwritepackets/ReadWritePackets.java
@@ -2,8 +2,10 @@ package readwritepackets;
 
 import com.google.common.reflect.ClassPath;
 import net.minestom.server.MinecraftServer;
+import net.minestom.server.item.ItemStack;
 import net.minestom.server.network.packet.client.ClientPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
+import net.minestom.server.network.packet.server.play.EntityEquipmentPacket;
 import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import net.minestom.server.utils.binary.Readable;
@@ -58,7 +60,19 @@ public class ReadWritePackets {
                         BinaryWriter writer = new BinaryWriter();
                         Constructor<?> constructor = clazz.getDeclaredConstructor();
                         constructor.setAccessible(true);
-                        T packet = (T) constructor.newInstance();
+                        T packet;
+
+                        // exceptions
+                        if(clazz.getSimpleName().equals("EntityEquipmentPacket")) {
+                            // requires at least one slot and one item
+                            EntityEquipmentPacket p = new EntityEquipmentPacket();
+                            p.itemStacks = new ItemStack[] { ItemStack.getAirItem() };
+                            p.slots = new EntityEquipmentPacket.Slot[] { EntityEquipmentPacket.Slot.MAIN_HAND };
+                            packet = (T) p;
+                        }
+                        else {
+                            packet = (T) constructor.newInstance();
+                        }
 
                         // write packet
                         packet.write(writer);

--- a/src/test/java/readwritepackets/ReadWritePackets.java
+++ b/src/test/java/readwritepackets/ReadWritePackets.java
@@ -68,7 +68,7 @@ public class ReadWritePackets {
                         BinaryReader reader = new BinaryReader(originalBytes);
                         packet.read(reader);
 
-                        Assertions.assertEquals(0, reader.getRemainingBytes().length, "Packet did not read all available data");
+                        Assertions.assertEquals(0, reader.readRemainingBytes().length, "Packet did not read all available data");
 
                         // re-write to ensure packet contents are the same
                         BinaryWriter secondWriter = new BinaryWriter();


### PR DESCRIPTION
This PR adds the `Readable` interface on `ServerPacket` and the `Writeable` interface on `ClientPacket`.
This can help with saving packets on disk to be replayed later.

More importantly, this is required if we want a pseudo-client for our test framework.

BREAKING CHANGES (might not be exhaustive):
* ParticlePacket no longer has `Consumer<BinaryWriter> dataConsumer` field, but simply a `byte[] data` field to allow for deserialization. `ParticleCreator::createParticlePacket` is not affected
* `OpenWindowPacket#title` is now a JsonMessage, but the class has a constructor that takes a String for the previous behaviour (creating a json message as such: `{"text": "your_title"}`
* `ChatMessagePacket#jsonMessage` is now a JsonMessage, but the class has a constructor that takes a String for the previous behaviour (creating a json message as such: `{"text": "your_title"}`
* DeclareCommandsPacket.Node no longer has `Consumer<BinaryWriter> properties` field, but simply a `byte[] data` field to allow for deserialization.