### PR TITLE
Avoid NPE when getting NBT in ItemTag

### DIFF
--- a/src/main/java/net/minestom/server/item/ItemTag.java
+++ b/src/main/java/net/minestom/server/item/ItemTag.java
@@ -84,7 +84,16 @@ public class ItemTag<T> {
 
     public static @NotNull ItemTag<NBT> NBT(@NotNull String key) {
         return new ItemTag<>(key,
-                nbt -> nbt.get(key).deepClone(),
+                nbt -> {
+                    var currentNBT = nbt.get(key);
+
+                    // Avoid a NPE when cloning a null variable.
+                    if (currentNBT == null) {
+                        return null;
+                    }
+
+                    return currentNBT.deepClone();
+                },
                 ((nbt, value) -> nbt.set(key, value.deepClone())));
     }
 


### PR DESCRIPTION
This stores an internal reference stopping an NPE from being thrown when getting NBT.