### PR TITLE
Convenience toMilliseconds, add UpdateOption methods to TaskBuilder

### DIFF
--- a/src/main/java/net/minestom/server/timer/TaskBuilder.java
+++ b/src/main/java/net/minestom/server/timer/TaskBuilder.java
@@ -3,6 +3,7 @@ package net.minestom.server.timer;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import net.minestom.server.extras.selfmodification.MinestomRootClassLoader;
 import net.minestom.server.utils.time.TimeUnit;
+import net.minestom.server.utils.time.UpdateOption;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -73,6 +74,18 @@ public class TaskBuilder {
     }
 
     /**
+     * Specifies that the {@link Task} should delay its execution by the specified amount of time.
+     *
+     * @param updateOption the UpdateOption for this builder.
+     * @return this builder, for chaining
+     */
+    @NotNull
+    public TaskBuilder delay(UpdateOption updateOption) {
+        this.delay = updateOption.toMilliseconds();
+        return this;
+    }
+
+    /**
      * Specifies that the {@link Task} should continue to run after waiting for the specified value until it is terminated.
      *
      * @param time The time until the repetition
@@ -82,6 +95,18 @@ public class TaskBuilder {
     @NotNull
     public TaskBuilder repeat(long time, @NotNull TimeUnit unit) {
         this.repeat = unit.toMilliseconds(time);
+        return this;
+    }
+
+    /**
+     * Specifies that the {@link Task} should continue to run after waiting for the specified value until it is terminated.
+     *
+     * @param updateOption the UpdateOption for this builder.
+     * @return this builder, for chaining
+     */
+    @NotNull
+    public TaskBuilder repeat(UpdateOption updateOption) {
+        this.repeat = updateOption.toMilliseconds();
         return this;
     }
 

--- a/src/main/java/net/minestom/server/utils/time/UpdateOption.java
+++ b/src/main/java/net/minestom/server/utils/time/UpdateOption.java
@@ -35,4 +35,13 @@ public class UpdateOption {
         UpdateOption updateOption = (UpdateOption) o;
         return Objects.equals(value, updateOption.value) && Objects.equals(timeUnit, updateOption.timeUnit);
     }
+
+    /**
+     * Converts this update option to milliseconds
+     *
+     * @return the converted milliseconds based on the time value and the unit
+     */
+    public long toMilliseconds() {
+        return timeUnit.toMilliseconds(value);
+    }
 }


### PR DESCRIPTION
This allows the usage of UpdateOption for delay and repeat settings in TaskBuilder.