### PR TITLE
Inline packet write

### DIFF
--- a/src/main/java/net/minestom/server/network/player/PlayerSocketConnection.java
+++ b/src/main/java/net/minestom/server/network/player/PlayerSocketConnection.java
@@ -262,18 +262,18 @@ public class PlayerSocketConnection extends PlayerConnection {
                 compressed = this.compressed;
                 final BinaryBuffer localBuffer = tickBuffer.getPlain();
                 if (localBuffer.canWrite(512)) { // Inline threshold
-                    var buff = localBuffer.writerBuffer();
+                    ByteBuffer buff = localBuffer.writerBuffer();
                     PacketUtils.writeFramedPacket(buff, packet, compressed);
-                    localBuffer.reset(localBuffer.readerOffset(), buff.position());
-                } else {
-                    write(PacketUtils.createFramedPacket(packet, compressed).flip());
-                    flush();
+                    localBuffer.writerOffset(buff.position());
+                    return;
                 }
             }
-        } catch (BufferOverflowException e) {
-            write(PacketUtils.createFramedPacket(packet, compressed).flip());
-            flush();
+        } catch (BufferOverflowException ignored) {
+            // Empty
         }
+        // Fallback code
+        write(PacketUtils.createFramedPacket(packet, compressed).flip());
+        flush();
     }
 
     public void writeAndFlush(@NotNull ServerPacket packet) {

--- a/src/main/java/net/minestom/server/utils/binary/BinaryBuffer.java
+++ b/src/main/java/net/minestom/server/utils/binary/BinaryBuffer.java
@@ -102,6 +102,10 @@ public final class BinaryBuffer {
         return writerOffset;
     }
 
+    public void writerOffset(int offset) {
+        this.writerOffset = offset;
+    }
+
     public int readableBytes() {
         return writerOffset - readerOffset;
     }

--- a/src/main/java/net/minestom/server/utils/binary/BinaryBuffer.java
+++ b/src/main/java/net/minestom/server/utils/binary/BinaryBuffer.java
@@ -132,6 +132,10 @@ public final class BinaryBuffer {
         return nioBuffer.position(reader).slice().limit(writer);
     }
 
+    public ByteBuffer writerBuffer() {
+        return nioBuffer.position(writerOffset);
+    }
+
     public boolean writeChannel(WritableByteChannel channel) throws IOException {
         var writeBuffer = asByteBuffer(readerOffset, writerOffset - readerOffset);
         final int count = channel.write(writeBuffer);


### PR DESCRIPTION
Try to avoid a memory copy from the thread local buffer to the player connection.

JMH shows a small but noticeable improvement:
```
Benchmark                     Mode  Cnt         Score          Error  Units
PacketWriteTest.copyWrite    thrpt    3  35319600.471 �} 10306408.493  ops/s
PacketWriteTest.inlineWrite  thrpt    3  40448569.545 �} 22039721.401  ops/s
```

Requires more testing to ensure no regression.