### PR TITLE
Switch annotations from `@ApiStatus.Internal` to `@ApiStatus.Experimental` for utility classes.

### DIFF
--- a/src/main/java/net/minestom/server/utils/ArrayUtils.java
+++ b/src/main/java/net/minestom/server/utils/ArrayUtils.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.function.LongConsumer;
 
-@ApiStatus.Internal
+@ApiStatus.Experimental
 public final class ArrayUtils {
 
     private ArrayUtils() {

--- a/src/main/java/net/minestom/server/utils/MathUtils.java
+++ b/src/main/java/net/minestom/server/utils/MathUtils.java
@@ -2,7 +2,7 @@ package net.minestom.server.utils;
 
 import org.jetbrains.annotations.ApiStatus;
 
-@ApiStatus.Internal
+@ApiStatus.Experimental
 public final class MathUtils {
 
     private MathUtils() {

--- a/src/main/java/net/minestom/server/utils/Utils.java
+++ b/src/main/java/net/minestom/server/utils/Utils.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
 import java.nio.ByteBuffer;
 import java.util.UUID;
 
-@ApiStatus.Internal
+@ApiStatus.Experimental
 public final class Utils {
 
     private Utils() {

--- a/src/main/java/net/minestom/server/utils/async/AsyncUtils.java
+++ b/src/main/java/net/minestom/server/utils/async/AsyncUtils.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.CompletableFuture;
 
-@ApiStatus.Internal
+@ApiStatus.Experimental
 public final class AsyncUtils {
     public static final CompletableFuture<Void> VOID_FUTURE = CompletableFuture.completedFuture(null);
 

--- a/src/main/java/net/minestom/server/utils/chunk/ChunkUtils.java
+++ b/src/main/java/net/minestom/server/utils/chunk/ChunkUtils.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
-@ApiStatus.Internal
+@ApiStatus.Experimental
 public final class ChunkUtils {
 
     private ChunkUtils() {


### PR DESCRIPTION
`@ApiStatus.Experimental` implies that the class is usable, but is expected to change often and break code.
This annotation in my opinion fits utility classes better than the current `@ApiStatus.Internal` which implies that the class is used only for internal code and shouldn't be used as a public API, but in my opinion, the utility classes affected are okay to be included as apart of the API.