### PR TITLE
Expose player to/from boss bar methods

### DIFF
--- a/src/main/java/net/minestom/server/adventure/bossbar/BossBarManager.java
+++ b/src/main/java/net/minestom/server/adventure/bossbar/BossBarManager.java
@@ -141,7 +141,7 @@ public class BossBarManager {
      * @param player the player
      * @return the boss bars
      */
-    public @NotNull Collection<BossBar> getPlayersBossBars(@NotNull Player player) {
+    public @NotNull Collection<BossBar> getPlayerBossBars(@NotNull Player player) {
         Collection<BossBarHolder> holders = this.playerBars.get(player.getUuid());
 
         if (holders == null) {

--- a/src/main/java/net/minestom/server/adventure/bossbar/BossBarManager.java
+++ b/src/main/java/net/minestom/server/adventure/bossbar/BossBarManager.java
@@ -136,6 +136,38 @@ public class BossBarManager {
     }
 
     /**
+     * Gets a collection of all boss bars currently visible to a given player.
+     *
+     * @param player the player
+     * @return the boss bars
+     */
+    public @NotNull Collection<BossBar> getPlayersBossBars(@NotNull Player player) {
+        Collection<BossBarHolder> holders = this.playerBars.get(player.getUuid());
+
+        if (holders == null) {
+            return Collections.emptyList();
+        } else {
+            return holders.stream().map(holder -> holder.bar).collect(Collectors.toUnmodifiableList());
+        }
+    }
+
+    /**
+     * Gets all the players for whom the given boss bar is currently visible.
+     *
+     * @param bossBar the boss bar
+     * @return the players
+     */
+    public @NotNull Collection<Player> getBossBarViewers(@NotNull BossBar bossBar) {
+        BossBarHolder holder = this.bars.get(bossBar);
+
+        if (holder == null) {
+            return Collections.emptyList();
+        } else {
+            return Collections.unmodifiableCollection(holder.players);
+        }
+    }
+
+    /**
      * Gets or creates a handler for this bar.
      *
      * @param bar the bar


### PR DESCRIPTION
This PR adds two methods to `BossBarManager` that allow developers to obtain a collection of boss bars currently visible to a player (`#getPlayersBossBars`) and to obtain a collection of players that can see a boss bar (`#getBossBarViewers`).