### PR TITLE
Add ItemStack constructor without amount parameter

### DIFF
--- a/src/main/java/net/minestom/server/item/ItemStack.java
+++ b/src/main/java/net/minestom/server/item/ItemStack.java
@@ -96,6 +96,10 @@ public class ItemStack implements DataContainer, PublicCloneable<ItemStack> {
         this(material, amount, (short) 0);
     }
 
+    public ItemStack(@NotNull Material material) {
+        this(material, (byte) 1, (short) 0);
+    }
+
     /**
      * Gets a new {@link ItemStack} with the material sets to {@link Material#AIR}.
      * <p>


### PR DESCRIPTION
Added a constructor to ItemStack without the amount parameter that defaults to 1 for convenience.