### PR TITLE
Add sound and animation to damage event

### DIFF
--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -351,7 +351,7 @@ public class LivingEntity extends Entity implements EquipmentHandler {
 
             float remainingDamage = entityDamageEvent.getDamage();
 
-            if (entityDamageEvent.isAnimation()) {
+            if (entityDamageEvent.shouldAnimate()) {
                 sendPacketToViewersAndSelf(new EntityAnimationPacket(getEntityId(), EntityAnimationPacket.Animation.TAKE_DAMAGE));
             }
 

--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -344,14 +344,16 @@ public class LivingEntity extends Entity implements EquipmentHandler {
             return false;
         }
 
-        EntityDamageEvent entityDamageEvent = new EntityDamageEvent(this, type, value);
+        EntityDamageEvent entityDamageEvent = new EntityDamageEvent(this, type, value, type.getSound(this));
         EventDispatcher.callCancellable(entityDamageEvent, () -> {
             // Set the last damage type since the event is not cancelled
             this.lastDamageSource = entityDamageEvent.getDamageType();
 
             float remainingDamage = entityDamageEvent.getDamage();
 
-            sendPacketToViewersAndSelf(new EntityAnimationPacket(getEntityId(), EntityAnimationPacket.Animation.TAKE_DAMAGE));
+            if (entityDamageEvent.isAnimation()) {
+                sendPacketToViewersAndSelf(new EntityAnimationPacket(getEntityId(), EntityAnimationPacket.Animation.TAKE_DAMAGE));
+            }
 
             // Additional hearts support
             if (this instanceof Player player) {
@@ -371,7 +373,7 @@ public class LivingEntity extends Entity implements EquipmentHandler {
             setHealth(getHealth() - remainingDamage);
 
             // play damage sound
-            final SoundEvent sound = type.getSound(this);
+            final SoundEvent sound = entityDamageEvent.getSound();
             if (sound != null) {
                 Source soundCategory;
                 if (this instanceof Player) {

--- a/src/main/java/net/minestom/server/event/entity/EntityDamageEvent.java
+++ b/src/main/java/net/minestom/server/event/entity/EntityDamageEvent.java
@@ -88,7 +88,7 @@ public class EntityDamageEvent implements EntityInstanceEvent, CancellableEvent 
      *
      * @return true if the animation should be played
      */
-    public boolean isAnimation() {
+    public boolean shouldAnimate() {
         return animation;
     }
 

--- a/src/main/java/net/minestom/server/event/entity/EntityDamageEvent.java
+++ b/src/main/java/net/minestom/server/event/entity/EntityDamageEvent.java
@@ -5,7 +5,9 @@ import net.minestom.server.entity.LivingEntity;
 import net.minestom.server.entity.damage.DamageType;
 import net.minestom.server.event.trait.CancellableEvent;
 import net.minestom.server.event.trait.EntityInstanceEvent;
+import net.minestom.server.sound.SoundEvent;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Called with {@link LivingEntity#damage(DamageType, float)}.
@@ -15,13 +17,17 @@ public class EntityDamageEvent implements EntityInstanceEvent, CancellableEvent 
     private final Entity entity;
     private final DamageType damageType;
     private float damage;
+    private SoundEvent sound;
+    private boolean animation = true;
 
     private boolean cancelled;
 
-    public EntityDamageEvent(@NotNull LivingEntity entity, @NotNull DamageType damageType, float damage) {
+    public EntityDamageEvent(@NotNull LivingEntity entity, @NotNull DamageType damageType,
+                             float damage, @Nullable SoundEvent sound) {
         this.entity = entity;
         this.damageType = damageType;
         this.damage = damage;
+        this.sound = sound;
     }
 
     @NotNull
@@ -56,6 +62,43 @@ public class EntityDamageEvent implements EntityInstanceEvent, CancellableEvent 
      */
     public void setDamage(float damage) {
         this.damage = damage;
+    }
+
+    /**
+     * Gets the damage sound.
+     *
+     * @return the damage sound
+     */
+    @Nullable
+    public SoundEvent getSound() {
+        return sound;
+    }
+
+    /**
+     * Changes the damage sound.
+     *
+     * @param sound the new damage sound
+     */
+    public void setSound(@Nullable SoundEvent sound) {
+        this.sound = sound;
+    }
+
+    /**
+     * Gets whether the damage animation should be played.
+     *
+     * @return true if the animation should be played
+     */
+    public boolean isAnimation() {
+        return animation;
+    }
+
+    /**
+     * Sets whether the damage animation should be played.
+     *
+     * @param animation whether the animation should be played or not
+     */
+    public void setAnimation(boolean animation) {
+        this.animation = animation;
     }
 
     @Override


### PR DESCRIPTION
This pull requests adds a way to change the sound and whether the animation is played in `EntityDamageEvent`.