### PR TITLE
Make Mojang SessionServer Configurable

### DIFF
--- a/src/main/java/net/minestom/server/network/packet/client/login/EncryptionResponsePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/login/EncryptionResponsePacket.java
@@ -26,7 +26,7 @@ import java.util.Arrays;
 import java.util.UUID;
 
 public class EncryptionResponsePacket implements ClientPreplayPacket {
-    private static final MOJANG_AUTH_URL = System.getProperty("minestom.auth.url", "https://sessionserver.mojang.com/session/minecraft/hasJoined").concat("?username=%s&serverId=%s");
+    private static final String MOJANG_AUTH_URL = System.getProperty("minestom.auth.url", "https://sessionserver.mojang.com/session/minecraft/hasJoined").concat("?username=%s&serverId=%s");
     private static final Gson GSON = new Gson();
     private byte[] sharedSecret;
     private byte[] verifyToken;


### PR DESCRIPTION
This allows users of minestom to modify the sessionserver for mojang when grabbing hasJoined responses.

1) Allows users from china to use NetEase session servers for using minestom as a viable server
2) Allows simple info forwarding for auth proxying