### PR TITLE
Implement some Adventure methods into ConsoleSender

### DIFF
--- a/src/main/java/net/minestom/server/command/CommandSender.java
+++ b/src/main/java/net/minestom/server/command/CommandSender.java
@@ -84,11 +84,4 @@ public interface CommandSender extends PermissionHandler, Audience, Taggable, Id
     default ConsoleSender asConsole() {
         throw new ClassCastException("CommandSender is not the ConsoleSender");
     }
-
-    /**
-     * Gets the UUID for this command sender.
-     *
-     * @return the UUID
-     */
-    @NotNull UUID getUuid();
 }

--- a/src/main/java/net/minestom/server/command/CommandSender.java
+++ b/src/main/java/net/minestom/server/command/CommandSender.java
@@ -1,6 +1,9 @@
 package net.minestom.server.command;
 
+import java.util.UUID;
+
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.text.Component;
 import net.minestom.server.entity.Player;
 import net.minestom.server.permission.PermissionHandler;
@@ -12,7 +15,7 @@ import org.jetbrains.annotations.NotNull;
  * <p>
  * Main implementations are {@link Player} and {@link ConsoleSender}.
  */
-public interface CommandSender extends PermissionHandler, Audience, Taggable {
+public interface CommandSender extends PermissionHandler, Audience, Taggable, Identified {
 
     /**
      * Sends a raw string message.
@@ -81,4 +84,11 @@ public interface CommandSender extends PermissionHandler, Audience, Taggable {
     default ConsoleSender asConsole() {
         throw new ClassCastException("CommandSender is not the ConsoleSender");
     }
+
+    /**
+     * Gets the UUID for this command sender.
+     *
+     * @return the UUID
+     */
+    @NotNull UUID getUuid();
 }

--- a/src/main/java/net/minestom/server/command/CommandSender.java
+++ b/src/main/java/net/minestom/server/command/CommandSender.java
@@ -1,7 +1,5 @@
 package net.minestom.server.command;
 
-import java.util.UUID;
-
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.text.Component;

--- a/src/main/java/net/minestom/server/command/ConsoleSender.java
+++ b/src/main/java/net/minestom/server/command/ConsoleSender.java
@@ -1,7 +1,11 @@
 package net.minestom.server.command;
 
+import java.util.UUID;
+
 import net.kyori.adventure.audience.MessageType;
+import net.kyori.adventure.identity.Identified;
 import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.pointer.Pointers;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
 import net.minestom.server.permission.Permission;
@@ -19,6 +23,11 @@ public class ConsoleSender implements CommandSender {
 
     private final Set<Permission> permissions = new CopyOnWriteArraySet<>();
     private final TagHandler tagHandler = TagHandler.newHandler();
+
+    private final Identity identity = Identity.nil();
+    private final Pointers pointers = Pointers.builder()
+            .withStatic(Identity.UUID, this.identity.uuid())
+            .build();
 
     @Override
     public void sendMessage(@NotNull String message) {
@@ -49,5 +58,20 @@ public class ConsoleSender implements CommandSender {
     @Override
     public @NotNull TagHandler tagHandler() {
         return tagHandler;
+    }
+
+    @Override
+    public @NotNull Identity identity() {
+        return this.identity;
+    }
+
+    @Override
+    public @NotNull Pointers pointers() {
+        return this.pointers;
+    }
+
+    @Override
+    public @NotNull UUID getUuid() {
+        return this.identity.uuid();
     }
 }

--- a/src/main/java/net/minestom/server/command/ConsoleSender.java
+++ b/src/main/java/net/minestom/server/command/ConsoleSender.java
@@ -69,9 +69,4 @@ public class ConsoleSender implements CommandSender {
     public @NotNull Pointers pointers() {
         return this.pointers;
     }
-
-    @Override
-    public @NotNull UUID getUuid() {
-        return this.identity.uuid();
-    }
 }

--- a/src/main/java/net/minestom/server/command/ServerSender.java
+++ b/src/main/java/net/minestom/server/command/ServerSender.java
@@ -1,6 +1,7 @@
 package net.minestom.server.command;
 
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.identity.Identity;
 import net.minestom.server.command.builder.CommandContext;
 import net.minestom.server.permission.Permission;
 import net.minestom.server.tag.TagHandler;
@@ -31,5 +32,10 @@ public class ServerSender implements CommandSender {
     @Override
     public @NotNull TagHandler tagHandler() {
         return tagHandler;
+    }
+
+    @Override
+    public @NotNull Identity identity() {
+        return Identity.nil();
     }
 }

--- a/src/test/java/net/minestom/server/command/CommandConditionTest.java
+++ b/src/test/java/net/minestom/server/command/CommandConditionTest.java
@@ -1,5 +1,6 @@
 package net.minestom.server.command;
 
+import net.kyori.adventure.identity.Identity;
 import net.minestom.server.command.builder.Command;
 import net.minestom.server.command.builder.CommandDispatcher;
 import net.minestom.server.permission.Permission;
@@ -133,6 +134,11 @@ public class CommandConditionTest {
         @Override
         public @NotNull TagHandler tagHandler() {
             return null;
+        }
+
+        @Override
+        public @NotNull Identity identity() {
+            return Identity.nil();
         }
     }
 }

--- a/src/test/java/net/minestom/server/command/CommandSenderTest.java
+++ b/src/test/java/net/minestom/server/command/CommandSenderTest.java
@@ -76,5 +76,10 @@ public class CommandSenderTest {
         public @Nullable Component getMostRecentMessage() {
             return mostRecentMessage;
         }
+
+        @Override
+        public @NotNull Identity identity() {
+            return Identity.nil();
+        }
     }
 }


### PR DESCRIPTION
As `ConsoleSender` is also an `Audience`, it should implement some other common Adventure methods to increase cross-platform compatibility and prep for potential upcoming Adventure Audience type checking.