### PR TITLE
Mapped Event nodes

### DIFF
--- a/src/main/java/net/minestom/server/event/EventBinding.java
+++ b/src/main/java/net/minestom/server/event/EventBinding.java
@@ -1,5 +1,6 @@
 package net.minestom.server.event;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -9,6 +10,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
+@ApiStatus.Experimental
 public interface EventBinding<E extends Event> {
 
     static <E extends Event, T> @NotNull FilteredBuilder<E, T> filtered(@NotNull EventFilter<E, T> filter, @NotNull Predicate<T> predicate) {

--- a/src/main/java/net/minestom/server/event/EventFilter.java
+++ b/src/main/java/net/minestom/server/event/EventFilter.java
@@ -4,8 +4,10 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.*;
 import net.minestom.server.instance.Instance;
+import net.minestom.server.instance.block.Block;
 import net.minestom.server.inventory.Inventory;
 import net.minestom.server.item.ItemStack;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -27,14 +29,16 @@ import java.util.function.Function;
  */
 public interface EventFilter<E extends Event, H> {
 
-    EventFilter<Event, ?> ALL = from(Event.class, null);
-    EventFilter<EntityEvent, Entity> ENTITY = from(EntityEvent.class, EntityEvent::getEntity);
-    EventFilter<PlayerEvent, Player> PLAYER = from(PlayerEvent.class, PlayerEvent::getPlayer);
-    EventFilter<ItemEvent, ItemStack> ITEM = from(ItemEvent.class, ItemEvent::getItemStack);
-    EventFilter<InstanceEvent, Instance> INSTANCE = from(InstanceEvent.class, InstanceEvent::getInstance);
-    EventFilter<InventoryEvent, Inventory> INVENTORY = from(InventoryEvent.class, InventoryEvent::getInventory);
+    EventFilter<Event, ?> ALL = from(Event.class, null, null);
+    EventFilter<EntityEvent, Entity> ENTITY = from(EntityEvent.class, Entity.class, EntityEvent::getEntity);
+    EventFilter<PlayerEvent, Player> PLAYER = from(PlayerEvent.class, Player.class, PlayerEvent::getPlayer);
+    EventFilter<ItemEvent, ItemStack> ITEM = from(ItemEvent.class, ItemStack.class, ItemEvent::getItemStack);
+    EventFilter<InstanceEvent, Instance> INSTANCE = from(InstanceEvent.class, Instance.class, InstanceEvent::getInstance);
+    EventFilter<InventoryEvent, Inventory> INVENTORY = from(InventoryEvent.class, Inventory.class, InventoryEvent::getInventory);
+    EventFilter<BlockEvent, Block> BLOCK = from(BlockEvent.class, Block.class, BlockEvent::getBlock);
 
     static <E extends Event, H> EventFilter<E, H> from(@NotNull Class<E> eventType,
+                                                       @Nullable Class<H> handlerType,
                                                        @Nullable Function<E, H> handlerGetter) {
         return new EventFilter<>() {
             @Override
@@ -43,8 +47,13 @@ public interface EventFilter<E extends Event, H> {
             }
 
             @Override
-            public @NotNull Class<E> getEventType() {
+            public @NotNull Class<E> eventType() {
                 return eventType;
+            }
+
+            @Override
+            public @Nullable Class<H> handlerType() {
+                return handlerType;
             }
         };
     }
@@ -58,10 +67,23 @@ public interface EventFilter<E extends Event, H> {
      */
     @Nullable H getHandler(@NotNull E event);
 
+    @ApiStatus.Internal
+    default @Nullable H castHandler(@NotNull Object event) {
+        //noinspection unchecked
+        return getHandler((E) event);
+    }
+
     /**
      * The event type to filter on.
      *
      * @return The event type.
      */
-    @NotNull Class<E> getEventType();
+    @NotNull Class<E> eventType();
+
+    /**
+     * The type returned by {@link #getHandler(Event)}.
+     *
+     * @return the handler type, null if not any
+     */
+    @Nullable Class<H> handlerType();
 }

--- a/src/main/java/net/minestom/server/event/EventInterface.java
+++ b/src/main/java/net/minestom/server/event/EventInterface.java
@@ -48,7 +48,6 @@ public interface EventInterface<E extends Event> {
                     final T handler = filter.getHandler(event);
                     if (!predicate.test(handler)) return;
                     final var consumer = copy.get(event.getClass());
-                    if (consumer == null) return;
                     consumer.accept(handler, event);
                 }
             };

--- a/src/main/java/net/minestom/server/event/EventInterface.java
+++ b/src/main/java/net/minestom/server/event/EventInterface.java
@@ -1,0 +1,35 @@
+package net.minestom.server.event;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+public final class EventInterface<T> {
+
+    public static <T> @NotNull Builder<T> builder(@NotNull Class<T> type) {
+        return new Builder<>();
+    }
+
+    final Map<Class<? extends Event>, BiConsumer<T, Event>> mapped;
+
+    EventInterface(Map<Class<? extends Event>, BiConsumer<T, Event>> map) {
+        this.mapped = map;
+    }
+
+    public static class Builder<T> {
+        private final Map<Class<? extends Event>, BiConsumer<T, Event>> mapped = new HashMap<>();
+
+        @SuppressWarnings("unchecked")
+        public <E extends Event> Builder<T> map(@NotNull Class<E> eventType,
+                                                @NotNull BiConsumer<@NotNull T, @NotNull E> consumer) {
+            this.mapped.put(eventType, (BiConsumer<T, Event>) consumer);
+            return this;
+        }
+
+        public @NotNull EventInterface<T> build() {
+            return new EventInterface<>(Map.copyOf(mapped));
+        }
+    }
+}

--- a/src/main/java/net/minestom/server/event/EventNode.java
+++ b/src/main/java/net/minestom/server/event/EventNode.java
@@ -320,5 +320,7 @@ public interface EventNode<T extends Event> {
 
     boolean unmap(@NotNull Object value);
 
-    void registerInterface(@NotNull EventInterface<? extends T> eventInterface);
+    void register(@NotNull EventBinding<? extends T> binding);
+
+    void unregister(@NotNull EventBinding<? extends T> binding);
 }

--- a/src/main/java/net/minestom/server/event/EventNode.java
+++ b/src/main/java/net/minestom/server/event/EventNode.java
@@ -528,11 +528,12 @@ public class EventNode<T extends Event> {
 
     public void map(@NotNull EventNode<? extends T> node, @NotNull Object value) {
         final var nodeType = node.eventType;
+        final var valueType = value.getClass();
         final boolean correct = getEventFilters(nodeType).stream().anyMatch(eventFilter -> {
             final var handlerType = eventFilter.handlerType();
-            return handlerType != null && handlerType.isAssignableFrom(value.getClass());
+            return handlerType != null && handlerType.isAssignableFrom(valueType);
         });
-        Check.stateCondition(!correct, "The node {0} is not compatible with objects of type {1}", nodeType, value.getClass());
+        Check.stateCondition(!correct, "The node filter {0} is not compatible with type {1}", nodeType, valueType);
         //noinspection unchecked
         this.mappedNode.put(value, (EventNode<T>) node);
     }

--- a/src/main/java/net/minestom/server/event/EventNode.java
+++ b/src/main/java/net/minestom/server/event/EventNode.java
@@ -577,17 +577,21 @@ public class EventNode<T extends Event> {
     private static List<Function<Event, Object>> getEventMapping(Class<? extends Event> eventClass) {
         return HANDLER_SUPPLIERS.computeIfAbsent(eventClass, clazz -> {
             List<Function<Event, Object>> result = new ArrayList<>();
-            if (EntityEvent.class.isAssignableFrom(clazz)) {
-                result.add(e -> ((EntityEvent) e).getEntity());
-            } else if (PlayerEvent.class.isAssignableFrom(clazz)) {
+            if (PlayerEvent.class.isAssignableFrom(clazz)) {
                 result.add(e -> ((PlayerEvent) e).getPlayer());
-            } else if (ItemEvent.class.isAssignableFrom(clazz)) {
+            } else if (EntityEvent.class.isAssignableFrom(clazz)) {
+                result.add(e -> ((EntityEvent) e).getEntity());
+            }
+            if (ItemEvent.class.isAssignableFrom(clazz)) {
                 result.add(e -> ((ItemEvent) e).getItemStack());
-            } else if (InstanceEvent.class.isAssignableFrom(clazz)) {
+            }
+            if (InstanceEvent.class.isAssignableFrom(clazz)) {
                 result.add(e -> ((InstanceEvent) e).getInstance());
-            } else if (InventoryEvent.class.isAssignableFrom(clazz)) {
+            }
+            if (InventoryEvent.class.isAssignableFrom(clazz)) {
                 result.add(e -> ((InventoryEvent) e).getInventory());
-            } else if (BlockEvent.class.isAssignableFrom(clazz)) {
+            }
+            if (BlockEvent.class.isAssignableFrom(clazz)) {
                 result.add(e -> ((BlockEvent) e).getBlock());
             }
             return result;

--- a/src/main/java/net/minestom/server/event/EventNode.java
+++ b/src/main/java/net/minestom/server/event/EventNode.java
@@ -318,11 +318,15 @@ public interface EventNode<T extends Event> {
     @Contract(value = "_ -> this")
     @NotNull EventNode<T> removeListener(@NotNull EventListener<? extends T> listener);
 
+    @ApiStatus.Experimental
     void map(@NotNull EventNode<? extends T> node, @NotNull Object value);
 
+    @ApiStatus.Experimental
     boolean unmap(@NotNull Object value);
 
+    @ApiStatus.Experimental
     void register(@NotNull EventBinding<? extends T> binding);
 
+    @ApiStatus.Experimental
     void unregister(@NotNull EventBinding<? extends T> binding);
 }

--- a/src/main/java/net/minestom/server/event/EventNode.java
+++ b/src/main/java/net/minestom/server/event/EventNode.java
@@ -514,6 +514,13 @@ public class EventNode<T extends Event> {
         return this;
     }
 
+    public <I> void addInter(@NotNull EventInterface<I> inter, @NotNull I value) {
+        inter.mapped.forEach((eventType, consumer) -> {
+            // TODO cache so listeners can be removed from the EventInterface
+            addListener((EventListener<? extends T>) EventListener.builder(eventType).handler(event -> consumer.accept(value, event)).build());
+        });
+    }
+
     private void increaseChildListenerCount(Class<? extends T> eventClass, int count) {
         var entry = listenerMap.computeIfAbsent(eventClass, aClass -> new ListenerEntry<>());
         ListenerEntry.addAndGet(entry, count);

--- a/src/main/java/net/minestom/server/event/EventNode.java
+++ b/src/main/java/net/minestom/server/event/EventNode.java
@@ -1,5 +1,7 @@
 package net.minestom.server.event;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.event.trait.CancellableEvent;
 import net.minestom.server.tag.Tag;
@@ -190,7 +192,7 @@ public class EventNode<T extends Event> {
 
     private final Map<Class<? extends T>, ListenerEntry<T>> listenerMap = new ConcurrentHashMap<>();
     private final Set<EventNode<T>> children = new CopyOnWriteArraySet<>();
-    private final Map<Object, EventNode<T>> mappedNode = new ConcurrentHashMap<>();
+    private final Map<Object, EventNode<T>> mappedNode;
 
     protected final String name;
     protected final EventFilter<T, ?> filter;
@@ -206,6 +208,9 @@ public class EventNode<T extends Event> {
         this.filter = filter;
         this.predicate = predicate;
         this.eventType = filter.eventType();
+
+        Cache<Object, EventNode<T>> mapCache = Caffeine.newBuilder().weakKeys().build();
+        this.mappedNode = mapCache.asMap();
     }
 
     /**

--- a/src/main/java/net/minestom/server/event/EventNode.java
+++ b/src/main/java/net/minestom/server/event/EventNode.java
@@ -311,7 +311,9 @@ public interface EventNode<T extends Event> {
     @NotNull EventNode<T> addListener(@NotNull EventListener<? extends T> listener);
 
     @Contract(value = "_, _ -> this")
-    <E extends T> @NotNull EventNode<T> addListener(@NotNull Class<E> eventType, @NotNull Consumer<@NotNull E> listener);
+    default <E extends T> @NotNull EventNode<T> addListener(@NotNull Class<E> eventType, @NotNull Consumer<@NotNull E> listener) {
+        return addListener(EventListener.of(eventType, listener));
+    }
 
     @Contract(value = "_ -> this")
     @NotNull EventNode<T> removeListener(@NotNull EventListener<? extends T> listener);

--- a/src/main/java/net/minestom/server/event/EventNodeImpl.java
+++ b/src/main/java/net/minestom/server/event/EventNodeImpl.java
@@ -1,0 +1,356 @@
+package net.minestom.server.event;
+
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.utils.validate.Check;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.function.BiPredicate;
+import java.util.function.Consumer;
+import java.util.function.IntUnaryOperator;
+import java.util.stream.Collectors;
+
+class EventNodeImpl<T extends Event> implements EventNode<T> {
+    private static final Object GLOBAL_CHILD_LOCK = new Object();
+    private final Object lock = new Object();
+
+    private final Map<Class<? extends T>, ListenerEntry<T>> listenerMap = new ConcurrentHashMap<>();
+    private final Set<EventNode<T>> children = new CopyOnWriteArraySet<>();
+    private final Map<Object, ListenerEntry<T>> mappedNodeCache = new WeakHashMap<>();
+
+    private final String name;
+    private final EventFilter<T, ?> filter;
+    private final BiPredicate<T, Object> predicate;
+    private final Class<T> eventType;
+    private volatile int priority;
+    private volatile EventNodeImpl<? super T> parent;
+
+    protected EventNodeImpl(@NotNull String name,
+                            @NotNull EventFilter<T, ?> filter,
+                            @Nullable BiPredicate<T, Object> predicate) {
+        this.name = name;
+        this.filter = filter;
+        this.predicate = predicate;
+        this.eventType = filter.eventType();
+    }
+
+    @Override
+    public void call(@NotNull T event) {
+        final var eventClass = event.getClass();
+        if (!eventType.isAssignableFrom(eventClass)) return; // Invalid event type
+        // Conditions
+        if (predicate != null) {
+            try {
+                final var value = filter.getHandler(event);
+                if (!predicate.test(event, value)) return;
+            } catch (Exception e) {
+                MinecraftServer.getExceptionManager().handleException(e);
+                return;
+            }
+        }
+        // Process listeners list
+        final var entry = listenerMap.get(eventClass);
+        if (entry == null) return; // No listener nor children
+        {
+            // Event interfaces
+            final var interfaces = entry.interfaces;
+            if (!interfaces.isEmpty()) {
+                for (EventInterface<T> inter : interfaces) {
+                    if (!inter.eventTypes().contains(eventClass)) continue;
+                    inter.call(event);
+                }
+            }
+            // Mapped listeners
+            final var mapped = entry.mappedNode;
+            if (!mapped.isEmpty()) {
+                synchronized (mappedNodeCache) {
+                    if (!mapped.isEmpty()) {
+                        // Check mapped listeners for each individual event handler
+                        for (var filter : entry.filters) {
+                            final var handler = filter.castHandler(event);
+                            final var map = mapped.get(handler);
+                            if (map != null) map.call(event);
+                        }
+                    }
+                }
+            }
+            // Basic listeners
+            final var listeners = entry.listeners;
+            if (!listeners.isEmpty()) {
+                for (EventListener<T> listener : listeners) {
+                    EventListener.Result result;
+                    try {
+                        result = listener.run(event);
+                    } catch (Exception e) {
+                        result = EventListener.Result.EXCEPTION;
+                        MinecraftServer.getExceptionManager().handleException(e);
+                    }
+                    if (result == EventListener.Result.EXPIRED) {
+                        listeners.remove(listener);
+                    }
+                }
+            }
+        }
+        // Process children
+        if (entry.childCount > 0) {
+            this.children.stream()
+                    .sorted(Comparator.comparing(EventNode::getPriority))
+                    .forEach(child -> child.call(event));
+        }
+    }
+
+    @Override
+    public <E extends T> @NotNull List<EventNode<E>> findChildren(@NotNull String name, Class<E> eventType) {
+        if (children.isEmpty()) return Collections.emptyList();
+        synchronized (GLOBAL_CHILD_LOCK) {
+            List<EventNode<E>> result = new ArrayList<>();
+            for (EventNode<T> child : children) {
+                if (equals(child, name, eventType)) {
+                    result.add((EventNode<E>) child);
+                }
+                result.addAll(child.findChildren(name, eventType));
+            }
+            return result;
+        }
+    }
+
+    @Contract(pure = true)
+    public @NotNull Set<@NotNull EventNode<T>> getChildren() {
+        return Collections.unmodifiableSet(children);
+    }
+
+    @Override
+    public <E extends T> void replaceChildren(@NotNull String name, @NotNull Class<E> eventType, @NotNull EventNode<E> eventNode) {
+        if (children.isEmpty()) return;
+        synchronized (GLOBAL_CHILD_LOCK) {
+            for (EventNode<T> child : children) {
+                if (equals(child, name, eventType)) {
+                    removeChild(child);
+                    addChild(eventNode);
+                    continue;
+                }
+                child.replaceChildren(name, eventType, eventNode);
+            }
+        }
+    }
+
+    @Override
+    public void removeChildren(@NotNull String name, @NotNull Class<? extends T> eventType) {
+        if (children.isEmpty()) return;
+        synchronized (GLOBAL_CHILD_LOCK) {
+            for (EventNode<T> child : children) {
+                if (equals(child, name, eventType)) {
+                    removeChild(child);
+                    continue;
+                }
+                child.removeChildren(name, eventType);
+            }
+        }
+    }
+
+    @Override
+    public void removeChildren(@NotNull String name) {
+        removeChildren(name, eventType);
+    }
+
+    @Override
+    public @NotNull EventNode<T> addChild(@NotNull EventNode<? extends T> child) {
+        synchronized (GLOBAL_CHILD_LOCK) {
+            final var childImpl = (EventNodeImpl<? extends T>) child;
+            Check.stateCondition(childImpl.parent != null, "Node already has a parent");
+            Check.stateCondition(Objects.equals(parent, child), "Cannot have a child as parent");
+            final boolean result = this.children.add((EventNodeImpl<T>) childImpl);
+            if (result) {
+                childImpl.parent = this;
+                // Increase listener count
+                propagateNode(childImpl, IntUnaryOperator.identity());
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public @NotNull EventNode<T> removeChild(@NotNull EventNode<? extends T> child) {
+        synchronized (GLOBAL_CHILD_LOCK) {
+            final boolean result = this.children.remove(child);
+            if (result) {
+                final var childImpl = (EventNodeImpl<? extends T>) child;
+                childImpl.parent = null;
+                // Decrease listener count
+                propagateNode(childImpl, count -> -count);
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public @NotNull EventNode<T> addListener(@NotNull EventListener<? extends T> listener) {
+        synchronized (GLOBAL_CHILD_LOCK) {
+            final var eventType = listener.getEventType();
+            var entry = getEntry(eventType);
+            entry.listeners.add((EventListener<T>) listener);
+            final var parent = this.parent;
+            if (parent != null) {
+                synchronized (parent.lock) {
+                    parent.propagateChildCountChange(eventType, 1);
+                }
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public <E extends T> @NotNull EventNode<T> addListener(@NotNull Class<E> eventType, @NotNull Consumer<@NotNull E> listener) {
+        return addListener(EventListener.of(eventType, listener));
+    }
+
+    @Override
+    public @NotNull EventNode<T> removeListener(@NotNull EventListener<? extends T> listener) {
+        synchronized (GLOBAL_CHILD_LOCK) {
+            final var eventType = listener.getEventType();
+            var entry = listenerMap.get(eventType);
+            if (entry == null) return this;
+            var listeners = entry.listeners;
+            final boolean removed = listeners.remove(listener);
+            if (removed && parent != null) {
+                synchronized (parent.lock) {
+                    parent.propagateChildCountChange(eventType, -1);
+                }
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public void map(@NotNull EventNode<? extends T> node, @NotNull Object value) {
+        final var nodeImpl = (EventNodeImpl<? extends T>) node;
+        final var nodeType = nodeImpl.eventType;
+        final var valueType = value.getClass();
+        synchronized (GLOBAL_CHILD_LOCK) {
+            nodeImpl.listenerMap.forEach((type, listenerEntry) -> {
+                final var entry = getEntry(type);
+                final boolean correct = entry.filters.stream().anyMatch(eventFilter -> {
+                    final var handlerType = eventFilter.handlerType();
+                    return handlerType != null && handlerType.isAssignableFrom(valueType);
+                });
+                Check.stateCondition(!correct, "The node filter {0} is not compatible with type {1}", nodeType, valueType);
+                synchronized (mappedNodeCache) {
+                    entry.mappedNode.put(value, (EventNode<T>) node);
+                    mappedNodeCache.put(value, entry);
+                }
+            });
+        }
+    }
+
+    @Override
+    public boolean unmap(@NotNull Object value) {
+        synchronized (GLOBAL_CHILD_LOCK) {
+            synchronized (mappedNodeCache) {
+                var entry = mappedNodeCache.remove(value);
+                if (entry == null) return false;
+                return entry.mappedNode.remove(value) != null;
+            }
+        }
+    }
+
+    @Override
+    public void registerInterface(@NotNull EventInterface<? extends T> eventInterface) {
+        synchronized (GLOBAL_CHILD_LOCK) {
+            for (var eventType : eventInterface.eventTypes()) {
+                var entry = getEntry((Class<? extends T>) eventType);
+                entry.interfaces.add((EventInterface<T>) eventInterface);
+            }
+        }
+    }
+
+    @Override
+    public @NotNull Class<T> getEventType() {
+        return eventType;
+    }
+
+    @Override
+    public @NotNull String getName() {
+        return name;
+    }
+
+    @Override
+    public int getPriority() {
+        return priority;
+    }
+
+    @Override
+    public @NotNull EventNode<T> setPriority(int priority) {
+        this.priority = priority;
+        return this;
+    }
+
+    @Override
+    public @Nullable EventNode<? super T> getParent() {
+        return parent;
+    }
+
+    private void propagateChildCountChange(Class<? extends T> eventClass, int count) {
+        var entry = getEntry(eventClass);
+        final int result = ListenerEntry.addAndGet(entry, count);
+        if (result == 0 && entry.listeners.isEmpty()) {
+            this.listenerMap.remove(eventClass);
+        } else if (result < 0) {
+            throw new IllegalStateException("Something wrong happened, listener count: " + result);
+        }
+        if (parent != null) {
+            parent.propagateChildCountChange(eventClass, count);
+        }
+    }
+
+    private void propagateNode(EventNodeImpl<? extends T> child, IntUnaryOperator operator) {
+        synchronized (lock) {
+            final var listeners = child.listenerMap;
+            listeners.forEach((eventClass, eventListeners) -> {
+                final var entry = listeners.get(eventClass);
+                if (entry == null) return;
+                final int childCount = entry.listeners.size() + entry.childCount;
+                propagateChildCountChange(eventClass, operator.applyAsInt(childCount));
+            });
+        }
+    }
+
+    private ListenerEntry<T> getEntry(Class<? extends T> type) {
+        return listenerMap.computeIfAbsent(type, aClass -> new ListenerEntry<>((Class<T>) aClass));
+    }
+
+    private static boolean equals(EventNode<?> node, String name, Class<?> eventType) {
+        final boolean nameCheck = node.getName().equals(name);
+        final boolean typeCheck = eventType.isAssignableFrom(((EventNodeImpl<?>) node).eventType);
+        return nameCheck && typeCheck;
+    }
+
+    private static class ListenerEntry<T extends Event> {
+        private static final List<EventFilter<? extends Event, ?>> FILTERS = List.of(
+                EventFilter.ENTITY,
+                EventFilter.ITEM, EventFilter.INSTANCE,
+                EventFilter.INVENTORY, EventFilter.BLOCK);
+        @SuppressWarnings("rawtypes")
+        private static final AtomicIntegerFieldUpdater<ListenerEntry> CHILD_UPDATER =
+                AtomicIntegerFieldUpdater.newUpdater(ListenerEntry.class, "childCount");
+
+        final List<EventFilter<?, ?>> filters;
+        final List<EventListener<T>> listeners = new CopyOnWriteArrayList<>();
+        final Set<EventInterface<T>> interfaces = new CopyOnWriteArraySet<>();
+        final Map<Object, EventNode<T>> mappedNode = new WeakHashMap<>();
+        volatile int childCount;
+
+        ListenerEntry(Class<T> eventType) {
+            this.filters = FILTERS.stream().filter(eventFilter -> eventFilter.eventType().isAssignableFrom(eventType)).collect(Collectors.toList());
+        }
+
+        private static int addAndGet(ListenerEntry<?> entry, int add) {
+            return CHILD_UPDATER.addAndGet(entry, add);
+        }
+    }
+}

--- a/src/main/java/net/minestom/server/event/GlobalEventHandler.java
+++ b/src/main/java/net/minestom/server/event/GlobalEventHandler.java
@@ -7,7 +7,7 @@ import java.util.function.Consumer;
 /**
  * Object containing all the global event listeners.
  */
-public final class GlobalEventHandler extends EventNode<Event> {
+public final class GlobalEventHandler extends EventNodeImpl<Event> {
     public GlobalEventHandler() {
         super("global", EventFilter.ALL, null);
     }

--- a/src/main/java/net/minestom/server/instance/DynamicChunk.java
+++ b/src/main/java/net/minestom/server/instance/DynamicChunk.java
@@ -2,6 +2,7 @@ package net.minestom.server.instance;
 
 import com.extollit.gaming.ai.path.model.ColumnarOcclusionFieldList;
 import it.unimi.dsi.fastutil.ints.Int2ObjectAVLTreeMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Player;
@@ -10,8 +11,8 @@ import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockHandler;
 import net.minestom.server.network.packet.server.play.ChunkDataPacket;
 import net.minestom.server.network.packet.server.play.UpdateLightPacket;
-import net.minestom.server.network.player.PlayerSocketConnection;
 import net.minestom.server.network.player.PlayerConnection;
+import net.minestom.server.network.player.PlayerSocketConnection;
 import net.minestom.server.utils.ArrayUtils;
 import net.minestom.server.utils.PacketUtils;
 import net.minestom.server.utils.chunk.ChunkUtils;
@@ -88,20 +89,18 @@ public class DynamicChunk extends Chunk {
 
     @Override
     public void tick(long time) {
-        if (tickableMap.isEmpty())
-            return;
-        for (var entry : tickableMap.int2ObjectEntrySet()) {
+        if (tickableMap.isEmpty()) return;
+        Int2ObjectMaps.fastForEach(tickableMap, entry -> {
             final int index = entry.getIntKey();
             final Block block = entry.getValue();
-            final var handler = block.handler();
-            if (handler != null) {
-                final int x = ChunkUtils.blockIndexToChunkPositionX(index);
-                final int y = ChunkUtils.blockIndexToChunkPositionY(index);
-                final int z = ChunkUtils.blockIndexToChunkPositionZ(index);
-                final Vec blockPosition = new Vec(x, y, z);
-                handler.tick(new BlockHandler.Tick(block, instance, blockPosition));
-            }
-        }
+            final BlockHandler handler = block.handler();
+            if (handler == null) return;
+            final int x = ChunkUtils.blockIndexToChunkPositionX(index);
+            final int y = ChunkUtils.blockIndexToChunkPositionY(index);
+            final int z = ChunkUtils.blockIndexToChunkPositionZ(index);
+            final Vec blockPosition = new Vec(x, y, z);
+            handler.tick(new BlockHandler.Tick(block, instance, blockPosition));
+        });
     }
 
     @Override

--- a/src/main/java/net/minestom/server/instance/block/BlockImpl.java
+++ b/src/main/java/net/minestom/server/instance/block/BlockImpl.java
@@ -69,6 +69,8 @@ final class BlockImpl implements Block {
     private final NBTCompound nbt;
     private final BlockHandler handler;
 
+    private int hashCode; // Cache
+
     BlockImpl(@NotNull Registry.BlockEntry registry,
               @NotNull Map<Map<String, String>, Block> propertyEntry,
               @NotNull Map<String, String> properties,
@@ -151,7 +153,12 @@ final class BlockImpl implements Block {
 
     @Override
     public int hashCode() {
-        return Objects.hash(stateId(), nbt, handler);
+        int result = hashCode;
+        if (result == 0) {
+            result = Objects.hash(stateId(), nbt, handler);
+            this.hashCode = result;
+        }
+        return result;
     }
 
     @Override


### PR DESCRIPTION
Goals:
- Allow user-defined interfaces acting as listeners
- Create a new type of EventNode mapped to a specific object (e.g. per player/instance listeners) with less overhead