### PR TITLE
Extension exposing and cleanup

### DIFF
--- a/src/main/java/net/minestom/server/MinecraftServer.java
+++ b/src/main/java/net/minestom/server/MinecraftServer.java
@@ -750,7 +750,6 @@ public final class MinecraftServer {
             // Load extensions
             extensionManager.loadExtensions();
             // Init extensions
-            // TODO: Extensions should handle depending on each other and have a load-order.
             extensionManager.getExtensions().forEach(Extension::preInitialize);
             extensionManager.getExtensions().forEach(Extension::initialize);
             extensionManager.getExtensions().forEach(Extension::postInitialize);

--- a/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
+++ b/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
@@ -11,24 +11,59 @@ import java.net.URL;
 import java.util.LinkedList;
 import java.util.List;
 
+/**
+ * Represents an extension from an `extension.json` that is capable of powering an Extension object.
+ *
+ * This has no constructor as its properties are set via GSON.
+ */
 public final class DiscoveredExtension {
 
-    public final static Logger LOGGER = LoggerFactory.getLogger(DiscoveredExtension.class);
+    /** Static logger for this class. */
+    public static final Logger LOGGER = LoggerFactory.getLogger(DiscoveredExtension.class);
 
+    /** The regex that this name must pass. If it doesn't, it will not be accepted. */
     public static final String NAME_REGEX = "[A-Za-z][_A-Za-z0-9]+";
+
+    /** Name of the DiscoveredExtension. Unique for all extensions. */
     private String name;
+
+    /** Main class of this DiscoveredExtension, must extend Extension. */
     private String entrypoint;
+
+    /** Version of this extension, highly reccomended to set it. */
     private String version;
+
+    /** Points to sponge mixin config in resources folder. */
     private String mixinConfig;
+
+    /** People who have made this extension. */
     private String[] authors;
+
+    /** All code modifiers (the classes they point to) */
     private String[] codeModifiers;
+
+    /** List of extension names that this depends on. */
     private String[] dependencies;
+
+    /** List of Repositories and URLs that this depends on. */
     private ExternalDependencies externalDependencies;
+
+    /** A list of any missing code modifiers to be used for logging. */
     private final List<String> missingCodeModifiers = new LinkedList<>();
+
+    /** If this extension couldn't load its mixin configuration. */
     private boolean failedToLoadMixin = false;
+
+    /** All files of this extension */
     transient List<URL> files = new LinkedList<>();
+
+    /** The load status of this extension -- LOAD_SUCCESS is the only good one. */
     transient LoadStatus loadStatus = LoadStatus.LOAD_SUCCESS;
+
+    /** The original jar this is from. */
     transient private File originalJar;
+
+    /** The class loader that powers it. */
     transient private MinestomExtensionClassLoader minestomExtensionClassLoader;
 
     @NotNull
@@ -74,7 +109,7 @@ public final class DiscoveredExtension {
         return externalDependencies;
     }
 
-    void setOriginalJar(@Nullable File file) {
+    public void setOriginalJar(@Nullable File file) {
         originalJar = file;
     }
 
@@ -83,13 +118,13 @@ public final class DiscoveredExtension {
         return originalJar;
     }
 
-    MinestomExtensionClassLoader removeMinestomExtensionClassLoader() {
+    public MinestomExtensionClassLoader removeMinestomExtensionClassLoader() {
         MinestomExtensionClassLoader oldClassLoader = getMinestomExtensionClassLoader();
         setMinestomExtensionClassLoader(null);
         return oldClassLoader;
     }
 
-    void setMinestomExtensionClassLoader(@Nullable MinestomExtensionClassLoader minestomExtensionClassLoader) {
+    public void setMinestomExtensionClassLoader(@Nullable MinestomExtensionClassLoader minestomExtensionClassLoader) {
         this.minestomExtensionClassLoader = minestomExtensionClassLoader;
     }
 
@@ -98,7 +133,14 @@ public final class DiscoveredExtension {
         return this.minestomExtensionClassLoader;
     }
 
-    static void verifyIntegrity(@NotNull DiscoveredExtension extension) {
+    /**
+     * Ensures that all properties of this extension are properly set if they aren't
+     *
+     * TODO this is an impure function.
+     *
+     * @param extension The extension to verify
+     */
+    public static void verifyIntegrity(@NotNull DiscoveredExtension extension) {
         if (extension.name == null) {
             StringBuilder fileList = new StringBuilder();
             for (URL f : extension.files) {
@@ -181,6 +223,11 @@ public final class DiscoveredExtension {
         return failedToLoadMixin;
     }
 
+    /**
+     * The status this extension has, all are breakpoints.
+     *
+     * LOAD_SUCCESS is the only valid one.
+     */
     enum LoadStatus {
         LOAD_SUCCESS("Actually, it did not fail. This message should not have been printed."),
         MISSING_DEPENDENCIES("Missing dependencies, check your logs."),

--- a/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
+++ b/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
@@ -120,13 +120,13 @@ public final class DiscoveredExtension {
         return originalJar;
     }
 
-    public MinestomExtensionClassLoader removeMinestomExtensionClassLoader() {
+    MinestomExtensionClassLoader removeMinestomExtensionClassLoader() {
         MinestomExtensionClassLoader oldClassLoader = getMinestomExtensionClassLoader();
         setMinestomExtensionClassLoader(null);
         return oldClassLoader;
     }
 
-    public void setMinestomExtensionClassLoader(@Nullable MinestomExtensionClassLoader minestomExtensionClassLoader) {
+    void setMinestomExtensionClassLoader(@Nullable MinestomExtensionClassLoader minestomExtensionClassLoader) {
         this.minestomExtensionClassLoader = minestomExtensionClassLoader;
     }
 

--- a/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
+++ b/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
@@ -10,7 +10,7 @@ import java.net.URL;
 import java.util.LinkedList;
 import java.util.List;
 
-final class DiscoveredExtension {
+public final class DiscoveredExtension {
 
     public final static Logger LOGGER = LoggerFactory.getLogger(DiscoveredExtension.class);
 
@@ -23,7 +23,7 @@ final class DiscoveredExtension {
     private String[] codeModifiers;
     private String[] dependencies;
     private ExternalDependencies externalDependencies;
-    private List<String> missingCodeModifiers = new LinkedList<>();
+    private final List<String> missingCodeModifiers = new LinkedList<>();
     private boolean failedToLoadMixin = false;
     transient List<URL> files = new LinkedList<>();
     transient LoadStatus loadStatus = LoadStatus.LOAD_SUCCESS;
@@ -77,7 +77,7 @@ final class DiscoveredExtension {
     }
 
     @Nullable
-    File getOriginalJar() {
+    public File getOriginalJar() {
         return originalJar;
     }
 

--- a/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
+++ b/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
@@ -95,6 +95,7 @@ public final class DiscoveredExtension {
             extension.name = extension.loadStatus.name();
             return;
         }
+
         if (!extension.name.matches(NAME_REGEX)) {
             LOGGER.error("Extension '{}' specified an invalid name.", extension.name);
             LOGGER.error("Extension '{}' will not be loaded.", extension.name);
@@ -104,6 +105,7 @@ public final class DiscoveredExtension {
             extension.name = extension.loadStatus.name();
             return;
         }
+
         if (extension.entrypoint == null) {
             LOGGER.error("Extension '{}' did not specify an entry point (via 'entrypoint').", extension.name);
             LOGGER.error("Extension '{}' will not be loaded.", extension.name);
@@ -113,6 +115,7 @@ public final class DiscoveredExtension {
             extension.entrypoint = extension.loadStatus.name();
             return;
         }
+
         // Handle defaults
         // If we reach this code, then the extension will most likely be loaded:
         if (extension.version == null) {
@@ -120,19 +123,24 @@ public final class DiscoveredExtension {
             LOGGER.warn("Extension '{}' will continue to load but should specify a plugin version.", extension.name);
             extension.version = "Unspecified";
         }
+
         if (extension.mixinConfig == null) {
             extension.mixinConfig = "";
         }
+
         if (extension.authors == null) {
             extension.authors = new String[0];
         }
+
         if (extension.codeModifiers == null) {
             extension.codeModifiers = new String[0];
         }
+
         // No dependencies were specified
         if (extension.dependencies == null) {
             extension.dependencies = new String[0];
         }
+
         // No external dependencies were specified;
         if (extension.externalDependencies == null) {
             extension.externalDependencies = new ExternalDependencies();
@@ -177,11 +185,11 @@ public final class DiscoveredExtension {
         }
     }
 
-    static final class ExternalDependencies {
+    public static final class ExternalDependencies {
         Repository[] repositories = new Repository[0];
         String[] artifacts = new String[0];
 
-        static class Repository {
+        public static class Repository {
             String name = "";
             String url = "";
         }

--- a/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
+++ b/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
@@ -1,5 +1,6 @@
 package net.minestom.server.extensions;
 
+import net.minestom.server.extras.selfmodification.MinestomExtensionClassLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -28,6 +29,7 @@ public final class DiscoveredExtension {
     transient List<URL> files = new LinkedList<>();
     transient LoadStatus loadStatus = LoadStatus.LOAD_SUCCESS;
     transient private File originalJar;
+    transient private MinestomExtensionClassLoader minestomExtensionClassLoader;
 
     @NotNull
     public String getName() {
@@ -79,6 +81,21 @@ public final class DiscoveredExtension {
     @Nullable
     public File getOriginalJar() {
         return originalJar;
+    }
+
+    MinestomExtensionClassLoader removeMinestomExtensionClassLoader() {
+        MinestomExtensionClassLoader oldClassLoader = getMinestomExtensionClassLoader();
+        setMinestomExtensionClassLoader(null);
+        return oldClassLoader;
+    }
+
+    void setMinestomExtensionClassLoader(@Nullable MinestomExtensionClassLoader minestomExtensionClassLoader) {
+        this.minestomExtensionClassLoader = minestomExtensionClassLoader;
+    }
+
+    @Nullable
+    public MinestomExtensionClassLoader getMinestomExtensionClassLoader() {
+        return this.minestomExtensionClassLoader;
     }
 
     static void verifyIntegrity(@NotNull DiscoveredExtension extension) {

--- a/src/main/java/net/minestom/server/extensions/Extension.java
+++ b/src/main/java/net/minestom/server/extensions/Extension.java
@@ -13,7 +13,7 @@ import java.util.function.Consumer;
 public abstract class Extension {
     // Set by reflection
     @SuppressWarnings("unused")
-    private ExtensionDescription description;
+    private DiscoveredExtension origin;
     // Set by reflection
     @SuppressWarnings("unused")
     private Logger logger;
@@ -24,8 +24,13 @@ public abstract class Extension {
      * this extension holds a reference to it. A WeakReference makes sure this extension does not prevent the memory
      * from being cleaned up.
      */
-    private Set<WeakReference<IExtensionObserver>> observers = Collections.newSetFromMap(new ConcurrentHashMap<>());
-    private ReferenceQueue<IExtensionObserver> observerReferenceQueue = new ReferenceQueue<>();
+    protected final Set<WeakReference<IExtensionObserver>> observers = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    protected final ReferenceQueue<IExtensionObserver> observerReferenceQueue = new ReferenceQueue<>();
+
+    /**
+     * List of extensions that depend on this extension.
+     */
+    protected final Set<String> dependents = new HashSet<>();
 
     protected Extension() {
 
@@ -59,10 +64,14 @@ public abstract class Extension {
     }
 
     @NotNull
-    public ExtensionDescription getDescription() {
-        return description;
+    public DiscoveredExtension getOrigin() {
+        return origin;
     }
 
+    /**
+     * Gets the logger for the extension
+     * @return The logger for the extension
+     */
     @NotNull
     protected Logger getLogger() {
         return logger;
@@ -71,7 +80,8 @@ public abstract class Extension {
     /**
      * Adds a new observer to this extension.
      * Will be kept as a WeakReference.
-     * @param observer
+     *
+     * @param observer The observer to add
      */
     public void observe(IExtensionObserver observer) {
         observers.add(new WeakReference<>(observer, observerReferenceQueue));
@@ -82,9 +92,9 @@ public abstract class Extension {
      * @param action code to execute on each observer
      */
     public void triggerChange(Consumer<IExtensionObserver> action) {
-        for(WeakReference<IExtensionObserver> weakObserver : observers) {
+        for (WeakReference<IExtensionObserver> weakObserver : observers) {
             IExtensionObserver observer = weakObserver.get();
-            if(observer != null) {
+            if (observer != null) {
                 action.accept(observer);
             }
         }
@@ -94,7 +104,7 @@ public abstract class Extension {
      * If this extension registers code modifiers and/or mixins, are they loaded correctly?
      */
     public boolean areCodeModifiersAllLoadedCorrectly() {
-        return !getDescription().failedToLoadMixin && getDescription().getMissingCodeModifiers().isEmpty();
+        return !getOrigin().hasFailedToLoadMixin() && getOrigin().getMissingCodeModifiers().isEmpty();
     }
 
     /**
@@ -109,57 +119,10 @@ public abstract class Extension {
         }
     }
 
-    public static class ExtensionDescription {
-        private final String name;
-        private final String version;
-        private final List<String> authors;
-        private final List<String> dependents = new ArrayList<>();
-        private final List<String> missingCodeModifiers = new LinkedList<>();
-        private final boolean failedToLoadMixin;
-        private final DiscoveredExtension origin;
-
-        ExtensionDescription(@NotNull String name, @NotNull String version, @NotNull List<String> authors, @NotNull DiscoveredExtension origin) {
-            this.name = name;
-            this.version = version;
-            this.authors = authors;
-            this.origin = origin;
-            failedToLoadMixin = origin.hasFailedToLoadMixin();
-            missingCodeModifiers.addAll(origin.getMissingCodeModifiers());
-        }
-
-        @NotNull
-        public String getName() {
-            return name;
-        }
-
-        @NotNull
-        public String getVersion() {
-            return version;
-        }
-
-        @NotNull
-        public List<String> getAuthors() {
-            return authors;
-        }
-
-        @NotNull
-        public List<String> getDependents() {
-            return dependents;
-        }
-
-        @NotNull
-        DiscoveredExtension getOrigin() {
-            return origin;
-        }
-
-        @NotNull
-        public List<String> getMissingCodeModifiers() {
-            return missingCodeModifiers;
-        }
-
-        @NotNull
-        public boolean hasFailedToLoadMixin() {
-            return failedToLoadMixin;
-        }
+    /**
+     * @return A modifiable list of dependents.
+     */
+    public Set<String> getDependents() {
+        return dependents;
     }
 }

--- a/src/main/java/net/minestom/server/extensions/Extension.java
+++ b/src/main/java/net/minestom/server/extensions/Extension.java
@@ -73,7 +73,7 @@ public abstract class Extension {
      * @return The logger for the extension
      */
     @NotNull
-    protected Logger getLogger() {
+    public Logger getLogger() {
         return logger;
     }
 

--- a/src/main/java/net/minestom/server/extensions/ExtensionDependencyResolver.java
+++ b/src/main/java/net/minestom/server/extensions/ExtensionDependencyResolver.java
@@ -37,11 +37,13 @@ public class ExtensionDependencyResolver implements DependencyResolver {
             // B depends on A (A<-B)
             // When loading B, with no deep conversion, Ext will not be added to the list of dependencies (because it is not a direct dependency)
             // But when trying to call/access code from extension A, the parts dependent on Ext won't be inside B's dependencies, triggering a ClassNotFoundException
-            List<ResolvedDependency> deps = new LinkedList<>();
-            for (URL u : ext.files) {
-                deps.add(new ResolvedDependency(u.toExternalForm(), u.toExternalForm(), "", u, new LinkedList<>()));
+            List<ResolvedDependency> dependencies = new LinkedList<>();
+
+            for (URL url : ext.files) {
+                dependencies.add(new ResolvedDependency(url.toExternalForm(), url.toExternalForm(), "", url, new LinkedList<>()));
             }
-            return new ResolvedDependency(ext.getName(), ext.getName(), ext.getVersion(), ext.files.get(0), deps);
+
+            return new ResolvedDependency(ext.getName(), ext.getName(), ext.getVersion(), ext.files.get(0), dependencies);
         }
         throw new UnresolvedDependencyException("No extension named " + extensionName);
     }

--- a/src/main/java/net/minestom/server/extensions/ExtensionManager.java
+++ b/src/main/java/net/minestom/server/extensions/ExtensionManager.java
@@ -127,10 +127,21 @@ public class ExtensionManager {
             }
         }
 
+        // Periodically cleanup observers
+        MinecraftServer.getSchedulerManager().buildTask(() -> {
+            for (Extension ext : extensions.values()) {
+                ext.cleanupObservers();
+            }
+        }).repeat(1L, TimeUnit.MINUTE).schedule();
+
         // Load extensions
         {
             // Get all extensions and order them accordingly.
             List<DiscoveredExtension> discoveredExtensions = discoverExtensions();
+
+            // Don't waste resources on doing extra actions if there is nothing to do.
+            if (discoveredExtensions.isEmpty()) return;
+
             discoveredExtensions = generateLoadOrder(discoveredExtensions);
             loadDependencies(discoveredExtensions);
 
@@ -164,13 +175,6 @@ public class ExtensionManager {
                 }
             }
         }
-
-        // periodically cleanup observers
-        MinecraftServer.getSchedulerManager().buildTask(() -> {
-            for (Extension ext : extensions.values()) {
-                ext.cleanupObservers();
-            }
-        }).repeat(1L, TimeUnit.MINUTE).schedule();
     }
 
     /**

--- a/src/main/java/net/minestom/server/extensions/ExtensionManager.java
+++ b/src/main/java/net/minestom/server/extensions/ExtensionManager.java
@@ -38,7 +38,7 @@ public class ExtensionManager {
     public final static String INDEV_RESOURCES_FOLDER = "minestom.extension.indevfolder.resources";
     private final static Gson GSON = new Gson();
 
-    // Not too much concurrency is done through extension managers.
+    // LinkedHashMaps are HashMaps that preserve order
     private final Map<String, Extension> extensions = new LinkedHashMap<>();
     private final Map<String, Extension> immutableExtensions = Collections.unmodifiableMap(extensions);
 
@@ -198,7 +198,7 @@ public class ExtensionManager {
      */
     @Nullable
     private Extension loadExtension(@NotNull DiscoveredExtension discoveredExtension) {
-        // Create ExtensionDescription (authors, version etc.)
+        // Create Extension (authors, version etc.)
         String extensionName = discoveredExtension.getName();
         String mainClass = discoveredExtension.getEntrypoint();
 
@@ -287,7 +287,7 @@ public class ExtensionManager {
             }
         }
 
-        // add to a linked hash map, as lists preserve order
+        // add to a linked hash map, as they preserve order
         extensions.put(extensionName.toLowerCase(), extension);
 
         return extension;

--- a/src/main/java/net/minestom/server/extensions/ExtensionManager.java
+++ b/src/main/java/net/minestom/server/extensions/ExtensionManager.java
@@ -85,9 +85,10 @@ public class ExtensionManager {
      * Turns its extension.json into a DiscoveredExtension object.
      * Verifies that all properties of extension.json are correctly set.
      *
-     * It then sorts all those jars depending on its load order (extensions can have dependencies)
+     * It then sorts all those jars by their load order (making sure that an extension's dependencies load before it)
+     * Note: Cyclic dependencies will stop both extensions from being loaded.
      *
-     * Afterwards, it loads all external dependencies (sort of an outsourced dynamic shadowJar)
+     * Afterwards, it loads all external dependencies and adds them to the extension's files
      *
      * Then removes any invalid extensions (Invalid being its Load Status isn't SUCCESS)
      *
@@ -100,7 +101,7 @@ public class ExtensionManager {
      *
      * If the extension successfully loads, add it to the global extension Map (Name to Extension)
      *
-     * Then makes a scheduler to clean observers per extension.
+     * And finally make a scheduler to clean observers per extension.
      *
      */
     public void loadExtensions() {

--- a/src/main/java/net/minestom/server/extensions/ExtensionManager.java
+++ b/src/main/java/net/minestom/server/extensions/ExtensionManager.java
@@ -127,7 +127,7 @@ public class ExtensionManager {
 
         // periodically cleanup observers
         MinecraftServer.getSchedulerManager().buildTask(() -> {
-            for(Extension ext : extensionList) {
+            for (Extension ext : extensionList) {
                 ext.cleanupObservers();
             }
         }).repeat(1L, TimeUnit.MINUTE).schedule();
@@ -448,9 +448,9 @@ public class ExtensionManager {
         LOGGER.trace("Added dependency {} to extension {} classpath", location.toExternalForm(), extension.getName());
 
         // recurse to add full dependency tree
-        if(!dependency.getSubdependencies().isEmpty()) {
+        if (!dependency.getSubdependencies().isEmpty()) {
             LOGGER.trace("Dependency {} has subdependencies, adding...", location.toExternalForm());
-            for(ResolvedDependency sub : dependency.getSubdependencies()) {
+            for (ResolvedDependency sub : dependency.getSubdependencies()) {
                 addDependencyFile(sub, extension);
             }
             LOGGER.trace("Dependency {} has had its subdependencies added.", location.toExternalForm());

--- a/src/main/java/net/minestom/server/extensions/ExtensionManager.java
+++ b/src/main/java/net/minestom/server/extensions/ExtensionManager.java
@@ -735,7 +735,7 @@ public class ExtensionManager {
      */
     public static void loadCodeModifiersEarly() {
         // allow users to disable early code modifier load
-        if("true".equalsIgnoreCase(System.getProperty(DISABLE_EARLY_LOAD_SYSTEM_KEY))) {
+        if ("true".equalsIgnoreCase(System.getProperty(DISABLE_EARLY_LOAD_SYSTEM_KEY))) {
             return;
         }
         LOGGER.info("Early load of code modifiers from extensions.");
@@ -765,8 +765,8 @@ public class ExtensionManager {
     public void unloadAllExtensions() {
         // copy names, as the extensions map will be modified via the calls to unload
         Set<String> extensionNames = new HashSet<>(extensions.keySet());
-        for(String ext : extensionNames) {
-            if(extensions.containsKey(ext)) { // is still loaded? Because extensions can depend on one another, it might have already been unloaded
+        for (String ext : extensionNames) {
+            if (extensions.containsKey(ext)) { // is still loaded? Because extensions can depend on one another, it might have already been unloaded
                 unloadExtension(ext);
             }
         }

--- a/src/main/java/net/minestom/server/extras/selfmodification/HierarchyClassLoader.java
+++ b/src/main/java/net/minestom/server/extras/selfmodification/HierarchyClassLoader.java
@@ -22,20 +22,25 @@ public abstract class HierarchyClassLoader extends URLClassLoader {
         children.add(loader);
     }
 
-    public InputStream getResourceAsStreamWithChildren(String name) {
+    public InputStream getResourceAsStreamWithChildren(@NotNull String name) {
         InputStream in = getResourceAsStream(name);
-        if(in != null) return in;
+        if (in != null) return in;
 
-        for(MinestomExtensionClassLoader child : children) {
+        for (MinestomExtensionClassLoader child : children) {
             InputStream childInput = child.getResourceAsStreamWithChildren(name);
-            if(childInput != null)
+            if (childInput != null)
                 return childInput;
         }
+
         return null;
     }
 
     public void removeChildInHierarchy(MinestomExtensionClassLoader child) {
         children.remove(child);
-        children.forEach(c -> c.removeChildInHierarchy(child));
+
+        // Also remove all children from these extension's children.
+        for (MinestomExtensionClassLoader subChild : children) {
+            subChild.removeChildInHierarchy(child);
+        }
     }
 }

--- a/src/main/java/net/minestom/server/extras/selfmodification/MinestomExtensionClassLoader.java
+++ b/src/main/java/net/minestom/server/extras/selfmodification/MinestomExtensionClassLoader.java
@@ -105,8 +105,14 @@ public class MinestomExtensionClassLoader extends HierarchyClassLoader {
      * @see MinestomRootClassLoader#loadBytes(String, boolean) for more information
      */
     protected boolean isMainExtensionClass(String name) {
-        if(mainClassName.equals(name))
+
+        if (mainClassName.equals(name))
             return true;
-        return children.stream().anyMatch(c -> c.isMainExtensionClass(name));
+
+        for (MinestomExtensionClassLoader child : children) {
+            if (child.isMainExtensionClass(name)) return true;
+        }
+
+        return false;
     }
 }

--- a/src/main/java/net/minestom/server/extras/selfmodification/MinestomRootClassLoader.java
+++ b/src/main/java/net/minestom/server/extras/selfmodification/MinestomRootClassLoader.java
@@ -10,7 +10,6 @@ import org.objectweb.asm.tree.ClassNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
@@ -220,9 +219,8 @@ public class MinestomRootClassLoader extends HierarchyClassLoader {
         return originalBytes;
     }
 
-    public byte[] loadBytesWithChildren(String name, boolean transform) throws IOException, ClassNotFoundException {
-        if (name == null)
-            throw new ClassNotFoundException();
+    public byte[] loadBytesWithChildren(@NotNull String name, boolean transform) throws IOException, ClassNotFoundException {
+
         String path = name.replace(".", "/") + ".class";
         InputStream input = getResourceAsStreamWithChildren(path);
         if (input == null) {
@@ -298,11 +296,7 @@ public class MinestomRootClassLoader extends HierarchyClassLoader {
             }
             return true;
         } catch (ClassNotFoundException | InvocationTargetException | InstantiationException | IllegalAccessException | NoSuchMethodException e) {
-            if(MinecraftServer.getExceptionManager() != null) {
-                MinecraftServer.getExceptionManager().handleException(e);
-            } else {
-                e.printStackTrace();
-            }
+            MinecraftServer.getExceptionManager().handleException(e);
         }
         return false;
     }
@@ -336,7 +330,7 @@ public class MinestomRootClassLoader extends HierarchyClassLoader {
     @Nullable
     public static String findExtensionObjectOwner(@NotNull Object obj) {
         ClassLoader cl = obj.getClass().getClassLoader();
-        if(cl instanceof MinestomExtensionClassLoader) {
+        if (cl instanceof MinestomExtensionClassLoader) {
             return ((MinestomExtensionClassLoader) cl).getExtensionName();
         }
         return null;

--- a/src/main/java/net/minestom/server/extras/selfmodification/MinestomRootClassLoader.java
+++ b/src/main/java/net/minestom/server/extras/selfmodification/MinestomRootClassLoader.java
@@ -296,7 +296,11 @@ public class MinestomRootClassLoader extends HierarchyClassLoader {
             }
             return true;
         } catch (ClassNotFoundException | InvocationTargetException | InstantiationException | IllegalAccessException | NoSuchMethodException e) {
-            MinecraftServer.getExceptionManager().handleException(e);
+            if (MinecraftServer.getExceptionManager() != null) {
+                MinecraftServer.getExceptionManager().handleException(e);
+            } else {
+                e.printStackTrace();
+            }
         }
         return false;
     }

--- a/src/main/java/net/minestom/server/extras/selfmodification/mixins/MixinServiceMinestom.java
+++ b/src/main/java/net/minestom/server/extras/selfmodification/mixins/MixinServiceMinestom.java
@@ -1,6 +1,7 @@
 package net.minestom.server.extras.selfmodification.mixins;
 
 import net.minestom.server.extras.selfmodification.MinestomRootClassLoader;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.launch.platform.container.ContainerHandleVirtual;
 import org.spongepowered.asm.launch.platform.container.IContainerHandle;
 import org.spongepowered.asm.mixin.MixinEnvironment;
@@ -64,7 +65,7 @@ public class MixinServiceMinestom extends MixinServiceAbstract {
     }
 
     @Override
-    public InputStream getResourceAsStream(String name) {
+    public InputStream getResourceAsStream(@NotNull String name) {
         return classLoader.getResourceAsStreamWithChildren(name);
     }
 

--- a/src/test/java/demo/commands/ReloadExtensionCommand.java
+++ b/src/test/java/demo/commands/ReloadExtensionCommand.java
@@ -25,7 +25,7 @@ public class ReloadExtensionCommand extends Command {
     static {
         ReloadExtensionCommand.extensionsName = MinecraftServer.getExtensionManager().getExtensions()
                 .stream()
-                .map(extension -> extension.getDescription().getName())
+                .map(extension -> extension.getOrigin().getName())
                 .toArray(String[]::new);
     }
 

--- a/src/test/java/improveextensions/MixinIntoMinestomCore.java
+++ b/src/test/java/improveextensions/MixinIntoMinestomCore.java
@@ -23,7 +23,7 @@ public class MixinIntoMinestomCore extends Extension {
         System.out.println(c.toString());
         try {
             Assertions.assertTrue(success, "InstanceContainer must have been mixed in with improveextensions.InstanceContainerMixin");
-            Assertions.assertEquals(1, MinecraftServer.getExtensionManager().getExtensionLoaders().size(), "Only one extension classloader (this extension's) must be active.");
+            Assertions.assertEquals(1, MinecraftServer.getExtensionManager().getExtensions().stream().map(extension -> extension.getOrigin().getMinestomExtensionClassLoader()).toArray().length, "Only one extension classloader (this extension's) must be active.");
         } catch (AssertionFailedError e) {
             e.printStackTrace();
         }

--- a/src/test/java/improveextensions/MixinIntoMinestomCoreWithJava9ModuleOnClasspath.java
+++ b/src/test/java/improveextensions/MixinIntoMinestomCoreWithJava9ModuleOnClasspath.java
@@ -28,7 +28,7 @@ public class MixinIntoMinestomCoreWithJava9ModuleOnClasspath extends Extension {
         System.out.println(c.toString());
         try {
             Assertions.assertTrue(MixinIntoMinestomCore.success, "InstanceContainer must have been mixed in with improveextensions.InstanceContainerMixin");
-            Assertions.assertEquals(1, MinecraftServer.getExtensionManager().getExtensionLoaders().size(), "Only one extension classloader (this extension's) must be active.");
+            Assertions.assertEquals(1, MinecraftServer.getExtensionManager().getExtensions().stream().map(extension -> extension.getOrigin().getMinestomExtensionClassLoader()).toArray().length, "Only one extension classloader (this extension's) must be active.");
             Assertions.assertEquals("Test", mockedList.get(0));
         } catch (AssertionFailedError e) {
             e.printStackTrace();

--- a/src/test/java/improveextensions/missingmodifiers/MissingCodeModifiersExtension.java
+++ b/src/test/java/improveextensions/missingmodifiers/MissingCodeModifiersExtension.java
@@ -12,9 +12,9 @@ public class MissingCodeModifiersExtension extends Extension {
         // force load of InstanceContainer class
         try {
             Assertions.assertFalse(areCodeModifiersAllLoadedCorrectly(), "Mixin configuration could not be loaded and code modifiers are unavailable, the failure should be reported");
-            Assertions.assertTrue(getDescription().hasFailedToLoadMixin(), "Mixin configuration does not exist and should not be loaded");
-            Assertions.assertEquals(1, getDescription().getMissingCodeModifiers().size(), "Code modifier does not exist, it should be reported as missing");
-            Assertions.assertEquals("InvalidCodeModifierClass", getDescription().getMissingCodeModifiers().get(0));
+            Assertions.assertTrue(getOrigin().hasFailedToLoadMixin(), "Mixin configuration does not exist and should not be loaded");
+            Assertions.assertEquals(1, getOrigin().getMissingCodeModifiers().size(), "Code modifier does not exist, it should be reported as missing");
+            Assertions.assertEquals("InvalidCodeModifierClass", getOrigin().getMissingCodeModifiers().get(0));
             System.out.println("All tests passed.");
         } catch (AssertionFailedError e) {
             e.printStackTrace();

--- a/src/test/java/improveextensions/unloadcallbacks/UnloadCallbacksExtension.java
+++ b/src/test/java/improveextensions/unloadcallbacks/UnloadCallbacksExtension.java
@@ -72,7 +72,7 @@ public class UnloadCallbacksExtension extends Extension {
 
         MinecraftServer.getSchedulerManager().buildTask(() -> {
             // unload self
-            MinecraftServer.getExtensionManager().unloadExtension(getDescription().getName());
+            MinecraftServer.getExtensionManager().unloadExtension(getOrigin().getName());
         }).delay(1L, TimeUnit.SECOND).schedule();
     }
 


### PR DESCRIPTION
In order for other plugins to manage extensions better, they need to know more about them, and this exposes the internal DiscoveredExtension object instead of the old ExtensionDescription.