### PR TITLE
Fix extension resource load in Windows

### DIFF
--- a/src/main/java/net/minestom/server/extensions/Extension.java
+++ b/src/main/java/net/minestom/server/extensions/Extension.java
@@ -151,7 +151,18 @@ public abstract class Extension {
      * @return The file contents, or null if there was an issue reading the file.
      */
     public @Nullable InputStream getPackagedResource(@NotNull String fileName) {
-        return getPackagedResource(Paths.get(fileName));
+        try {
+            final URL url = getOrigin().getMinestomExtensionClassLoader().getResource(fileName);
+            if (url == null) {
+                getLogger().debug("Resource not found: {}", fileName);
+                return null;
+            }
+
+            return url.openConnection().getInputStream();
+        } catch (IOException ex) {
+            getLogger().debug("Failed to load resource {}.", fileName, ex);
+            return null;
+        }
     }
 
     /**
@@ -163,19 +174,7 @@ public abstract class Extension {
      * @return The file contents, or null if there was an issue reading the file.
      */
     public @Nullable InputStream getPackagedResource(@NotNull Path target) {
-        try {
-            String path = target.toString().replace('\\', '/');
-            final URL url = getOrigin().getMinestomExtensionClassLoader().getResource(path);
-            if (url == null) {
-                getLogger().debug("Resource not found: {}", target);
-                return null;
-            }
-
-            return url.openConnection().getInputStream();
-        } catch (IOException ex) {
-            getLogger().debug("Failed to load resource {}.", target, ex);
-            return null;
-        }
+        return getPackagedResource(target.toString().replace('\\', '/'));
     }
 
     /**

--- a/src/main/java/net/minestom/server/extensions/Extension.java
+++ b/src/main/java/net/minestom/server/extensions/Extension.java
@@ -164,7 +164,8 @@ public abstract class Extension {
      */
     public @Nullable InputStream getPackagedResource(@NotNull Path target) {
         try {
-            final URL url = getOrigin().getMinestomExtensionClassLoader().getResource(target.toString());
+            String path = target.toString().replace('\\', '/');
+            final URL url = getOrigin().getMinestomExtensionClassLoader().getResource(path);
             if (url == null) {
                 getLogger().debug("Resource not found: {}", target);
                 return null;


### PR DESCRIPTION
In windows, `Path#toString` will use `\` as the separator, but `ClassLoader#getResource` needs `/`. This will cause resources in subfolders to fail to load in Windows.