### PR TITLE
Made Player#setPermissionLevel persistent after death.

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -161,7 +161,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
 
     private BelowNameTag belowNameTag;
 
-    private int permissionLevel;
+    private byte permissionLevel;
 
     private boolean reducedDebugScreenInformation;
 
@@ -490,6 +490,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         getPlayerConnection().sendPacket(respawnPacket);
         PlayerRespawnEvent respawnEvent = new PlayerRespawnEvent(this);
         EventDispatcher.call(respawnEvent);
+        triggerStatus((byte) (24 + permissionLevel)); // Set permission level
         refreshIsDead(false);
 
         // Runnable called when teleportation is successful (after loading and sending necessary chunk)
@@ -2002,7 +2003,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
     public void setPermissionLevel(int permissionLevel) {
         Check.argCondition(!MathUtils.isBetween(permissionLevel, 0, 4), "permissionLevel has to be between 0 and 4");
 
-        this.permissionLevel = permissionLevel;
+        this.permissionLevel = (byte) permissionLevel;
 
         // Magic values: https://wiki.vg/Entity_statuses#Player
         // TODO remove magic values


### PR DESCRIPTION
Before, when you died, the client would forgot your permission level and you had to manually send the packet again. That has now been fixed.