### PR TITLE
Add null check to makeClassLoader

### DIFF
--- a/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
+++ b/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
@@ -230,7 +230,7 @@ public final class DiscoveredExtension {
 
         MinestomExtensionClassLoader loader = new MinestomExtensionClassLoader(this.getName(), this.getEntrypoint(), urls, root);
 
-        if (this.getDependencies().length == 0) {
+        if (this.getDependencies().length == 0 || MinecraftServer.getExtensionManager() == null) {
             // orphaned extension, we can insert it directly
             root.addChild(loader);
         } else {

--- a/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
+++ b/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
@@ -230,7 +230,7 @@ public final class DiscoveredExtension {
 
         MinestomExtensionClassLoader loader = new MinestomExtensionClassLoader(this.getName(), this.getEntrypoint(), urls, root);
 
-        if (this.getDependencies().length == 0 || MinecraftServer.getExtensionManager() == null) {
+        if (this.getDependencies().length == 0 || MinecraftServer.getExtensionManager() == null) { // it also may invoked in early class loader
             // orphaned extension, we can insert it directly
             root.addChild(loader);
         } else {


### PR DESCRIPTION
This fixes the issue of Minestom not being able to boot when early class loaders are loaded.