### PR TITLE
Fix incorrect coordinate encoding in RelativeBlockBatch

### DIFF
--- a/src/main/java/net/minestom/server/instance/batch/RelativeBlockBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/RelativeBlockBatch.java
@@ -69,9 +69,9 @@ public class RelativeBlockBatch implements Batch<Runnable> {
         Check.argCondition(Math.abs(y) > Short.MAX_VALUE, "Relative y position may not be more than 16 bits long.");
         Check.argCondition(Math.abs(z) > Short.MAX_VALUE, "Relative z position may not be more than 16 bits long.");
 
-        long pos = x;
-        pos = (pos << 16) | (short) y;
-        pos = (pos << 16) | (short) z;
+        long pos = Short.toUnsignedLong((short)x);
+        pos = (pos << 16) | Short.toUnsignedLong((short)y);
+        pos = (pos << 16) | Short.toUnsignedLong((short)z);
 
         //final int block = (blockStateId << 16) | customBlockId;
         synchronized (blockIdMap) {


### PR DESCRIPTION
RelativeBlockBatch encodes negative relative coordinates incorrectly.

### Current Behavior

RelativeBlockBatch contains a map of long to Block. The coordinates are encoded as the long key.
The key is set up like this:

```
                  /-------x-------\ /-------y-------\ /-------z-------\
00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
```

All of the longs are encoded as relative to the first position that is passed to `setBlock()`. If the first coordinate is not the smallest coordinate, then negatives can occur. This would be intended, but if, say, `z` is `-1`, then because of the current implementation of `(long) (short) z`, it will overwrite everything, since `(long) (short) z` will convert 
```java
short s = -1; //11111111 11111111
```
to 
```java
long l = -1; //11111111 11111111 11111111 11111111 11111111 11111111 11111111 11111111
```
thus overwriting the entire long.

### Correction

Converting to short with `Short.toUnsignedLong(short)` will convert
```java
short s = -1; //11111111 11111111
```
to
```java
long l = 65535L; //00000000 00000000 00000000 00000000 00000000 00000000 11111111 11111111
```
which is the intended number.