### PR TITLE
Block placement api

### DIFF
--- a/src/main/java/net/minestom/server/extras/vanilla/VanillaBlocks.java
+++ b/src/main/java/net/minestom/server/extras/vanilla/VanillaBlocks.java
@@ -1,0 +1,86 @@
+package net.minestom.server.extras.vanilla;
+
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.event.player.PlayerBlockPlaceEvent;
+import net.minestom.server.extras.vanilla.blocks.DAxisBlock;
+import net.minestom.server.extras.vanilla.blocks.DChestBlock;
+import net.minestom.server.instance.Chunk;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.instance.block.Block;
+import net.minestom.server.instance.block.BlockManager;
+import net.minestom.server.instance.block.CustomBlock;
+import net.minestom.server.network.packet.server.play.BlockChangePacket;
+import net.minestom.server.utils.BlockPosition;
+import org.jetbrains.annotations.NotNull;
+
+public final class VanillaBlocks {
+
+    private static final BlockManager BLOCK_MANAGER = MinecraftServer.getBlockManager();
+
+    private static final CustomBlock[] BLOCKS = new CustomBlock[Short.MAX_VALUE];
+
+    public static final short VANILLA_LAST_ID;
+
+    static {
+        short id = 1;
+        BLOCKS[Block.BONE_BLOCK.getBlockId()] = new DAxisBlock(Block.BONE_BLOCK, "dv_bone_block", id++);
+        BLOCKS[Block.HAY_BLOCK.getBlockId()] = new DAxisBlock(Block.HAY_BLOCK, "dv_hay_block", id++);
+        BLOCKS[Block.OAK_LOG.getBlockId()] = new DAxisBlock(Block.OAK_LOG, "dv_oak_log", id++);
+        BLOCKS[Block.SPRUCE_LOG.getBlockId()] = new DAxisBlock(Block.SPRUCE_LOG, "dv_spruce_log", id++);
+        BLOCKS[Block.BIRCH_LOG.getBlockId()] = new DAxisBlock(Block.BIRCH_LOG, "dv_birch_log", id++);
+        BLOCKS[Block.JUNGLE_LOG.getBlockId()] = new DAxisBlock(Block.JUNGLE_LOG, "dv_jungle_log", id++);
+        BLOCKS[Block.ACACIA_LOG.getBlockId()] = new DAxisBlock(Block.ACACIA_LOG, "dv_acacia_log", id++);
+        BLOCKS[Block.DARK_OAK_LOG.getBlockId()] = new DAxisBlock(Block.DARK_OAK_LOG, "dv_dark_oak_log", id++);
+        BLOCKS[Block.STRIPPED_OAK_LOG.getBlockId()] = new DAxisBlock(Block.STRIPPED_OAK_LOG, "dv_stripped_oak_log", id++);
+        BLOCKS[Block.STRIPPED_SPRUCE_LOG.getBlockId()] = new DAxisBlock(Block.STRIPPED_SPRUCE_LOG, "dv_stripped_spruce_log",  id++);
+        BLOCKS[Block.STRIPPED_BIRCH_LOG.getBlockId()] = new DAxisBlock(Block.STRIPPED_BIRCH_LOG, "dv_stripped_birch_log",  id++);
+        BLOCKS[Block.STRIPPED_JUNGLE_LOG.getBlockId()] = new DAxisBlock(Block.STRIPPED_JUNGLE_LOG, "dv_stripped_jungle_log",  id++);
+        BLOCKS[Block.STRIPPED_ACACIA_LOG.getBlockId()] = new DAxisBlock(Block.STRIPPED_ACACIA_LOG, "dv_stripped_acacia_log",  id++);
+        BLOCKS[Block.STRIPPED_DARK_OAK_LOG.getBlockId()] = new DAxisBlock(Block.STRIPPED_DARK_OAK_LOG, "dv_stripped_dark_oak_log",  id++);
+        BLOCKS[Block.PURPUR_PILLAR.getBlockId()] = new DAxisBlock(Block.PURPUR_PILLAR, "dv_purpur_pillar",  id++);
+        BLOCKS[Block.QUARTZ_PILLAR.getBlockId()] = new DAxisBlock(Block.QUARTZ_PILLAR, "dv_quartz_pillar",  id++);
+        BLOCKS[Block.OAK_WOOD.getBlockId()] = new DAxisBlock(Block.OAK_WOOD, "dv_oak_wood",  id++);
+        BLOCKS[Block.SPRUCE_WOOD.getBlockId()] = new DAxisBlock(Block.SPRUCE_WOOD, "dv_spruce_wood",  id++);
+        BLOCKS[Block.BIRCH_WOOD.getBlockId()] = new DAxisBlock(Block.BIRCH_WOOD, "dv_birch_wood",  id++);
+        BLOCKS[Block.JUNGLE_WOOD.getBlockId()] = new DAxisBlock(Block.JUNGLE_WOOD, "dv_jungle_wood",  id++);
+        BLOCKS[Block.ACACIA_WOOD.getBlockId()] = new DAxisBlock(Block.ACACIA_WOOD, "dv_acacia_wood",  id++);
+        BLOCKS[Block.DARK_OAK_WOOD.getBlockId()] = new DAxisBlock(Block.DARK_OAK_WOOD, "dv_dark_oak_wood",  id++);
+        BLOCKS[Block.STRIPPED_OAK_WOOD.getBlockId()] = new DAxisBlock(Block.STRIPPED_OAK_WOOD, "dv_stripped_oak_wood",  id++);
+        BLOCKS[Block.STRIPPED_SPRUCE_WOOD.getBlockId()] = new DAxisBlock(Block.STRIPPED_SPRUCE_WOOD, "dv_stripped_spruce_wood",  id++);
+        BLOCKS[Block.STRIPPED_BIRCH_WOOD.getBlockId()] = new DAxisBlock(Block.STRIPPED_BIRCH_WOOD, "dv_stripped_birch_wood",  id++);
+        BLOCKS[Block.STRIPPED_JUNGLE_WOOD.getBlockId()] = new DAxisBlock(Block.STRIPPED_JUNGLE_WOOD, "dv_stripped_jungle_wood",  id++);
+        BLOCKS[Block.STRIPPED_ACACIA_WOOD.getBlockId()] = new DAxisBlock(Block.STRIPPED_ACACIA_WOOD, "dv_stripped_acacia_wood",  id++);
+        BLOCKS[Block.STRIPPED_DARK_OAK_WOOD.getBlockId()] = new DAxisBlock(Block.STRIPPED_DARK_OAK_WOOD, "dv_stripped_dark_oak_wood",  id++);
+        BLOCKS[Block.CRIMSON_STEM.getBlockId()] = new DAxisBlock(Block.CRIMSON_STEM, "dv_crimson_stem",  id++);
+        BLOCKS[Block.WARPED_STEM.getBlockId()] = new DAxisBlock(Block.WARPED_STEM, "dv_warped_stem",  id++);
+        BLOCKS[Block.STRIPPED_WARPED_STEM.getBlockId()] = new DAxisBlock(Block.STRIPPED_WARPED_STEM, "dv_stripped_warped_stem",  id++);
+        BLOCKS[Block.STRIPPED_CRIMSON_STEM.getBlockId()] = new DAxisBlock(Block.STRIPPED_CRIMSON_STEM, "dv_stripped_crimson_stem",  id++);
+
+        BLOCKS[Block.CHEST.getBlockId()] = new DChestBlock(Block.CHEST, "dv_chest",  id++);
+        BLOCKS[Block.TRAPPED_CHEST.getBlockId()] = new DChestBlock(Block.TRAPPED_CHEST, "dv_trapped_chest",  id++);
+
+        VANILLA_LAST_ID = (short) (id - 1);
+
+        for (int i = 0; i < BLOCKS.length; i++) if (BLOCKS[i] != null) BLOCK_MANAGER.registerCustomBlock(BLOCKS[i]);
+    }
+
+    public static void registerBlocksInstance(Instance instance) {
+        instance.addEventCallback(PlayerBlockPlaceEvent.class, event -> {
+            CustomBlock customBlock = BLOCKS[event.getBlockStateId()];
+            if (customBlock == null) return;
+
+            event.setCustomBlock(customBlock.getCustomBlockId());
+        });
+    }
+
+    public static void registerBlock(short blockId, CustomBlock customBlock) {
+        BLOCKS[blockId] = customBlock;
+    }
+
+    public static void sendBlockChange(@NotNull Chunk chunk, @NotNull BlockPosition blockPosition, short blockStateId) { // Probs not best place to put this.
+        BlockChangePacket blockChangePacket = new BlockChangePacket();
+        blockChangePacket.blockPosition = blockPosition;
+        blockChangePacket.blockStateId = blockStateId;
+        chunk.sendPacketToViewers(blockChangePacket);
+    }
+}

