### PR TITLE
Remove deprecated copy methods

### DIFF
--- a/src/main/java/net/minestom/server/item/ItemStack.java
+++ b/src/main/java/net/minestom/server/item/ItemStack.java
@@ -666,15 +666,6 @@ public class ItemStack implements DataContainer, PublicCloneable<ItemStack>, Hov
     }
 
     /**
-     * @deprecated use {@link #clone()}
-     */
-    @Deprecated
-    @NotNull
-    public synchronized ItemStack copy() {
-        return clone();
-    }
-
-    /**
      * Clones this item stack.
      * <p>
      * Be aware that the identifier ({@link #getIdentifier()}) will change.

--- a/src/main/java/net/minestom/server/utils/BlockPosition.java
+++ b/src/main/java/net/minestom/server/utils/BlockPosition.java
@@ -212,18 +212,6 @@ public class BlockPosition implements PublicCloneable<BlockPosition> {
                 MathUtils.square(getZ() - blockPosition.getZ());
     }
 
-    /**
-     * Copies this block position.
-     *
-     * @return the cloned block position
-     * @deprecated use {@link #clone()}
-     */
-    @Deprecated
-    @NotNull
-    public BlockPosition copy() {
-        return clone();
-    }
-
     @NotNull
     @Override
     public BlockPosition clone() {

--- a/src/main/java/net/minestom/server/utils/Position.java
+++ b/src/main/java/net/minestom/server/utils/Position.java
@@ -213,14 +213,6 @@ public class Position implements PublicCloneable<Position> {
     }
 
     /**
-     * @deprecated Please use {@link #clone()}
-     */
-    @Deprecated
-    public Position copy() {
-        return clone();
-    }
-
-    /**
      * Gets if the two objects are position and have the same values.
      *
      * @param o the position to check the equality

--- a/src/main/java/net/minestom/server/utils/Vector.java
+++ b/src/main/java/net/minestom/server/utils/Vector.java
@@ -476,15 +476,6 @@ public class Vector implements PublicCloneable<Vector> {
                 '}';
     }
 
-    /**
-     * @deprecated use {@link #clone()}
-     */
-    @Deprecated
-    @NotNull
-    public Vector copy() {
-        return clone();
-    }
-
     @NotNull
     @Override
     public Vector clone() {


### PR DESCRIPTION
The copy methods have been deprecated for around 4 months at this point, and are unused in the codebase.

They have been replaced with `clone` methods and the `PublicCloneable` interface.

See [this commit](https://github.com/Minestom/Minestom/commit/f39f6444d727add78a6d4fc70f7943af8870f254) for more information.