### PR TITLE
Implemented BlockGetter for Block Batches

### DIFF
--- a/src/main/java/net/minestom/server/instance/batch/AbsoluteBlockBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/AbsoluteBlockBatch.java
@@ -66,6 +66,23 @@ public class AbsoluteBlockBatch implements Batch<Runnable> {
     }
 
     @Override
+    public @Nullable Block getBlock(int x, int y, int z, @NotNull Condition condition) {
+        final int chunkX = ChunkUtils.getChunkCoordinate(x);
+        final int chunkZ = ChunkUtils.getChunkCoordinate(z);
+        final long chunkIndex = ChunkUtils.getChunkIndex(chunkX, chunkZ);
+
+        final ChunkBatch chunkBatch = chunkBatchesMap.get(chunkIndex);
+        if (chunkBatch == null) {
+            return condition == Condition.NONE ? Block.AIR : null;
+        }
+
+        final int relativeX = x - (chunkX * Chunk.CHUNK_SIZE_X);
+        final int relativeZ = z - (chunkZ * Chunk.CHUNK_SIZE_Z);
+
+        return chunkBatch.getBlock(relativeX, y, relativeZ, condition);
+    }
+
+    @Override
     public void clear() {
         synchronized (chunkBatchesMap) {
             this.chunkBatchesMap.clear();

--- a/src/main/java/net/minestom/server/instance/batch/Batch.java
+++ b/src/main/java/net/minestom/server/instance/batch/Batch.java
@@ -2,6 +2,7 @@ package net.minestom.server.instance.batch;
 
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.instance.Instance;
+import net.minestom.server.instance.block.BlockGetter;
 import net.minestom.server.instance.block.BlockSetter;
 import net.minestom.server.utils.thread.MinestomThread;
 import org.jetbrains.annotations.NotNull;
@@ -27,7 +28,7 @@ import java.util.concurrent.ExecutorService;
  * @see AbsoluteBlockBatch
  * @see RelativeBlockBatch
  */
-public interface Batch<C> extends BlockSetter {
+public interface Batch<C> extends BlockSetter, BlockGetter {
 
     ExecutorService BLOCK_BATCH_POOL = new MinestomThread(
             MinecraftServer.THREAD_COUNT_BLOCK_BATCH,

--- a/src/main/java/net/minestom/server/instance/batch/ChunkBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/ChunkBatch.java
@@ -59,6 +59,16 @@ public class ChunkBatch implements Batch<ChunkCallback> {
             this.blocks.put(index, block);
         }
     }
+    @Override
+    public @Nullable Block getBlock(int x, int y, int z, @NotNull Condition condition) {
+        final int index = ChunkUtils.getBlockIndex(x, y, z);
+        final var block = this.blocks.get(index);
+
+        if (block == null) {
+            return condition == Condition.NONE ? Block.AIR : null;
+        }
+        return block;
+    }
 
     @Override
     public void clear() {

--- a/src/main/java/net/minestom/server/instance/batch/RelativeBlockBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/RelativeBlockBatch.java
@@ -80,6 +80,34 @@ public class RelativeBlockBatch implements Batch<Runnable> {
     }
 
     @Override
+    public @Nullable Block getBlock(int x, int y, int z, @NotNull Condition condition) {
+        if (firstEntry) {
+            // no blocks, so we immediately exit
+            return condition == Condition.NONE ? Block.AIR : null;
+        }
+
+        x -= offsetX;
+        y -= offsetY;
+        z -= offsetZ;
+
+        Check.argCondition(Math.abs(x) > Short.MAX_VALUE, "Relative x position may not be more than 16 bits long.");
+        Check.argCondition(Math.abs(y) > Short.MAX_VALUE, "Relative y position may not be more than 16 bits long.");
+        Check.argCondition(Math.abs(z) > Short.MAX_VALUE, "Relative z position may not be more than 16 bits long.");
+
+        long pos = Short.toUnsignedLong((short)x);
+        pos = (pos << 16) | Short.toUnsignedLong((short)y);
+        pos = (pos << 16) | Short.toUnsignedLong((short)z);
+
+        final var block = this.blockIdMap.get(pos);
+
+        if (block == null) {
+            return condition == Condition.NONE ? Block.AIR : null;
+        }
+
+        return block;
+    }
+
+    @Override
     public void clear() {
         synchronized (blockIdMap) {
             this.blockIdMap.clear();


### PR DESCRIPTION
In order to be able to test code that creates block batches, we need to be able to read the blocks out of a block batch. By implementing BlockGetter, it is not possible to read the data out of a block batch.

The condition is just used to determine what the return value should be if there is not block in the given position. It does not do any amount of filtering based on what blocks have handlers or NBT data.