### PR TITLE
Add ComponentHolding to packets for fully support automatic translation

### DIFF
--- a/src/main/java/net/minestom/server/item/ItemStack.java
+++ b/src/main/java/net/minestom/server/item/ItemStack.java
@@ -3,6 +3,7 @@ package net.minestom.server.item;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.event.HoverEventSource;
+import net.minestom.server.adventure.ComponentHolder;
 import net.minestom.server.item.rule.VanillaStackingRule;
 import net.minestom.server.tag.Tag;
 import net.minestom.server.tag.TagReadable;
@@ -12,6 +13,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jglrxavpok.hephaistos.nbt.NBTCompound;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -24,7 +27,7 @@ import java.util.function.UnaryOperator;
  * <p>
  * An item stack cannot be null, {@link ItemStack#AIR} should be used instead.
  */
-public final class ItemStack implements TagReadable, HoverEventSource<HoverEvent.ShowItem> {
+public final class ItemStack implements TagReadable, HoverEventSource<HoverEvent.ShowItem>, ComponentHolder<ItemStack> {
 
     /**
      * Constant AIR item. Should be used instead of 'null'.
@@ -208,5 +211,27 @@ public final class ItemStack implements TagReadable, HoverEventSource<HoverEvent
         return HoverEvent.showItem(op.apply(HoverEvent.ShowItem.of(this.material,
                 this.amount,
                 NBTUtils.asBinaryTagHolder(this.meta.toNBT().getCompound("tag")))));
+    }
+
+    @Override
+    public @NotNull Collection<Component> components() {
+        List<Component> components = new ArrayList<>(this.getLore());
+        if (this.getDisplayName() != null) {
+            components.add(getDisplayName());
+        }
+        return components;
+    }
+
+    @Override
+    public @NotNull ItemStack copyWithOperator(@NotNull UnaryOperator<Component> operator) {
+        List<Component> lore = new ArrayList<>();
+        for (Component component : this.getLore()) {
+            lore.add(operator.apply(component));
+        }
+        ItemStack itemStack = withLore(lore);
+        if (itemStack.getDisplayName() != null) {
+            itemStack = itemStack.withDisplayName(operator);
+        }
+        return itemStack;
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/ActionBarPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/ActionBarPacket.java
@@ -1,13 +1,18 @@
 package net.minestom.server.network.packet.server.play;
 
 import net.kyori.adventure.text.Component;
+import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
-public class ActionBarPacket implements ServerPacket {
+import java.util.Collection;
+import java.util.Collections;
+import java.util.function.UnaryOperator;
+
+public class ActionBarPacket implements ComponentHoldingServerPacket {
 
     public Component actionBarText;
 
@@ -32,5 +37,15 @@ public class ActionBarPacket implements ServerPacket {
     @Override
     public int getId() {
         return ServerPacketIdentifier.ACTION_BAR;
+    }
+
+    @Override
+    public @NotNull Collection<Component> components() {
+        return Collections.singleton(actionBarText);
+    }
+
+    @Override
+    public @NotNull ServerPacket copyWithOperator(@NotNull UnaryOperator<Component> operator) {
+        return new ActionBarPacket(operator.apply(actionBarText));
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/DeathCombatEventPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/DeathCombatEventPacket.java
@@ -1,13 +1,18 @@
 package net.minestom.server.network.packet.server.play;
 
 import net.kyori.adventure.text.Component;
+import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
-public class DeathCombatEventPacket implements ServerPacket {
+import java.util.Collection;
+import java.util.Collections;
+import java.util.function.UnaryOperator;
+
+public class DeathCombatEventPacket implements ComponentHoldingServerPacket {
 
     public int playerId;
     public int entityId;
@@ -38,5 +43,15 @@ public class DeathCombatEventPacket implements ServerPacket {
     @Override
     public int getId() {
         return ServerPacketIdentifier.DEATH_COMBAT_EVENT;
+    }
+
+    @Override
+    public @NotNull Collection<Component> components() {
+        return Collections.singleton(message);
+    }
+
+    @Override
+    public @NotNull ServerPacket copyWithOperator(@NotNull UnaryOperator<Component> operator) {
+        return DeathCombatEventPacket.of(playerId, entityId, operator.apply(message));
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityEquipmentPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityEquipmentPacket.java
@@ -1,17 +1,19 @@
 package net.minestom.server.network.packet.server.play;
 
+import net.kyori.adventure.text.Component;
 import net.minestom.server.entity.EquipmentSlot;
 import net.minestom.server.item.ItemStack;
+import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
+import java.util.function.UnaryOperator;
 
-public class EntityEquipmentPacket implements ServerPacket {
+public class EntityEquipmentPacket implements ComponentHoldingServerPacket {
 
     public int entityId;
     public EquipmentSlot[] slots;
@@ -71,4 +73,24 @@ public class EntityEquipmentPacket implements ServerPacket {
         return ServerPacketIdentifier.ENTITY_EQUIPMENT;
     }
 
+    @Override
+    public @NotNull Collection<Component> components() {
+        List<Component> components = new ArrayList<>();
+        for (ItemStack item : this.itemStacks) {
+            components.addAll(item.components());
+        }
+        return components;
+    }
+
+    @Override
+    public @NotNull ServerPacket copyWithOperator(@NotNull UnaryOperator<Component> operator) {
+        EntityEquipmentPacket packet = new EntityEquipmentPacket();
+        packet.entityId = this.entityId;
+        packet.slots = Arrays.copyOf(this.slots, this.slots.length);
+        packet.itemStacks = new ItemStack[this.itemStacks.length];
+        for (int i = 0; i < this.itemStacks.length; i++) {
+            packet.itemStacks[i] = this.itemStacks[i].copyWithOperator(operator);
+        }
+        return packet;
+    }
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityMetaDataPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityMetaDataPacket.java
@@ -1,16 +1,21 @@
 package net.minestom.server.network.packet.server.play;
 
+import net.kyori.adventure.text.Component;
 import net.minestom.server.entity.Metadata;
+import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.function.UnaryOperator;
 
-public class EntityMetaDataPacket implements ServerPacket {
+public class EntityMetaDataPacket implements ComponentHoldingServerPacket {
 
     public int entityId;
     public Collection<Metadata.Entry<?>> entries;
@@ -50,5 +55,37 @@ public class EntityMetaDataPacket implements ServerPacket {
     @Override
     public int getId() {
         return ServerPacketIdentifier.ENTITY_METADATA;
+    }
+
+    @Override
+    public @NotNull Collection<Component> components() {
+        List<Component> components = new ArrayList<>();
+        for (Metadata.Entry<?> entry : entries) {
+            int type = entry.getMetaValue().getType();
+            if (type == Metadata.TYPE_CHAT || type == Metadata.TYPE_OPTCHAT) {
+                components.add(((Metadata.Entry<Component>) entry).getMetaValue().getValue());
+            }
+        }
+        return components;
+    }
+
+    @Override
+    public @NotNull ServerPacket copyWithOperator(@NotNull UnaryOperator<Component> operator) {
+        EntityMetaDataPacket packet = new EntityMetaDataPacket();
+        packet.entityId = this.entityId;
+        packet.entries = new ArrayList<>();
+        for (Metadata.Entry<?> entry : this.entries) {
+            int type = entry.getMetaValue().getType();
+            Metadata.Value<Component> value;
+            if (type == Metadata.TYPE_OPTCHAT) {
+                value = Metadata.OptChat(operator.apply(((Metadata.Entry<Component>) entry).getMetaValue().getValue()));
+            }
+            else if (type == Metadata.TYPE_CHAT) {
+                value = Metadata.Chat(operator.apply(((Metadata.Entry<Component>) entry).getMetaValue().getValue()));
+            }
+            else continue;
+            packet.entries.add(new Metadata.Entry<>(entry.getIndex(), value));
+        }
+        return packet;
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/OpenWindowPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/OpenWindowPacket.java
@@ -1,13 +1,18 @@
 package net.minestom.server.network.packet.server.play;
 
 import net.kyori.adventure.text.Component;
+import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
-public class OpenWindowPacket implements ServerPacket {
+import java.util.Collection;
+import java.util.Collections;
+import java.util.function.UnaryOperator;
+
+public class OpenWindowPacket implements ComponentHoldingServerPacket {
 
     public int windowId;
     public int windowType;
@@ -37,5 +42,15 @@ public class OpenWindowPacket implements ServerPacket {
     @Override
     public int getId() {
         return ServerPacketIdentifier.OPEN_WINDOW;
+    }
+
+    @Override
+    public @NotNull Collection<Component> components() {
+        return Collections.singleton(title);
+    }
+
+    @Override
+    public @NotNull ServerPacket copyWithOperator(@NotNull UnaryOperator<Component> operator) {
+        return new OpenWindowPacket(operator.apply(title));
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/ResourcePackSendPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/ResourcePackSendPacket.java
@@ -66,11 +66,11 @@ public class ResourcePackSendPacket implements ComponentHoldingServerPacket {
 
     @Override
     public @NotNull Collection<Component> components() {
-        List<Component> components = new ArrayList<>();
         if (forcedMessage != null) {
-            components.add(forcedMessage);
+            return Collections.singleton(forcedMessage);
+        } else {
+            return Collections.emptyList();
         }
-        return components;
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/ResourcePackSendPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/ResourcePackSendPacket.java
@@ -1,6 +1,7 @@
 package net.minestom.server.network.packet.server.play;
 
 import net.kyori.adventure.text.Component;
+import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.resourcepack.ResourcePack;
@@ -8,7 +9,13 @@ import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
-public class ResourcePackSendPacket implements ServerPacket {
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+public class ResourcePackSendPacket implements ComponentHoldingServerPacket {
 
     public String url = "";
     public String hash = "0000000000000000000000000000000000000000"; // Size 40
@@ -55,5 +62,24 @@ public class ResourcePackSendPacket implements ServerPacket {
     @Override
     public int getId() {
         return ServerPacketIdentifier.RESOURCE_PACK_SEND;
+    }
+
+    @Override
+    public @NotNull Collection<Component> components() {
+        List<Component> components = new ArrayList<>();
+        if (forcedMessage != null) {
+            components.add(forcedMessage);
+        }
+        return components;
+    }
+
+    @Override
+    public @NotNull ServerPacket copyWithOperator(@NotNull UnaryOperator<Component> operator) {
+        ResourcePackSendPacket packet = new ResourcePackSendPacket();
+        packet.url = this.url;
+        packet.hash = this.hash;
+        packet.forced = this.forced;
+        packet.forcedMessage = this.forcedMessage == null ? null : operator.apply(this.forcedMessage);
+        return packet;
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/SetSlotPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/SetSlotPacket.java
@@ -1,13 +1,20 @@
 package net.minestom.server.network.packet.server.play;
 
+import net.kyori.adventure.text.Component;
 import net.minestom.server.item.ItemStack;
+import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
-public class SetSlotPacket implements ServerPacket {
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+public class SetSlotPacket implements ComponentHoldingServerPacket {
 
     public byte windowId;
     public short slot;
@@ -49,5 +56,19 @@ public class SetSlotPacket implements ServerPacket {
         setSlotPacket.slot = -1;
         setSlotPacket.itemStack = cursorItem;
         return setSlotPacket;
+    }
+
+    @Override
+    public @NotNull Collection<Component> components() {
+        return itemStack.components();
+    }
+
+    @Override
+    public @NotNull ServerPacket copyWithOperator(@NotNull UnaryOperator<Component> operator) {
+        SetSlotPacket packet = new SetSlotPacket();
+        packet.windowId = this.windowId;
+        packet.slot = this.slot;
+        packet.itemStack = this.itemStack.copyWithOperator(operator);
+        return packet;
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/SetTitleSubTitlePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/SetTitleSubTitlePacket.java
@@ -1,13 +1,18 @@
 package net.minestom.server.network.packet.server.play;
 
 import net.kyori.adventure.text.Component;
+import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
-public class SetTitleSubTitlePacket implements ServerPacket {
+import java.util.Collection;
+import java.util.Collections;
+import java.util.function.UnaryOperator;
+
+public class SetTitleSubTitlePacket implements ComponentHoldingServerPacket {
 
     public Component subtitle = Component.empty();
 
@@ -31,5 +36,15 @@ public class SetTitleSubTitlePacket implements ServerPacket {
     @Override
     public int getId() {
         return ServerPacketIdentifier.SET_TITLE_SUBTITLE;
+    }
+
+    @Override
+    public @NotNull Collection<Component> components() {
+        return Collections.singleton(subtitle);
+    }
+
+    @Override
+    public @NotNull ServerPacket copyWithOperator(@NotNull UnaryOperator<Component> operator) {
+        return new SetTitleSubTitlePacket(operator.apply(subtitle));
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/SetTitleTextPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/SetTitleTextPacket.java
@@ -1,13 +1,18 @@
 package net.minestom.server.network.packet.server.play;
 
 import net.kyori.adventure.text.Component;
+import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
-public class SetTitleTextPacket implements ServerPacket {
+import java.util.Collection;
+import java.util.Collections;
+import java.util.function.UnaryOperator;
+
+public class SetTitleTextPacket implements ComponentHoldingServerPacket {
 
     public Component title = Component.empty();
 
@@ -31,5 +36,15 @@ public class SetTitleTextPacket implements ServerPacket {
     @Override
     public int getId() {
         return ServerPacketIdentifier.SET_TITLE_TEXT;
+    }
+
+    @Override
+    public @NotNull Collection<Component> components() {
+        return Collections.singleton(title);
+    }
+
+    @Override
+    public @NotNull ServerPacket copyWithOperator(@NotNull UnaryOperator<Component> operator) {
+        return new SetTitleTextPacket(operator.apply(title));
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/WindowItemsPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/WindowItemsPacket.java
@@ -1,13 +1,20 @@
 package net.minestom.server.network.packet.server.play;
 
+import net.kyori.adventure.text.Component;
 import net.minestom.server.item.ItemStack;
+import net.minestom.server.network.packet.server.ComponentHoldingServerPacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.utils.binary.BinaryReader;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
-public class WindowItemsPacket implements ServerPacket {
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+public class WindowItemsPacket implements ComponentHoldingServerPacket {
 
     public byte windowId;
     public ItemStack[] items;
@@ -46,5 +53,24 @@ public class WindowItemsPacket implements ServerPacket {
     @Override
     public int getId() {
         return ServerPacketIdentifier.WINDOW_ITEMS;
+    }
+
+    @Override
+    public @NotNull Collection<Component> components() {
+        List<Component> components = new ArrayList<>();
+        for (ItemStack item : items) {
+            components.addAll(item.components());
+        }
+        return components;
+    }
+
+    @Override
+    public @NotNull ServerPacket copyWithOperator(@NotNull UnaryOperator<Component> operator) {
+        WindowItemsPacket packet = new WindowItemsPacket();
+        packet.items = new ItemStack[this.items.length];
+        for (int i = 0; i < this.items.length; i++) {
+            packet.items[i] = this.items[i].copyWithOperator(operator);
+        }
+        return packet;
     }
 }


### PR DESCRIPTION
The "automatic component translation" option only works for packets that inherit **ComponentHoldingServerPacket** interface, so I added this interface to all packets that contain components and items. Also I added inheritance **ComponentHolder** for **ItemStack**.