### PR TITLE
Air drag fix

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -1431,7 +1431,7 @@ public class Entity implements Viewable, Tickable, TagHandler, PermissionHandler
             //TODO check possible side effects of unnatural TPS (other than 20TPS)
             final Vec velocityModifier = new Vec(x, z)
                     .normalize()
-                    .mul(strength * MinecraftServer.TICK_PER_SECOND / 2);
+                    .mul(strength * MinecraftServer.TICK_PER_SECOND);
             setVelocity(new Vec(velocity.x() / 2d - velocityModifier.x(),
                     onGround ? Math.min(.4d, velocity.y() / 2d + strength) * MinecraftServer.TICK_PER_SECOND : velocity.y(),
                     velocity.z() / 2d - velocityModifier.z()

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -556,8 +556,9 @@ public class Entity implements Viewable, Tickable, TagHandler, PermissionHandler
                 // Stop player velocity
                 this.velocity = Vec.ZERO;
             } else {
+                final double airDrag = this instanceof LivingEntity ? 0.91 : 0.98;
                 final double drag = this.onGround ?
-                        finalChunk.getBlock(position).registry().friction() : 0.91;
+                        finalChunk.getBlock(position).registry().friction() : airDrag;
                 this.velocity = newVelocity
                         // Convert from block/tick to block/sec
                         .mul(tps)

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -1432,7 +1432,7 @@ public class Entity implements Viewable, Tickable, TagHandler, PermissionHandler
             //TODO check possible side effects of unnatural TPS (other than 20TPS)
             final Vec velocityModifier = new Vec(x, z)
                     .normalize()
-                    .mul(strength * MinecraftServer.TICK_PER_SECOND);
+                    .mul(strength * MinecraftServer.TICK_PER_SECOND / 2);
             setVelocity(new Vec(velocity.x() / 2d - velocityModifier.x(),
                     onGround ? Math.min(.4d, velocity.y() / 2d + strength) * MinecraftServer.TICK_PER_SECOND : velocity.y(),
                     velocity.z() / 2d - velocityModifier.z()


### PR DESCRIPTION
This pull request fixes the air drag of some entities being off.

Living entities have an air drag of 0.91, and other entities have 0.98. Minestom does not provide any rules for entities, so maybe it should be customizable? (Like `Entity.setAirDrag(0.98)`)