### PR TITLE
Fix deserialization issues w/ ItemMeta had Name/Lore containing lit…

### DIFF
--- a/src/main/java/net/minestom/server/utils/NBTUtils.java
+++ b/src/main/java/net/minestom/server/utils/NBTUtils.java
@@ -152,7 +152,11 @@ public final class NBTUtils {
         if (nbt.containsKey("display")) {
             final NBTCompound display = nbt.getCompound("display");
             if (display.containsKey("Name")) {
-                final String rawName = display.getString("Name");
+                //FIXME: Remove escaping fix once https://github.com/jglrxavpok/Hephaistos/issues/8 is resolved
+                //This fix prevents having a literal backslash followed by a literal quote,
+                // but its better than stuff breaking horribly
+                final String rawName = display.getString("Name")
+                        .replace("\\\"", "\"");
                 final Component displayName = GsonComponentSerializer.gson().deserialize(rawName);
                 metaBuilder.displayName(displayName);
             }
@@ -160,7 +164,11 @@ public final class NBTUtils {
                 NBTList<NBTString> loreList = display.getList("Lore");
                 List<Component> lore = new ArrayList<>();
                 for (NBTString s : loreList) {
-                    final String rawLore = s.getValue();
+                    //FIXME: Remove escaping fix once https://github.com/jglrxavpok/Hephaistos/issues/8 is resolved
+                    //This fix prevents having a literal backslash followed by a literal quote,
+                    // but its better than stuff breaking horribly
+                    final String rawLore = s.getValue()
+                            .replace("\\\"", "\"");
                     lore.add(GsonComponentSerializer.gson().deserialize(rawLore));
                 }
                 metaBuilder.lore(lore);

--- a/src/main/java/net/minestom/server/utils/NBTUtils.java
+++ b/src/main/java/net/minestom/server/utils/NBTUtils.java
@@ -152,7 +152,7 @@ public final class NBTUtils {
         if (nbt.containsKey("display")) {
             final NBTCompound display = nbt.getCompound("display");
             if (display.containsKey("Name")) {
-                final String rawName = StringUtils.unescapeJavaString(display.getString("Name"));
+                final String rawName = display.getString("Name");
                 final Component displayName = GsonComponentSerializer.gson().deserialize(rawName);
                 metaBuilder.displayName(displayName);
             }
@@ -160,7 +160,7 @@ public final class NBTUtils {
                 NBTList<NBTString> loreList = display.getList("Lore");
                 List<Component> lore = new ArrayList<>();
                 for (NBTString s : loreList) {
-                    final String rawLore = StringUtils.unescapeJavaString(s.getValue());
+                    final String rawLore = s.getValue();
                     lore.add(GsonComponentSerializer.gson().deserialize(rawLore));
                 }
                 metaBuilder.lore(lore);


### PR DESCRIPTION
Fix deserialization issues when ItemMeta had Name/Lore containing literal quote (") characters

It seems as though the call to unescapeJavaString is unnecessary, and in fact can cause issues with literal quote characters.