### PR TITLE
Set default UUID provider to Mojang UUIDs

### DIFF
--- a/src/main/java/net/minestom/server/network/ConnectionManager.java
+++ b/src/main/java/net/minestom/server/network/ConnectionManager.java
@@ -24,6 +24,7 @@ import net.minestom.server.network.player.PlayerConnection;
 import net.minestom.server.utils.StringUtils;
 import net.minestom.server.utils.async.AsyncUtils;
 import net.minestom.server.utils.callback.validator.PlayerValidator;
+import net.minestom.server.utils.mojang.MojangUtils;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -56,7 +57,7 @@ public final class ConnectionManager {
     // All the consumers to call once a packet is sent
     private final List<ServerPacketConsumer> sendClientPacketConsumers = new CopyOnWriteArrayList<>();
     // The uuid provider once a player login
-    private UuidProvider uuidProvider;
+    private UuidProvider uuidProvider = (playerConnection, username) -> MojangUtils.grabUUID(username);
     // The player provider to have your own Player implementation
     private PlayerProvider playerProvider;
     // The consumers to call once a player connect, mostly used to init events

--- a/src/main/java/net/minestom/server/utils/mojang/MojangUtils.java
+++ b/src/main/java/net/minestom/server/utils/mojang/MojangUtils.java
@@ -66,8 +66,10 @@ public final class MojangUtils {
 
         if (jsonObject == null) return null;
 
+        // Grab the UUID. It does not have hyphens, so it has to be parsed specially
         String unHyphenedUUID = jsonObject.get("id").getAsString();
 
+        // UUID is split into 2 logs -- this parses both of those in the UUID format
         return new UUID(
                 Long.parseUnsignedLong(unHyphenedUUID.substring(0, 16), 16),
                 Long.parseUnsignedLong(unHyphenedUUID.substring(16), 16)

--- a/src/main/java/net/minestom/server/utils/mojang/MojangUtils.java
+++ b/src/main/java/net/minestom/server/utils/mojang/MojangUtils.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -57,6 +58,20 @@ public final class MojangUtils {
         // Retrieve from the rate-limited Mojang API
         final String url = "https://api.mojang.com/users/profiles/minecraft/" + username;
         return retrieve(url, username, USERNAME_CACHE);
+    }
+
+    @Nullable
+    public static UUID grabUUID(@NotNull String username) {
+        JsonObject jsonObject = fromUsername(username);
+
+        if (jsonObject == null) return null;
+
+        String unHyphenedUUID = jsonObject.get("id").getAsString();
+
+        return new UUID(
+                Long.parseUnsignedLong(unHyphenedUUID.substring(0, 16), 16),
+                Long.parseUnsignedLong(unHyphenedUUID.substring(16), 16)
+        );
     }
 
     @Nullable


### PR DESCRIPTION
This sets the default UUID provider to use the UUIDs from MojangAuth.