### PR TITLE
Fix palette resize issue

### DIFF
--- a/src/main/java/net/minestom/server/instance/palette/PaletteStorage.java
+++ b/src/main/java/net/minestom/server/instance/palette/PaletteStorage.java
@@ -275,7 +275,7 @@ public class PaletteStorage implements PublicCloneable<PaletteStorage> {
 
         final int section = ChunkUtils.getSectionAt(y);
 
-        final int valuesPerLong = paletteStorage.valuesPerLong;
+        int valuesPerLong = paletteStorage.valuesPerLong;
 
         if (paletteStorage.sectionBlocks[section].length == 0) {
             if (blockId == 0) {
@@ -293,6 +293,9 @@ public class PaletteStorage implements PublicCloneable<PaletteStorage> {
 
         // Change to palette value
         blockId = paletteStorage.getPaletteIndex(section, blockId);
+
+        // The storage could have been resized
+        valuesPerLong = paletteStorage.valuesPerLong;
 
         final int sectionIndex = getSectionIndex(x, y, z);
 


### PR DESCRIPTION
Fix a bug caused by trying to write into the PaletteStorage with the wrong `valuesPerLong` creating corruption in the storage. This was fixed simply be resetting `valuesPerLong` after a possible resize.