### PR TITLE
Add chunk reference to Tick, blockPosition (Tick) -> relativeBlockPosition

### DIFF
--- a/src/main/java/net/minestom/server/instance/DynamicChunk.java
+++ b/src/main/java/net/minestom/server/instance/DynamicChunk.java
@@ -93,11 +93,11 @@ public class DynamicChunk extends Chunk {
             final Block block = entry.getValue();
             final BlockHandler handler = block.handler();
             if (handler == null) return;
-            final int x = ChunkUtils.blockIndexToChunkPositionX(index);
-            final int y = ChunkUtils.blockIndexToChunkPositionY(index);
-            final int z = ChunkUtils.blockIndexToChunkPositionZ(index);
+            final int x = ChunkUtils.blockIndexToPositionX(index, chunkX);
+            final int y = ChunkUtils.blockIndexToPositionY(index);
+            final int z = ChunkUtils.blockIndexToPositionZ(index, chunkZ);
             final Vec blockPosition = new Vec(x, y, z);
-            handler.tick(new BlockHandler.Tick(block, instance, blockPosition, this));
+            handler.tick(new BlockHandler.Tick(block, instance, blockPosition));
         });
     }
 

--- a/src/main/java/net/minestom/server/instance/DynamicChunk.java
+++ b/src/main/java/net/minestom/server/instance/DynamicChunk.java
@@ -97,7 +97,7 @@ public class DynamicChunk extends Chunk {
             final int y = ChunkUtils.blockIndexToChunkPositionY(index);
             final int z = ChunkUtils.blockIndexToChunkPositionZ(index);
             final Vec blockPosition = new Vec(x, y, z);
-            handler.tick(new BlockHandler.Tick(block, instance, blockPosition));
+            handler.tick(new BlockHandler.Tick(block, instance, blockPosition, this));
         });
     }
 

--- a/src/main/java/net/minestom/server/instance/block/BlockHandler.java
+++ b/src/main/java/net/minestom/server/instance/block/BlockHandler.java
@@ -3,8 +3,6 @@ package net.minestom.server.instance.block;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.Player;
-import net.minestom.server.instance.Chunk;
-import net.minestom.server.instance.DynamicChunk;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.tag.Tag;
 import net.minestom.server.utils.NamespaceID;

--- a/src/main/java/net/minestom/server/instance/block/BlockHandler.java
+++ b/src/main/java/net/minestom/server/instance/block/BlockHandler.java
@@ -271,15 +271,13 @@ public interface BlockHandler {
     class Tick {
         private final Block block;
         private final Instance instance;
-        private final Point relativeBlockPosition;
-        private final DynamicChunk chunk;
+        private final Point blockPosition;
 
         @ApiStatus.Internal
-        public Tick(Block block, Instance instance, Point relativeBlockPosition, DynamicChunk chunk) {
+        public Tick(Block block, Instance instance, Point blockPosition) {
             this.block = block;
             this.instance = instance;
-            this.relativeBlockPosition = relativeBlockPosition;
-            this.chunk = chunk;
+            this.blockPosition = blockPosition;
         }
 
         public @NotNull Block getBlock() {
@@ -290,17 +288,8 @@ public interface BlockHandler {
             return instance;
         }
 
-        /**
-         * Gets the block position relative to this {@link Tick}'s {@link DynamicChunk}
-         * 
-         * @return The relative block position to this Chunk
-         */
-        public @NotNull Point getRelativeBlockPosition() {
-            return relativeBlockPosition;
-        }
-
-        public @NotNull DynamicChunk getChunk() {
-            return chunk;
+        public @NotNull Point getBlockPosition() {
+            return blockPosition;
         }
     }
 

--- a/src/main/java/net/minestom/server/instance/block/BlockHandler.java
+++ b/src/main/java/net/minestom/server/instance/block/BlockHandler.java
@@ -3,6 +3,8 @@ package net.minestom.server.instance.block;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.Player;
+import net.minestom.server.instance.Chunk;
+import net.minestom.server.instance.DynamicChunk;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.tag.Tag;
 import net.minestom.server.utils.NamespaceID;
@@ -269,13 +271,15 @@ public interface BlockHandler {
     class Tick {
         private final Block block;
         private final Instance instance;
-        private final Point blockPosition;
+        private final Point relativeBlockPosition;
+        private final DynamicChunk chunk;
 
         @ApiStatus.Internal
-        public Tick(Block block, Instance instance, Point blockPosition) {
+        public Tick(Block block, Instance instance, Point relativeBlockPosition, DynamicChunk chunk) {
             this.block = block;
             this.instance = instance;
-            this.blockPosition = blockPosition;
+            this.relativeBlockPosition = relativeBlockPosition;
+            this.chunk = chunk;
         }
 
         public @NotNull Block getBlock() {
@@ -286,8 +290,17 @@ public interface BlockHandler {
             return instance;
         }
 
-        public @NotNull Point getBlockPosition() {
-            return blockPosition;
+        /**
+         * Gets the block position relative to this {@link Tick}'s {@link DynamicChunk}
+         * 
+         * @return The relative block position to this Chunk
+         */
+        public @NotNull Point getRelativeBlockPosition() {
+            return relativeBlockPosition;
+        }
+
+        public @NotNull DynamicChunk getChunk() {
+            return chunk;
         }
     }
 


### PR DESCRIPTION
This allows getting the absolute position of a block in Tick, and clears up the naming of blockPosition to relativeBlockPosition for Tick (and other future events which may be relative to the chunk).

(If requested) add a blockPosition as well with the relativeBlockPosition?