### PR TITLE
Fix timeRate 0 when time is 0

### DIFF
--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -416,15 +416,13 @@ public abstract class Instance implements BlockGetter, BlockSetter, Tickable, Ta
      * @return the {@link TimeUpdatePacket} with this instance data
      */
     private @NotNull TimeUpdatePacket createTimePacket() {
-        long timeOfDay;
+        long time = this.time;
         if (timeRate == 0) {
-            //Negative values make the sun and moon stop moving
+            //Negative values stop the sun and moon from moving
             //0 as a long cannot be negative
-            timeOfDay = time == 0 ? -24000L : -Math.abs(time);
-        } else {
-            timeOfDay = time;
+            time = time == 0 ? -24000L : -Math.abs(time);
         }
-        return new TimeUpdatePacket(worldAge, timeOfDay);
+        return new TimeUpdatePacket(worldAge, time);
     }
 
     /**

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -416,7 +416,15 @@ public abstract class Instance implements BlockGetter, BlockSetter, Tickable, Ta
      * @return the {@link TimeUpdatePacket} with this instance data
      */
     private @NotNull TimeUpdatePacket createTimePacket() {
-        return new TimeUpdatePacket(worldAge, timeRate == 0 ? -Math.abs(time) : time);
+        long timeOfDay;
+        if (timeRate == 0) {
+            //Negative values make the sun and moon stop moving
+            //0 as a long cannot be negative
+            timeOfDay = time == 0 ? -24000L : -Math.abs(time);
+        } else {
+            timeOfDay = time;
+        }
+        return new TimeUpdatePacket(worldAge, timeOfDay);
     }
 
     /**


### PR DESCRIPTION
Previously in #383 I fixed the `createTimePacket()` method of Instance, to allow users to stop the sun and moon from moving. I forgot the edge case of 0, since when the time is 0, `-Math.abs(0)` returns 0, since longs cannot be negative. That is not negative, thus the sun and moon still moves.

The fix for this explicitly checks the time for 0, and sets the time to -24000L instead, which is the equivalent of stopped time at 0.