### PR TITLE
Simplify Viewable packet sending

### DIFF
--- a/src/main/java/net/minestom/server/Viewable.java
+++ b/src/main/java/net/minestom/server/Viewable.java
@@ -80,9 +80,6 @@ public interface Viewable {
      * @param packet the packet to send
      */
     default void sendPacketToViewersAndSelf(@NotNull ServerPacket packet) {
-        if (this instanceof Player) {
-            ((Player) this).getPlayerConnection().sendPacket(packet);
-        }
         sendPacketToViewers(packet);
     }
 }

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -654,6 +654,12 @@ public class Player extends LivingEntity implements CommandSender {
         return result;
     }
 
+    @Override
+    public void sendPacketToViewersAndSelf(@NotNull ServerPacket packet) {
+        this.playerConnection.sendPacket(packet);
+        super.sendPacketToViewersAndSelf(packet);
+    }
+
     /**
      * Changes the player instance and load surrounding chunks if needed.
      * <p>


### PR DESCRIPTION
Just a small PR that removes the `instanceof` check in `Viewable#sendPacketToViewersAndSelf` in favour of overriding the method in the `Player` class. 