### PR TITLE
Fix Palette#resize not actually resizing the palette

### DIFF
--- a/src/main/java/net/minestom/server/instance/palette/Palette.java
+++ b/src/main/java/net/minestom/server/instance/palette/Palette.java
@@ -248,6 +248,7 @@ public final class Palette implements PublicCloneable<Palette> {
         if (lastPaletteIndex >= paletteBlockArray.length) {
             // Palette is full, must resize
             resize(bitsPerEntry + bitsIncrement);
+            if (!hasPalette) return blockId;
         }
         final short paletteIndex = (short) lastPaletteIndex++;
         this.paletteBlockArray[paletteIndex] = blockId;


### PR DESCRIPTION
Loading certain chunks (presumably those with more than 256 different block states) caused this exception:
```
java.lang.ArrayIndexOutOfBoundsException: Index 256 out of bounds for length 256
	at net.minestom.server.instance.palette.Palette.getPaletteIndex(Palette.java:256)
	at net.minestom.server.instance.palette.Palette.setBlockAt(Palette.java:92)
	at net.minestom.server.instance.Section.setBlockAt(Section.java:31)
	at net.minestom.server.instance.DynamicChunk.setBlock(DynamicChunk.java:62)
	at net.minestom.server.instance.AnvilLoader.loadBlocks(AnvilLoader.java:152)
	at net.minestom.server.instance.AnvilLoader.loadMCA(AnvilLoader.java:104)
	at net.minestom.server.instance.AnvilLoader.loadChunk(AnvilLoader.java:75)
	at net.minestom.server.instance.InstanceContainer.lambda$retrieveChunk$10(InstanceContainer.java:268)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run$$$capture(CompletableFuture.java:1804)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.exec(CompletableFuture.java:1796)
	at java.base/java.util.concurrent.ForkJoinTask.doExec$$$capture(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
```
`Palette#resize` creates a new palette, but replaces the new array with the old one (causing it to keep its old size). This PR lets `setBlockAt` populate the new array instead.