### PR TITLE
Area effect cloud holograms

### DIFF
--- a/src/main/java/net/minestom/server/entity/hologram/Hologram.java
+++ b/src/main/java/net/minestom/server/entity/hologram/Hologram.java
@@ -6,6 +6,7 @@ import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.EntityType;
 import net.minestom.server.entity.Player;
+import net.minestom.server.entity.metadata.other.AreaEffectCloudMeta;
 import net.minestom.server.entity.metadata.other.ArmorStandMeta;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.utils.validate.Check;
@@ -14,15 +15,13 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Set;
 
 /**
- * Represents an invisible armor stand showing a {@link Component}.
+ * Represents an invisible area effect cloud showing a {@link Component}.
  */
 public class Hologram implements Viewable {
 
-    private static final float OFFSET_Y = -0.9875f;
-    private static final float MARKER_OFFSET_Y = -0.40625f;
+    private static final float OFFSET_Y = -0.5f;
 
     private final Entity entity;
-    private final float yOffset;
 
     private Pos position;
     private Component text;
@@ -61,27 +60,20 @@ public class Hologram implements Viewable {
      * @param autoViewable  {@code true}if the hologram should be visible automatically, otherwise {@code false}.
      */
     public Hologram(Instance instance, Pos spawnPosition, Component text, boolean autoViewable, boolean marker) {
-        this.entity = new Entity(EntityType.ARMOR_STAND);
+        this.entity = new Entity(EntityType.AREA_EFFECT_CLOUD);
 
-        ArmorStandMeta armorStandMeta = (ArmorStandMeta) entity.getEntityMeta();
+        AreaEffectCloudMeta areaEffectCloudMeta = (AreaEffectCloudMeta) entity.getEntityMeta();
 
-        armorStandMeta.setNotifyAboutChanges(false);
+        areaEffectCloudMeta.setNotifyAboutChanges(false);
 
-        if (marker) {
-            this.yOffset = MARKER_OFFSET_Y;
-            armorStandMeta.setMarker(true);
-        } else {
-            this.yOffset = OFFSET_Y;
-            armorStandMeta.setSmall(true);
-        }
-        armorStandMeta.setHasNoGravity(true);
-        armorStandMeta.setCustomName(Component.empty());
-        armorStandMeta.setCustomNameVisible(true);
-        armorStandMeta.setInvisible(true);
+        areaEffectCloudMeta.setHasNoGravity(true);
+        areaEffectCloudMeta.setCustomName(Component.empty());
+        areaEffectCloudMeta.setCustomNameVisible(true);
+        areaEffectCloudMeta.setRadius(0f);
 
-        armorStandMeta.setNotifyAboutChanges(true);
+        areaEffectCloudMeta.setNotifyAboutChanges(true);
 
-        this.entity.setInstance(instance, spawnPosition.add(0, this.yOffset, 0));
+        this.entity.setInstance(instance, spawnPosition.add(0, OFFSET_Y, 0));
         this.entity.setAutoViewable(autoViewable);
 
         this.position = spawnPosition;
@@ -104,7 +96,7 @@ public class Hologram implements Viewable {
      */
     public void setPosition(Pos position) {
         checkRemoved();
-        this.position = position.add(0, this.yOffset, 0);
+        this.position = position.add(0, OFFSET_Y, 0);
         this.entity.teleport(this.position);
     }
 

--- a/src/test/java/demo/Main.java
+++ b/src/test/java/demo/Main.java
@@ -51,6 +51,7 @@ public class Main {
         commandManager.register(new GiveCommand());
         commandManager.register(new SetBlockCommand());
         commandManager.register(new AutoViewCommand());
+        commandManager.register(new HologramCommand());
 
 
         commandManager.setUnknownCommandCallback((sender, command) -> sender.sendMessage(Component.text("Unknown command", NamedTextColor.RED)));

--- a/src/test/java/demo/commands/HologramCommand.java
+++ b/src/test/java/demo/commands/HologramCommand.java
@@ -1,0 +1,43 @@
+package demo.commands;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.title.Title;
+import net.minestom.server.command.CommandSender;
+import net.minestom.server.command.builder.Command;
+import net.minestom.server.command.builder.CommandContext;
+import net.minestom.server.command.builder.arguments.ArgumentType;
+import net.minestom.server.command.builder.condition.Conditions;
+import net.minestom.server.entity.Player;
+import net.minestom.server.entity.hologram.Hologram;
+
+public class HologramCommand extends Command {
+    public HologramCommand() {
+        super("hologram");
+        setDefaultExecutor((source, args) -> source.sendMessage(Component.text("Unknown syntax (note: title must be quoted)")));
+        setCondition(Conditions::playerOnly);
+
+        var content = ArgumentType.String("content");
+        var count = ArgumentType.Integer("count");
+
+        addSyntax(this::handleHologram, content);
+        addSyntax(this::handleHologramWithCount, content, count);
+    }
+
+    private void handleHologram(CommandSender source, CommandContext context) {
+        Player player = source.asPlayer();
+        String hologramContent = context.get("content");
+
+        new Hologram(player.getInstance(), player.getPosition(), Component.text(hologramContent));
+    }
+
+    private void handleHologramWithCount(CommandSender source, CommandContext context) {
+        Player player = source.asPlayer();
+        String hologramContent = context.get("content");
+        Integer hologramCount = context.get("count");
+
+        for (int i = 0; i < hologramCount; i++)
+        {
+            new Hologram(player.getInstance(), player.getPosition(), Component.text(hologramContent));
+        }
+    }
+}


### PR DESCRIPTION
Changes holograms from invisible armor stands to area effect clouds with radius 0. This is much much faster for client side rendering, and increases client side performance drastically when there are lots of holograms present. 

Also adds a basic /hologram command to the test demo. Usage: /hologram <text> [count]