### PR TITLE
Fix bungeecord pinging

### DIFF
--- a/src/main/java/net/minestom/server/network/packet/client/handshake/HandshakePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/handshake/HandshakePacket.java
@@ -48,7 +48,7 @@ public record HandshakePacket(int protocolVersion, @NotNull String serverAddress
 
         String address = serverAddress;
         // Bungee support (IP forwarding)
-        if (BungeeCordProxy.isEnabled() && connection instanceof PlayerSocketConnection socketConnection) {
+        if (BungeeCordProxy.isEnabled() && connection instanceof PlayerSocketConnection socketConnection && nextState == 2) {
             if (address != null) {
                 final String[] split = address.split("\00");
 


### PR DESCRIPTION
When the server is pinged, and `BungeeCordProxy.enable()` has been called, it kicks the player incorrectly during the kick event, due to the extra information missing (which would be present by BungeeCord during login) which makes the client try to legacy ping. This PR fixes that bug, by making sure to only check for the extra details, when the next state is login.