### PR TITLE
Modify /gamemode to behave more like vanilla

### DIFF
--- a/src/test/java/demo/commands/GamemodeCommand.java
+++ b/src/test/java/demo/commands/GamemodeCommand.java
@@ -19,12 +19,15 @@ import java.util.Locale;
 /**
  * Command that make a player change gamemode, made in
  * the style of the vanilla /gamemode command.
+ * 
+ * @see https://minecraft.fandom.com/wiki/Commands/gamemode
  */
 public class GamemodeCommand extends Command {
 
     public GamemodeCommand() {
         super("gamemode", "gm");
 
+        //GameMode parameter
         ArgumentEnum<GameMode> gamemode = ArgumentType.Enum("gamemode", GameMode.class).setFormat(ArgumentEnum.Format.LOWER_CASED);
         gamemode.setCallback((sender, exception) -> {
             sender.sendMessage(
@@ -33,57 +36,102 @@ public class GamemodeCommand extends Command {
                             .append(Component.text("!")), MessageType.SYSTEM);
         });
 
-
+        //Targets parameter, can accept multiple players
         ArgumentEntity player = ArgumentType.Entity("targets").onlyPlayers(true);
 
+        //Upon invalid usage, print the correct usage of the command to the sender
         setDefaultExecutor((sender, context) -> {
-            sender.sendMessage(Component.text("Usage: /" + context.getCommandName() + " <gamemode> [targets]", NamedTextColor.RED), MessageType.SYSTEM);
+            //The used alias
+            String commandName = context.getCommandName();
+            
+            sender.sendMessage(Component.text("Usage: /" + commandName + " <gamemode> [targets]", NamedTextColor.RED), MessageType.SYSTEM);
         });
 
+        //Command Syntax for /gamemode <gamemode>
         addSyntax((sender, context) -> {
+            //Limit execution to players only
             if (!sender.isPlayer()) {
                 sender.sendMessage(Component.text("Please run this command in-game.", NamedTextColor.RED));
                 return;
             }
+            //Check permission, this could be replaced with hasPermission
             if (sender.asPlayer().getPermissionLevel() < 2) {
                 sender.sendMessage(Component.text("You don't have permission to use this command.", NamedTextColor.RED));
                 return;
             }
+            
+            //Arguments
             GameMode mode = context.get(gamemode);
+            
+            //Set the gamemode for the sender
             executeSelf(sender.asPlayer(), mode);
         }, gamemode);
 
+        //Command Syntax for /gamemode <gamemode> [targets]
         addSyntax((sender, context) -> {
+            //Check permission for players only
+            //This allows the console to use this syntax too
             if (sender.isPlayer() && sender.asPlayer().getPermissionLevel() < 2) {
                 sender.sendMessage(Component.text("You don't have permission to use this command.", NamedTextColor.RED));
                 return;
             }
+            
+            //Arguments
             EntityFinder finder = context.get(player);
             GameMode mode = context.get(gamemode);
-            executeOthers(sender.asPlayer(), mode, finder.find(sender));
+            
+            //Set the gamemode for the targets
+            executeOthers(sender, mode, finder.find(sender));
         }, gamemode, player);
     }
 
+    /**
+     * Sets the gamemode for the specified entities, and
+     * notifies them (and the sender) in the chat.
+     */
     private void executeOthers(CommandSender sender, GameMode mode, List<Entity> entities) {
         if (entities.size() == 0) {
+            //If there are no players that could be modified, display an error message
             if (sender.isPlayer()) sender.sendMessage(Component.translatable("argument.entity.notfound.player", NamedTextColor.RED), MessageType.SYSTEM);
             else sender.sendMessage(Component.text("No player was found", NamedTextColor.RED), MessageType.SYSTEM);
         } else for (Entity entity : entities) {
             if (entity instanceof Player) {
                 Player p = (Player) entity;
                 if (p == sender) {
+                    //If the player is the same as the sender, call
+                    //executeSelf to display one message instead of two
                     executeSelf(sender.asPlayer(), mode);
                 } else {
                     p.setGameMode(mode);
-                    p.sendMessage(Component.translatable("gameMode.changed").args(Component.translatable("gameMode." + mode.name().toLowerCase(Locale.ROOT))), MessageType.SYSTEM);
-                    sender.sendMessage(Component.translatable("commands.gamemode.success.other").args(p.getDisplayName() == null ? p.getName() : p.getDisplayName(), Component.translatable("gameMode." + mode.name().toLowerCase(Locale.ROOT))), MessageType.SYSTEM);
+                    
+                    //Create necessary components
+                    String gamemodeString = "gameMode." + mode.name().toLowerCase(Locale.ROOT);
+                    Component gamemodeComponent = Component.translatable(gamemodeString);
+                    Component playerName = p.getDisplayName() == null ? p.getName() : p.getDisplayName();
+                    
+                    //Send a message to the changed player
+                    p.sendMessage(Component.translatable("gameMode.changed", gamemodeComponent), MessageType.SYSTEM);
+                    
+                    //Send a message to the sender
+                    sender.sendMessage(Component.translatable("commands.gamemode.success.other", playername, gamemodeComponent), MessageType.SYSTEM);
                 }
             }
         }
     }
 
+    /**
+     * Sets the gamemode for the executing Player, and
+     * notifies them in the chat.
+     */
     private void executeSelf(Player sender, GameMode mode) {
         sender.setGameMode(mode);
-        sender.sendMessage(Component.translatable("commands.gamemode.success.self").args(Component.translatable("gameMode." + mode.name().toLowerCase(Locale.ROOT))), MessageType.SYSTEM);
+        
+        //The translation keys 'gameMode.survival', 'gameMode.creative', etc.
+        //correspond to the translated game mode names.
+        String gamemodeString = "gameMode." + mode.name().toLowerCase(Locale.ROOT);
+        Component gamemodeComponent = Component.translatable(gamemodeString);
+        
+        //Send the translated message to the player.
+        sender.sendMessage(Component.translatable("commands.gamemode.success.self", gamemodeComponent), MessageType.SYSTEM);
     }
 }

--- a/src/test/java/demo/commands/GamemodeCommand.java
+++ b/src/test/java/demo/commands/GamemodeCommand.java
@@ -113,7 +113,7 @@ public class GamemodeCommand extends Command {
                     p.sendMessage(Component.translatable("gameMode.changed", gamemodeComponent), MessageType.SYSTEM);
                     
                     //Send a message to the sender
-                    sender.sendMessage(Component.translatable("commands.gamemode.success.other", playername, gamemodeComponent), MessageType.SYSTEM);
+                    sender.sendMessage(Component.translatable("commands.gamemode.success.other", playerName, gamemodeComponent), MessageType.SYSTEM);
                 }
             }
         }

