### PR TITLE
Use proper logging to log class loader finalization

### DIFF
--- a/src/main/java/net/minestom/server/extras/selfmodification/MinestomExtensionClassLoader.java
+++ b/src/main/java/net/minestom/server/extras/selfmodification/MinestomExtensionClassLoader.java
@@ -1,5 +1,8 @@
 package net.minestom.server.extras.selfmodification;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -14,6 +17,8 @@ public class MinestomExtensionClassLoader extends HierarchyClassLoader {
      * Main of the main class of the extension linked to this classloader
      */
     private final String mainClassName;
+
+    private final Logger logger = LoggerFactory.getLogger(MinestomExtensionClassLoader.class);
 
     public MinestomExtensionClassLoader(String extensionName, String mainClassName, URL[] urls, MinestomRootClassLoader root) {
         super(extensionName, urls, root);
@@ -95,7 +100,7 @@ public class MinestomExtensionClassLoader extends HierarchyClassLoader {
     @Override
     protected void finalize() throws Throwable {
         super.finalize();
-        System.err.println("Class loader "+getName()+" finalized.");
+        logger.info("Class loader " + getName() + " finalized.");
     }
 
     /**


### PR DESCRIPTION
This uses the proper slf4j logger instead of println, meaning log messages for finalized class loaders can appear in proper logged format.

Note: Seeing 2 different formats in the console has been hurting for a week and I finally bothered to do something about it.
![image](https://user-images.githubusercontent.com/26509014/132962306-e8940e89-9615-40f3-a031-4b1b55fa3313.png)
