### PR TITLE
EntityProjectile improvements

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -1547,8 +1547,7 @@ public class Entity implements Viewable, Tickable, TagHandler, PermissionHandler
 
         var it = new BlockIterator(start, direction.normalize(), 0D, maxDistance);
         while (it.hasNext()) {
-            Block block = instance.getBlock(it.next());
-            if (!block.isAir() && !block.isLiquid()) {
+            if (instance.getBlock(it.next()).isSolid()) {
                 return false;
             }
         }
@@ -1585,8 +1584,7 @@ public class Entity implements Viewable, Tickable, TagHandler, PermissionHandler
         var iterator = new BlockIterator(start, direction.normalize(), 0D, maxDistance);
         while (iterator.hasNext()) {
             Point blockPos = iterator.next();
-            Block block = instance.getBlock(blockPos);
-            if (!block.isAir() && !block.isLiquid()) {
+            if (instance.getBlock(blockPos).isSolid()) {
                 maxVisibleDistanceSquared = blockPos.distanceSquared(position);
                 break;
             }

--- a/src/main/java/net/minestom/server/entity/EntityProjectile.java
+++ b/src/main/java/net/minestom/server/entity/EntityProjectile.java
@@ -153,8 +153,7 @@ public class EntityProjectile extends Entity {
             } else {
                 pos = pos.add(direction);
             }
-            Block block = instance.getBlock(pos);
-            if (!block.isAir() && !block.isLiquid()) {
+            if (instance.getBlock(pos).isSolid()) {
                 teleport(pos);
                 return true;
             }

--- a/src/main/java/net/minestom/server/entity/EntityProjectile.java
+++ b/src/main/java/net/minestom/server/entity/EntityProjectile.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Class that allows to instantiate entities with projectile-like physics handling.
@@ -165,17 +166,18 @@ public class EntityProjectile extends Entity {
                         .filter(entity -> entity instanceof LivingEntity)
                         .collect(Collectors.toSet());
             }
+
+            final Pos finalPos = pos;
+            Stream<Entity> victims = entities.stream().filter(entity -> entity.getBoundingBox().intersect(finalPos));
+
             /*
-              We won't check collisions with entities for first ticks of arrow's life, because it spawns in the
-              shooter and will immediately damage him.
+              We won't check collisions with self for first ticks of arrow's life, because it spawns in the
+              shooter and will immediately be triggered by him.
              */
             if (getAliveTicks() < 3) {
-                continue;
+                victims = victims.filter(entity -> entity != getShooter());
             }
-            final Pos finalPos = pos;
-            Optional<Entity> victimOptional = entities.stream()
-                    .filter(entity -> entity.getBoundingBox().intersect(finalPos))
-                    .findAny();
+            Optional<Entity> victimOptional = victims.findAny();
             if (victimOptional.isPresent()) {
                 LivingEntity victim = (LivingEntity) victimOptional.get();
                 victim.setArrowCount(victim.getArrowCount() + 1);

--- a/src/test/java/demo/commands/ShootCommand.java
+++ b/src/test/java/demo/commands/ShootCommand.java
@@ -20,17 +20,17 @@ public class ShootCommand extends Command {
         super("shoot");
         setCondition(Conditions::playerOnly);
         setDefaultExecutor(this::defaultExecutor);
-        var typeArg = ArgumentType.Word("type").from("default", "spectral", "colored");
+        var typeArg = ArgumentType.Word("type").from("default", "spectral", "colored", "ender");
         setArgumentCallback(this::onTypeError, typeArg);
         addSyntax(this::onShootCommand, typeArg);
     }
 
     private void defaultExecutor(CommandSender sender, CommandContext context) {
-        sender.sendMessage(Component.text("Correct usage: shoot [default/spectral/colored]"));
+        sender.sendMessage(Component.text("Correct usage: shoot [default/spectral/colored/ender]"));
     }
 
     private void onTypeError(CommandSender sender, ArgumentSyntaxException exception) {
-        sender.sendMessage(Component.text("SYNTAX ERROR: '" + exception.getInput() + "' should be replaced by 'default', 'spectral' or 'colored'"));
+        sender.sendMessage(Component.text("SYNTAX ERROR: '" + exception.getInput() + "' should be replaced by 'default', 'spectral', 'colored' or 'ender'"));
     }
 
     private void onShootCommand(CommandSender sender, CommandContext context) {
@@ -39,15 +39,18 @@ public class ShootCommand extends Command {
         EntityProjectile projectile;
         switch (mode) {
             case "default":
-                projectile = new EntityProjectile(player, EntityType.ARROW);
+                projectile = new EntityProjectile.EntityArrow(player, false);
                 break;
             case "spectral":
-                projectile = new EntityProjectile(player, EntityType.SPECTRAL_ARROW);
+                projectile = new EntityProjectile.EntityArrow(player, true);
                 break;
             case "colored":
-                projectile = new EntityProjectile(player, EntityType.ARROW);
+                projectile = new EntityProjectile.EntityArrow(player, false);
                 var meta = (ArrowMeta) projectile.getEntityMeta();
                 meta.setColor(ThreadLocalRandom.current().nextInt());
+                break;
+            case "ender":
+                projectile = new EntityProjectile(player, EntityType.ENDER_PEARL, null);
                 break;
             default:
                 return;


### PR DESCRIPTION
1. Projectiles can hurt entities other than shooter in first 3 ticks of their life.
2. They don't stuck in non-solid blocks such as torches, high grass.
3. Previously all projectiles were treated as arrows whilst hitting an entity: they could hit only living ones and always increased victim's arrow count by one. Now this can be configured, also `EntityArrow` class is invented to provide an out-of-the-box way to achieve previous behaviour for those projectiles that are arrows.