### PR TITLE
Allow player to use creative mode features in creative mode

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -1331,8 +1331,14 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
             sendChangeGameStatePacket(ChangeGameStatePacket.Reason.CHANGE_GAMEMODE, gameMode.getId());
 
             PlayerInfoPacket infoPacket = new PlayerInfoPacket(PlayerInfoPacket.Action.UPDATE_GAMEMODE);
+            PlayerAbilitiesPacket abilitiesPacket = new PlayerAbilitiesPacket();
+            if (gameMode.equals(GameMode.CREATIVE)) {
+                abilitiesPacket.flags = 0b1101;
+                abilitiesPacket.flyingSpeed = 0.05f;
+            }
             infoPacket.playerInfos.add(new PlayerInfoPacket.UpdateGamemode(getUuid(), gameMode));
             sendPacketToViewersAndSelf(infoPacket);
+            getPlayerConnection().sendPacket(abilitiesPacket);
         }
     }
 


### PR DESCRIPTION
Disables client side prediction of water buckets being emptied when placed in creative mode. wiki.vg labels this flag incorrectly as instant-break: https://wiki.vg/Protocol#Player_Abilities_.28clientbound.29