### PR TITLE
Dirty tracking

### DIFF
--- a/src/main/java/net/minestom/server/instance/EntityTracker.java
+++ b/src/main/java/net/minestom/server/instance/EntityTracker.java
@@ -5,7 +5,10 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.ExperienceOrb;
 import net.minestom.server.entity.ItemEntity;
 import net.minestom.server.entity.Player;
-import org.jetbrains.annotations.*;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 import java.util.Collection;
 import java.util.List;
@@ -67,10 +70,10 @@ public sealed interface EntityTracker permits EntityTrackerImpl {
      * Returns a copy of the entities present in the specified chunk.
      */
     @ApiStatus.Experimental
-    @Unmodifiable <T extends Entity> Collection<T> chunkEntities(int chunkX, int chunkZ, @NotNull Target<T> target);
+    @UnmodifiableView <T extends Entity> Collection<T> chunkEntities(int chunkX, int chunkZ, @NotNull Target<T> target);
 
     @ApiStatus.Experimental
-    @Unmodifiable
+    @UnmodifiableView
     default <T extends Entity> @NotNull Collection<T> chunkEntities(@NotNull Point point, @NotNull Target<T> target) {
         return chunkEntities(point.chunkX(), point.chunkZ(), target);
     }
@@ -113,11 +116,6 @@ public sealed interface EntityTracker permits EntityTrackerImpl {
     default @NotNull Set<@NotNull Entity> entities() {
         return entities(Target.ENTITIES);
     }
-
-    /**
-     * Run {@code runnable} and ensure that the tracking state is locked during execution.
-     */
-    void synchronize(@NotNull Point point, @NotNull Runnable runnable);
 
     /**
      * Represents the type of entity you want to retrieve.

--- a/src/main/java/net/minestom/server/instance/EntityTracker.java
+++ b/src/main/java/net/minestom/server/instance/EntityTracker.java
@@ -56,17 +56,6 @@ public sealed interface EntityTracker permits EntityTrackerImpl {
     }
 
     /**
-     * Gets the entities present in the specified chunk.
-     */
-    <T extends Entity> void chunkEntities(int chunkX, int chunkZ,
-                                          @NotNull Target<T> target, @NotNull Query<T> query);
-
-    default <T extends Entity> void chunkEntities(@NotNull Point point,
-                                                  @NotNull Target<T> target, @NotNull Query<T> query) {
-        chunkEntities(point.chunkX(), point.chunkZ(), target, query);
-    }
-
-    /**
      * Returns a copy of the entities present in the specified chunk.
      */
     @ApiStatus.Experimental

--- a/src/main/java/net/minestom/server/instance/EntityTrackerImpl.java
+++ b/src/main/java/net/minestom/server/instance/EntityTrackerImpl.java
@@ -1,9 +1,5 @@
 package net.minestom.server.instance;
 
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
-import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Entity;
@@ -12,6 +8,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jetbrains.annotations.UnmodifiableView;
+import space.vectrix.flare.fastutil.Int2ObjectSyncMap;
+import space.vectrix.flare.fastutil.Long2ObjectSyncMap;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -31,11 +29,11 @@ final class EntityTrackerImpl implements EntityTracker {
     // The array index is the Target enum ordinal
     private final TargetEntry<Entity>[] entries = EntityTracker.Target.TARGETS.stream().map((Function<Target<?>, TargetEntry>) TargetEntry::new).toArray(TargetEntry[]::new);
 
-    private final Int2ObjectMap<Point> entityPositions = new Int2ObjectOpenHashMap<>();
+    private final Int2ObjectSyncMap<Point> entityPositions = Int2ObjectSyncMap.hashmap();
 
     @Override
-    public synchronized <T extends Entity> void register(@NotNull Entity entity, @NotNull Point point,
-                                                         @NotNull Target<T> target, @Nullable Update<T> update) {
+    public <T extends Entity> void register(@NotNull Entity entity, @NotNull Point point,
+                                            @NotNull Target<T> target, @Nullable Update<T> update) {
         var prevPoint = entityPositions.putIfAbsent(entity.getEntityId(), point);
         if (prevPoint != null) return;
         final long index = getChunkIndex(point);
@@ -54,8 +52,8 @@ final class EntityTrackerImpl implements EntityTracker {
     }
 
     @Override
-    public synchronized <T extends Entity> void unregister(@NotNull Entity entity,
-                                                           @NotNull Target<T> target, @Nullable Update<T> update) {
+    public <T extends Entity> void unregister(@NotNull Entity entity,
+                                              @NotNull Target<T> target, @Nullable Update<T> update) {
         final Point point = entityPositions.remove(entity.getEntityId());
         if (point == null) return;
         final long index = getChunkIndex(point);
@@ -71,8 +69,8 @@ final class EntityTrackerImpl implements EntityTracker {
     }
 
     @Override
-    public synchronized <T extends Entity> void move(@NotNull Entity entity, @NotNull Point newPoint,
-                                                     @NotNull Target<T> target, @Nullable Update<T> update) {
+    public <T extends Entity> void move(@NotNull Entity entity, @NotNull Point newPoint,
+                                        @NotNull Target<T> target, @Nullable Update<T> update) {
         Point oldPoint = entityPositions.put(entity.getEntityId(), newPoint);
         if (oldPoint == null || oldPoint.sameChunk(newPoint)) return;
         final long oldIndex = getChunkIndex(oldPoint);
@@ -99,9 +97,9 @@ final class EntityTrackerImpl implements EntityTracker {
     }
 
     @Override
-    public synchronized <T extends Entity> void difference(int oldChunkX, int oldChunkZ,
-                                                           int newChunkX, int newChunkZ,
-                                                           @NotNull Target<T> target, @NotNull Update<T> update) {
+    public <T extends Entity> void difference(int oldChunkX, int oldChunkZ,
+                                              int newChunkX, int newChunkZ,
+                                              @NotNull Target<T> target, @NotNull Update<T> update) {
         final TargetEntry<Entity> entry = entries[target.ordinal()];
         forDifferingChunksInRange(newChunkX, newChunkZ, oldChunkX, oldChunkZ,
                 MinecraftServer.getEntityViewDistance(), (chunkX, chunkZ) -> {
@@ -118,7 +116,7 @@ final class EntityTrackerImpl implements EntityTracker {
     }
 
     @Override
-    public synchronized <T extends Entity> void chunkEntities(int chunkX, int chunkZ, @NotNull Target<T> target, @NotNull Query<T> query) {
+    public <T extends Entity> void chunkEntities(int chunkX, int chunkZ, @NotNull Target<T> target, @NotNull Query<T> query) {
         final TargetEntry<Entity> entry = entries[target.ordinal()];
         final List<Entity> entities = entry.chunkEntities.get(getChunkIndex(chunkX, chunkZ));
         if (entities == null || entities.isEmpty()) return;
@@ -126,7 +124,7 @@ final class EntityTrackerImpl implements EntityTracker {
     }
 
     @Override
-    public synchronized @Unmodifiable <T extends Entity> Collection<T> chunkEntities(int chunkX, int chunkZ, @NotNull Target<T> target) {
+    public @Unmodifiable <T extends Entity> Collection<T> chunkEntities(int chunkX, int chunkZ, @NotNull Target<T> target) {
         final TargetEntry<Entity> entry = entries[target.ordinal()];
         final List<Entity> entities = entry.chunkEntities.get(getChunkIndex(chunkX, chunkZ));
         return entities != null ? (Collection<T>) List.copyOf(entities) : List.of();
@@ -141,7 +139,7 @@ final class EntityTrackerImpl implements EntityTracker {
     }
 
     @Override
-    public synchronized @NotNull <T extends Entity> List<List<T>> references(int chunkX, int chunkZ, @NotNull Target<T> target) {
+    public @NotNull <T extends Entity> List<List<T>> references(int chunkX, int chunkZ, @NotNull Target<T> target) {
         // Gets reference to all chunk entities lists within the range
         // This is used to avoid a map lookup per chunk
         final TargetEntry<T> entry = (TargetEntry<T>) entries[target.ordinal()];
@@ -156,7 +154,7 @@ final class EntityTrackerImpl implements EntityTracker {
     }
 
     @Override
-    public synchronized <T extends Entity> void nearbyEntities(@NotNull Point point, double range, @NotNull Target<T> target, @NotNull Query<T> query) {
+    public <T extends Entity> void nearbyEntities(@NotNull Point point, double range, @NotNull Target<T> target, @NotNull Query<T> query) {
         final int chunkRange = Math.abs((int) (range / Chunk.CHUNK_SECTION_SIZE)) + 1;
         final double squaredRange = range * range;
         ChunkUtils.forChunksInRange(point, chunkRange, (chunkX, chunkZ) ->
@@ -174,7 +172,7 @@ final class EntityTrackerImpl implements EntityTracker {
     }
 
     @Override
-    public synchronized void synchronize(@NotNull Point point, @NotNull Runnable runnable) {
+    public void synchronize(@NotNull Point point, @NotNull Runnable runnable) {
         runnable.run();
     }
 
@@ -183,9 +181,9 @@ final class EntityTrackerImpl implements EntityTracker {
         private final Set<T> entities = ConcurrentHashMap.newKeySet(); // Thread-safe since exposed
         private final Set<T> entitiesView = Collections.unmodifiableSet(entities);
         // Chunk index -> entities inside it
-        private final Long2ObjectMap<List<T>> chunkEntities = new Long2ObjectOpenHashMap<>(0);
+        private final Long2ObjectSyncMap<List<T>> chunkEntities = Long2ObjectSyncMap.hashmap();
         // Chunk index -> lists of visible entities (references to chunkEntities entries)
-        private final Long2ObjectMap<List<List<T>>> chunkRangeEntities = new Long2ObjectOpenHashMap<>(0);
+        private final Long2ObjectSyncMap<List<List<T>>> chunkRangeEntities = Long2ObjectSyncMap.hashmap();
 
         TargetEntry(Target<T> target) {
             this.target = target;

--- a/src/main/java/net/minestom/server/instance/EntityTrackerImpl.java
+++ b/src/main/java/net/minestom/server/instance/EntityTrackerImpl.java
@@ -126,8 +126,8 @@ final class EntityTrackerImpl implements EntityTracker {
     @Override
     public @Unmodifiable <T extends Entity> Collection<T> chunkEntities(int chunkX, int chunkZ, @NotNull Target<T> target) {
         final TargetEntry<Entity> entry = entries[target.ordinal()];
-        final List<Entity> entities = entry.chunkEntities.get(getChunkIndex(chunkX, chunkZ));
-        return entities != null ? (Collection<T>) List.copyOf(entities) : List.of();
+        //noinspection unchecked
+        return (Collection<T>) entry.chunkEntities.computeIfAbsent(getChunkIndex(chunkX, chunkZ), i -> LIST_SUPPLIER.get());
     }
 
     @Override
@@ -169,11 +169,6 @@ final class EntityTrackerImpl implements EntityTracker {
     public @UnmodifiableView @NotNull <T extends Entity> Set<@NotNull T> entities(@NotNull Target<T> target) {
         //noinspection unchecked
         return (Set<T>) entries[target.ordinal()].entitiesView;
-    }
-
-    @Override
-    public void synchronize(@NotNull Point point, @NotNull Runnable runnable) {
-        runnable.run();
     }
 
     private static final class TargetEntry<T extends Entity> {

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -1,5 +1,6 @@
 package net.minestom.server.instance;
 
+import it.unimi.dsi.fastutil.objects.ObjectArraySet;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.pointer.Pointers;
 import net.minestom.server.MinecraftServer;
@@ -486,9 +487,8 @@ public abstract class Instance implements Block.Getter, Block.Setter, Tickable, 
      * if {@code chunk} is unloaded, return an empty {@link HashSet}
      */
     public @NotNull Set<@NotNull Entity> getChunkEntities(Chunk chunk) {
-        Set<Entity> result = new HashSet<>();
-        this.entityTracker.chunkEntities(chunk.toPosition(), EntityTracker.Target.ENTITIES, result::add);
-        return result;
+        var chunkEntities = entityTracker.chunkEntities(chunk.toPosition(), EntityTracker.Target.ENTITIES);
+        return ObjectArraySet.ofUnchecked(chunkEntities.toArray(Entity[]::new));
     }
 
     /**

--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -219,7 +219,7 @@ public class InstanceContainer extends Instance {
 
         EventDispatcher.call(new InstanceChunkUnloadEvent(this, chunk));
         // Remove all entities in chunk
-        getEntityTracker().chunkEntities(chunkX, chunkZ, EntityTracker.Target.ENTITIES, Entity::remove);
+        getEntityTracker().chunkEntities(chunkX, chunkZ, EntityTracker.Target.ENTITIES).forEach(Entity::remove);
         // Clear cache
         this.chunks.remove(index);
         chunk.unload();

--- a/src/main/java/net/minestom/server/utils/ViewEngine.java
+++ b/src/main/java/net/minestom/server/utils/ViewEngine.java
@@ -2,7 +2,6 @@ package net.minestom.server.utils;
 
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
-import it.unimi.dsi.fastutil.objects.ObjectArraySet;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.Player;
@@ -12,6 +11,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Consumer;
@@ -23,7 +23,7 @@ import java.util.function.Predicate;
 @ApiStatus.Internal
 public final class ViewEngine {
     private final Entity entity;
-    private final ObjectArraySet<Player> manualViewers = new ObjectArraySet<>();
+    private final Set<Player> manualViewers = ConcurrentHashMap.newKeySet();
 
     private EntityTracker tracker;
     private Point lastTrackingPoint;
@@ -110,6 +110,10 @@ public final class ViewEngine {
 
     private boolean validAutoViewer(Player player) {
         return entity == null || viewableOption.isRegistered(player);
+    }
+
+    public Object mutex() {
+        return mutex;
     }
 
     public Set<Player> asSet() {

--- a/src/main/java/net/minestom/server/utils/ViewEngine.java
+++ b/src/main/java/net/minestom/server/utils/ViewEngine.java
@@ -196,17 +196,15 @@ public final class ViewEngine {
                             Predicate<T> visibilityPredicate,
                             Consumer<T> action) {
             if (tracker == null || references == null) return;
-            tracker.synchronize(lastTrackingPoint, () -> {
-                for (List<T> entities : references) {
-                    if (entities.isEmpty()) continue;
-                    for (T entity : entities) {
-                        if (entity == ViewEngine.this.entity || !visibilityPredicate.test(entity)) continue;
-                        if (entity instanceof Player player && manualViewers.contains(player)) continue;
-                        if (entity.getVehicle() != null) continue;
-                        action.accept(entity);
-                    }
+            for (List<T> entities : references) {
+                if (entities.isEmpty()) continue;
+                for (T entity : entities) {
+                    if (entity == ViewEngine.this.entity || !visibilityPredicate.test(entity)) continue;
+                    if (entity instanceof Player player && manualViewers.contains(player)) continue;
+                    if (entity.getVehicle() != null) continue;
+                    action.accept(entity);
                 }
-            });
+            }
         }
     }
 


### PR DESCRIPTION
Allow concurrent access to tracked entities. Noticeably improve viewing performance