### PR TITLE
Set time to negative when timeRate is 0

### DIFF
--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -405,7 +405,7 @@ public abstract class Instance implements BlockGetter, BlockSetter, Tickable, Ta
      * @return the {@link TimeUpdatePacket} with this instance data
      */
     private @NotNull TimeUpdatePacket createTimePacket() {
-        return new TimeUpdatePacket(worldAge, timeRate == 0 ? -time : time);
+        return new TimeUpdatePacket(worldAge, timeRate == 0 ? -Math.abs(time) : time);
     }
 
     /**

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -405,7 +405,7 @@ public abstract class Instance implements BlockGetter, BlockSetter, Tickable, Ta
      * @return the {@link TimeUpdatePacket} with this instance data
      */
     private @NotNull TimeUpdatePacket createTimePacket() {
-        return new TimeUpdatePacket(worldAge, time);
+        return new TimeUpdatePacket(worldAge, timeRate == 0 ? -time : time);
     }
 
     /**


### PR DESCRIPTION
Modifies the `createTimePacket()` to set the time to negative is the `timeRate` is 0, to disable the sun moving

Reference: [wiki.vg](https://wiki.vg/Protocol#Time_Update)

Current code produces this (recorded for 2 seconds, notice how the clouds do not reset):
![sun bug](https://user-images.githubusercontent.com/44264503/127196827-23116caa-20ce-41c4-b2d9-e5550e551632.gif)