### PR TITLE
Chunk-related improvements

### DIFF
--- a/src/main/java/net/minestom/server/event/instance/InstanceChunkLoadEvent.java
+++ b/src/main/java/net/minestom/server/event/instance/InstanceChunkLoadEvent.java
@@ -1,6 +1,7 @@
 package net.minestom.server.event.instance;
 
 import net.minestom.server.event.trait.InstanceEvent;
+import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.Instance;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,12 +11,11 @@ import org.jetbrains.annotations.NotNull;
 public class InstanceChunkLoadEvent implements InstanceEvent {
 
     private final Instance instance;
-    private final int chunkX, chunkZ;
+    private final Chunk chunk;
 
-    public InstanceChunkLoadEvent(@NotNull Instance instance, int chunkX, int chunkZ) {
+    public InstanceChunkLoadEvent(@NotNull Instance instance, @NotNull Chunk chunk) {
         this.instance = instance;
-        this.chunkX = chunkX;
-        this.chunkZ = chunkZ;
+        this.chunk = chunk;
     }
 
     @Override
@@ -29,7 +29,7 @@ public class InstanceChunkLoadEvent implements InstanceEvent {
      * @return the chunk X
      */
     public int getChunkX() {
-        return chunkX;
+        return chunk.getChunkX();
     }
 
     /**
@@ -38,6 +38,15 @@ public class InstanceChunkLoadEvent implements InstanceEvent {
      * @return the chunk Z
      */
     public int getChunkZ() {
-        return chunkZ;
+        return chunk.getChunkZ();
+    }
+
+    /**
+     * Gets the chunk.
+     *
+     * @return the chunk.
+     */
+    public @NotNull Chunk getChunk() {
+        return chunk;
     }
 }

--- a/src/main/java/net/minestom/server/event/instance/InstanceChunkUnloadEvent.java
+++ b/src/main/java/net/minestom/server/event/instance/InstanceChunkUnloadEvent.java
@@ -1,6 +1,7 @@
 package net.minestom.server.event.instance;
 
 import net.minestom.server.event.trait.InstanceEvent;
+import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.Instance;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,12 +11,11 @@ import org.jetbrains.annotations.NotNull;
 public class InstanceChunkUnloadEvent implements InstanceEvent {
 
     private final Instance instance;
-    private final int chunkX, chunkZ;
+    private final Chunk chunk;
 
-    public InstanceChunkUnloadEvent(@NotNull Instance instance, int chunkX, int chunkZ) {
+    public InstanceChunkUnloadEvent(@NotNull Instance instance, @NotNull Chunk chunk) {
         this.instance = instance;
-        this.chunkX = chunkX;
-        this.chunkZ = chunkZ;
+        this.chunk = chunk;
     }
 
     @Override
@@ -29,7 +29,7 @@ public class InstanceChunkUnloadEvent implements InstanceEvent {
      * @return the chunk X
      */
     public int getChunkX() {
-        return chunkX;
+        return chunk.getChunkX();
     }
 
     /**
@@ -38,6 +38,15 @@ public class InstanceChunkUnloadEvent implements InstanceEvent {
      * @return the chunk Z
      */
     public int getChunkZ() {
-        return chunkZ;
+        return chunk.getChunkZ();
+    }
+
+    /**
+     * Gets the chunk.
+     *
+     * @return the chunk.
+     */
+    public @NotNull Chunk getChunk() {
+        return chunk;
     }
 }

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -550,7 +550,7 @@ public abstract class Instance implements BlockGetter, BlockSetter, Tickable, Ta
     /**
      * Gets the {@link Chunk} at the given {@link Point}, null if not loaded.
      *
-     * @param point the chunk position
+     * @param point the position
      * @return the chunk at the given position, null if not loaded
      */
     public @Nullable Chunk getChunkAt(@NotNull Point point) {

--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -217,7 +217,7 @@ public class InstanceContainer extends Instance {
             chunk.removeViewer(viewer);
         }
 
-        EventDispatcher.call(new InstanceChunkUnloadEvent(this, chunkX, chunkZ));
+        EventDispatcher.call(new InstanceChunkUnloadEvent(this, chunk));
         // Remove all entities in chunk
         getChunkEntities(chunk).forEach(entity -> {
             if (!(entity instanceof Player)) entity.remove();
@@ -272,7 +272,7 @@ public class InstanceContainer extends Instance {
                 .whenComplete((chunk, throwable) -> {
                     // TODO run in the instance thread?
                     cacheChunk(chunk);
-                    GlobalHandles.INSTANCE_CHUNK_LOAD.call(new InstanceChunkLoadEvent(this, chunkX, chunkZ));
+                    GlobalHandles.INSTANCE_CHUNK_LOAD.call(new InstanceChunkLoadEvent(this, chunk));
                     synchronized (loadingChunks) {
                         this.loadingChunks.remove(ChunkUtils.getChunkIndex(chunk));
                     }


### PR DESCRIPTION
1. `InstanceChunkLoadEvent` and `InstanceChunkUnloadEvent` now have exact references to a chunk (previous there were only coordinates), because listener would like to retrieve `Chunk` instance itself to do something about it pretty much always.
2. There are `Instance#getChunks` and `Instance#getChunksAt` methods which decrease synchronizations count in `InstanceContainer` drastically whenever you need to get (or check whether they're loaded) multiple chunks at once.