### PR TITLE
Changed how the position turned into a short

### DIFF
--- a/src/main/java/net/minestom/server/network/packet/server/play/MultiBlockChangePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/MultiBlockChangePacket.java
@@ -60,9 +60,9 @@ public class MultiBlockChangePacket implements ServerPacket {
     }
 
     public static short getLocalBlockPosAsShort(int x, int y, int z) {
-        x = x % Chunk.CHUNK_SIZE_X;
-        y = y % 16;
-        z = z % Chunk.CHUNK_SIZE_Z;
+        x = x & 0xF;
+        y = y & 0xF;
+        z = z & 0xF;
         return (short) (x << 8 | z << 4 | y);
     }
 


### PR DESCRIPTION
Using modulo is not the proper way to get the relative position in a chunk because it creates issues for negative coordinates.
This change will fix the issue with negative coordinates.