### PR TITLE
Free event calling

### DIFF
--- a/src/main/java/net/minestom/server/event/EventListener.java
+++ b/src/main/java/net/minestom/server/event/EventListener.java
@@ -19,7 +19,7 @@ import java.util.function.Predicate;
  */
 public interface EventListener<T extends Event> {
 
-    @NotNull Class<T> getEventType();
+    @NotNull Class<T> eventType();
 
     @NotNull Result run(@NotNull T event);
 
@@ -122,7 +122,7 @@ public interface EventListener<T extends Event> {
             final var handler = this.handler;
             return new EventListener<>() {
                 @Override
-                public @NotNull Class<T> getEventType() {
+                public @NotNull Class<T> eventType() {
                     return eventType;
                 }
 

--- a/src/main/java/net/minestom/server/event/EventNode.java
+++ b/src/main/java/net/minestom/server/event/EventNode.java
@@ -214,6 +214,20 @@ public interface EventNode<T extends Event> {
     <E extends T> @NotNull ListenerHandle<E> getHandle(@NotNull Class<E> handleType);
 
     /**
+     * Gets if any listener has been registered for the given handle.
+     * May trigger an update if the cached data is not correct.
+     * <p>
+     * Useful if you are able to avoid expensive computation in the case where
+     * the event is unused. Be aware that {@link #call(Event, ListenerHandle)}
+     * has similar optimization built-in.
+     *
+     * @param handle the listener handle
+     * @param <E>    the event type
+     * @return true if the event has 1 or more listeners
+     */
+    <E extends T> boolean hasListener(@NotNull ListenerHandle<E> handle);
+
+    /**
      * Execute a cancellable event with a callback to execute if the event is successful.
      * Event conditions and propagation is the same as {@link #call(Event)}.
      *

--- a/src/main/java/net/minestom/server/event/EventNode.java
+++ b/src/main/java/net/minestom/server/event/EventNode.java
@@ -222,10 +222,9 @@ public interface EventNode<T extends Event> {
      * has similar optimization built-in.
      *
      * @param handle the listener handle
-     * @param <E>    the event type
      * @return true if the event has 1 or more listeners
      */
-    <E extends T> boolean hasListener(@NotNull ListenerHandle<E> handle);
+    boolean hasListener(@NotNull ListenerHandle<? extends T> handle);
 
     /**
      * Execute a cancellable event with a callback to execute if the event is successful.

--- a/src/main/java/net/minestom/server/event/EventNode.java
+++ b/src/main/java/net/minestom/server/event/EventNode.java
@@ -352,9 +352,24 @@ public interface EventNode<T extends Event> {
     @Contract(value = "_ -> this")
     @NotNull EventNode<T> removeListener(@NotNull EventListener<? extends T> listener);
 
+    /**
+     * Maps a specific object to a node.
+     * <p>
+     * Be aware that such structure have huge performance penalty as they will
+     * always require a map lookup. Use only at last resort.
+     *
+     * @param node  the node to map
+     * @param value the mapped value
+     */
     @ApiStatus.Experimental
     void map(@NotNull EventNode<? extends T> node, @NotNull Object value);
 
+    /**
+     * Undo {@link #map(EventNode, Object)}
+     *
+     * @param value the value to unmap
+     * @return true if the value has been unmapped, false if nothing happened
+     */
     @ApiStatus.Experimental
     boolean unmap(@NotNull Object value);
 

--- a/src/main/java/net/minestom/server/event/EventNode.java
+++ b/src/main/java/net/minestom/server/event/EventNode.java
@@ -182,21 +182,36 @@ public interface EventNode<T extends Event> {
     }
 
     /**
-     * Executes the given event on this node. The event must pass all conditions before
-     * it will be forwarded to the listeners.
-     * <p>
-     * Calling an event on a node will execute all child nodes, however, an event may be
-     * called anywhere on the event graph and it will propagate down from there only.
+     * Calls an event starting from this node.
      *
-     * @param event the event to execute
+     * @param event the event to call
      */
     default void call(@NotNull T event) {
+        //noinspection unchecked
         call(event, getHandle((Class<T>) event.getClass()));
     }
 
-    <E extends T> void call(@NotNull E event, ListenerHandle<E> handle);
+    /**
+     * Calls an event starting from this node.
+     * <p>
+     * The event handle can be retrieved using {@link #getHandle(Class)}
+     * and is useful to avoid map lookups for high-frequency events.
+     *
+     * @param event  the event to call
+     * @param handle the event handle linked to this node
+     * @param <E>    the event type
+     * @throws IllegalArgumentException if {@param handle}'s owner is not {@code this}
+     */
+    <E extends T> void call(@NotNull E event, @NotNull ListenerHandle<E> handle);
 
-    <E extends T> ListenerHandle<E> getHandle(Class<E> handleType);
+    /**
+     * Gets the handle of an event type.
+     *
+     * @param handleType the handle type
+     * @param <E>        the event type
+     * @return the handle linked to {@param handleType}
+     */
+    <E extends T> @NotNull ListenerHandle<E> getHandle(@NotNull Class<E> handleType);
 
     /**
      * Execute a cancellable event with a callback to execute if the event is successful.

--- a/src/main/java/net/minestom/server/event/EventNode.java
+++ b/src/main/java/net/minestom/server/event/EventNode.java
@@ -190,7 +190,13 @@ public interface EventNode<T extends Event> {
      *
      * @param event the event to execute
      */
-    void call(@NotNull T event);
+    default void call(@NotNull T event) {
+        call(event, getHandle((Class<T>) event.getClass()));
+    }
+
+    <E extends T> void call(@NotNull E event, ListenerHandle<E> handle);
+
+    <E extends T> ListenerHandle<E> getHandle(Class<E> handleType);
 
     /**
      * Execute a cancellable event with a callback to execute if the event is successful.

--- a/src/main/java/net/minestom/server/event/EventNodeImpl.java
+++ b/src/main/java/net/minestom/server/event/EventNodeImpl.java
@@ -58,7 +58,7 @@ class EventNodeImpl<T extends Event> implements EventNode<T> {
     }
 
     @Override
-    public <E extends T> boolean hasListener(@NotNull ListenerHandle<E> handle) {
+    public boolean hasListener(@NotNull ListenerHandle<? extends T> handle) {
         final Handle<T> castedHandle = (Handle<T>) handle;
         if (!castedHandle.updated) castedHandle.update();
         return !castedHandle.listeners.isEmpty();

--- a/src/main/java/net/minestom/server/event/EventNodeImpl.java
+++ b/src/main/java/net/minestom/server/event/EventNodeImpl.java
@@ -326,8 +326,7 @@ class EventNodeImpl<T extends Event> implements EventNode<T> {
             // Retrieve all filters used to retrieve potential handlers
             for (var mappedEntry : mappedNodeCache.entrySet()) {
                 final EventNodeImpl<E> mappedNode = mappedEntry.getValue();
-                final Class<E> mappedNodeType = mappedNode.eventType;
-                if (!mappedNodeType.isAssignableFrom(eventType)) continue;
+                if (!mappedNode.eventType.isAssignableFrom(eventType)) continue;
                 if (mappedNode.listenerMap.isEmpty())
                     continue; // The mapped node does not have any listener (perhaps throw a warning?)
                 filters.add(mappedNode.filter);

--- a/src/main/java/net/minestom/server/event/EventNodeImpl.java
+++ b/src/main/java/net/minestom/server/event/EventNodeImpl.java
@@ -383,7 +383,7 @@ class EventNodeImpl<T extends Event> implements EventNode<T> {
                 return;
             }
 
-            // Worth case scenario, try to run everything
+            // Worse case scenario, try to run everything
             this.listeners.add(e -> {
                 if (hasPredicate) {
                     final var value = filter.getHandler(e);

--- a/src/main/java/net/minestom/server/event/EventNodeImpl.java
+++ b/src/main/java/net/minestom/server/event/EventNodeImpl.java
@@ -262,10 +262,9 @@ class EventNodeImpl<T extends Event> implements EventNode<T> {
         consumer.accept(type);
         // Recursion
         if (RecursiveEvent.class.isAssignableFrom(type)) {
-            final var superclass = type.getSuperclass();
-            if (superclass != null && RecursiveEvent.class.isAssignableFrom(superclass)) consumer.accept(superclass);
-            for (var inter : type.getInterfaces()) {
-                if (RecursiveEvent.class.isAssignableFrom(inter)) consumer.accept(inter);
+            final Class<?> superclass = type.getSuperclass();
+            if (superclass != null && RecursiveEvent.class.isAssignableFrom(superclass)) {
+                forTargetEvents(superclass, consumer);
             }
         }
     }

--- a/src/main/java/net/minestom/server/event/EventNodeImpl.java
+++ b/src/main/java/net/minestom/server/event/EventNodeImpl.java
@@ -172,7 +172,7 @@ class EventNodeImpl<T extends Event> implements EventNode<T> {
     @Override
     public @NotNull EventNode<T> addListener(@NotNull EventListener<? extends T> listener) {
         synchronized (GLOBAL_CHILD_LOCK) {
-            final var eventType = listener.getEventType();
+            final var eventType = listener.eventType();
             var entry = getEntry(eventType);
             entry.listeners.add((EventListener<T>) listener);
             propagateEvent(eventType);
@@ -183,7 +183,7 @@ class EventNodeImpl<T extends Event> implements EventNode<T> {
     @Override
     public @NotNull EventNode<T> removeListener(@NotNull EventListener<? extends T> listener) {
         synchronized (GLOBAL_CHILD_LOCK) {
-            final var eventType = listener.getEventType();
+            final var eventType = listener.eventType();
             var entry = listenerMap.get(eventType);
             if (entry == null) return this;
             var listeners = entry.listeners;

--- a/src/main/java/net/minestom/server/event/EventNodeImpl.java
+++ b/src/main/java/net/minestom/server/event/EventNodeImpl.java
@@ -38,9 +38,9 @@ class EventNodeImpl<T extends Event> implements EventNode<T> {
     }
 
     @Override
-    public <E extends T> void call(@NotNull E event, ListenerHandle<E> handle) {
+    public <E extends T> void call(@NotNull E event, @NotNull ListenerHandle<E> handle) {
         var castedHandle = (Handle<T>) handle;
-        Check.stateCondition(castedHandle.node != this, "Invalid handle owner");
+        Check.argCondition(castedHandle.node != this, "Invalid handle owner");
         List<Consumer<T>> listeners = castedHandle.listeners;
         if (!castedHandle.updated) {
             synchronized (GLOBAL_CHILD_LOCK) {
@@ -56,7 +56,8 @@ class EventNodeImpl<T extends Event> implements EventNode<T> {
     }
 
     @Override
-    public <E extends T> ListenerHandle<E> getHandle(Class<E> handleType) {
+    public <E extends T> @NotNull ListenerHandle<E> getHandle(@NotNull Class<E> handleType) {
+        //noinspection unchecked
         return (ListenerHandle<E>) handleMap.computeIfAbsent(handleType,
                 aClass -> new Handle<>(this, (Class<T>) aClass));
     }

--- a/src/main/java/net/minestom/server/event/ListenerHandle.java
+++ b/src/main/java/net/minestom/server/event/ListenerHandle.java
@@ -1,0 +1,7 @@
+package net.minestom.server.event;
+
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.NonExtendable
+public interface ListenerHandle<E extends Event> {
+}

--- a/src/main/java/net/minestom/server/event/trait/RecursiveEvent.java
+++ b/src/main/java/net/minestom/server/event/trait/RecursiveEvent.java
@@ -1,0 +1,6 @@
+package net.minestom.server.event.trait;
+
+import net.minestom.server.event.Event;
+
+public interface RecursiveEvent extends Event {
+}

--- a/src/main/java/net/minestom/server/item/ItemStackBuilder.java
+++ b/src/main/java/net/minestom/server/item/ItemStackBuilder.java
@@ -51,6 +51,7 @@ public class ItemStackBuilder {
         MATERIAL_SUPPLIER_MAP.put(Material.LEATHER_CHESTPLATE, LeatherArmorMeta.Builder::new);
         MATERIAL_SUPPLIER_MAP.put(Material.LEATHER_LEGGINGS, LeatherArmorMeta.Builder::new);
         MATERIAL_SUPPLIER_MAP.put(Material.LEATHER_BOOTS, LeatherArmorMeta.Builder::new);
+        MATERIAL_SUPPLIER_MAP.put(Material.LEATHER_HORSE_ARMOR, LeatherArmorMeta.Builder::new);
     }
 
     protected ItemStackBuilder(@NotNull Material material) {


### PR DESCRIPTION
Introduce `ListenerHandle<Event>` representing a direct access to an `EventNode` listener list. Useful when an event is often called and map lookup should be avoided.

Listeners propagation also changed, each `EventNode` will cache a list of consumers for each event type. The list will be updated whenever a new listener is added to a child or itself.

This is far from being remotely usable, but this is much more efficient than the current approach (I even noticed that no event allocation is performed at all when the event does not have any listener on Hotspot JDK 16)