### PR TITLE
Automatically trigger a jitpack build on new commits

### DIFF
--- a/.github/workflows/trigger-jitpack-build.yml
+++ b/.github/workflows/trigger-jitpack-build.yml
@@ -1,25 +1,12 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Trigger Jitpack Build
-
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ master ]
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Runs a single command using the runners shell
       - name: Trigger Jitpack Build
         run: curl "https://jitpack.io/com/github/Minestom/Minestom/${GITHUB_SHA:0:10}/build.log"


### PR DESCRIPTION
This PR adds a Github Action, which will trigger a jitpack build upon new commits to the master branch.

This exists, because the first person to use a commit has to wait until Jitpack builds the requested commit, and that takes a while. This PR ensures that new commits automatically get built on Jitpack, thus the waiting time is removed.