### PR TITLE
Food animation fix

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -2299,7 +2299,10 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
      * @param allowFood true if food should be updated, false otherwise
      * @return the called {@link ItemUpdateStateEvent},
      * null if there is no item to update the state
+     *
+     * @deprecated Use {@link #callItemUpdateStateEvent(Hand)} instead
      */
+    @Deprecated
     public @Nullable ItemUpdateStateEvent callItemUpdateStateEvent(boolean allowFood, @Nullable Hand hand) {
         if (hand == null)
             return null;

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -1141,7 +1141,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
      *
      * @return the eating hand, null if none
      */
-    public Hand getEatingHand() {
+    public @Nullable Hand getEatingHand() {
         return eatingHand;
     }
 
@@ -2296,19 +2296,35 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
      * Used to call {@link ItemUpdateStateEvent} with the proper item
      * It does check which hand to get the item to update.
      *
+     * @param allowFood true if food should be updated, false otherwise
      * @return the called {@link ItemUpdateStateEvent},
      * null if there is no item to update the state
      */
-    public @Nullable ItemUpdateStateEvent callItemUpdateStateEvent(@Nullable Hand hand) {
+    public @Nullable ItemUpdateStateEvent callItemUpdateStateEvent(boolean allowFood, @Nullable Hand hand) {
         if (hand == null)
             return null;
 
         final ItemStack updatedItem = getItemInHand(hand);
+        final boolean isFood = updatedItem.getMaterial().isFood();
+
+        if (isFood && !allowFood)
+            return null;
 
         ItemUpdateStateEvent itemUpdateStateEvent = new ItemUpdateStateEvent(this, hand, updatedItem);
         callEvent(ItemUpdateStateEvent.class, itemUpdateStateEvent);
 
         return itemUpdateStateEvent;
+    }
+
+    /**
+     * Used to call {@link ItemUpdateStateEvent} with the proper item
+     * It does check which hand to get the item to update. Allows food.
+     *
+     * @return the called {@link ItemUpdateStateEvent},
+     * null if there is no item to update the state
+     */
+    public @Nullable ItemUpdateStateEvent callItemUpdateStateEvent(@Nullable Hand hand) {
+        return callItemUpdateStateEvent(true, hand);
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -401,7 +401,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         if (isEating()) {
             if (time - startEatingTime >= eatingTime) {
                 triggerStatus((byte) 9); // Mark item use as finished
-                ItemUpdateStateEvent itemUpdateStateEvent = callItemUpdateStateEvent(true, eatingHand);
+                ItemUpdateStateEvent itemUpdateStateEvent = callItemUpdateStateEvent(eatingHand);
 
                 Check.notNull(itemUpdateStateEvent, "#callItemUpdateStateEvent returned null.");
 
@@ -1134,6 +1134,15 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
      */
     public boolean isEating() {
         return eatingHand != null;
+    }
+
+    /**
+     * Gets the hand which the player is eating from.
+     *
+     * @return the eating hand, null if none
+     */
+    public Hand getEatingHand() {
+        return eatingHand;
     }
 
     /**
@@ -2287,19 +2296,14 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
      * Used to call {@link ItemUpdateStateEvent} with the proper item
      * It does check which hand to get the item to update.
      *
-     * @param allowFood true if food should be updated, false otherwise
      * @return the called {@link ItemUpdateStateEvent},
      * null if there is no item to update the state
      */
-    public @Nullable ItemUpdateStateEvent callItemUpdateStateEvent(boolean allowFood, @Nullable Hand hand) {
+    public @Nullable ItemUpdateStateEvent callItemUpdateStateEvent(@Nullable Hand hand) {
         if (hand == null)
             return null;
 
         final ItemStack updatedItem = getItemInHand(hand);
-        final boolean isFood = updatedItem.getMaterial().isFood();
-
-        if (isFood && !allowFood)
-            return null;
 
         ItemUpdateStateEvent itemUpdateStateEvent = new ItemUpdateStateEvent(this, hand, updatedItem);
         callEvent(ItemUpdateStateEvent.class, itemUpdateStateEvent);

--- a/src/main/java/net/minestom/server/listener/PlayerDiggingListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerDiggingListener.java
@@ -136,14 +136,18 @@ public class PlayerDiggingListener {
 
         } else if (status == ClientPlayerDiggingPacket.Status.UPDATE_ITEM_STATE) {
             Player.Hand hand = null;
-            if (player.getItemInHand(Player.Hand.OFF).getMaterial().hasState()) {
+            if (player.isEating()) {
+                hand = player.getEatingHand();
+            } else if (player.getItemInHand(Player.Hand.OFF).getMaterial().hasState()) {
                 hand = Player.Hand.OFF;
             } else if (player.getItemInHand(Player.Hand.MAIN).getMaterial().hasState()) {
                 hand = Player.Hand.MAIN;
             }
 
             player.refreshEating(null);
-            ItemUpdateStateEvent itemUpdateStateEvent = player.callItemUpdateStateEvent(false, hand);
+            player.triggerStatus((byte) 9);
+
+            ItemUpdateStateEvent itemUpdateStateEvent = player.callItemUpdateStateEvent(hand);
 
             if (itemUpdateStateEvent == null) {
                 player.refreshActiveHand(true, false, false);

--- a/src/main/java/net/minestom/server/listener/UseItemListener.java
+++ b/src/main/java/net/minestom/server/listener/UseItemListener.java
@@ -50,6 +50,8 @@ public class UseItemListener {
         PlayerItemAnimationEvent.ItemAnimationType itemAnimationType = null;
         boolean riptideSpinAttack = false;
 
+        boolean cancelAnimation = false;
+
         if (material == Material.BOW) {
             itemAnimationType = PlayerItemAnimationEvent.ItemAnimationType.BOW;
         } else if (material == Material.CROSSBOW) {
@@ -64,9 +66,13 @@ public class UseItemListener {
             // Eating code, contains the eating time customisation
             PlayerPreEatEvent playerPreEatEvent = new PlayerPreEatEvent(player, itemStack, hand, player.getDefaultEatingTime());
             player.callCancellableEvent(PlayerPreEatEvent.class, playerPreEatEvent, () -> player.refreshEating(hand, playerPreEatEvent.getEatingTime()));
+
+            if (playerPreEatEvent.isCancelled()) {
+                cancelAnimation = true;
+            }
         }
 
-        if (itemAnimationType != null) {
+        if (!cancelAnimation && itemAnimationType != null) {
             PlayerItemAnimationEvent playerItemAnimationEvent = new PlayerItemAnimationEvent(player, itemAnimationType);
             player.callCancellableEvent(PlayerItemAnimationEvent.class, playerItemAnimationEvent, () -> {
                 player.refreshActiveHand(true, hand == Player.Hand.OFF, riptideSpinAttack);


### PR DESCRIPTION
This pull request fixes 2 issues related to food:

- Fixed other players still being able to see eating particles when a player stops eating
- Fixed eating animation being shown when PlayerPreEatEvent is cancelled