### PR TITLE
Use Pre/PostCommandEvent instead of CommandEvent, give CommandResult

### DIFF
--- a/src/main/java/net/minestom/server/command/CommandManager.java
+++ b/src/main/java/net/minestom/server/command/CommandManager.java
@@ -115,7 +115,7 @@ public final class CommandManager {
             }
         }
 
-        PostCommandEvent postCommandEvent = new PostCommandEvent(player, command, result);
+        PostCommandEvent postCommandEvent = new PostCommandEvent(sender, command, result);
         EventDispatcher.call(postCommandEvent);
 
         return result;

--- a/src/main/java/net/minestom/server/command/CommandManager.java
+++ b/src/main/java/net/minestom/server/command/CommandManager.java
@@ -101,8 +101,7 @@ public final class CommandManager {
      */
     public @NotNull CommandResult execute(@NotNull CommandSender sender, @NotNull String command) {
         // Command event
-        final Player player = (Player) sender;
-        PreCommandEvent preCommandEvent = new PreCommandEvent(player, command);
+        PreCommandEvent preCommandEvent = new PreCommandEvent(sender, command);
         EventDispatcher.call(preCommandEvent);
         if (preCommandEvent.isCancelled())
             return CommandResult.of(CommandResult.Type.CANCELLED, command);

--- a/src/main/java/net/minestom/server/command/CommandManager.java
+++ b/src/main/java/net/minestom/server/command/CommandManager.java
@@ -115,7 +115,7 @@ public final class CommandManager {
             }
         }
 
-        PostCommandEvent postCommandEvent = new PostCommandEvent(sender, command, result);
+        PostCommandEvent postCommandEvent = new PostCommandEvent(sender, result);
         EventDispatcher.call(postCommandEvent);
 
         return result;

--- a/src/main/java/net/minestom/server/event/command/CommandEvent.java
+++ b/src/main/java/net/minestom/server/event/command/CommandEvent.java
@@ -1,0 +1,19 @@
+package net.minestom.server.event.command;
+
+import net.minestom.server.command.CommandSender;
+import net.minestom.server.event.Event;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called every time a sender sends a command.
+ */
+interface CommandEvent extends Event {
+    @NotNull CommandSender getSender();
+
+    /**
+     * Gets the command used (command name + arguments).
+     *
+     * @return the command that the player wants to execute
+     */
+    @NotNull String getCommand();
+}

--- a/src/main/java/net/minestom/server/event/command/CommandEvent.java
+++ b/src/main/java/net/minestom/server/event/command/CommandEvent.java
@@ -9,11 +9,4 @@ import org.jetbrains.annotations.NotNull;
  */
 interface CommandEvent extends Event {
     @NotNull CommandSender getSender();
-
-    /**
-     * Gets the command used (command name + arguments).
-     *
-     * @return the command that the player wants to execute
-     */
-    @NotNull String getCommand();
 }

--- a/src/main/java/net/minestom/server/event/command/PostCommandEvent.java
+++ b/src/main/java/net/minestom/server/event/command/PostCommandEvent.java
@@ -12,6 +12,7 @@ public class PostCommandEvent implements CommandEvent {
 
     private final CommandSender sender;
     private final String command;
+    private final CommandResult commandResult;
 
     public PostCommandEvent(
             @NotNull CommandSender sender,
@@ -20,6 +21,7 @@ public class PostCommandEvent implements CommandEvent {
     ) {
         this.sender = sender;
         this.command = command;
+        this.commandResult = commandResult;
     }
 
     @Override
@@ -32,8 +34,15 @@ public class PostCommandEvent implements CommandEvent {
      *
      * @return the command that the player wants to execute
      */
-    @Override
     public @NotNull String getCommand() {
         return command;
+    }
+
+    /**
+     * Gets the command result from the command.
+     * @return The command result from the command.
+     */
+    public @NotNull CommandResult getCommandResult() {
+        return commandResult;
     }
 }

--- a/src/main/java/net/minestom/server/event/command/PostCommandEvent.java
+++ b/src/main/java/net/minestom/server/event/command/PostCommandEvent.java
@@ -1,0 +1,39 @@
+package net.minestom.server.event.command;
+
+import net.minestom.server.command.CommandSender;
+import net.minestom.server.command.builder.CommandResult;
+import net.minestom.server.event.trait.CancellableEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called after a command is processed by the command manager
+ */
+public class PostCommandEvent implements CommandEvent {
+
+    private final CommandSender sender;
+    private final String command;
+
+    public PostCommandEvent(
+            @NotNull CommandSender sender,
+            @NotNull String command,
+            @NotNull CommandResult commandResult
+    ) {
+        this.sender = sender;
+        this.command = command;
+    }
+
+    @Override
+    public @NotNull CommandSender getSender() {
+        return sender;
+    }
+
+    /**
+     * Gets the command used (command name + arguments).
+     *
+     * @return the command that the player wants to execute
+     */
+    @Override
+    public @NotNull String getCommand() {
+        return command;
+    }
+}

--- a/src/main/java/net/minestom/server/event/command/PostCommandEvent.java
+++ b/src/main/java/net/minestom/server/event/command/PostCommandEvent.java
@@ -11,31 +11,19 @@ import org.jetbrains.annotations.NotNull;
 public class PostCommandEvent implements CommandEvent {
 
     private final CommandSender sender;
-    private final String command;
     private final CommandResult commandResult;
 
     public PostCommandEvent(
             @NotNull CommandSender sender,
-            @NotNull String command,
             @NotNull CommandResult commandResult
     ) {
         this.sender = sender;
-        this.command = command;
         this.commandResult = commandResult;
     }
 
     @Override
     public @NotNull CommandSender getSender() {
         return sender;
-    }
-
-    /**
-     * Gets the command used (command name + arguments).
-     *
-     * @return the command that the player wants to execute
-     */
-    public @NotNull String getCommand() {
-        return command;
     }
 
     /**

--- a/src/main/java/net/minestom/server/event/command/PreCommandEvent.java
+++ b/src/main/java/net/minestom/server/event/command/PreCommandEvent.java
@@ -1,23 +1,26 @@
-package net.minestom.server.event.player;
+package net.minestom.server.event.command;
 
-import net.minestom.server.entity.Player;
+import net.minestom.server.command.CommandSender;
 import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.PlayerEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Called every time a player send a message starting by '/'.
+ * Called before a command is processed by the command manager
  */
-public class PlayerCommandEvent implements PlayerEvent, CancellableEvent {
+public class PreCommandEvent implements CommandEvent, CancellableEvent {
 
-    private final Player player;
+    private final CommandSender sender;
     private String command;
-
     private boolean cancelled;
 
-    public PlayerCommandEvent(@NotNull Player player, @NotNull String command) {
-        this.player = player;
+    public PreCommandEvent(@NotNull CommandSender sender, @NotNull String command) {
+        this.sender = sender;
         this.command = command;
+    }
+
+    @Override
+    public @NotNull CommandSender getSender() {
+        return sender;
     }
 
     /**
@@ -25,16 +28,11 @@ public class PlayerCommandEvent implements PlayerEvent, CancellableEvent {
      *
      * @return the command that the player wants to execute
      */
-    @NotNull
-    public String getCommand() {
+    @Override
+    public @NotNull String getCommand() {
         return command;
     }
 
-    /**
-     * Changes the command to execute.
-     *
-     * @param command the new command
-     */
     public void setCommand(@NotNull String command) {
         this.command = command;
     }
@@ -47,10 +45,5 @@ public class PlayerCommandEvent implements PlayerEvent, CancellableEvent {
     @Override
     public void setCancelled(boolean cancel) {
         this.cancelled = cancel;
-    }
-
-    @Override
-    public @NotNull Player getPlayer() {
-        return player;
     }
 }

--- a/src/main/java/net/minestom/server/event/command/PreCommandEvent.java
+++ b/src/main/java/net/minestom/server/event/command/PreCommandEvent.java
@@ -28,7 +28,6 @@ public class PreCommandEvent implements CommandEvent, CancellableEvent {
      *
      * @return the command that the player wants to execute
      */
-    @Override
     public @NotNull String getCommand() {
         return command;
     }


### PR DESCRIPTION
This pull request expands the command events, making a CommandEvent interface, a PreCommandEvent for changing the command, and a PostCommandEvent for getting the result of the command the `CommandSender` ran.