### PR TITLE
Fix a bug with the map api

### DIFF
--- a/src/main/java/net/minestom/server/map/LargeFramebuffer.java
+++ b/src/main/java/net/minestom/server/map/LargeFramebuffer.java
@@ -37,7 +37,7 @@ public interface LargeFramebuffer {
         final int height = Math.min(height(), top + Framebuffer.HEIGHT) - top;
         for (int y = top; y < height; y++) {
             for (int x = left; x < width; x++) {
-                final byte color = getMapColor(left, top);
+                final byte color = getMapColor(x, y);
                 colors[Framebuffer.index(x - left, y - top)] = color;
             }
         }


### PR DESCRIPTION
When creating maps directly from a LargeFramebuffer without the use of sub-views, preparePacket didn't work correctly.

Current behavior:
The entire map is the color of the first pixel in the chosen region

Expected behavior:
Each pixel has their assigned color

Solution:
Use the x and y variables from the loop instead of the left and top arguments which were passed in to the function.