### PR TITLE
Add cursor position to BlockPlacementRule

### DIFF
--- a/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java
+++ b/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java
@@ -34,10 +34,32 @@ public abstract class BlockPlacementRule {
      * @param blockPosition the block position
      * @param pl            the player who placed the block
      * @return the block to place, {@code null} to cancel
+     * 
+     * @deprecated use {@link #blockPlace(Instance, Block, BlockFace, Point, Player, Point)} instead
      */
-    public abstract @Nullable Block blockPlace(@NotNull Instance instance,
+    @Deprecated
+    public @Nullable Block blockPlace(@NotNull Instance instance,
                                                @NotNull Block block, @NotNull BlockFace blockFace, @NotNull Point blockPosition,
-                                               @NotNull Player pl);
+                                               @NotNull Player pl) {
+        return block;
+    }
+    
+    /**
+     * Called when the block is placed.
+     *
+     * @param instance        the instance of the block
+     * @param block           the block placed
+     * @param blockFace       the block face
+     * @param blockPosition   the block position
+     * @param pl              the player who placed the block
+     * @param cursorPosition  the cursor position
+     * @return the block to place, {@code null} to cancel
+     */
+    public @Nullable Block blockPlace(@NotNull Instance instance,
+                                               @NotNull Block block, @NotNull BlockFace blockFace, @NotNull Point blockPosition,
+                                               @NotNull Player pl, @Nullable Point cursorPosition) {
+        return blockPlace(instance, block, blockFace, blockPosition, pl);
+    }
 
     public @NotNull Block getBlock() {
         return block;

--- a/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
+++ b/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
@@ -150,7 +150,7 @@ public class BlockPlacementListener {
         final BlockPlacementRule blockPlacementRule = BLOCK_MANAGER.getBlockPlacementRule(resultBlock);
         if (blockPlacementRule != null) {
             // Get id from block placement rule instead of the event
-            resultBlock = blockPlacementRule.blockPlace(instance, resultBlock, blockFace, blockPosition, player);
+            resultBlock = blockPlacementRule.blockPlace(instance, resultBlock, blockFace, blockPosition, player, placementPosition);
         }
         if (resultBlock == null) {
             refresh(player, chunk);


### PR DESCRIPTION
This PR adds the cursor position parameter to BlockPlacementRule's `blockPlace` method.

BlockPlacementRule implementations currently cannot be used to create functioning slab/stair placement, as they depend on the Player's cursor (if the cursor is above 0.5 Y, then a top slab/stair block will be placed). This would require the exact cursor position.
A possible alternative is to raycast server-side, but because the player's yaw can slightly differ server-side, than client-side, it might give incorrect results.

In order to not break existing BlockPlacementRule implementations, the existing method was left in, it was marked as deprecated, and a new one with the new parameter was added. Both methods have received a default implementation, again, to not break existing BlockPlacementRule implementations (and to not require implementing the old method on newer implementations).
The old method can be:
 - left as is,
 - marked for removal, then removed later, or
 - removed completely.
 
 This PR does not yet include new implementations for the existing built-in BlockPlacementRules.