--- a/src/main/java/net/minestom/server/extras/vanilla/blocks/DAxisBlock.java
+++ b/src/main/java/net/minestom/server/extras/vanilla/blocks/DAxisBlock.java
@@ -1,0 +1,71 @@
+package net.minestom.server.extras.vanilla.blocks;
+
+import net.minestom.server.data.Data;
+import net.minestom.server.entity.Player;
+import net.minestom.server.extras.vanilla.VanillaBlocks;
+import net.minestom.server.instance.Chunk;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.instance.block.Block;
+import net.minestom.server.instance.block.BlockFace;
+import net.minestom.server.instance.block.CustomBlock;
+import net.minestom.server.utils.BlockPosition;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class DAxisBlock extends CustomBlock {
+
+    private final short customBlockId;
+
+    public DAxisBlock(short defaultBlockStateId, @NotNull String identifier, short customBlockId) {
+        super(defaultBlockStateId, identifier);
+        this.customBlockId = customBlockId;
+    }
+
+    public DAxisBlock(@NotNull Block block, @NotNull String identifier, short customBlockId) {
+        super(block, identifier);
+        this.customBlockId = customBlockId;
+    }
+
+    @Override
+    public void updateBlockVisual(@NotNull Instance instance, @NotNull Chunk chunk, @NotNull BlockPosition blockPosition, short blockId, @Nullable Data data) {
+        int x = blockPosition.getX();
+        int y = blockPosition.getY();
+        int z = blockPosition.getZ();
+
+        chunk.UNSAFE_setBlock(x, y, z, blockId, customBlockId, data, false);
+        VanillaBlocks.sendBlockChange(chunk, blockPosition, blockId);
+    }
+
+    @Override
+    public void updateBlockVisual(@NotNull Instance instance, @NotNull Chunk chunk, @NotNull Player player, @NotNull BlockFace blockFace, @NotNull BlockPosition blockPosition, short blockId, @Nullable Data data) {
+        int x = blockPosition.getX();
+        int y = blockPosition.getY();
+        int z = blockPosition.getZ();
+
+        // Perhaps add support for different mechanics when sneaking?
+
+        byte offset = 0;
+        if (blockFace == BlockFace.WEST || blockFace == BlockFace.EAST) {
+            offset = -1;
+        } else if (blockFace == BlockFace.SOUTH || blockFace == BlockFace.NORTH) {
+            offset = 1;
+        }
+
+        chunk.UNSAFE_setBlock(x, y, z, (short) (blockId + offset), customBlockId, data, false);
+        VanillaBlocks.sendBlockChange(chunk, blockPosition, (short) (blockId + offset));
+    }
+
+    @Override
+    public void onPlace(@NotNull Instance instance, @NotNull BlockPosition blockPosition, @Nullable Data data) {}
+
+    @Override
+    public void onDestroy(@NotNull Instance instance, @NotNull BlockPosition blockPosition, @Nullable Data data) {}
+
+    @Override
+    public boolean onInteract(@NotNull Player player, Player.@NotNull Hand hand, @NotNull BlockPosition blockPosition, @Nullable Data data) { return false;}
+
+    @Override
+    public short getCustomBlockId() {
+        return this.customBlockId;
+    }
+}

