### PR TITLE
Fix a tab completion bug/crash

### DIFF
--- a/src/main/java/net/minestom/server/listener/TabCompleteListener.java
+++ b/src/main/java/net/minestom/server/listener/TabCompleteListener.java
@@ -14,7 +14,7 @@ import net.minestom.server.network.packet.server.play.TabCompletePacket;
 import net.minestom.server.utils.StringUtils;
 
 import java.util.Arrays;
-import java.util.regex.PatternSyntaxException;
+import java.util.regex.Pattern;
 
 public class TabCompleteListener {
 
@@ -24,13 +24,7 @@ public class TabCompleteListener {
         String commandString = packet.text.replaceFirst(CommandManager.COMMAND_PREFIX, "");
         String[] split = commandString.split(StringUtils.SPACE);
         String commandName = split[0];
-        String args;
-
-        try {
-            args = commandString.replaceFirst(commandName, "");
-        } catch (PatternSyntaxException exception) {
-            args = commandName.replaceFirst(String.format("\\%s", commandName), "");
-        }
+        String args = commandString.replaceFirst(Pattern.quote(commandName), "");
 
         final CommandQueryResult commandQueryResult = CommandParser.findCommand(commandString);
         if (commandQueryResult == null) {

--- a/src/main/java/net/minestom/server/listener/TabCompleteListener.java
+++ b/src/main/java/net/minestom/server/listener/TabCompleteListener.java
@@ -14,6 +14,7 @@ import net.minestom.server.network.packet.server.play.TabCompletePacket;
 import net.minestom.server.utils.StringUtils;
 
 import java.util.Arrays;
+import java.util.regex.PatternSyntaxException;
 
 public class TabCompleteListener {
 
@@ -23,8 +24,13 @@ public class TabCompleteListener {
         String commandString = packet.text.replaceFirst(CommandManager.COMMAND_PREFIX, "");
         String[] split = commandString.split(StringUtils.SPACE);
         String commandName = split[0];
+        String args;
 
-        String args = commandString.replaceFirst(commandName, "");
+        try {
+            args = commandString.replaceFirst(commandName, "");
+        } catch (PatternSyntaxException exception) {
+            args = commandName.replaceFirst(String.format("\\%s", commandName), "");
+        }
 
         final CommandQueryResult commandQueryResult = CommandParser.findCommand(commandString);
         if (commandQueryResult == null) {


### PR DESCRIPTION
This pull request fixes a bug where you could not use metacharacters (`?`, `!`, `+` etc.) in tab completion, otherwise the server would crash.