### PR TITLE
Add MessageConsumer to ConsoleSender

### DIFF
--- a/src/main/java/net/minestom/server/command/ConsoleSender.java
+++ b/src/main/java/net/minestom/server/command/ConsoleSender.java
@@ -25,15 +25,27 @@ public class ConsoleSender implements CommandSender {
     private final Set<Permission> permissions = new CopyOnWriteArraySet<>();
     private final NBTCompound nbtCompound = new NBTCompound();
 
-    @Override
-    public void sendMessage(@NotNull String message) {
-        LOGGER.info(message);
+    @FunctionalInterface
+    interface MessageConsumer {
+        void send(@NotNull Identity source, @NotNull Component message, @NotNull MessageType type);
     }
+
+    private MessageConsumer messageConsumer = (source, message, type) -> {
+        LOGGER.info(PLAIN_SERIALIZER.serialize(message));
+    };
 
     @Override
     public void sendMessage(@NotNull Identity source, @NotNull Component message, @NotNull MessageType type) {
         // we don't use the serializer here as we just need the plain text of the message
-        this.sendMessage(PLAIN_SERIALIZER.serialize(message));
+        messageConsumer.send(source, message, type);
+    }
+
+    public @NotNull MessageConsumer getMessageConsumer() {
+        return messageConsumer;
+    }
+
+    public void setMessageConsumer(@NotNull MessageConsumer messageConsumer) {
+        this.messageConsumer = messageConsumer;
     }
 
     @NotNull

--- a/src/main/java/net/minestom/server/command/ConsoleSender.java
+++ b/src/main/java/net/minestom/server/command/ConsoleSender.java
@@ -6,6 +6,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.minestom.server.permission.Permission;
 import net.minestom.server.tag.Tag;
+import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jglrxavpok.hephaistos.nbt.NBTCompound;
@@ -45,6 +46,9 @@ public class ConsoleSender implements CommandSender {
     }
 
     public void setMessageConsumer(@NotNull MessageConsumer messageConsumer) {
+
+        Check.notNull(messageConsumer, "Message consumer can not be null!");
+
         this.messageConsumer = messageConsumer;
     }
 


### PR DESCRIPTION
This allows developers to hook into ConsoleSender without permissions, for example:

> In-game console sending
> Rendering components in console
> Redirecting to a live console