### PR TITLE
Fixing BoundingBoxes caching

### DIFF
--- a/src/main/java/net/minestom/server/collision/BoundingBox.java
+++ b/src/main/java/net/minestom/server/collision/BoundingBox.java
@@ -417,7 +417,7 @@ public class BoundingBox {
 
     private class CachedFace {
 
-        private final AtomicReference<@NotNull PositionedPoints> reference = new AtomicReference<>(new PositionedPoints());
+        private final AtomicReference<@Nullable PositionedPoints> reference = new AtomicReference<>(null);
         private final Supplier<@NotNull List<Vec>> faceProducer;
 
         private CachedFace(Supplier<@NotNull List<Vec>> faceProducer) {
@@ -425,11 +425,11 @@ public class BoundingBox {
         }
 
         @NotNull List<Vec> get() {
+            //noinspection ConstantConditions
             return reference.updateAndGet(value -> {
                 Pos entityPosition = entity.getPosition();
-                if (value.lastPosition == null || !value.lastPosition.samePoint(entityPosition)) {
-                    value.lastPosition = entityPosition;
-                    value.points = faceProducer.get();
+                if (value == null || !value.lastPosition.samePoint(entityPosition)) {
+                    return new PositionedPoints(entityPosition, faceProducer.get());
                 }
                 return value;
             }).points;
@@ -439,8 +439,13 @@ public class BoundingBox {
 
     private static class PositionedPoints {
 
-        private @Nullable Pos lastPosition;
-        private @NotNull List<Vec> points = Collections.emptyList();
+        private final @NotNull Pos lastPosition;
+        private final @NotNull List<Vec> points;
+
+        private PositionedPoints(@NotNull Pos lastPosition, @NotNull List<Vec> points) {
+            this.lastPosition = lastPosition;
+            this.points = points;
+        }
 
     }
 

--- a/src/main/java/net/minestom/server/collision/BoundingBox.java
+++ b/src/main/java/net/minestom/server/collision/BoundingBox.java
@@ -1,6 +1,5 @@
 package net.minestom.server.collision;
 
-import com.google.common.collect.ImmutableList;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
@@ -23,7 +22,7 @@ public class BoundingBox {
     private final CachedFace bottomFace = new CachedFace() {
         @Override
         @NotNull List<Vec> producePoints() {
-            return ImmutableList.of(
+            return List.of(
                     new Vec(getMinX(), getMinY(), getMinZ()),
                     new Vec(getMaxX(), getMinY(), getMinZ()),
                     new Vec(getMaxX(), getMinY(), getMaxZ()),
@@ -34,7 +33,7 @@ public class BoundingBox {
     private final CachedFace topFace = new CachedFace() {
         @Override
         @NotNull List<Vec> producePoints() {
-            return ImmutableList.of(
+            return List.of(
                     new Vec(getMinX(), getMaxY(), getMinZ()),
                     new Vec(getMaxX(), getMaxY(), getMinZ()),
                     new Vec(getMaxX(), getMaxY(), getMaxZ()),
@@ -45,7 +44,7 @@ public class BoundingBox {
     private final CachedFace leftFace = new CachedFace() {
         @Override
         @NotNull List<Vec> producePoints() {
-            return ImmutableList.of(
+            return List.of(
                     new Vec(getMinX(), getMinY(), getMinZ()),
                     new Vec(getMinX(), getMaxY(), getMinZ()),
                     new Vec(getMinX(), getMaxY(), getMaxZ()),
@@ -56,7 +55,7 @@ public class BoundingBox {
     private final CachedFace rightFace = new CachedFace() {
         @Override
         @NotNull List<Vec> producePoints() {
-            return ImmutableList.of(
+            return List.of(
                     new Vec(getMaxX(), getMinY(), getMinZ()),
                     new Vec(getMaxX(), getMaxY(), getMinZ()),
                     new Vec(getMaxX(), getMaxY(), getMaxZ()),
@@ -67,7 +66,7 @@ public class BoundingBox {
     private final CachedFace frontFace = new CachedFace() {
         @Override
         @NotNull List<Vec> producePoints() {
-            return ImmutableList.of(
+            return List.of(
                     new Vec(getMinX(), getMinY(), getMinZ()),
                     new Vec(getMaxX(), getMinY(), getMinZ()),
                     new Vec(getMaxX(), getMaxY(), getMinZ()),
@@ -78,7 +77,7 @@ public class BoundingBox {
     private final CachedFace backFace = new CachedFace() {
         @Override
         @NotNull List<Vec> producePoints() {
-            return ImmutableList.of(
+            return List.of(
                     new Vec(getMinX(), getMinY(), getMaxZ()),
                     new Vec(getMaxX(), getMinY(), getMaxZ()),
                     new Vec(getMaxX(), getMaxY(), getMaxZ()),


### PR DESCRIPTION
There was a problem with bounding boxes facings caching (which reflected to `CollisionUtils#handlePhysics` issue): if you requested more than one face during the same position of the entity, first will be updated and remain relevant, but the second one won't update and therefore remain the same as it was before. If you continue to retrieve those faces for some period of time (assuming entity is moving) in the same order, the state of the second one will be too outdated, what can lead to collision checks with blocks far away from the actual position of an entity.