### PR TITLE
Add Tick as a TemporalUnit

### DIFF
--- a/src/main/java/net/minestom/server/network/packet/server/play/TitlePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/TitlePacket.java
@@ -5,8 +5,8 @@ import net.kyori.adventure.title.Title;
 import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
-import net.minestom.server.utils.TickUtils;
 import net.minestom.server.utils.binary.BinaryWriter;
+import net.minestom.server.utils.time.Tick;
 import org.apache.commons.lang3.Validate;
 import org.jetbrains.annotations.NotNull;
 
@@ -136,9 +136,9 @@ public class TitlePacket implements ComponentHoldingServerPacket {
         // times packet
         Title.Times times = title.times();
         if (times != null) {
-            packets.add(new TitlePacket(TickUtils.fromDuration(times.fadeIn(), TickUtils.CLIENT_TICK_MS),
-                    TickUtils.fromDuration(times.stay(), TickUtils.CLIENT_TICK_MS),
-                    TickUtils.fromDuration(times.fadeOut(), TickUtils.CLIENT_TICK_MS)));
+            packets.add(new TitlePacket(Tick.CLIENT.fromDuration(times.fadeIn()),
+                    Tick.CLIENT.fromDuration(times.stay()),
+                    Tick.CLIENT.fromDuration(times.fadeOut())));
         }
 
         return packets;

--- a/src/main/java/net/minestom/server/utils/TickUtils.java
+++ b/src/main/java/net/minestom/server/utils/TickUtils.java
@@ -1,6 +1,7 @@
 package net.minestom.server.utils;
 
 import net.minestom.server.MinecraftServer;
+import net.minestom.server.utils.time.Tick;
 import org.apache.commons.lang3.Validate;
 import org.jetbrains.annotations.NotNull;
 
@@ -8,16 +9,21 @@ import java.time.Duration;
 
 /**
  * Tick related utilities.
+ * @deprecated Use {@link Tick}
  */
+@Deprecated
 public class TickUtils {
     /**
      * Number of ticks per second for the default Java-edition client.
+     * @deprecated Use some math
      */
     public static final int CLIENT_TPS = 20;
 
     /**
      * Length of time per tick for the default Java-edition client.
+     * @deprecated Use {@link Tick#getDuration()} on {@link Tick#CLIENT}
      */
+    @Deprecated
     public static final int CLIENT_TICK_MS = 50;
 
     /**
@@ -25,7 +31,9 @@ public class TickUtils {
      * @param duration the duration
      * @return the number of ticks
      * @throws IllegalArgumentException if duration is negative
+     * @deprecated Use {@link Tick#fromDuration(Duration)} on {@link Tick#SERVER}
      */
+    @Deprecated
     public static int fromDuration(@NotNull Duration duration) {
         return TickUtils.fromDuration(duration, MinecraftServer.TICK_MS);
     }
@@ -36,7 +44,9 @@ public class TickUtils {
      * @param msPerTick the number of milliseconds per tick
      * @return the number of ticks
      * @throws IllegalArgumentException if duration is negative
+     * @deprecated Use {@link Tick#fromDuration(Duration)} on {@link Tick#SERVER} or {@link Tick#CLIENT}
      */
+    @Deprecated
     public static int fromDuration(@NotNull Duration duration, int msPerTick) {
         Validate.isTrue(!duration.isNegative(), "Duration cannot be negative");
 

--- a/src/main/java/net/minestom/server/utils/time/Tick.java
+++ b/src/main/java/net/minestom/server/utils/time/Tick.java
@@ -1,0 +1,112 @@
+package net.minestom.server.utils.time;
+
+import net.minestom.server.MinecraftServer;
+
+import java.time.Duration;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalUnit;
+
+/**
+ * A TemporalUnit that represents one server tick.
+ */
+public final class Tick implements TemporalUnit {
+    /**
+     * A TemporalUnit representing the server tick. This is defined using
+     * {@link MinecraftServer#TICK_MS}.
+     */
+    public static Tick SERVER = new Tick(MinecraftServer.TICK_MS);
+
+    /**
+     * A TemporalUnit representing the client tick. This is always equal to 50ms.
+     */
+    public static Tick CLIENT = new Tick(50);
+
+    private final long milliseconds;
+    private final int tps;
+
+    /**
+     * Creates a new tick.
+     *
+     * @param length the length of the tick in milliseconds
+     */
+    private Tick(long length) {
+        if (length <= 0) {
+            throw new IllegalArgumentException("length cannot be negative");
+        }
+
+        this.milliseconds = length;
+        this.tps = Math.toIntExact(Duration.ofSeconds(1).dividedBy(Duration.ofMillis(this.milliseconds)));
+    }
+
+    /**
+     * Creates a duration from an amount of ticks.
+     *
+     * @param ticks the amount of ticks
+     * @return the duration
+     */
+    public static Duration server(long ticks) {
+        return Duration.of(ticks, SERVER);
+    }
+
+    /**
+     * Creates a duration from an amount of client-side ticks.
+     *
+     * @param ticks the amount of ticks
+     * @return the duration
+     */
+    public static Duration client(long ticks) {
+        return Duration.of(ticks, CLIENT);
+    }
+
+    /**
+     * Gets the number of whole ticks that occur in the provided duration. Note that this
+     * method returns an {@code int} as this is the unit that Minecraft stores ticks in.
+     *
+     * @param duration the duration
+     * @return the number of whole ticks in this duration
+     * @throws ArithmeticException if the duration is zero or an overflow occurs
+     */
+    public int fromDuration(Duration duration) {
+        return Math.toIntExact(duration.dividedBy(this.getDuration()));
+    }
+
+    /**
+     * Gets the whole number of these ticks that occur in one second.
+     *
+     * @return the number
+     */
+    public int getTicksPerSecond() {
+        return this.tps;
+    }
+
+    @Override
+    public Duration getDuration() {
+        return Duration.ofMillis(this.milliseconds);
+    }
+
+    @Override
+    public boolean isDurationEstimated() {
+        return false;
+    }
+
+    @Override
+    public boolean isDateBased() {
+        return false;
+    }
+
+    @Override
+    public boolean isTimeBased() {
+        return true;
+    }
+
+    @SuppressWarnings("unchecked") // following ChronoUnit#addTo
+    @Override
+    public <R extends Temporal> R addTo(R temporal, long amount) {
+        return (R) temporal.plus(amount, this);
+    }
+
+    @Override
+    public long between(Temporal start, Temporal end) {
+        return start.until(end, this);
+    }
+}

--- a/src/test/java/misc/TickTest.java
+++ b/src/test/java/misc/TickTest.java
@@ -1,0 +1,21 @@
+package misc;
+
+import net.minestom.server.utils.time.Tick;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TickTest {
+
+    @Test
+    public void testTicks() {
+        assertEquals(50, Duration.of(1, Tick.CLIENT).toMillis());
+        assertEquals(100, Duration.of(2, Tick.CLIENT).toMillis());
+        assertEquals(0, Tick.CLIENT.fromDuration(Duration.ofMillis(0)));
+        assertEquals(0, Tick.CLIENT.fromDuration(Duration.ofMillis(10)));
+        assertEquals(1, Tick.CLIENT.fromDuration(Duration.ofMillis(60)));
+        assertEquals(2, Tick.CLIENT.fromDuration(Duration.ofMillis(100)));
+    }
+}


### PR DESCRIPTION
This PR adds a `TemporalUnit` implementation called `Tick`, which represents one server tick.

This means that the server tick can be used when calculating durations. For example, the following code will produce the number of milliseconds in 10 ticks, regardless of the length of each server tick.
```java
Tick.ticks(10).toMillis()
```