### PR TITLE
Prefer position over entity

### DIFF
--- a/src/main/java/net/minestom/server/utils/location/RelativeBlockPosition.java
+++ b/src/main/java/net/minestom/server/utils/location/RelativeBlockPosition.java
@@ -17,11 +17,11 @@ public class RelativeBlockPosition extends RelativeLocation<BlockPosition> {
     }
 
     @Override
-    public BlockPosition from(@Nullable Entity entity) {
+    public BlockPosition from(@Nullable Position position) {
         if (!relativeX && !relativeY && !relativeZ) {
             return location.clone();
         }
-        final Position entityPosition = entity != null ? entity.getPosition() : new Position();
+        final Position entityPosition = position != null ? position : new Position();
 
         final int x = location.getX() + (relativeX ? (int) entityPosition.getX() : 0);
         final int y = location.getY() + (relativeY ? (int) entityPosition.getY() : 0);

--- a/src/main/java/net/minestom/server/utils/location/RelativeLocation.java
+++ b/src/main/java/net/minestom/server/utils/location/RelativeLocation.java
@@ -1,6 +1,7 @@
 package net.minestom.server.utils.location;
 
 import net.minestom.server.entity.Entity;
+import net.minestom.server.utils.Position;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -27,7 +28,7 @@ public abstract class RelativeLocation<T> {
      * @param entity the entity to get the relative position from
      * @return the location
      */
-    public abstract T from(@Nullable Entity entity);
+    public abstract T from(@Nullable Position entity);
 
     /**
      * Gets if the 'x' field is relative.

--- a/src/main/java/net/minestom/server/utils/location/RelativeLocation.java
+++ b/src/main/java/net/minestom/server/utils/location/RelativeLocation.java
@@ -28,7 +28,20 @@ public abstract class RelativeLocation<T> {
      * @param entity the entity to get the relative position from
      * @return the location
      */
-    public abstract T from(@Nullable Position entity);
+    public T from(@Nullable Entity entity) {
+
+        final Position entityPosition = entity != null ? entity.getPosition() : new Position();
+
+        return from(entityPosition);
+    }
+
+    /**
+     * Gets the location based on the relative fields and {@code position}.
+     *
+     * @param position the relative position
+     * @return the location
+     */
+    public abstract T from(@Nullable Position position);
 
     /**
      * Gets if the 'x' field is relative.

--- a/src/main/java/net/minestom/server/utils/location/RelativeVec.java
+++ b/src/main/java/net/minestom/server/utils/location/RelativeVec.java
@@ -17,11 +17,11 @@ public class RelativeVec extends RelativeLocation<Vector> {
     }
 
     @Override
-    public Vector from(@Nullable Entity entity) {
+    public Vector from(@Nullable Position position) {
         if (!relativeX && !relativeY && !relativeZ) {
             return location.clone();
         }
-        final Position entityPosition = entity != null ? entity.getPosition() : new Position();
+        final Position entityPosition = position != null ? position : new Position();
 
         final double x = location.getX() + (relativeX ? entityPosition.getX() : 0);
         final double y = location.getY() + (relativeY ? entityPosition.getY() : 0);

--- a/src/test/java/demo/commands/TeleportCommand.java
+++ b/src/test/java/demo/commands/TeleportCommand.java
@@ -38,7 +38,7 @@ public class TeleportCommand extends Command {
         final Player player = sender.asPlayer();
 
         final RelativeVec relativeVec = args.getRelativeVector("pos");
-        final Position position = relativeVec.from(player).toPosition();
+        final Position position = relativeVec.from(player.getPosition()).toPosition();
 
         player.teleport(position);
         player.sendMessage("You have been teleported to " + position);

--- a/src/test/java/demo/commands/TeleportCommand.java
+++ b/src/test/java/demo/commands/TeleportCommand.java
@@ -38,7 +38,7 @@ public class TeleportCommand extends Command {
         final Player player = sender.asPlayer();
 
         final RelativeVec relativeVec = args.getRelativeVector("pos");
-        final Position position = relativeVec.from(player.getPosition()).toPosition();
+        final Position position = relativeVec.from(player).toPosition();
 
         player.teleport(position);
         player.sendMessage("You have been teleported to " + position);


### PR DESCRIPTION
For all RelativePositions, use a `Position` object internally instead of an `Entity` to allow relative positions related to a non-entity.