### PR TITLE
Additional methods for playing block actions for Player

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -41,6 +41,7 @@ import net.minestom.server.event.player.*;
 import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.EntityTracker;
 import net.minestom.server.instance.Instance;
+import net.minestom.server.instance.block.Block;
 import net.minestom.server.inventory.Inventory;
 import net.minestom.server.inventory.PlayerInventory;
 import net.minestom.server.item.ItemStack;
@@ -655,6 +656,20 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         ClientChatMessagePacket chatMessagePacket = new ClientChatMessagePacket();
         chatMessagePacket.message = message;
         addPacketToQueue(chatMessagePacket);
+    }
+
+    public void playBlockAction(@NotNull Point point, byte actionId, byte actionParam) {
+        Check.stateCondition(instance == null, "Instance should be not null");
+        this.playBlockAction(instance.getBlock(point), point, actionId, actionParam);
+    }
+
+    public void playBlockAction(@NotNull Block block, @NotNull Point point, byte actionId, byte actionParam) {
+        BlockActionPacket packet = new BlockActionPacket();
+        packet.blockPosition = point;
+        packet.actionId = actionId;
+        packet.actionParam = actionParam;
+        packet.blockId = block.id();
+        playerConnection.sendPacket(packet);
     }
 
     @Override


### PR DESCRIPTION
Added new methods for the Player class.

Why two methods? 
> If an out of sync was deliberately created. (For example, one player at point (0;0) has a chest, and another player has a bell).
> Just shortens the code