### PR TITLE
Added Command Permission.

### DIFF
--- a/src/main/java/net/minestom/server/command/CommandManager.java
+++ b/src/main/java/net/minestom/server/command/CommandManager.java
@@ -37,6 +37,7 @@ public final class CommandManager {
     private final CommandDispatcher dispatcher = new CommandDispatcher();
 
     private CommandCallback unknownCommandCallback;
+    private CommandCallback notEnoughPermissionCallback;
 
     public CommandManager() {
     }
@@ -134,6 +135,25 @@ public final class CommandManager {
 
     public @NotNull CommandDispatcher getDispatcher() {
         return dispatcher;
+    }
+
+    /**
+     * Gets the callback executed once an command was run where the sender does not have enough permission.
+     *
+     * @return the not enough permission command callback, null if not any
+     */
+    public @Nullable CommandCallback getNotEnoughPermissionCallback() {
+        return notEnoughPermissionCallback;
+    }
+
+    /**
+     * Sets the callback executed once an command was run where the sender does not have enough permission.
+     *
+     * @param notEnoughPermissionCallback the not enough permission command callback,
+     *                                    setting it to null mean that nothing will be executed
+     */
+    public void setNotEnoughPermissionCallback(@Nullable CommandCallback notEnoughPermissionCallback) {
+        this.notEnoughPermissionCallback = notEnoughPermissionCallback;
     }
 
     /**

--- a/src/main/java/net/minestom/server/command/CommandManager.java
+++ b/src/main/java/net/minestom/server/command/CommandManager.java
@@ -142,7 +142,7 @@ public final class CommandManager {
      *
      * @return the not enough permission command callback, null if not any
      */
-    public @Nullable CommandCallback getNotEnoughPermissionCallback() {
+    public @Nullable CommandCallback getDefaultNotEnoughPermissionCallback() {
         return notEnoughPermissionCallback;
     }
 
@@ -152,7 +152,7 @@ public final class CommandManager {
      * @param notEnoughPermissionCallback the not enough permission command callback,
      *                                    setting it to null mean that nothing will be executed
      */
-    public void setNotEnoughPermissionCallback(@Nullable CommandCallback notEnoughPermissionCallback) {
+    public void setDefaultNotEnoughPermissionCallback(@Nullable CommandCallback notEnoughPermissionCallback) {
         this.notEnoughPermissionCallback = notEnoughPermissionCallback;
     }
 

--- a/src/main/java/net/minestom/server/command/builder/Command.java
+++ b/src/main/java/net/minestom/server/command/builder/Command.java
@@ -48,6 +48,8 @@ public class Command {
     private final String[] aliases;
     private final String[] names;
 
+    private String permission;
+
     private CommandExecutor defaultExecutor;
     private CommandCondition condition;
 
@@ -273,6 +275,24 @@ public class Command {
      */
     public void setDefaultExecutor(@Nullable CommandExecutor executor) {
         this.defaultExecutor = executor;
+    }
+
+    /**
+     * Gets the default permission
+     *
+     * @return  permission the default permission, null if not any
+     */
+    public @Nullable String getPermission() {
+        return permission;
+    }
+
+    /**
+     * Sets the default permission
+     *
+     * @param permission the new default permission, null to remove it
+     */
+    public void setPermission(@Nullable String permission) {
+        this.permission = permission;
     }
 
     /**

--- a/src/main/java/net/minestom/server/command/builder/Command.java
+++ b/src/main/java/net/minestom/server/command/builder/Command.java
@@ -3,11 +3,13 @@ package net.minestom.server.command.builder;
 import com.google.common.annotations.Beta;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import net.minestom.server.command.CommandManager;
 import net.minestom.server.command.CommandSender;
 import net.minestom.server.command.builder.arguments.*;
 import net.minestom.server.command.builder.arguments.minecraft.SuggestionType;
 import net.minestom.server.command.builder.condition.CommandCondition;
 import net.minestom.server.utils.StringUtils;
+import net.minestom.server.utils.callback.CommandCallback;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -52,6 +54,7 @@ public class Command {
 
     private CommandExecutor defaultExecutor;
     private CommandCondition condition;
+    private CommandCallback notEnoughPermissionCallback;
 
     private final List<Command> subcommands;
     private final List<CommandSyntax> syntaxes;
@@ -275,6 +278,25 @@ public class Command {
      */
     public void setDefaultExecutor(@Nullable CommandExecutor executor) {
         this.defaultExecutor = executor;
+    }
+
+    /**
+     * Gets the callback executed once this command was run and the sender does not have enough permission.
+     *
+     * @return the not enough permission command callback, null if not any
+     */
+    public @Nullable CommandCallback getNotEnoughPermissionCallback() {
+        return notEnoughPermissionCallback;
+    }
+
+    /**
+     * Sets the callback executed once this command was run and the sender does not have enough permission.
+     *
+     * @param notEnoughPermissionCallback the not enough permission command callback,
+     *                                    setting it to null means that the default {{@link CommandManager#getUnknownCommandCallback()}} will be called
+     */
+    public void setNotEnoughPermissionCallback(@Nullable CommandCallback notEnoughPermissionCallback) {
+        this.notEnoughPermissionCallback = notEnoughPermissionCallback;
     }
 
     /**

--- a/src/main/java/net/minestom/server/command/builder/ParsedCommand.java
+++ b/src/main/java/net/minestom/server/command/builder/ParsedCommand.java
@@ -85,14 +85,19 @@ public class ParsedCommand {
 
     private void executeCommand(CommandExecutor executor, Command command, @NotNull CommandSender source) {
         if (command.getPermission() == null) {
-            executor.apply(source, context);
+                executor.apply(source, context);
         } else {
             if (source.hasPermission(command.getPermission())) {
                 executor.apply(source, context);
             } else {
+                if (command.getNotEnoughPermissionCallback() != null) {
+                    command.getNotEnoughPermissionCallback().apply(source, context.getCommandName());
+                    return;
+                }
+
                 CommandManager manager = MinecraftServer.getCommandManager();
-                if (manager.getNotEnoughPermissionCallback() != null) {
-                    manager.getNotEnoughPermissionCallback().apply(source, command.getName());
+                if (manager.getDefaultNotEnoughPermissionCallback() != null) {
+                    manager.getDefaultNotEnoughPermissionCallback().apply(source, command.getName());
                 }
             }
         }

--- a/src/test/java/demo/Main.java
+++ b/src/test/java/demo/Main.java
@@ -57,7 +57,6 @@ public class Main {
 
         commandManager.setUnknownCommandCallback((sender, command) -> sender.sendMessage(Component.text("Unknown command", NamedTextColor.RED)));
 
-
         StorageManager storageManager = MinecraftServer.getStorageManager();
         storageManager.defineDefaultStorageSystem(FileStorageSystem::new);
 


### PR DESCRIPTION
Added command permission, its used like this:
Example Command:
```java
public class Command extends Command {
    public Command() {
        super("command");

        setPermission("commands.examplecommand");
    }
}
```

Set Permission Error:
```java
MinecraftServer.getCommandManager().setNotEnoughPermissionCallback((sender, command) -> {
    // Handle your not enough permission thing
});
```

Closes #253.