### PR TITLE
Don't enforce automatic scheduling of `Task`  within `TaskBuilder`

### DIFF
--- a/src/main/java/net/minestom/server/timer/Task.java
+++ b/src/main/java/net/minestom/server/timer/Task.java
@@ -100,12 +100,26 @@ public class Task implements Runnable {
      * Sets up the task for correct execution.
      */
     public void schedule() {
+        Int2ObjectMap<Task> tasks = this.schedulerManager.tasks;
+        synchronized (tasks) {
+            tasks.put(getId(), this);
+        }
         if(owningExtension != null) {
             this.schedulerManager.onScheduleFromExtension(owningExtension, this);
         }
         this.future = this.repeat == 0L ?
                 this.schedulerManager.getTimerExecutionService().schedule(this, this.delay, TimeUnit.MILLISECONDS) :
                 this.schedulerManager.getTimerExecutionService().scheduleAtFixedRate(this, this.delay, this.repeat, TimeUnit.MILLISECONDS);
+    }
+
+    public void scheduleForShutdown() {
+        Int2ObjectMap<Task> shutdownTasks = this.schedulerManager.shutdownTasks;
+        synchronized (shutdownTasks) {
+            shutdownTasks.put(getId(), this);
+        }
+        if (owningExtension != null) {
+            this.schedulerManager.onScheduleShutdownFromExtension(owningExtension, this);
+        }
     }
 
     /**

--- a/src/main/java/net/minestom/server/timer/TaskBuilder.java
+++ b/src/main/java/net/minestom/server/timer/TaskBuilder.java
@@ -138,9 +138,26 @@ public class TaskBuilder {
     }
 
     /**
-     * Schedules this {@link Task} for execution.
+     * Builds a {@link Task}.
      *
      * @return the built {@link Task}
+     */
+    @NotNull
+    public Task build() {
+        return new Task(
+                this.schedulerManager,
+                this.runnable,
+                this.shutdown,
+                this.delay,
+                this.repeat,
+                this.isTransient,
+                this.owningExtension);
+    }
+
+    /**
+     * Schedules this {@link Task} for execution.
+     *
+     * @return the scheduled {@link Task}
      */
     @NotNull
     public Task schedule() {

--- a/src/main/java/net/minestom/server/timer/TaskBuilder.java
+++ b/src/main/java/net/minestom/server/timer/TaskBuilder.java
@@ -144,27 +144,10 @@ public class TaskBuilder {
      */
     @NotNull
     public Task schedule() {
-        Task task = new Task(
-                this.schedulerManager,
-                this.runnable,
-                this.shutdown,
-                this.delay,
-                this.repeat,
-                this.isTransient,
-                this.owningExtension);
+        Task task = build();
         if (this.shutdown) {
-            Int2ObjectMap<Task> shutdownTasks = this.schedulerManager.shutdownTasks;
-            synchronized (shutdownTasks) {
-                shutdownTasks.put(task.getId(), task);
-            }
-            if (owningExtension != null) {
-                this.schedulerManager.onScheduleShutdownFromExtension(owningExtension, task);
-            }
+            task.scheduleForShutdown();
         } else {
-            Int2ObjectMap<Task> tasks = this.schedulerManager.tasks;
-            synchronized (tasks) {
-                tasks.put(task.getId(), task);
-            }
             task.schedule();
         }
         return task;


### PR DESCRIPTION
This PR allows you to build a `Task` from `TaskBuilder` if you need to schedule it at a later time.
You could do the same by constructing the `Task` by yourself, but there were no methods inside the builder to do that without it scheduling it (as the only method available for that is `TaskBuilder#schedule`).

This adds a `TaskBuilder#build` method and moves practically all functionality from `TaskBuilder#schedule` to `Task#schedule` and a new method, `Task#scheduleForShutdown`.