### PR TITLE
Fix player stop sprinting when changing attributes

### DIFF
--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -507,10 +507,11 @@ public class LivingEntity extends Entity implements EquipmentHandler {
                 // connection null during Player initialization (due to #super call)
                 self = playerConnection != null && playerConnection.getConnectionState() == ConnectionState.PLAY;
             }
+            EntityPropertiesPacket propertiesPacket = getPropertiesPacket(Collections.singleton(attributeInstance));
             if (self) {
-                sendPacketToViewersAndSelf(getPropertiesPacket());
+                sendPacketToViewersAndSelf(propertiesPacket);
             } else {
-                sendPacketToViewers(getPropertiesPacket());
+                sendPacketToViewers(propertiesPacket);
             }
         }
     }
@@ -632,8 +633,19 @@ public class LivingEntity extends Entity implements EquipmentHandler {
      */
     @NotNull
     protected EntityPropertiesPacket getPropertiesPacket() {
+        return getPropertiesPacket(attributeModifiers.values());
+    }
+
+    /**
+     * Gets an {@link EntityPropertiesPacket} for this entity with the specified attribute values.
+     *
+     * @param attributes the attributes to include in the packet
+     * @return an {@link EntityPropertiesPacket} linked to this entity
+     */
+    @NotNull
+    protected EntityPropertiesPacket getPropertiesPacket(@NotNull Collection<AttributeInstance> attributes) {
         // Get all the attributes which should be sent to the client
-        final AttributeInstance[] instances = attributeModifiers.values().stream()
+        final AttributeInstance[] instances = attributes.stream()
                 .filter(i -> i.getAttribute().isShared())
                 .toArray(AttributeInstance[]::new);
 

--- a/src/main/java/net/minestom/server/item/metadata/CrossbowMeta.java
+++ b/src/main/java/net/minestom/server/item/metadata/CrossbowMeta.java
@@ -81,7 +81,9 @@ public class CrossbowMeta extends ItemMeta implements ItemMetaBuilder.Provider<S
     public static class Builder extends ItemMetaBuilder {
 
         private boolean triple;
-        private ItemStack projectile1, projectile2, projectile3 = ItemStack.AIR;
+        private ItemStack projectile1 = ItemStack.AIR;
+        private ItemStack projectile2 = ItemStack.AIR;
+        private ItemStack projectile3 = ItemStack.AIR;
         private boolean charged;
 
         /**


### PR DESCRIPTION
This pull request fixes an issue I encountered: the player stops sprinting when you change attributes.
The fix is to send only the required attributes in the packet, instead of all.

This pull request also contains a fix for `CrossbowMeta`, because the fix is very small and it didn't make sense to put it in a separate pull request.