### PR TITLE
Fix Exception in MojangUtils

### DIFF
--- a/src/main/java/net/minestom/server/utils/mojang/MojangUtils.java
+++ b/src/main/java/net/minestom/server/utils/mojang/MojangUtils.java
@@ -39,6 +39,11 @@ public final class MojangUtils {
             try {
                 // Retrieve from the rate-limited Mojang API
                 final String response = URLUtils.getText(url);
+                // If our response is "", that means the url did not get a proper object from the url
+                // So the username or UUID was invalid, and therefore we return null
+                if(response.isEmpty()) {
+                    return null;
+                }
                 return JsonParser.parseString(response).getAsJsonObject();
             } catch (IOException e) {
                 MinecraftServer.getExceptionManager().handleException(e);

--- a/src/test/java/misc/TestMojangUtils.java
+++ b/src/test/java/misc/TestMojangUtils.java
@@ -1,0 +1,21 @@
+package misc;
+
+import net.minestom.server.utils.mojang.MojangUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestMojangUtils {
+    @Test
+    public void testValidNameWorks() {
+        var result = MojangUtils.fromUsername("jeb_");
+        assertNotNull(result);
+        assertEquals("jeb_", result.get("name").getAsString());
+    }
+
+    @Test
+    public void testInvalidNameReturnsNull() {
+        var result = MojangUtils.fromUsername("jfdsa84vvcxadubasdfcvn"); // Longer than 16, always invalid
+        assert result == null;
+    }
+}


### PR DESCRIPTION
With the current MojangUtils, retrieving an invalid username results in this exception:

```
java.lang.IllegalStateException: Not a JSON Object: null
at com.google.gson.JsonElement.getAsJsonObject(JsonElement.java:91)
at Minestom Root ClassLoader//net.minestom.server.utils.mojang.MojangUtils.lambda$retrieve$0(MojangUtils.java:42)
    at Minestom Root ClassLoader//com.github.benmanes.caffeine.cache.BoundedLocalCache.lambda$doComputeIfAbsent$13(BoundedLocalCache.java:2457)
    at java.base/java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1916)
    at Minestom Root ClassLoader//com.github.benmanes.caffeine.cache.BoundedLocalCache.doComputeIfAbsent(BoundedLocalCache.java:2455)
    at Minestom Root ClassLoader//com.github.benmanes.caffeine.cache.BoundedLocalCache.computeIfAbsent(BoundedLocalCache.java:2438)
    at Minestom Root ClassLoader//com.github.benmanes.caffeine.cache.LocalCache.computeIfAbsent(LocalCache.java:107)
    at Minestom Root ClassLoader//com.github.benmanes.caffeine.cache.LocalManualCache.get(LocalManualCache.java:62)
    at Minestom Root ClassLoader//net.minestom.server.utils.mojang.MojangUtils.retrieve(MojangUtils.java:38)
    at Minestom Root ClassLoader//net.minestom.server.utils.mojang.MojangUtils.fromUsername(MojangUtils.java:34)
```


This is caused by the Mojang API returning an empty string for invalid usernames/uuids, and the JSONParser.parseString(response).getAsJsonObject(); not having a valid JSON object, and throwing the above exception.
This PR rectifies this by checking if the string is empty and returning null if it is before running the parseString() function.