### PR TITLE
Use active hand when updating item state

### DIFF
--- a/src/main/java/net/minestom/server/listener/PlayerDiggingListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerDiggingListener.java
@@ -2,6 +2,7 @@ package net.minestom.server.listener;
 
 import net.minestom.server.entity.GameMode;
 import net.minestom.server.entity.Player;
+import net.minestom.server.entity.metadata.PlayerMeta;
 import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.item.ItemUpdateStateEvent;
 import net.minestom.server.event.player.PlayerStartDiggingEvent;
@@ -136,14 +137,9 @@ public class PlayerDiggingListener {
             }
 
         } else if (status == ClientPlayerDiggingPacket.Status.UPDATE_ITEM_STATE) {
-            Player.Hand hand = null;
-            if (player.isEating()) {
-                hand = player.getEatingHand();
-            } else if (player.getItemInHand(Player.Hand.OFF).getMaterial().hasState()) {
-                hand = Player.Hand.OFF;
-            } else if (player.getItemInHand(Player.Hand.MAIN).getMaterial().hasState()) {
-                hand = Player.Hand.MAIN;
-            }
+            PlayerMeta meta = player.getEntityMeta();
+            if (!meta.isHandActive()) return;
+            Player.Hand hand = meta.getActiveHand();
 
             player.refreshEating(null);
             player.triggerStatus((byte) 9);


### PR DESCRIPTION
Before, when you tried to release the item you were using (like a bow) in your mainhand, and you had a different usable item in your offhand, an `ItemUpdateStateEvent` would be called for the item in your offhand.
This pull request fixes that by using the active hand of the player, instead of checking for usable items.

(When the player is eating, the active hand is also set, which is why I removed that check as well.)