### PR TITLE
Add #equals method to VanillaStackingRule

### DIFF
--- a/src/main/java/net/minestom/server/item/ItemStack.java
+++ b/src/main/java/net/minestom/server/item/ItemStack.java
@@ -31,7 +31,7 @@ public final class ItemStack implements TagReadable, HoverEventSource<HoverEvent
      */
     public static final @NotNull ItemStack AIR = ItemStack.of(Material.AIR);
 
-    public static final @NotNull VanillaStackingRule DEFAULT_STACKING_RULE = new VanillaStackingRule();
+    private static final @NotNull VanillaStackingRule DEFAULT_STACKING_RULE = new VanillaStackingRule();
 
     private final StackingRule stackingRule;
 

--- a/src/main/java/net/minestom/server/item/ItemStack.java
+++ b/src/main/java/net/minestom/server/item/ItemStack.java
@@ -31,6 +31,8 @@ public final class ItemStack implements TagReadable, HoverEventSource<HoverEvent
      */
     public static final @NotNull ItemStack AIR = ItemStack.of(Material.AIR);
 
+    public static final @NotNull VanillaStackingRule DEFAULT_STACKING_RULE = new VanillaStackingRule();
+
     private final StackingRule stackingRule;
 
     private final Material material;
@@ -43,7 +45,7 @@ public final class ItemStack implements TagReadable, HoverEventSource<HoverEvent
         this.material = material;
         this.amount = amount;
         this.meta = meta;
-        this.stackingRule = Objects.requireNonNullElseGet(stackingRule, VanillaStackingRule::new);
+        this.stackingRule = Objects.requireNonNullElse(stackingRule, DEFAULT_STACKING_RULE);
     }
 
     @Contract(value = "_ -> new", pure = true)

--- a/src/main/java/net/minestom/server/item/rule/VanillaStackingRule.java
+++ b/src/main/java/net/minestom/server/item/rule/VanillaStackingRule.java
@@ -33,4 +33,11 @@ public class VanillaStackingRule implements StackingRule {
     public int getMaxSize(@NotNull ItemStack itemStack) {
         return itemStack.getMaterial().getMaxDefaultStackSize();
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+
+        return obj != null && getClass() == obj.getClass();
+    }
 }


### PR DESCRIPTION
This adds a #equals method to VanillaStackingRule making ItemStack's #equal method work