### PR TITLE
Attribute packet fix

### DIFF
--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityPropertiesPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityPropertiesPacket.java
@@ -38,15 +38,9 @@ public record EntityPropertiesPacket(int entityId, List<AttributeInstance> prope
         writer.writeVarInt(properties.size());
         for (AttributeInstance instance : properties) {
             final Attribute attribute = instance.getAttribute();
-            double value = instance.getValue();
-
-            float maxValue = attribute.getMaxValue();
-
-            // Bypass vanilla limit client-side if needed (by sending the max value allowed)
-            final double v = value > maxValue ? maxValue : value;
 
             writer.writeSizedString(attribute.getKey());
-            writer.writeDouble(v);
+            writer.writeDouble(instance.getBaseValue());
 
             {
                 Collection<AttributeModifier> modifiers = instance.getModifiers();


### PR DESCRIPTION
This pull request fixes the `EntityPropertiesPacket`. Previously, it would send the current computed value (including modifiers) as the base value, which resulted in the modifiers being doubled (the client also applies the modifiers to the base value).