--- a/src/main/java/net/minestom/server/extras/vanilla/blocks/DChestBlock.java
+++ b/src/main/java/net/minestom/server/extras/vanilla/blocks/DChestBlock.java
@@ -1,0 +1,94 @@
+package net.minestom.server.extras.vanilla.blocks;
+
+import net.minestom.server.data.Data;
+import net.minestom.server.entity.Player;
+import net.minestom.server.extras.vanilla.VanillaBlocks;
+import net.minestom.server.instance.Chunk;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.instance.block.Block;
+import net.minestom.server.instance.block.BlockFace;
+import net.minestom.server.instance.block.CustomBlock;
+import net.minestom.server.utils.BlockPosition;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class DChestBlock extends CustomBlock {
+
+    private final short customBlockId;
+
+    public DChestBlock(short defaultBlockStateId, @NotNull String identifier, short customBlockId) {
+        super(defaultBlockStateId, identifier);
+        this.customBlockId = customBlockId;
+    }
+
+    public DChestBlock(@NotNull Block block, @NotNull String identifier, short customBlockId) {
+        super(block, identifier);
+        this.customBlockId = customBlockId;
+    }
+
+    @Override
+    public void updateBlockVisual(@NotNull Instance instance, @NotNull Chunk chunk, @NotNull BlockPosition blockPosition, short blockId, @Nullable Data data) {
+        int x = blockPosition.getX();
+        int y = blockPosition.getY();
+        int z = blockPosition.getZ();
+
+        chunk.UNSAFE_setBlock(x, y, z, blockId, customBlockId, data, false);
+        VanillaBlocks.sendBlockChange(chunk, blockPosition, blockId);
+    }
+
+    @Override
+    public void updateBlockVisual(@NotNull Instance instance, @NotNull Chunk chunk, @NotNull Player player, @NotNull BlockFace blockFace, @NotNull BlockPosition blockPosition, short blockId, @Nullable Data data) {
+        int x = blockPosition.getX();
+        int y = blockPosition.getY();
+        int z = blockPosition.getZ();
+
+        // Perhaps add support for different mechanics when sneaking?
+
+        float yaw = (player.getPosition().getYaw() % 360) - 45;
+        if (yaw < 0) yaw += 360f;
+
+        byte dir = (byte) (yaw  / (90f));
+
+        switch (blockFace) {
+            case TOP:
+            case BOTTOM:
+                short newBlockId =  blockId;
+                switch (dir) {
+                    case 0:
+                        newBlockId += 18;
+                        break;
+                    case 1:
+                        newBlockId += 6;
+                        break;
+                    case 2:
+                        newBlockId += 12;
+                        break;
+                    case 3:
+                        break;
+                }
+
+                chunk.UNSAFE_setBlock(x, y, z, newBlockId, customBlockId, data, false);
+                VanillaBlocks.sendBlockChange(chunk, blockPosition, newBlockId);
+                break;
+            case EAST:
+            case WEST:
+            case NORTH:
+            case SOUTH:
+                break;
+        }
+    }
+
+    @Override
+    public void onPlace(@NotNull Instance instance, @NotNull BlockPosition blockPosition, @Nullable Data data) {}
+
+    @Override
+    public void onDestroy(@NotNull Instance instance, @NotNull BlockPosition blockPosition, @Nullable Data data) {}
+
+    @Override
+    public boolean onInteract(@NotNull Player player, Player.@NotNull Hand hand, @NotNull BlockPosition blockPosition, @Nullable Data data) { return false; }
+
+    @Override
+    public short getCustomBlockId() {
+        return this.customBlockId;
+    }
+}

