### PR TITLE
Command API improvement

### DIFF
--- a/src/main/java/net/minestom/server/command/builder/CommandDispatcher.java
+++ b/src/main/java/net/minestom/server/command/builder/CommandDispatcher.java
@@ -47,6 +47,7 @@ public class CommandDispatcher {
         }
 
         this.commands.add(command);
+        command.addParent(null);
     }
 
     public void unregister(@NotNull Command command) {
@@ -60,6 +61,7 @@ public class CommandDispatcher {
         }
 
         this.commands.remove(command);
+        command.removeParent(null);
 
         // Clear cache
         this.cache.invalidateAll();

--- a/src/main/java/net/minestom/server/command/builder/ParsedCommand.java
+++ b/src/main/java/net/minestom/server/command/builder/ParsedCommand.java
@@ -37,6 +37,10 @@ public class ParsedCommand {
      */
     @Nullable
     public CommandData execute(@NotNull CommandSender source) {
+        if (command.shouldRemove()) {
+            command.unregisterSelf(true);
+            return null;
+        }
         // Global listener
         command.globalListener(source, context, commandString);
         // Command condition check
@@ -46,6 +50,10 @@ public class ParsedCommand {
             if (!result)
                 return null;
         }
+        if (!command.canBeUsedBy(source)) {
+            return null;
+        }
+        command.incrementUsageCounter();
         // Condition is respected
         if (executor != null) {
             // An executor has been found

--- a/src/test/java/demo/PlayerInit.java
+++ b/src/test/java/demo/PlayerInit.java
@@ -3,8 +3,10 @@ package demo;
 import demo.generator.ChunkGeneratorDemo;
 import demo.generator.NoiseTestGenerator;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.adventure.audience.Audiences;
+import net.minestom.server.command.builder.Command;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.GameMode;
 import net.minestom.server.entity.ItemEntity;
@@ -16,7 +18,10 @@ import net.minestom.server.event.EventNode;
 import net.minestom.server.event.entity.EntityAttackEvent;
 import net.minestom.server.event.item.ItemDropEvent;
 import net.minestom.server.event.item.PickupItemEvent;
-import net.minestom.server.event.player.*;
+import net.minestom.server.event.player.PlayerDeathEvent;
+import net.minestom.server.event.player.PlayerDisconnectEvent;
+import net.minestom.server.event.player.PlayerLoginEvent;
+import net.minestom.server.event.player.PlayerSpawnEvent;
 import net.minestom.server.event.trait.PlayerEvent;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.InstanceContainer;
@@ -38,6 +43,7 @@ import net.minestom.server.world.DimensionType;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -93,6 +99,17 @@ public class PlayerInit {
                 int x = Math.abs(ThreadLocalRandom.current().nextInt()) % 500 - 250;
                 int z = Math.abs(ThreadLocalRandom.current().nextInt()) % 500 - 250;
                 player.setRespawnPoint(new Position(0, 42f, 0));
+
+                // Command test
+                final String commandName = MinecraftServer.getCommandManager().register(Command.builder(((command, sender, context) -> {
+                   sender.asPlayer().getInventory().addItemStack(ItemStack.of(Material.DIAMOND));
+                })).maxUsage(5).whitelistedSenders(List.of(player)).build());
+
+                MinecraftServer.getCommandManager().register(Command.builder(((command, sender, context) -> {
+                    sender.sendMessage(command.getTimeUntilExpiration().toString());
+                })).ttl(Duration.ofSeconds(90)).hidden(false).build());
+
+                player.sendMessage(Component.text("Get 1 diamond (only usable 5 times)").clickEvent(ClickEvent.runCommand("/"+commandName)));
             })
             .addListener(PlayerSpawnEvent.class, event -> {
                 final Player player = event.getPlayer();


### PR DESCRIPTION
# New features
* automatically unregister commands after
   * specific time - `#setTtl(Duration)`
   * usage limit is reached - `#setMaxUsage(Integer)`
* white- and blacklist command senders to limit access
* hide commands - `#setHidden(boolean)`

# Possible features
The following features are just proposals, they might not make it into the final PR.
## Command builder (Status: proposed, implemented)
A command builder can be used to inline command creation, this is useful for simple commands. The same command implemented in three different ways:
**1. Using the command builder**
```java
final String timeCommand = MinecraftServer.getCommandManager().register(
        Command.builder((command, sender, context) -> sender.sendMessage(timeUntilNextHour())).build());

player.sendMessage(Component.text("Time until the next hour")
        .clickEvent(ClickEvent.runCommand("/"+timeCommand)));
```
2. Using the `Command` class
```java
final Command timeCommand = new Command(UUID.randomUUID().toString());
timeCommand.setDefaultExecutor(((sender, context) -> sender.sendMessage(timeUntilNextHour())));
timeCommand.setHidden(true);
MinecraftServer.getCommandManager().register(timeCommand);

player.sendMessage(Component.text("Time until the next hour")
        .clickEvent(ClickEvent.runCommand("/"+timeCommand.getName())));
```
3. Extending `Command` class
```java
// TimeCommand.java
public class TimeCommand extends Command {
    public TimeCommand() {
        super(UUID.randomUUID().toString());
        
        setDefaultExecutor(this::execute);
        setHidden(true);
    }

    private void execute(@NotNull CommandSender commandSender, @NotNull CommandContext context) {
        commandSender.sendMessage(timeUntilNextHour());
    }
}

// other file
final String timeCommand = MinecraftServer.getCommandManager().register(new TimeCommand());
player.sendMessage(Component.text("Time until the next hour")
        .clickEvent(ClickEvent.runCommand("/"+timeCommand)));
```
## Multiple condition with priority (Status: proposed)
Allowing multiple `CommandCondition`s can be useful to break down a big condition check into smaller chunks that could be reused among other commands. This would also mean that white- and blacklist, expiration and usage checks become automatically handled conditions.<br>
_No code examples yet_