### PR TITLE
Add the Jansi library.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,6 +154,10 @@ dependencies {
     // https://mvnrepository.com/artifact/org.jline/jline
     implementation group: 'org.jline', name: 'jline', version: '3.20.0'
 
+    // Jline compatibility for windows
+    // https://search.maven.org/artifact/org.fusesource.jansi/jansi/2.3.2/jar
+    implementation 'org.fusesource.jansi:jansi:2.3.2'
+
     // Guava 21.0+ required for Mixin, but Authlib imports 17.0
     api 'com.google.guava:guava:30.1-jre'
     api 'com.mojang:authlib:1.5.21'


### PR DESCRIPTION
The jansi library itself is needed in addition to jline's bridge for it.