### PR TITLE
Use NIO for extension manager instead of IO

### DIFF
--- a/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
+++ b/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
@@ -74,7 +74,7 @@ public final class DiscoveredExtension {
     transient LoadStatus loadStatus = LoadStatus.LOAD_SUCCESS;
 
     /** The original jar this is from. */
-    transient private File originalJar;
+    transient private Path originalJar;
 
     transient private Path dataDirectory;
 
@@ -124,12 +124,12 @@ public final class DiscoveredExtension {
         return externalDependencies;
     }
 
-    public void setOriginalJar(@Nullable File file) {
+    public void setOriginalJar(@Nullable Path file) {
         originalJar = file;
     }
 
     @Nullable
-    public File getOriginalJar() {
+    public Path getOriginalJar() {
         return originalJar;
     }
 

--- a/src/main/java/net/minestom/server/extensions/ExtensionManager.java
+++ b/src/main/java/net/minestom/server/extensions/ExtensionManager.java
@@ -354,10 +354,10 @@ public class ExtensionManager {
             LOGGER.info("Found indev folders for extension. Adding to list of discovered extensions.");
             final String extensionClasses = System.getProperty(INDEV_CLASSES_FOLDER);
             final String extensionResources = System.getProperty(INDEV_RESOURCES_FOLDER);
-            try (InputStreamReader reader = new InputStreamReader(new FileInputStream(new File(extensionResources, "extension.json")))) {
+            try (InputStreamReader reader = new InputStreamReader(Files.newInputStream(Path.of(extensionResources, "extension.json")))) {
                 DiscoveredExtension extension = GSON.fromJson(reader, DiscoveredExtension.class);
-                extension.files.add(new File(extensionClasses).toURI().toURL());
-                extension.files.add(new File(extensionResources).toURI().toURL());
+                extension.files.add(Path.of(extensionClasses).toUri().toURL());
+                extension.files.add(Path.of(extensionResources).toUri().toURL());
                 extension.setDataDirectory(getExtensionFolder().resolve(extension.getName()));
 
                 // Verify integrity and ensure defaults

--- a/src/main/java/net/minestom/server/extensions/ExtensionManager.java
+++ b/src/main/java/net/minestom/server/extensions/ExtensionManager.java
@@ -330,23 +330,23 @@ public class ExtensionManager {
         Stream<Path> fileList = Files.list(extensionFolder);
 
         // Loop through all files in extension folder
-        for (Path file : fileList.collect(Collectors.toList())) {
+        fileList.forEach(file -> {
 
             // Ignore folders
             if (Files.isDirectory(file)) {
-                continue;
+                return;
             }
 
             // Ignore non .jar files
             if (!file.getFileName().endsWith(".jar")) {
-                continue;
+                return;
             }
 
             DiscoveredExtension extension = discoverFromJar(file);
             if (extension != null && extension.loadStatus == DiscoveredExtension.LoadStatus.LOAD_SUCCESS) {
                 extensions.add(extension);
             }
-        }
+        });
 
 
         // this allows developers to have their extension discovered while working on it, without having to build a jar and put in the extension folder

--- a/src/test/java/demo/commands/LoadExtensionCommand.java
+++ b/src/test/java/demo/commands/LoadExtensionCommand.java
@@ -37,7 +37,7 @@ public class LoadExtensionCommand extends Command {
         sender.sendMessage(Component.text("extensionFile = " + name + "...."));
 
         ExtensionManager extensionManager = MinecraftServer.getExtensionManager();
-        Path extensionFolder = extensionManager.getExtensionFolder().toPath().toAbsolutePath();
+        Path extensionFolder = extensionManager.getExtensionFolder().toAbsolutePath();
         Path extensionJar = extensionFolder.resolve(name);
         try {
             if (!extensionJar.toFile().getCanonicalPath().startsWith(extensionFolder.toFile().getCanonicalPath())) {
@@ -51,7 +51,7 @@ public class LoadExtensionCommand extends Command {
         }
 
         try {
-            boolean managed = extensionManager.loadDynamicExtension(extensionJar.toFile());
+            boolean managed = extensionManager.loadDynamicExtension(extensionJar);
             if (managed) {
                 sender.sendMessage(Component.text("Extension loaded!"));
             } else {


### PR DESCRIPTION
Since Minestom bumped to JDK 17, this means that the FileSystem API (introduced in Java 14) can be used, thus the entire extension management can be switched to using NIO instead of IO.

However, this does require https://github.com/Minestom/DependencyGetter/pull/3