--- a/src/test/java/demo/commands/GamemodeCommand.java
+++ b/src/test/java/demo/commands/GamemodeCommand.java
@@ -69,7 +69,8 @@ public class GamemodeCommand extends Command {
             if (sender.isPlayer()) sender.sendMessage(Component.translatable("argument.entity.notfound.player", NamedTextColor.RED), MessageType.SYSTEM);
             else sender.sendMessage(Component.text("No player was found", NamedTextColor.RED), MessageType.SYSTEM);
         } else for (Entity entity : entities) {
-            if (entity instanceof Player p) {
+            if (entity instanceof Player) {
+                Player p = (Player) entity;
                 if (p == sender) {
                     executeSelf(sender.asPlayer(), mode);
                 } else {

--- a/src/test/java/demo/commands/GamemodeCommand.java
+++ b/src/test/java/demo/commands/GamemodeCommand.java
@@ -36,12 +36,10 @@ public class GamemodeCommand extends Command {
                             .append(Component.text("!")), MessageType.SYSTEM);
         });
 
-        //Targets parameter, can accept multiple players
         ArgumentEntity player = ArgumentType.Entity("targets").onlyPlayers(true);
 
         //Upon invalid usage, print the correct usage of the command to the sender
         setDefaultExecutor((sender, context) -> {
-            //The used alias
             String commandName = context.getCommandName();
             
             sender.sendMessage(Component.text("Usage: /" + commandName + " <gamemode> [targets]", NamedTextColor.RED), MessageType.SYSTEM);
@@ -54,13 +52,13 @@ public class GamemodeCommand extends Command {
                 sender.sendMessage(Component.text("Please run this command in-game.", NamedTextColor.RED));
                 return;
             }
+            
             //Check permission, this could be replaced with hasPermission
             if (sender.asPlayer().getPermissionLevel() < 2) {
                 sender.sendMessage(Component.text("You don't have permission to use this command.", NamedTextColor.RED));
                 return;
             }
             
-            //Arguments
             GameMode mode = context.get(gamemode);
             
             //Set the gamemode for the sender
@@ -76,7 +74,6 @@ public class GamemodeCommand extends Command {
                 return;
             }
             
-            //Arguments
             EntityFinder finder = context.get(player);
             GameMode mode = context.get(gamemode);
             
@@ -104,15 +101,12 @@ public class GamemodeCommand extends Command {
                 } else {
                     p.setGameMode(mode);
                     
-                    //Create necessary components
                     String gamemodeString = "gameMode." + mode.name().toLowerCase(Locale.ROOT);
                     Component gamemodeComponent = Component.translatable(gamemodeString);
                     Component playerName = p.getDisplayName() == null ? p.getName() : p.getDisplayName();
                     
-                    //Send a message to the changed player
+                    //Send a message to the changed player and the sender
                     p.sendMessage(Component.translatable("gameMode.changed", gamemodeComponent), MessageType.SYSTEM);
-                    
-                    //Send a message to the sender
                     sender.sendMessage(Component.translatable("commands.gamemode.success.other", playerName, gamemodeComponent), MessageType.SYSTEM);
                 }
             }


### PR DESCRIPTION
Modifies the /gamemode command in the demo, to function like the vanilla /gamemode command, with the syntax `/gamemode <gamemode> [target]`. It also utilizes translation components for players, and allows the console to run the command as well as players.