### PR TITLE
Add util method to send a packet to an audience

### DIFF
--- a/src/main/java/net/minestom/server/utils/PacketUtils.java
+++ b/src/main/java/net/minestom/server/utils/PacketUtils.java
@@ -4,8 +4,11 @@ import com.velocitypowered.natives.compression.VelocityCompressor;
 import com.velocitypowered.natives.util.Natives;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.audience.ForwardingAudience;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.adventure.AdventureSerializer;
+import net.minestom.server.adventure.audience.PacketGroupingAudience;
 import net.minestom.server.entity.Player;
 import net.minestom.server.listener.manager.PacketListenerManager;
 import net.minestom.server.network.netty.packet.FramedPacket;
@@ -18,6 +21,7 @@ import net.minestom.server.utils.callback.validator.PlayerValidator;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.zip.DataFormatException;
 
@@ -32,6 +36,39 @@ public final class PacketUtils {
 
     private PacketUtils() {
 
+    }
+
+    /**
+     * Sends a packet to an audience. This method performs the following steps in the
+     * following order:
+     * <ol>
+     *     <li>If {@code audience} is a {@link Player}, send the packet to them.</li>
+     *     <li>Otherwise, if {@code audience} is a {@link PacketGroupingAudience}, call
+     *     {@link #sendGroupedPacket(Collection, ServerPacket)} on the players that the
+     *     grouping audience contains.</li>
+     *     <li>Otherwise, if {@code audience} is a {@link ForwardingAudience.Single},
+     *     call this method on the single audience inside the forwarding audience.</li>
+     *     <li>Otherwise, if {@code audience} is a {@link ForwardingAudience}, call this
+     *     method for each audience member of the forwarding audience.</li>
+     *     <li>Otherwise, do nothing.</li>
+     * </ol>
+     *
+     * @param audience the audience
+     * @param packet the packet
+     */
+    @SuppressWarnings("OverrideOnly") // we need to access the audiences inside ForwardingAudience
+    public static void sendPacket(@NotNull Audience audience, @NotNull ServerPacket packet) {
+        if (audience instanceof Player) {
+            ((Player) audience).getPlayerConnection().sendPacket(packet);
+        } else if (audience instanceof PacketGroupingAudience) {
+            PacketUtils.sendGroupedPacket(((PacketGroupingAudience) audience).getPlayers(), packet);
+        } else if (audience instanceof ForwardingAudience.Single) {
+            PacketUtils.sendPacket(((ForwardingAudience.Single) audience).audience(), packet);
+        } else if (audience instanceof ForwardingAudience) {
+            for (Audience member : ((ForwardingAudience) audience).audiences()) {
+                PacketUtils.sendPacket(member, packet);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adds the method `PacketUtils#sendPacket(Audience, ServerPacket)` which sends a packet to an arbitrary audience. This can be used to, for example, send a packet to every member of a team using something like `PacketUtils.sendPacket(team, packet)`.