### PR TITLE
Add external javadoc links

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,16 @@ allprojects {
             links "https://jd.adventure.kyori.net/api/$adventureVersion/"
             links "https://docs.oracle.com/en/java/javase/11/docs/api/"
         }
+
+        // see https://stackoverflow.com/a/56641766
+        doLast {
+            // Append the fix to the file
+            def searchScript = new File(destinationDir.getAbsolutePath() + '/search.js')
+            searchScript.append '\n\n' +
+                    'getURLPrefix = function(ui) {\n' +
+                    '    return \'\';\n' +
+                    '};\n'
+        }
     }
 
     checkstyle {

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,8 @@ allprojects {
         options {
             destinationDir(file("docs"))
             addBooleanOption('html5', true)
+            links "https://jd.adventure.kyori.net/api/$adventureVersion/"
+            links "https://docs.oracle.com/en/java/javase/11/docs/api/"
         }
     }
 


### PR DESCRIPTION
This PR adds the Adventure and Java javadocs as external links, making the elements clickable in our Javadoc. It also fixes the 404 error found when using the Javadoc searchbar.

I'd appreciate if people could add or suggest additional libraries that need external links!

**Before**
![Screenshot from 2021-03-30 13-30-05](https://user-images.githubusercontent.com/1526243/112988792-22b15d80-915c-11eb-8758-aa9f7aa0042e.png)

**After**
![Screenshot from 2021-03-30 13-31-14](https://user-images.githubusercontent.com/1526243/112988857-378df100-915c-11eb-97d2-816701b68f11.png)
