### PR TITLE
Fix up tab completion for EntityType

### DIFF
--- a/src/main/java/net/minestom/server/command/builder/arguments/minecraft/registry/ArgumentEntityType.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/minecraft/registry/ArgumentEntityType.java
@@ -23,7 +23,7 @@ public class ArgumentEntityType extends ArgumentRegistry<EntityType> {
     @Override
     public void processNodes(@NotNull NodeMaker nodeMaker, boolean executable) {
         DeclareCommandsPacket.Node argumentNode = simpleArgumentNode(this, executable, false, true);
-        argumentNode.parser = "minecraft:entity_summon";
+        argumentNode.parser = "minecraft:resource_location";
         argumentNode.suggestionsType = SuggestionType.SUMMONABLE_ENTITIES.getIdentifier();
 
         nodeMaker.addNodes(new DeclareCommandsPacket.Node[]{argumentNode});

--- a/src/test/java/demo/commands/SummonCommand.java
+++ b/src/test/java/demo/commands/SummonCommand.java
@@ -3,32 +3,39 @@ package demo.commands;
 import net.minestom.server.command.CommandSender;
 import net.minestom.server.command.builder.Command;
 import net.minestom.server.command.builder.CommandContext;
+import net.minestom.server.command.builder.arguments.Argument;
 import net.minestom.server.command.builder.arguments.ArgumentEnum;
 import net.minestom.server.command.builder.arguments.ArgumentType;
 import net.minestom.server.command.builder.arguments.minecraft.registry.ArgumentEntityType;
 import net.minestom.server.command.builder.arguments.relative.ArgumentRelativeVec3;
 import net.minestom.server.command.builder.condition.Conditions;
+import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.EntityCreature;
 import net.minestom.server.entity.EntityType;
 import net.minestom.server.entity.LivingEntity;
+import net.minestom.server.utils.location.RelativeVec;
 import org.jetbrains.annotations.NotNull;
 
 public class SummonCommand extends Command {
 
     private final ArgumentEntityType entity;
-    private final ArgumentRelativeVec3 pos;
-    private final ArgumentEnum<EntityClass> entityClass;
+    private final Argument<RelativeVec> pos;
+    private final Argument<EntityClass> entityClass;
 
     public SummonCommand() {
         super("summon");
         setCondition(Conditions::playerOnly);
 
         entity = ArgumentType.EntityType("entity type");
-        pos = ArgumentType.RelativeVec3("pos");
-        entityClass = ArgumentType.Enum("class", EntityClass.class);
-        entityClass.setFormat(ArgumentEnum.Format.LOWER_CASED);
-        entityClass.setDefaultValue(EntityClass.CREATURE);
+        pos = ArgumentType.RelativeVec3("pos").setDefaultValue(() -> new RelativeVec(
+                new Vec(0, 0, 0),
+                RelativeVec.CoordinateType.RELATIVE,
+                true, true, true
+        ));
+        entityClass = ArgumentType.Enum("class", EntityClass.class)
+                .setFormat(ArgumentEnum.Format.LOWER_CASED)
+                .setDefaultValue(EntityClass.CREATURE);;
         addSyntax(this::execute, entity, pos, entityClass);
         setDefaultExecutor((sender, context) -> sender.sendMessage("Usage: /summon <type> <x> <y> <z> <class>"));
     }


### PR DESCRIPTION
This uses resource_location, which makes the tab completion for entities much better.

`bee` without this PR would be red client side, while `bee` with this PR works perfectly -- 

`minecraft:bee` works for both types of arguments, however using resource_location makes it lenient.