### PR TITLE
Write scoreboard values using legacy strings

### DIFF
--- a/src/main/java/net/minestom/server/network/packet/server/play/ScoreboardObjectivePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/ScoreboardObjectivePacket.java
@@ -38,7 +38,7 @@ public class ScoreboardObjectivePacket implements ComponentHoldingServerPacket {
         writer.writeByte(mode);
 
         if (mode == 0 || mode == 2) {
-            writer.writeComponent(objectiveValue);
+            writer.writeComponentAsLegacy(objectiveValue);
             writer.writeVarInt(type.ordinal());
         }
     }

--- a/src/main/java/net/minestom/server/utils/binary/BinaryWriter.java
+++ b/src/main/java/net/minestom/server/utils/binary/BinaryWriter.java
@@ -3,6 +3,7 @@ package net.minestom.server.utils.binary;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.adventure.AdventureSerializer;
 import net.minestom.server.item.ItemStack;
@@ -71,6 +72,17 @@ public class BinaryWriter extends OutputStream {
      */
     public void writeComponent(@NotNull Component component) {
         this.writeSizedString(AdventureSerializer.serialize(component));
+    }
+
+    /**
+     * Writes a component to the buffer as a sized string. This method uses
+     * {@link LegacyComponentSerializer} to convert the component into a string
+     * containing the legacy section signs.
+     *
+     * @param component the component
+     */
+    public void writeComponentAsLegacy(@NotNull Component component) {
+        this.writeSizedString(LegacyComponentSerializer.legacySection().serialize(component));
     }
 
     /**


### PR DESCRIPTION
This PR adds a new method to `BinaryWriter` to write a string using the legacy section sign format for places where Mojang is dumb enough to not use proper components.