### PR TITLE
Cleared up `Section#toChunkCoordinate`

### DIFF
--- a/src/main/java/net/minestom/server/instance/Section.java
+++ b/src/main/java/net/minestom/server/instance/Section.java
@@ -20,14 +20,14 @@ public class Section implements PublicCloneable<Section> {
     }
 
     public short getBlockAt(int x, int y, int z) {
-        x = toChunkCoordinate(x);
-        z = toChunkCoordinate(z);
+        x = toChunkRelativeCoordinate(x);
+        z = toChunkRelativeCoordinate(z);
         return palette.getBlockAt(x, y, z);
     }
 
     public void setBlockAt(int x, int y, int z, short blockId) {
-        x = toChunkCoordinate(x);
-        z = toChunkCoordinate(z);
+        x = toChunkRelativeCoordinate(x);
+        z = toChunkRelativeCoordinate(z);
         palette.setBlockAt(x, y, z, blockId);
     }
 
@@ -65,12 +65,12 @@ public class Section implements PublicCloneable<Section> {
     }
 
     /**
-     * Converts a world coordinate to a chunk one.
+     * Returns a coordinate that is relative to a chunk the provided coordinate is in.
      *
      * @param xz the world coordinate
-     * @return the chunk coordinate of {@code xz}
+     * @return a coordinate relative to the closest chunk
      */
-    private static int toChunkCoordinate(int xz) {
+    private static int toChunkRelativeCoordinate(int xz) {
         xz %= 16;
         if (xz < 0) {
             xz += Chunk.CHUNK_SECTION_SIZE;

--- a/src/main/java/net/minestom/server/utils/ArrayUtils.java
+++ b/src/main/java/net/minestom/server/utils/ArrayUtils.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.function.LongConsumer;
 
-@ApiStatus.Internal
+@ApiStatus.Experimental
 public final class ArrayUtils {
 
     private ArrayUtils() {

--- a/src/main/java/net/minestom/server/utils/MathUtils.java
+++ b/src/main/java/net/minestom/server/utils/MathUtils.java
@@ -2,7 +2,7 @@ package net.minestom.server.utils;
 
 import org.jetbrains.annotations.ApiStatus;
 
-@ApiStatus.Internal
+@ApiStatus.Experimental
 public final class MathUtils {
 
     private MathUtils() {

--- a/src/main/java/net/minestom/server/utils/Utils.java
+++ b/src/main/java/net/minestom/server/utils/Utils.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
 import java.nio.ByteBuffer;
 import java.util.UUID;
 
-@ApiStatus.Internal
+@ApiStatus.Experimental
 public final class Utils {
 
     private Utils() {

--- a/src/main/java/net/minestom/server/utils/async/AsyncUtils.java
+++ b/src/main/java/net/minestom/server/utils/async/AsyncUtils.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.CompletableFuture;
 
-@ApiStatus.Internal
+@ApiStatus.Experimental
 public final class AsyncUtils {
     public static final CompletableFuture<Void> VOID_FUTURE = CompletableFuture.completedFuture(null);
 

--- a/src/main/java/net/minestom/server/utils/chunk/ChunkUtils.java
+++ b/src/main/java/net/minestom/server/utils/chunk/ChunkUtils.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
-@ApiStatus.Internal
+@ApiStatus.Experimental
 public final class ChunkUtils {
 
     private ChunkUtils() {


### PR DESCRIPTION
Cleared up the definition and documentation for the method.
There is a possibility other methods in `ChunkUtils` and other classes could be made more understandable if they also follow a similar idea of "relativeness", but was a bit afraid of changing such, in my opinion, important class.