### PR TITLE
Fix automatic component translation 

### DIFF
--- a/src/main/java/net/minestom/server/adventure/MinestomAdventure.java
+++ b/src/main/java/net/minestom/server/adventure/MinestomAdventure.java
@@ -26,7 +26,7 @@ public final class MinestomAdventure {
     /**
      * If components should be automatically translated in outgoing packets.
      */
-    public static final boolean AUTOMATIC_COMPONENT_TRANSLATION = false;
+    public static boolean AUTOMATIC_COMPONENT_TRANSLATION = false;
 
     static final Localizable NULL_LOCALIZABLE = () -> null;
 


### PR DESCRIPTION
I removed the "final" modifier from the field "AUTOMATIC_COMPONENT_TRANSLATION" to enable component translation.