### PR TITLE
Add events for player sneaking and sprinting changes

### DIFF
--- a/src/main/java/net/minestom/server/event/player/PlayerStartSneakingEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerStartSneakingEvent.java
@@ -1,0 +1,15 @@
+package net.minestom.server.event.player;
+
+import net.minestom.server.entity.Player;
+import net.minestom.server.event.PlayerEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called when a player starts sneaking.
+ */
+public class PlayerStartSneakingEvent extends PlayerEvent {
+
+    public PlayerStartSneakingEvent(@NotNull Player player) {
+        super(player);
+    }
+}

--- a/src/main/java/net/minestom/server/event/player/PlayerStartSprintingEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerStartSprintingEvent.java
@@ -1,0 +1,15 @@
+package net.minestom.server.event.player;
+
+import net.minestom.server.entity.Player;
+import net.minestom.server.event.PlayerEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called when a player starts sprinting.
+ */
+public class PlayerStartSprintingEvent extends PlayerEvent {
+
+    public PlayerStartSprintingEvent(@NotNull Player player) {
+        super(player);
+    }
+}

--- a/src/main/java/net/minestom/server/event/player/PlayerStopSneakingEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerStopSneakingEvent.java
@@ -1,0 +1,15 @@
+package net.minestom.server.event.player;
+
+import net.minestom.server.entity.Player;
+import net.minestom.server.event.PlayerEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called when a player stops sneaking.
+ */
+public class PlayerStopSneakingEvent extends PlayerEvent {
+
+    public PlayerStopSneakingEvent(@NotNull Player player) {
+        super(player);
+    }
+}

--- a/src/main/java/net/minestom/server/event/player/PlayerStopSprintingEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerStopSprintingEvent.java
@@ -1,0 +1,15 @@
+package net.minestom.server.event.player;
+
+import net.minestom.server.entity.Player;
+import net.minestom.server.event.PlayerEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called when a player stops sprinting.
+ */
+public class PlayerStopSprintingEvent extends PlayerEvent {
+
+    public PlayerStopSprintingEvent(@NotNull Player player) {
+        super(player);
+    }
+}

--- a/src/main/java/net/minestom/server/listener/EntityActionListener.java
+++ b/src/main/java/net/minestom/server/listener/EntityActionListener.java
@@ -1,6 +1,10 @@
 package net.minestom.server.listener;
 
 import net.minestom.server.entity.Player;
+import net.minestom.server.event.player.PlayerStartSneakingEvent;
+import net.minestom.server.event.player.PlayerStartSprintingEvent;
+import net.minestom.server.event.player.PlayerStopSneakingEvent;
+import net.minestom.server.event.player.PlayerStopSprintingEvent;
 import net.minestom.server.network.packet.client.play.ClientEntityActionPacket;
 
 public class EntityActionListener {
@@ -9,18 +13,46 @@ public class EntityActionListener {
         ClientEntityActionPacket.Action action = packet.action;
         switch (action) {
             case START_SNEAKING:
-                player.setSneaking(true);
+                EntityActionListener.setSneaking(player, true);
                 break;
             case STOP_SNEAKING:
-                player.setSneaking(false);
+                EntityActionListener.setSneaking(player, false);
                 break;
             case START_SPRINTING:
-                player.setSprinting(true);
+                EntityActionListener.setSprinting(player, true);
                 break;
             case STOP_SPRINTING:
-                player.setSprinting(false);
+                EntityActionListener.setSprinting(player, false);
                 break;
             // TODO do remaining actions
+        }
+    }
+
+    private static void setSneaking(Player player, boolean sneaking) {
+        boolean oldState = player.isSneaking();
+
+        player.setSneaking(sneaking);
+
+        if (oldState != sneaking) {
+            if (sneaking) {
+                player.callEvent(PlayerStartSneakingEvent.class, new PlayerStartSneakingEvent(player));
+            } else {
+                player.callEvent(PlayerStopSneakingEvent.class, new PlayerStopSneakingEvent(player));
+            }
+        }
+    }
+
+    private static void setSprinting(Player player, boolean sprinting) {
+        boolean oldState = player.isSprinting();
+
+        player.setSprinting(sprinting);
+
+        if (oldState != sprinting) {
+            if (sprinting) {
+                player.callEvent(PlayerStartSprintingEvent.class, new PlayerStartSprintingEvent(player));
+            } else {
+                player.callEvent(PlayerStopSprintingEvent.class, new PlayerStopSprintingEvent(player));
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds events for when the player changes their sprinting or sneaking state. These event calls could be moved into the `Player` class but in order to stay in line with the fly event they are only called when the client actively changes their state.