### PR TITLE
Add 'addFlag' and 'removeFlag' to PlayerAbilitiesPacket

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -1787,13 +1787,13 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
     protected void refreshAbilities() {
         byte flags = 0;
         if (invulnerable)
-            flags |= 0x01;
+            flags |= PlayerAbilitiesPacket.FLAG_INVULNERABLE;
         if (flying)
-            flags |= 0x02;
+            flags |= PlayerAbilitiesPacket.FLAG_FLYING;
         if (allowFlying)
-            flags |= 0x04;
+            flags |= PlayerAbilitiesPacket.FLAG_ALLOW_FLYING;
         if (instantBreak)
-            flags |= 0x08;
+            flags |= PlayerAbilitiesPacket.FLAG_INSTANT_BREAK;
         playerConnection.sendPacket(new PlayerAbilitiesPacket(flags, flyingSpeed, fieldViewModifier));
     }
 

--- a/src/main/java/net/minestom/server/network/packet/server/play/PlayerAbilitiesPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/PlayerAbilitiesPacket.java
@@ -7,6 +7,10 @@ import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
 public class PlayerAbilitiesPacket implements ServerPacket {
+    public static final byte FLAG_INVULNERABLE  = 0x01;
+    public static final byte FLAG_FLYING        = 0x02;
+    public static final byte FLAG_ALLOW_FLYING  = 0x04;
+    public static final byte FLAG_INSTANT_BREAK = 0x08;
 
     public byte flags;
     public float flyingSpeed;
@@ -20,6 +24,30 @@ public class PlayerAbilitiesPacket implements ServerPacket {
 
     public PlayerAbilitiesPacket() {
         this((byte) 0, 0f, 0f);
+    }
+    
+    /**
+     * Adds a flag to the 'flags' byte.
+     * 
+     * @see PlayerAbilitiesPacket#FLAG_INVULNERABLE
+     * @see PlayerAbilitiesPacket#FLAG_FLYING
+     * @see PlayerAbilitiesPacket#FLAG_ALLOW_FLYING
+     * @see PlayerAbilitiesPacket#FLAG_INSTANT_BREAK
+     */
+    public void addFlag(byte flag) {
+        flags |= flag;
+    }
+    
+    /**
+     * Removes a flag from the 'flags' byte.
+     * 
+     * @see PlayerAbilitiesPacket#FLAG_INVULNERABLE
+     * @see PlayerAbilitiesPacket#FLAG_FLYING
+     * @see PlayerAbilitiesPacket#FLAG_ALLOW_FLYING
+     * @see PlayerAbilitiesPacket#FLAG_INSTANT_BREAK
+     */
+    public void removeFlag(byte flag) {
+        flags &= ~(flag);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/PlayerAbilitiesPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/PlayerAbilitiesPacket.java
@@ -29,6 +29,8 @@ public class PlayerAbilitiesPacket implements ServerPacket {
     /**
      * Adds a flag to the 'flags' byte.
      * 
+     * @param flag the flag
+     * 
      * @see PlayerAbilitiesPacket#FLAG_INVULNERABLE
      * @see PlayerAbilitiesPacket#FLAG_FLYING
      * @see PlayerAbilitiesPacket#FLAG_ALLOW_FLYING
@@ -41,6 +43,8 @@ public class PlayerAbilitiesPacket implements ServerPacket {
     /**
      * Removes a flag from the 'flags' byte.
      * 
+     * @param flag the flag
+     * 
      * @see PlayerAbilitiesPacket#FLAG_INVULNERABLE
      * @see PlayerAbilitiesPacket#FLAG_FLYING
      * @see PlayerAbilitiesPacket#FLAG_ALLOW_FLYING
@@ -48,6 +52,19 @@ public class PlayerAbilitiesPacket implements ServerPacket {
      */
     public void removeFlag(byte flag) {
         flags &= ~(flag);
+    }
+    
+    /**
+     * @param flag the flag
+     * @returns true if the 'flags' byte contains the specified flag
+     * 
+     * @see PlayerAbilitiesPacket#FLAG_INVULNERABLE
+     * @see PlayerAbilitiesPacket#FLAG_FLYING
+     * @see PlayerAbilitiesPacket#FLAG_ALLOW_FLYING
+     * @see PlayerAbilitiesPacket#FLAG_INSTANT_BREAK
+     */
+    public boolean hasFlag(byte flag) {
+        return (flags & flag) > 0;
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/PlayerAbilitiesPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/PlayerAbilitiesPacket.java
@@ -25,47 +25,6 @@ public class PlayerAbilitiesPacket implements ServerPacket {
     public PlayerAbilitiesPacket() {
         this((byte) 0, 0f, 0f);
     }
-    
-    /**
-     * Adds a flag to the 'flags' byte.
-     * 
-     * @param flag the flag
-     * 
-     * @see PlayerAbilitiesPacket#FLAG_INVULNERABLE
-     * @see PlayerAbilitiesPacket#FLAG_FLYING
-     * @see PlayerAbilitiesPacket#FLAG_ALLOW_FLYING
-     * @see PlayerAbilitiesPacket#FLAG_INSTANT_BREAK
-     */
-    public void addFlag(byte flag) {
-        flags |= flag;
-    }
-    
-    /**
-     * Removes a flag from the 'flags' byte.
-     * 
-     * @param flag the flag
-     * 
-     * @see PlayerAbilitiesPacket#FLAG_INVULNERABLE
-     * @see PlayerAbilitiesPacket#FLAG_FLYING
-     * @see PlayerAbilitiesPacket#FLAG_ALLOW_FLYING
-     * @see PlayerAbilitiesPacket#FLAG_INSTANT_BREAK
-     */
-    public void removeFlag(byte flag) {
-        flags &= ~(flag);
-    }
-    
-    /**
-     * @param flag the flag
-     * @returns true if the 'flags' byte contains the specified flag
-     * 
-     * @see PlayerAbilitiesPacket#FLAG_INVULNERABLE
-     * @see PlayerAbilitiesPacket#FLAG_FLYING
-     * @see PlayerAbilitiesPacket#FLAG_ALLOW_FLYING
-     * @see PlayerAbilitiesPacket#FLAG_INSTANT_BREAK
-     */
-    public boolean hasFlag(byte flag) {
-        return (flags & flag) > 0;
-    }
 
     @Override
     public void write(@NotNull BinaryWriter writer) {


### PR DESCRIPTION
Adds static fields and utility methods to PlayerAbilitiesPacket. (make magic numbers public)

The fields contain the bitmasks for each of the flags, and the utility methods allow for easily modifying the 'flags' byte.

Example usage:
```java
Player p = ...;
PlayerAbilitiesPacket packet = new PlayerAbilitiesPacket();
packet.addFlag(PlayerAbilitiesPacket.FLAG_ALLOW_FLYING);
p.getPlayerConnection().sendPacket(packet);
```

This PR modifies [Player](https://github.com/Minestom/Minestom/blob/new-block-api/src/main/java/net/minestom/server/entity/Player.java) to use these flags as well.