### PR TITLE
Make PlayerUseItemOnBlockEvent.getBlockFace() return a BlockFace

### DIFF
--- a/src/main/java/net/minestom/server/event/player/PlayerUseItemOnBlockEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerUseItemOnBlockEvent.java
@@ -5,8 +5,8 @@ import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.EntityInstanceEvent;
 import net.minestom.server.event.trait.ItemEvent;
 import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.item.ItemStack;
-import net.minestom.server.utils.Direction;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -18,11 +18,11 @@ public class PlayerUseItemOnBlockEvent implements PlayerEvent, EntityInstanceEve
     private final Player.Hand hand;
     private final ItemStack itemStack;
     private final Point position;
-    private final Direction blockFace;
+    private final BlockFace blockFace;
 
     public PlayerUseItemOnBlockEvent(@NotNull Player player, @NotNull Player.Hand hand,
                                      @NotNull ItemStack itemStack,
-                                     @NotNull Point position, @NotNull Direction blockFace) {
+                                     @NotNull Point position, @NotNull BlockFace blockFace) {
         this.player = player;
         this.hand = hand;
         this.itemStack = itemStack;
@@ -44,7 +44,7 @@ public class PlayerUseItemOnBlockEvent implements PlayerEvent, EntityInstanceEve
      *
      * @return the block face
      */
-    public @NotNull Direction getBlockFace() {
+    public @NotNull BlockFace getBlockFace() {
         return blockFace;
     }
 

--- a/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
+++ b/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
@@ -37,7 +37,6 @@ public class BlockPlacementListener {
         final Player.Hand hand = packet.hand();
         final BlockFace blockFace = packet.blockFace();
         final Point blockPosition = packet.blockPosition();
-        final Direction direction = blockFace.toDirection();
 
         final Instance instance = player.getInstance();
         if (instance == null)
@@ -72,7 +71,7 @@ public class BlockPlacementListener {
         final Material useMaterial = usedItem.getMaterial();
         if (!useMaterial.isBlock()) {
             // Player didn't try to place a block but interacted with one
-            PlayerUseItemOnBlockEvent event = new PlayerUseItemOnBlockEvent(player, hand, usedItem, blockPosition, direction);
+            PlayerUseItemOnBlockEvent event = new PlayerUseItemOnBlockEvent(player, hand, usedItem, blockPosition, blockFace);
             EventDispatcher.call(event);
             return;
         }

--- a/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
+++ b/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
@@ -23,7 +23,6 @@ import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
 import net.minestom.server.network.packet.client.play.ClientPlayerBlockPlacementPacket;
 import net.minestom.server.network.packet.server.play.BlockChangePacket;
-import net.minestom.server.utils.Direction;
 import net.minestom.server.utils.chunk.ChunkUtils;
 import net.minestom.server.utils.validate.Check;
 


### PR DESCRIPTION
Currently PlayerUseItemOnBlockEvent.getBlockFace() returns a Direction instead of a BlockFace. Since there's a BlockFace.toDirection() method you can easily convert a BlockFace back to a Direction if you really need to, however there's no such easy way of getting a BlockFace from a Direction.