--- a/src/main/java/net/minestom/server/instance/BlockModifier.java
+++ b/src/main/java/net/minestom/server/instance/BlockModifier.java
@@ -70,27 +70,23 @@ public interface BlockModifier {
      * @param player             the {@link Player} that places the block
      * @param chunk              the {@link Chunk} in which the block is being placed
      * @param blockFace          the {@link BlockFace} of the block that the block being placed was placed against
-     * @param x                  the x coordinates at which to place the block
-     * @param y                  the y coordinates at which to place the block
-     * @param z                  the z coordinates at which to place the block
+     * @param blockPosition      the {@link BlockPosition} at which the block is being placed
      * @param blockId            the base id of the block being placed (no properties)
      * @param customBlockId      the id of the custom block, 0 if none
      * @param data               the block {@link Data}, can be null
      */
-    void placeBlock(@NotNull Player player, @NotNull Chunk chunk, @NotNull BlockFace blockFace, int x, int y, int z, short blockId, short customBlockId, @Nullable Data data);
+    void placeBlock(@NotNull Player player, @NotNull Chunk chunk, @NotNull BlockFace blockFace, @NotNull BlockPosition blockPosition, short blockId, short customBlockId, @Nullable Data data);
 
     /**
      *
      * Sets a block, possibly {@link CustomBlock}, at a position.
      *
-     * @param x                  the x coordinates at which to place the block
-     * @param y                  the y coordinates at which to place the block
-     * @param z                  the z coordinates at which to place the block
+     * @param blockPosition      the {@link BlockPosition} at which the block is being placed
      * @param blockId            the base id of the block being placed (no properties)
      * @param customBlockId      the id of the custom block, 0 if none
      * @param data               the block {@link Data}, can be null
      */
-    void setBlock(int x, int y, int z, short blockId, short customBlockId, @Nullable Data data);
+    void setBlock(@NotNull BlockPosition blockPosition, short blockId, short customBlockId, @Nullable Data data);
 
     default void setBlockStateId(int x, int y, int z, short blockStateId) {
         setBlockStateId(x, y, z, blockStateId, null);

--- a/src/main/java/net/minestom/server/instance/BlockModifier.java
+++ b/src/main/java/net/minestom/server/instance/BlockModifier.java
@@ -2,6 +2,7 @@ package net.minestom.server.instance;
 
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.data.Data;
+import net.minestom.server.entity.Player;
 import net.minestom.server.instance.batch.Batch;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockManager;
@@ -60,6 +61,33 @@ public interface BlockModifier {
      * @param data          the block {@link Data}, can be null
      */
     void setSeparateBlocks(int x, int y, int z, short blockStateId, short customBlockId, @Nullable Data data);
+
+    /**
+     *
+     * Sets a block, possibly {@link CustomBlock}, with player context at a position.
+     *
+     * @param player             the {@link Player} that places the block
+     * @param x                  the x coordinates at which to place the block
+     * @param y                  the y coordinates at which to place the block
+     * @param z                  the z coordinates at which to place the block
+     * @param blockId            the base id of the block being placed (no properties)
+     * @param customBlockId      the id of the custom block, 0 if none
+     * @param data               the block {@link Data}, can be null
+     */
+    void placeBlock(@NotNull Player player, int x, int y, int z, short blockId, short customBlockId, @Nullable Data data);
+
+    /**
+     *
+     * Sets a block, possibly {@link CustomBlock}, at a position.
+     *
+     * @param x                  the x coordinates at which to place the block
+     * @param y                  the y coordinates at which to place the block
+     * @param z                  the z coordinates at which to place the block
+     * @param blockId            the base id of the block being placed (no properties)
+     * @param customBlockId      the id of the custom block, 0 if none
+     * @param data               the block {@link Data}, can be null
+     */
+    void setBlock(int x, int y, int z, short blockId, short customBlockId, @Nullable Data data);
 
     default void setBlockStateId(int x, int y, int z, short blockStateId) {
         setBlockStateId(x, y, z, blockStateId, null);

--- a/src/main/java/net/minestom/server/instance/BlockModifier.java
+++ b/src/main/java/net/minestom/server/instance/BlockModifier.java
@@ -67,6 +67,7 @@ public interface BlockModifier {
      * Sets a block, possibly {@link CustomBlock}, with player context at a position.
      *
      * @param player             the {@link Player} that places the block
+     * @param chunk              the {@link Chunk} in which the block is being placed
      * @param x                  the x coordinates at which to place the block
      * @param y                  the y coordinates at which to place the block
      * @param z                  the z coordinates at which to place the block
@@ -74,7 +75,7 @@ public interface BlockModifier {
      * @param customBlockId      the id of the custom block, 0 if none
      * @param data               the block {@link Data}, can be null
      */
-    void placeBlock(@NotNull Player player, int x, int y, int z, short blockId, short customBlockId, @Nullable Data data);
+    void placeBlock(@NotNull Player player, @NotNull Chunk chunk, int x, int y, int z, short blockId, short customBlockId, @Nullable Data data);
 
     /**
      *

--- a/src/main/java/net/minestom/server/instance/BlockModifier.java
+++ b/src/main/java/net/minestom/server/instance/BlockModifier.java
@@ -5,6 +5,7 @@ import net.minestom.server.data.Data;
 import net.minestom.server.entity.Player;
 import net.minestom.server.instance.batch.Batch;
 import net.minestom.server.instance.block.Block;
+import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.instance.block.BlockManager;
 import net.minestom.server.instance.block.CustomBlock;
 import net.minestom.server.utils.BlockPosition;
@@ -68,6 +69,7 @@ public interface BlockModifier {
      *
      * @param player             the {@link Player} that places the block
      * @param chunk              the {@link Chunk} in which the block is being placed
+     * @param blockFace          the {@link BlockFace} of the block that the block being placed was placed against
      * @param x                  the x coordinates at which to place the block
      * @param y                  the y coordinates at which to place the block
      * @param z                  the z coordinates at which to place the block
@@ -75,7 +77,7 @@ public interface BlockModifier {
      * @param customBlockId      the id of the custom block, 0 if none
      * @param data               the block {@link Data}, can be null
      */
-    void placeBlock(@NotNull Player player, @NotNull Chunk chunk, int x, int y, int z, short blockId, short customBlockId, @Nullable Data data);
+    void placeBlock(@NotNull Player player, @NotNull Chunk chunk, @NotNull BlockFace blockFace, int x, int y, int z, short blockId, short customBlockId, @Nullable Data data);
 
     /**
      *

--- a/src/main/java/net/minestom/server/instance/Chunk.java
+++ b/src/main/java/net/minestom/server/instance/Chunk.java
@@ -156,7 +156,7 @@ public abstract class Chunk implements Viewable, DataContainer {
      * @param blockStateId  the new block state id
      * @param customBlockId the new custom block id
      */
-    protected abstract void refreshBlockValue(int x, int y, int z, short blockStateId, short customBlockId);
+    public abstract void refreshBlockValue(int x, int y, int z, short blockStateId, short customBlockId);
 
     /**
      * Changes the block state id at a position (the custom block id stays the same).
@@ -166,7 +166,7 @@ public abstract class Chunk implements Viewable, DataContainer {
      * @param z            the block Z
      * @param blockStateId the new block state id
      */
-    protected abstract void refreshBlockStateId(int x, int y, int z, short blockStateId);
+    public abstract void refreshBlockStateId(int x, int y, int z, short blockStateId);
 
     /**
      * Gets the {@link Data} at a block index.

--- a/src/main/java/net/minestom/server/instance/DynamicChunk.java
+++ b/src/main/java/net/minestom/server/instance/DynamicChunk.java
@@ -77,7 +77,6 @@ public class DynamicChunk extends Chunk {
 
     @Override
     public void UNSAFE_setBlock(int x, int y, int z, short blockStateId, short customBlockId, Data data, boolean updatable) {
-
         {
             // Update pathfinder
             if (columnarSpace != null) {

--- a/src/main/java/net/minestom/server/instance/DynamicChunk.java
+++ b/src/main/java/net/minestom/server/instance/DynamicChunk.java
@@ -169,13 +169,13 @@ public class DynamicChunk extends Chunk {
     }
 
     @Override
-    protected void refreshBlockValue(int x, int y, int z, short blockStateId, short customBlockId) {
+    public void refreshBlockValue(int x, int y, int z, short blockStateId, short customBlockId) {
         setBlockAt(blockPalette, x, y, z, blockStateId);
         setBlockAt(customBlockPalette, x, y, z, customBlockId);
     }
 
     @Override
-    protected void refreshBlockStateId(int x, int y, int z, short blockStateId) {
+    public void refreshBlockStateId(int x, int y, int z, short blockStateId) {
         setBlockAt(blockPalette, x, y, z, blockStateId);
     }
 

--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -12,6 +12,7 @@ import net.minestom.server.event.instance.InstanceChunkUnloadEvent;
 import net.minestom.server.event.player.PlayerBlockBreakEvent;
 import net.minestom.server.instance.batch.ChunkGenerationBatch;
 import net.minestom.server.instance.block.Block;
+import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.instance.block.CustomBlock;
 import net.minestom.server.instance.block.rule.BlockPlacementRule;
 import net.minestom.server.network.packet.server.play.BlockChangePacket;
@@ -124,8 +125,8 @@ public class InstanceContainer extends Instance {
     }
 
     @Override
-    public void placeBlock(@NotNull Player player, @NotNull Chunk chunk, int x, int y, int z, short blockId, short customBlockId, @Nullable Data data) {
-        setBlock(player, chunk, x, y, z, blockId, customBlockId, data);
+    public void placeBlock(@NotNull Player player, @NotNull Chunk chunk, @NotNull BlockFace blockFace,  int x, int y, int z, short blockId, short customBlockId, @Nullable Data data) {
+        setBlock(player, chunk, blockFace, x, y, z, blockId, customBlockId, data);
     }
 
     @Override
@@ -142,7 +143,7 @@ public class InstanceContainer extends Instance {
         }
     }
 
-    private void setBlock(@NotNull Player player, @NotNull Chunk chunk, int x, int y, int z, short blockId, short customBlockId, @Nullable Data data) {
+    private void setBlock(@NotNull Player player, @NotNull Chunk chunk, @NotNull BlockFace blockFace, int x, int y, int z, short blockId, short customBlockId, @Nullable Data data) {
         synchronized (chunk) {
             this.lastBlockChangeTime = System.currentTimeMillis();
 
@@ -158,7 +159,7 @@ public class InstanceContainer extends Instance {
 
             CustomBlock customBlock = BLOCK_MANAGER.getCustomBlock(customBlockId);
             if (customBlock != null) {
-                customBlock.updateBlockVisual(this, chunk, player, blockPosition, blockId, data);
+                customBlock.updateBlockVisual(this, chunk, player, blockFace, blockPosition, blockId, data);
                 customBlock.onPlace(this, blockPosition, data);
             } else {
                 chunk.UNSAFE_setBlock(x, y, z, blockId, (short) 0, data, false);

--- a/src/main/java/net/minestom/server/instance/SharedInstance.java
+++ b/src/main/java/net/minestom/server/instance/SharedInstance.java
@@ -134,13 +134,13 @@ public class SharedInstance extends Instance {
     }
 
     @Override
-    public void placeBlock(@NotNull Player player, @NotNull Chunk chunk, @NotNull BlockFace blockFace, int x, int y, int z, short blockId, short customBlockId, @Nullable Data data) {
-        this.instanceContainer.placeBlock(player, chunk, blockFace, x, y, z, blockId, customBlockId, data);
+    public void placeBlock(@NotNull Player player, @NotNull Chunk chunk, @NotNull BlockFace blockFace, @NotNull BlockPosition blockPosition, short blockId, short customBlockId, @Nullable Data data) {
+        this.instanceContainer.placeBlock(player, chunk, blockFace, blockPosition, blockId, customBlockId, data);
     }
 
     @Override
-    public void setBlock(int x, int y, int z, short blockId, short customBlockId, @Nullable Data data) {
-        this.instanceContainer.setBlock(x, y, z, blockId, customBlockId, data);
+    public void setBlock(@NotNull BlockPosition blockPosition, short blockId, short customBlockId, @Nullable Data data) {
+        this.instanceContainer.setBlock(blockPosition, blockId, customBlockId, data);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/instance/SharedInstance.java
+++ b/src/main/java/net/minestom/server/instance/SharedInstance.java
@@ -2,6 +2,7 @@ package net.minestom.server.instance;
 
 import net.minestom.server.data.Data;
 import net.minestom.server.entity.Player;
+import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.storage.StorageLocation;
 import net.minestom.server.utils.BlockPosition;
 import net.minestom.server.utils.Position;
@@ -130,6 +131,16 @@ public class SharedInstance extends Instance {
     @Override
     public void setSeparateBlocks(int x, int y, int z, short blockStateId, short customBlockId, Data data) {
         this.instanceContainer.setSeparateBlocks(x, y, z, blockStateId, customBlockId, data);
+    }
+
+    @Override
+    public void placeBlock(@NotNull Player player, @NotNull Chunk chunk, @NotNull BlockFace blockFace, int x, int y, int z, short blockId, short customBlockId, @Nullable Data data) {
+        this.instanceContainer.placeBlock(player, chunk, blockFace, x, y, z, blockId, customBlockId, data);
+    }
+
+    @Override
+    public void setBlock(int x, int y, int z, short blockId, short customBlockId, @Nullable Data data) {
+        this.instanceContainer.setBlock(x, y, z, blockId, customBlockId, data);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/instance/batch/AbsoluteBlockBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/AbsoluteBlockBatch.java
@@ -8,6 +8,7 @@ import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.InstanceContainer;
 import net.minestom.server.instance.block.BlockFace;
+import net.minestom.server.utils.BlockPosition;
 import net.minestom.server.utils.chunk.ChunkUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -64,12 +65,12 @@ public class AbsoluteBlockBatch implements Batch<Runnable> {
     }
 
     @Override
-    public void placeBlock(@NotNull Player player, @NotNull Chunk chunk, @NotNull BlockFace blockFace, int x, int y, int z, short blockId, short customBlockId, @Nullable Data data) {
+    public void placeBlock(@NotNull Player player, @NotNull Chunk chunk, @NotNull BlockFace blockFace, @NotNull BlockPosition blockPosition, short blockId, short customBlockId, @Nullable Data data) {
         throw new UnsupportedOperationException("Unsupported for now.");
     }
 
     @Override
-    public void setBlock(int x, int y, int z, short blockId, short customBlockId, @Nullable Data data) {
+    public void setBlock(@NotNull BlockPosition blockPosition, short blockId, short customBlockId, @Nullable Data data) {
         throw new UnsupportedOperationException("Unsupported for now.");
     }
 

--- a/src/main/java/net/minestom/server/instance/batch/AbsoluteBlockBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/AbsoluteBlockBatch.java
@@ -3,9 +3,11 @@ package net.minestom.server.instance.batch;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import net.minestom.server.data.Data;
+import net.minestom.server.entity.Player;
 import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.InstanceContainer;
+import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.utils.chunk.ChunkUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -59,6 +61,16 @@ public class AbsoluteBlockBatch implements Batch<Runnable> {
         final int relativeX = x - (chunkX * Chunk.CHUNK_SIZE_X);
         final int relativeZ = z - (chunkZ * Chunk.CHUNK_SIZE_Z);
         chunkBatch.setSeparateBlocks(relativeX, y, relativeZ, blockStateId, customBlockId, data);
+    }
+
+    @Override
+    public void placeBlock(@NotNull Player player, @NotNull Chunk chunk, @NotNull BlockFace blockFace, int x, int y, int z, short blockId, short customBlockId, @Nullable Data data) {
+        throw new UnsupportedOperationException("Unsupported for now.");
+    }
+
+    @Override
+    public void setBlock(int x, int y, int z, short blockId, short customBlockId, @Nullable Data data) {
+        throw new UnsupportedOperationException("Unsupported for now.");
     }
 
     @Override

--- a/src/main/java/net/minestom/server/instance/batch/ChunkBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/ChunkBatch.java
@@ -7,9 +7,11 @@ import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongList;
 import net.minestom.server.data.Data;
+import net.minestom.server.entity.Player;
 import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.InstanceContainer;
+import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.network.packet.server.play.ChunkDataPacket;
 import net.minestom.server.utils.PacketUtils;
 import net.minestom.server.utils.block.CustomBlockUtils;
@@ -88,6 +90,16 @@ public class ChunkBatch implements Batch<ChunkCallback> {
                 this.blockDataMap.put(index, data);
             }
         }
+    }
+
+    @Override
+    public void placeBlock(@NotNull Player player, @NotNull Chunk chunk, @NotNull BlockFace blockFace, int x, int y, int z, short blockId, short customBlockId, @Nullable Data data) {
+        throw new UnsupportedOperationException("Unsupported for now.");
+    }
+
+    @Override
+    public void setBlock(int x, int y, int z, short blockId, short customBlockId, @Nullable Data data) {
+        throw new UnsupportedOperationException("Unsupported for now.");
     }
 
     @Override

--- a/src/main/java/net/minestom/server/instance/batch/ChunkBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/ChunkBatch.java
@@ -13,6 +13,7 @@ import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.InstanceContainer;
 import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.network.packet.server.play.ChunkDataPacket;
+import net.minestom.server.utils.BlockPosition;
 import net.minestom.server.utils.PacketUtils;
 import net.minestom.server.utils.block.CustomBlockUtils;
 import net.minestom.server.utils.callback.OptionalCallback;
@@ -93,12 +94,12 @@ public class ChunkBatch implements Batch<ChunkCallback> {
     }
 
     @Override
-    public void placeBlock(@NotNull Player player, @NotNull Chunk chunk, @NotNull BlockFace blockFace, int x, int y, int z, short blockId, short customBlockId, @Nullable Data data) {
+    public void placeBlock(@NotNull Player player, @NotNull Chunk chunk, @NotNull BlockFace blockFace, @NotNull BlockPosition blockPosition, short blockId, short customBlockId, @Nullable Data data) {
         throw new UnsupportedOperationException("Unsupported for now.");
     }
 
     @Override
-    public void setBlock(int x, int y, int z, short blockId, short customBlockId, @Nullable Data data) {
+    public void setBlock(@NotNull BlockPosition blockPosition, short blockId, short customBlockId, @Nullable Data data) {
         throw new UnsupportedOperationException("Unsupported for now.");
     }
 

--- a/src/main/java/net/minestom/server/instance/batch/RelativeBlockBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/RelativeBlockBatch.java
@@ -97,12 +97,12 @@ public class RelativeBlockBatch implements Batch<Runnable> {
     }
 
     @Override
-    public void placeBlock(@NotNull Player player, @NotNull Chunk chunk, @NotNull BlockFace blockFace, int x, int y, int z, short blockId, short customBlockId, @Nullable Data data) {
+    public void placeBlock(@NotNull Player player, @NotNull Chunk chunk, @NotNull BlockFace blockFace, @NotNull BlockPosition blockPosition, short blockId, short customBlockId, @Nullable Data data) {
         throw new UnsupportedOperationException("Unsupported for now.");
     }
 
     @Override
-    public void setBlock(int x, int y, int z, short blockId, short customBlockId, @Nullable Data data) {
+    public void setBlock(@NotNull BlockPosition blockPosition, short blockId, short customBlockId, @Nullable Data data) {
         throw new UnsupportedOperationException("Unsupported for now.");
     }
 

--- a/src/main/java/net/minestom/server/instance/batch/RelativeBlockBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/RelativeBlockBatch.java
@@ -5,7 +5,10 @@ import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import net.minestom.server.data.Data;
+import net.minestom.server.entity.Player;
+import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.Instance;
+import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.utils.BlockPosition;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.NotNull;
@@ -91,6 +94,16 @@ public class RelativeBlockBatch implements Batch<Runnable> {
                 }
             }
         }
+    }
+
+    @Override
+    public void placeBlock(@NotNull Player player, @NotNull Chunk chunk, @NotNull BlockFace blockFace, int x, int y, int z, short blockId, short customBlockId, @Nullable Data data) {
+        throw new UnsupportedOperationException("Unsupported for now.");
+    }
+
+    @Override
+    public void setBlock(int x, int y, int z, short blockId, short customBlockId, @Nullable Data data) {
+        throw new UnsupportedOperationException("Unsupported for now.");
     }
 
     @Override

--- a/src/main/java/net/minestom/server/instance/block/CustomBlock.java
+++ b/src/main/java/net/minestom/server/instance/block/CustomBlock.java
@@ -230,6 +230,33 @@ public abstract class CustomBlock {
     }
 
     /**
+     *
+     * Updates the visuals for the block with player context. In vanilla minecraft this is usually based off of the neighbouring blocks.
+     *
+     * @param instance           the {@link Instance} in which the block is being placed
+     * @param player             the {@link Player} that placed the block
+     * @param blockPosition      the {@link BlockPosition} at which the block is placed
+     * @param blockId            the base id of the block being placed
+     * @param data               the {@link Data} of the block, can be null
+     */
+    public void updateBlockVisual(@NotNull Instance instance, @NotNull Player player, @NotNull BlockPosition blockPosition, short blockId, @Nullable Data data) {
+
+    }
+
+    /**
+     *
+     * Updates the visuals for the block. In vanilla minecraft this is usually based off of the neighbouring blocks.
+     *
+     * @param instance           the {@link Instance} in which the block is being placed
+     * @param blockPosition      the {@link BlockPosition} at which the block is placed
+     * @param blockId            the base id of the block being placed
+     * @param data               the {@link Data} of the block, can be null
+     */
+    public void updateBlockVisual(@NotNull Instance instance, @NotNull BlockPosition blockPosition, short blockId, @Nullable Data data) {
+
+    }
+
+    /**
      * Updates this block from a neighbor. By default calls 'update' if directNeighbor is true.
      *
      * @param instance         current instance

--- a/src/main/java/net/minestom/server/instance/block/CustomBlock.java
+++ b/src/main/java/net/minestom/server/instance/block/CustomBlock.java
@@ -234,27 +234,25 @@ public abstract class CustomBlock {
      * Updates the visuals for the block with player context. In vanilla minecraft this is usually based off of the neighbouring blocks.
      *
      * @param instance           the {@link Instance} in which the block is being placed
+     * @param chunk              the {@link Chunk} in which the block is being placed
      * @param player             the {@link Player} that placed the block
      * @param blockPosition      the {@link BlockPosition} at which the block is placed
      * @param blockId            the base id of the block being placed
      * @param data               the {@link Data} of the block, can be null
      */
-    public void updateBlockVisual(@NotNull Instance instance, @NotNull Player player, @NotNull BlockPosition blockPosition, short blockId, @Nullable Data data) {
-
-    }
+    public void updateBlockVisual(@NotNull Instance instance, @NotNull Chunk chunk, @NotNull Player player, @NotNull BlockPosition blockPosition, short blockId, @Nullable Data data) {}
 
     /**
      *
      * Updates the visuals for the block. In vanilla minecraft this is usually based off of the neighbouring blocks.
      *
      * @param instance           the {@link Instance} in which the block is being placed
+     * @param chunk              the {@link Chunk} in which the block is being placed
      * @param blockPosition      the {@link BlockPosition} at which the block is placed
      * @param blockId            the base id of the block being placed
      * @param data               the {@link Data} of the block, can be null
      */
-    public void updateBlockVisual(@NotNull Instance instance, @NotNull BlockPosition blockPosition, short blockId, @Nullable Data data) {
-
-    }
+    public void updateBlockVisual(@NotNull Instance instance, @NotNull Chunk chunk, @NotNull BlockPosition blockPosition, short blockId, @Nullable Data data) {}
 
     /**
      * Updates this block from a neighbor. By default calls 'update' if directNeighbor is true.
@@ -264,6 +262,7 @@ public abstract class CustomBlock {
      * @param neighborPosition the neighboring block which triggered the update
      * @param directNeighbor   is the neighbor directly connected to this block? (No diagonals)
      */
+    @Deprecated
     public void updateFromNeighbor(@NotNull Instance instance, @NotNull BlockPosition thisPosition,
                                    @NotNull BlockPosition neighborPosition, boolean directNeighbor) {
         if (directNeighbor && hasUpdate()) {

--- a/src/main/java/net/minestom/server/instance/block/CustomBlock.java
+++ b/src/main/java/net/minestom/server/instance/block/CustomBlock.java
@@ -236,11 +236,12 @@ public abstract class CustomBlock {
      * @param instance           the {@link Instance} in which the block is being placed
      * @param chunk              the {@link Chunk} in which the block is being placed
      * @param player             the {@link Player} that placed the block
+     * @param blockFace          the {@link BlockFace} of the block that the block being placed was placed against
      * @param blockPosition      the {@link BlockPosition} at which the block is placed
      * @param blockId            the base id of the block being placed
      * @param data               the {@link Data} of the block, can be null
      */
-    public void updateBlockVisual(@NotNull Instance instance, @NotNull Chunk chunk, @NotNull Player player, @NotNull BlockPosition blockPosition, short blockId, @Nullable Data data) {}
+    public void updateBlockVisual(@NotNull Instance instance, @NotNull Chunk chunk, @NotNull Player player, @NotNull BlockFace blockFace, @NotNull BlockPosition blockPosition, short blockId, @Nullable Data data) {}
 
     /**
      *

--- a/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
+++ b/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
@@ -40,14 +40,7 @@ public class BlockPlacementListener {
         final Direction direction = blockFace.toDirection();
 
         final Instance instance = player.getInstance();
-        if (instance == null)
-            return;
-
-        // Prevent outdated/modified client data
-        if (!ChunkUtils.isLoaded(instance.getChunkAt(blockPosition))) {
-            // Client tried to place a block in an unloaded chunk, ignore the request
-            return;
-        }
+        if (instance == null) return;
 
         final ItemStack usedItem = player.getItemInHand(hand);
 
@@ -58,35 +51,25 @@ public class BlockPlacementListener {
         playerBlockInteractEvent.setBlockingItemUse(cancel);
         player.callCancellableEvent(PlayerBlockInteractEvent.class, playerBlockInteractEvent, () -> {
             final CustomBlock customBlock = instance.getCustomBlock(blockPosition);
-            if (customBlock != null) {
-                final Data data = instance.getBlockData(blockPosition);
-                final boolean blocksItem = customBlock.onInteract(player, hand, blockPosition, data);
-                if (blocksItem) {
-                    playerBlockInteractEvent.setBlockingItemUse(true);
-                }
-            }
+            if (customBlock == null) return;
+
+            final Data data = instance.getBlockData(blockPosition);
+            final boolean blocksItem = customBlock.onInteract(player, hand, blockPosition, data);
+            if (blocksItem) playerBlockInteractEvent.setBlockingItemUse(true);
         });
 
-        if (playerBlockInteractEvent.isBlockingItemUse()) {
-            return;
-        }
+        if (playerBlockInteractEvent.isBlockingItemUse()) return;
 
         final Material useMaterial = usedItem.getMaterial();
+        if (useMaterial == Material.AIR) return;
 
         // Verify if the player can place the block
-        boolean canPlaceBlock = true;
-        {
-            if (useMaterial == Material.AIR) { // Can't place air
-                return;
-            }
-
-            //Check if the player is allowed to place blocks based on their game mode
-            if (player.getGameMode() == GameMode.SPECTATOR) {
-                canPlaceBlock = false; //Spectators can't place blocks
-            } else if (player.getGameMode() == GameMode.ADVENTURE) {
-                //Check if the block can placed on the block
-                canPlaceBlock = usedItem.canPlaceOn(instance.getBlock(blockPosition).getName());
-            }
+        if (player.getGameMode() == GameMode.SPECTATOR || !usedItem.canPlaceOn(instance.getBlock(blockPosition).getName())) {
+            BlockChangePacket blockChangePacket = new BlockChangePacket();
+            blockChangePacket.blockPosition = blockPosition;
+            blockChangePacket.blockStateId = Block.AIR.getBlockId();
+            player.getPlayerConnection().sendPacket(blockChangePacket);
+            return;
         }
 
         // Get the newly placed block position
@@ -96,108 +79,70 @@ public class BlockPlacementListener {
 
         blockPosition.add(offsetX, offsetY, offsetZ);
 
-        if (!canPlaceBlock) {
-            //Send a block change with AIR as block to keep the client in sync,
-            //using refreshChunk results in the client not being in sync
-            //after rapid invalid block placements
-            BlockChangePacket blockChangePacket = new BlockChangePacket();
-            blockChangePacket.blockPosition = blockPosition;
-            blockChangePacket.blockStateId = Block.AIR.getBlockId();
-            player.getPlayerConnection().sendPacket(blockChangePacket);
-            return;
-        }
-
         final Chunk chunk = instance.getChunkAt(blockPosition);
+        if (!ChunkUtils.isLoaded(chunk)) return;
 
-        Check.stateCondition(!ChunkUtils.isLoaded(chunk),
-                "A player tried to place a block in the border of a loaded chunk " + blockPosition);
-
-        // The concerned chunk will be send to the player if an error occur
-        // This will ensure that the player has the correct version of the chunk
-        boolean refreshChunk = false;
-
-        if (useMaterial.isBlock()) {
-            if (!chunk.isReadOnly()) {
-                final Block block = useMaterial.getBlock();
-                final Set<Entity> entities = instance.getChunkEntities(chunk);
-                // Check if the player is trying to place a block in an entity
-                boolean intersect = player.getBoundingBox().intersect(blockPosition);
-                if (!intersect && block.isSolid()) {
-                    // TODO push entities too close to the position
-                    for (Entity entity : entities) {
-                        // 'player' has already been checked
-                        if (entity == player ||
-                                entity.getEntityType() == EntityType.ITEM)
-                            continue;
-
-                        intersect = entity.getBoundingBox().intersect(blockPosition);
-                        if (intersect)
-                            break;
-                    }
-                }
-
-                if (!intersect) {
-
-                    // BlockPlaceEvent check
-                    PlayerBlockPlaceEvent playerBlockPlaceEvent = new PlayerBlockPlaceEvent(player, block, blockPosition, packet.hand);
-                    playerBlockPlaceEvent.consumeBlock(player.getGameMode() != GameMode.CREATIVE);
-
-                    player.callEvent(PlayerBlockPlaceEvent.class, playerBlockPlaceEvent);
-                    if (!playerBlockPlaceEvent.isCancelled()) {
-
-                        // BlockPlacementRule check
-                        short blockStateId = playerBlockPlaceEvent.getBlockStateId();
-                        final Block resultBlock = Block.fromStateId(blockStateId);
-                        final BlockPlacementRule blockPlacementRule = BLOCK_MANAGER.getBlockPlacementRule(resultBlock);
-                        if (blockPlacementRule != null) {
-                            // Get id from block placement rule instead of the event
-                            blockStateId = blockPlacementRule.blockPlace(instance, resultBlock, blockFace, blockPosition, player);
-                        }
-                        final boolean placementRuleCheck = blockStateId != BlockPlacementRule.CANCEL_CODE;
-
-                        if (placementRuleCheck) {
-
-                            // Place the block
-                            final short customBlockId = playerBlockPlaceEvent.getCustomBlockId();
-                            final Data blockData = playerBlockPlaceEvent.getBlockData(); // Possibly null
-                            instance.setSeparateBlocks(blockPosition.getX(), blockPosition.getY(), blockPosition.getZ(),
-                                    blockStateId, customBlockId, blockData);
-
-                            // Block consuming
-                            if (playerBlockPlaceEvent.doesConsumeBlock()) {
-                                // Consume the block in the player's hand
-                                final ItemStack newUsedItem = usedItem.consume(1);
-
-                                if (newUsedItem != null) {
-                                    playerInventory.setItemInHand(hand, newUsedItem);
-                                }
-                            }
-                        } else {
-                            refreshChunk = true;
-                        }
-                    } else {
-                        refreshChunk = true;
-                    }
-                } else {
-                    refreshChunk = true;
-                }
-            } else {
-                refreshChunk = true;
-            }
-        } else {
-            // Player didn't try to place a block but interacted with one
+        if (!useMaterial.isBlock()) {
             final BlockPosition usePosition = blockPosition.clone().subtract(offsetX, offsetY, offsetZ);
             PlayerUseItemOnBlockEvent event = new PlayerUseItemOnBlockEvent(player, hand, usedItem, usePosition, direction);
             player.callEvent(PlayerUseItemOnBlockEvent.class, event);
-            refreshChunk = true;
-        }
 
-        // Refresh chunk section if needed
-        if (refreshChunk) {
             chunk.sendChunkSectionUpdate(ChunkUtils.getSectionAt(blockPosition.getY()), player);
+            return;
         }
 
-        player.getInventory().refreshSlot(player.getHeldSlot());
+        if (chunk.isReadOnly()) {
+            chunk.sendChunkSectionUpdate(ChunkUtils.getSectionAt(blockPosition.getY()), player);
+            return;
+        }
+
+        final Block block = useMaterial.getBlock();
+        final Set<Entity> entities = instance.getChunkEntities(chunk);
+        // Check if the player is trying to place a block in an entity
+        boolean intersect = player.getBoundingBox().intersect(blockPosition);
+        if (!intersect && block.isSolid()) {
+            // TODO push entities too close to the position
+            for (Entity entity : entities) {
+                // 'player' has already been checked
+                if (entity == player || entity.getEntityType() == EntityType.ITEM) continue;
+
+                intersect = entity.getBoundingBox().intersect(blockPosition);
+                if (intersect) {
+                    chunk.sendChunkSectionUpdate(ChunkUtils.getSectionAt(blockPosition.getY()), player);
+                    return;
+                }
+            }
+        } else {
+            chunk.sendChunkSectionUpdate(ChunkUtils.getSectionAt(blockPosition.getY()), player);
+            return;
+        }
+
+        // BlockPlaceEvent check
+        PlayerBlockPlaceEvent playerBlockPlaceEvent = new PlayerBlockPlaceEvent(player, block, blockPosition, packet.hand);
+        playerBlockPlaceEvent.consumeBlock(player.getGameMode() != GameMode.CREATIVE);
+        player.callEvent(PlayerBlockPlaceEvent.class, playerBlockPlaceEvent);
+
+        if (playerBlockPlaceEvent.isCancelled()) {
+            chunk.sendChunkSectionUpdate(ChunkUtils.getSectionAt(blockPosition.getY()), player);
+            return;
+        }
+
+        // BlockPlacementRule check
+        short blockStateId = playerBlockPlaceEvent.getBlockStateId();
+        short customBlockId = playerBlockPlaceEvent.getCustomBlockId();
+        Data blockData = playerBlockPlaceEvent.getBlockData(); // Possibly null
+
+        // Place the block
+        instance.placeBlock(player, chunk, offsetX, offsetY, offsetZ, blockStateId, customBlockId, blockData);
+
+        // Block consuming
+        if (playerBlockPlaceEvent.doesConsumeBlock()) {
+            // Consume the block in the player's hand
+            final ItemStack newUsedItem = usedItem.consume(1);
+            if (newUsedItem != null) playerInventory.setItemInHand(hand, newUsedItem);
+        }
+
+        player.getInventory().refreshSlot(player.getHeldSlot()); // Perhaps this should be inside the if statement? What could update if the block wasn't consumed?
     }
 
 }

--- a/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
+++ b/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
@@ -49,6 +49,7 @@ public class BlockPlacementListener {
         PlayerBlockInteractEvent playerBlockInteractEvent = new PlayerBlockInteractEvent(player, blockPosition, hand, blockFace);
         playerBlockInteractEvent.setCancelled(cancel);
         playerBlockInteractEvent.setBlockingItemUse(cancel);
+
         player.callCancellableEvent(PlayerBlockInteractEvent.class, playerBlockInteractEvent, () -> {
             final CustomBlock customBlock = instance.getCustomBlock(blockPosition);
             if (customBlock == null) return;
@@ -64,7 +65,8 @@ public class BlockPlacementListener {
         if (useMaterial == Material.AIR) return;
 
         // Verify if the player can place the block
-        if (player.getGameMode() == GameMode.SPECTATOR || !usedItem.canPlaceOn(instance.getBlock(blockPosition).getName())) {
+//        if (player.getGameMode() == GameMode.SPECTATOR || !usedItem.canPlaceOn(instance.getBlock(blockPosition).getName())) { Investigate what canPlaceOn does.
+        if (player.getGameMode() == GameMode.SPECTATOR) {
             BlockChangePacket blockChangePacket = new BlockChangePacket();
             blockChangePacket.blockPosition = blockPosition;
             blockChangePacket.blockStateId = Block.AIR.getBlockId();
@@ -133,7 +135,7 @@ public class BlockPlacementListener {
         Data blockData = playerBlockPlaceEvent.getBlockData(); // Possibly null
 
         // Place the block
-        instance.placeBlock(player, chunk, blockFace, offsetX, offsetY, offsetZ, blockStateId, customBlockId, blockData);
+        instance.placeBlock(player, chunk, blockFace, blockPosition, blockStateId, customBlockId, blockData);
 
         // Block consuming
         if (playerBlockPlaceEvent.doesConsumeBlock()) {

--- a/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
+++ b/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
@@ -133,7 +133,7 @@ public class BlockPlacementListener {
         Data blockData = playerBlockPlaceEvent.getBlockData(); // Possibly null
 
         // Place the block
-        instance.placeBlock(player, chunk, offsetX, offsetY, offsetZ, blockStateId, customBlockId, blockData);
+        instance.placeBlock(player, chunk, blockFace, offsetX, offsetY, offsetZ, blockStateId, customBlockId, blockData);
 
         // Block consuming
         if (playerBlockPlaceEvent.doesConsumeBlock()) {


### PR DESCRIPTION
Updates to the block placement code/api. It allows for easier block updates with custom blocks.

I added default/vanilla block mechanics for some blocks. This feature is optional. Use "VanillaBlocks.registerBlocksInstance(instance)" on the instance that you want to have vanilla mechanics. Chests work partially.

The old API remains, but the block placement listener now uses the new methods.