### PR TITLE
Entity#lookAt

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -40,6 +40,7 @@ import net.minestom.server.utils.block.BlockIterator;
 import net.minestom.server.utils.chunk.ChunkUtils;
 import net.minestom.server.utils.entity.EntityUtils;
 import net.minestom.server.utils.player.PlayerUtils;
+import net.minestom.server.utils.position.PositionUtils;
 import net.minestom.server.utils.time.Cooldown;
 import net.minestom.server.utils.time.TimeUnit;
 import net.minestom.server.utils.validate.Check;
@@ -278,6 +279,29 @@ public class Entity implements Viewable, Tickable, TagHandler, PermissionHandler
         this.position = position.withView(yaw, pitch);
         sendPacketToViewersAndSelf(new EntityHeadLookPacket(getEntityId(), yaw));
         sendPacketToViewersAndSelf(new EntityRotationPacket(getEntityId(), yaw, pitch, onGround));
+    }
+
+    /**
+     * Changes the view of the entity so that it looks in a direction to the given position.
+     *
+     * @param position the position to look at.
+     */
+    public void lookAt(@NotNull Pos position) {
+        Vec delta = position.sub(getPosition()).asVec().normalize();
+        setView(
+                PositionUtils.getLookYaw(delta.x(), delta.z()),
+                PositionUtils.getLookPitch(delta.x(), delta.y(), delta.z())
+        );
+    }
+
+    /**
+     * Changes the view of the entity so that it looks in a direction to the given entity.
+     *
+     * @param entity the entity to look at.
+     */
+    public void lookAt(@NotNull Entity entity) {
+        Check.argCondition(entity.instance != instance, "Entity can look at another entity that is within it's own instance");
+        lookAt(entity.position);
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/ai/goal/CombinedAttackGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/CombinedAttackGoal.java
@@ -198,6 +198,7 @@ public class CombinedAttackGoal extends GoalSelector {
             if (pathPosition != null) {
                 navigator.setPathTo(null);
             }
+            this.entityCreature.lookAt(target);
             return;
         }
         // Otherwise going to the target.

--- a/src/main/java/net/minestom/server/entity/ai/goal/FollowTargetGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/FollowTargetGoal.java
@@ -60,8 +60,7 @@ public class FollowTargetGoal extends GoalSelector {
             navigator.setPathTo(null);
             return;
         }
-        if (navigator.getPathPosition() == null ||
-                (!navigator.getPathPosition().samePoint(lastTargetPos))) {
+        if (navigator.getPathPosition() == null || !navigator.getPathPosition().samePoint(lastTargetPos)) {
             navigator.setPathTo(lastTargetPos);
         } else {
             forceEnd = true;

--- a/src/main/java/net/minestom/server/entity/ai/goal/MeleeAttackGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/MeleeAttackGoal.java
@@ -81,6 +81,7 @@ public class MeleeAttackGoal extends GoalSelector {
 
             // Attack the target entity
             if (entityCreature.getDistance(target) <= range) {
+                entityCreature.lookAt(target);
                 if (!Cooldown.hasCooldown(time, lastHit, delay)) {
                     entityCreature.attack(target, true);
                     this.lastHit = time;

--- a/src/main/java/net/minestom/server/entity/ai/goal/RangedAttackGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/RangedAttackGoal.java
@@ -124,6 +124,7 @@ public class RangedAttackGoal extends GoalSelector {
             if (pathPosition != null) {
                 navigator.setPathTo(null);
             }
+            this.entityCreature.lookAt(target);
             return;
         }
         final var targetPosition = target.getPosition();


### PR DESCRIPTION
Added methods for settings entity's view to be pointed towards given position/another entity.
Updating entity's view when it's within attackable range (currently entity stops it's rotations when comes closely to it's target and just hits despite the fact it may look in a completely different direction).