### PR TITLE
Typo in demo PlayerInit

### DIFF
--- a/src/test/java/demo/PlayerInit.java
+++ b/src/test/java/demo/PlayerInit.java
@@ -91,7 +91,7 @@ public class PlayerInit {
                 event.setSpawningInstance(instance);
                 int x = Math.abs(ThreadLocalRandom.current().nextInt()) % 500 - 250;
                 int z = Math.abs(ThreadLocalRandom.current().nextInt()) % 500 - 250;
-                player.setRespawnPoint(new Pos(0, 42f, 0));
+                player.setRespawnPoint(new Pos(x, 42f, z));
             })
             .addListener(PlayerSpawnEvent.class, event -> {
                 final Player player = event.getPlayer();


### PR DESCRIPTION
I've noticed that in the demo file PlayerInit, under PlayerLoginEvent, there are `x` and `z` variables created, possibly to randomize the spawn location. These are unused though, so i don't really understand what the point of these variables are..?

This PR fixes this by using the `x` and `z` values in `new Pos(x, 42f, z)`