### PR TITLE
Expand RelativeBlockBatch to allow for larger range

### DIFF
--- a/src/main/java/net/minestom/server/instance/batch/RelativeBlockBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/RelativeBlockBatch.java
@@ -208,14 +208,14 @@ public class RelativeBlockBatch implements Batch<Runnable> {
                 //For details on the bits used, see #setBlock(int, int, int, Block)
                 
                 //Get relative unsigned coordinates from the data
-                long relXUnsigned = (int) ((pos >> 40) & 1_048_575);
-                long relYUnsigned = (int) ((pos >> 20) & 1_048_575);
-                long relZUnsigned = (int) ( pos        & 1_048_575);
+                long relXUnsigned = (pos >> 40) & 1_048_575;
+                long relYUnsigned = (pos >> 20) & 1_048_575;
+                long relZUnsigned =  pos        & 1_048_575;
 
                 //Get and apply the stored sign
-                int relX = relXUnsigned * (((pos >> 60) & 1) == 1 ? -1 : 1);
-                int relY = relYUnsigned * (((pos >> 61) & 1) == 1 ? -1 : 1);
-                int relZ = relZUnsigned * (((pos >> 62) & 1) == 1 ? -1 : 1);
+                int relX = (int) (relXUnsigned * (((pos >> 60) & 1) == 1 ? -1 : 1));
+                int relY = (int) (relYUnsigned * (((pos >> 61) & 1) == 1 ? -1 : 1));
+                int relZ = (int) (relZUnsigned * (((pos >> 62) & 1) == 1 ? -1 : 1));
 
                 final Block block = entry.getValue();
 


### PR DESCRIPTION
Modifies RelativeBlockBranch to allow larger differences between the first point, and further ones.
This takes advantage of the previously unused bits in a long. The previous implementation used 16 bits per coordinate, to encode a coordinate as a long, thus only using 48 bits out of the available 64. By using 20 bits per coordinate, we increase the maximum range to about 1,048,575 blocks in each direction. This is much larger, compared to the previous range (32,767).
The bits are used in the following way:
```
    Sign of Z
    |
    |Sign of Y
    ||
    ||Sign of X                                          Bits 0-19: Z
    |||                           Bits 20-39: Y     /--------------------\
    |||     Bits 40-59: X     /--------------------\|                    |
    |||/--------------------\ |                    ||                    |
    ||||                    | |                    ||                    |
    ||||                    | |                    ||                    |
    ||||                    | |                    ||                    |
   00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
```

This can further be improved potentionally by using less bits per Y coordinate, since it is unlikely that the Y values will be that large, however the possibility is there, and it is future proof for 1.18+ levels.