### PR TITLE
Debug grid (/dg) command

### DIFF
--- a/src/test/java/demo/Main.java
+++ b/src/test/java/demo/Main.java
@@ -55,6 +55,7 @@ public class Main {
         commandManager.register(new SummonCommand());
         commandManager.register(new RemoveCommand());
         commandManager.register(new GiveCommand());
+        commandManager.register(new DebugGridCommand());
 
         commandManager.setUnknownCommandCallback((sender, command) -> sender.sendMessage(Component.text("Unknown command", NamedTextColor.RED)));
 

--- a/src/test/java/demo/commands/DebugGridCommand.java
+++ b/src/test/java/demo/commands/DebugGridCommand.java
@@ -1,0 +1,42 @@
+package demo.commands;
+
+import net.minestom.server.command.CommandSender;
+import net.minestom.server.command.builder.Command;
+import net.minestom.server.command.builder.CommandContext;
+import net.minestom.server.command.builder.arguments.number.ArgumentInteger;
+import net.minestom.server.command.builder.arguments.relative.ArgumentRelativeBlockPosition;
+import net.minestom.server.command.builder.condition.Conditions;
+import net.minestom.server.instance.batch.RelativeBlockBatch;
+import net.minestom.server.instance.block.Block;
+import net.minestom.server.utils.BlockPosition;
+import net.minestom.server.utils.location.RelativeBlockPosition;
+import org.jetbrains.annotations.NotNull;
+
+public class DebugGridCommand extends Command {
+    private final ArgumentRelativeBlockPosition center;
+    private final ArgumentInteger radius;
+
+    public DebugGridCommand() {
+        super("dg");
+        setCondition(Conditions::playerOnly);
+
+        center = new ArgumentRelativeBlockPosition("center");
+        center.setDefaultValue(new RelativeBlockPosition(new BlockPosition(0,-1,0), true, true, true));
+        radius = new ArgumentInteger("radius");
+        radius.setDefaultValue(100);
+
+        addSyntax(this::execute, radius, center);
+    }
+
+    private void execute(@NotNull CommandSender sender, @NotNull CommandContext context) {
+        final RelativeBlockBatch relativeBlockBatch = new RelativeBlockBatch();
+        final Integer radius = context.get(this.radius);
+        for (int x = -radius/2; x < radius/2; x++) {
+            for (int z = -radius/2; z < radius/2; z++) {
+                relativeBlockBatch.setBlock(x,0,z, ((x % 2 == 0) ^ (z % 2) == 0) ? Block.WHITE_CONCRETE : Block.BLACK_CONCRETE);
+            }
+        }
+        //noinspection ConstantConditions
+        relativeBlockBatch.apply(sender.asPlayer().getInstance(), context.get(center).from(sender.asPlayer()), () -> {});
+    }
+}


### PR DESCRIPTION
This PR adds a new command: **/dg [radius] [center]**, which generates a checkerboard. This is useful for testing entity movement since it makes easier to see block borders. For easy usage both parameters are optional, defaulting to 100 block radius and centering below the player's feet.
**The default checkerboard**
![100x100 checkerboard](https://user-images.githubusercontent.com/45130268/123666949-f6c87580-d839-11eb-8976-b28e2575f643.png)
