### PR TITLE
Fix ChunkData including "fake" Block Entities

### DIFF
--- a/src/main/java/net/minestom/server/network/packet/server/play/data/ChunkData.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/data/ChunkData.java
@@ -22,7 +22,7 @@ public record ChunkData(@NotNull NBTCompound heightmaps, byte @NotNull [] data,
     public ChunkData {
         blockEntities = blockEntities.entrySet()
                 .stream()
-                .filter((block) -> block.getValue().registry().isBlockEntity())
+                .filter((entry) -> entry.getValue().registry().isBlockEntity())
                 .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 

--- a/src/main/java/net/minestom/server/network/packet/server/play/data/ChunkData.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/data/ChunkData.java
@@ -17,9 +17,13 @@ import java.util.Map;
 import java.util.Objects;
 
 public record ChunkData(@NotNull NBTCompound heightmaps, byte @NotNull [] data,
-                        @NotNull Map<Integer, Block> blockEntities) implements Writeable {
+        @NotNull Map<Integer, Block> blockEntities) implements Writeable {
     public ChunkData {
-        blockEntities = Map.copyOf(blockEntities);
+        blockEntities = Map.copyOf(blockEntities.entrySet()
+                .stream()
+                .filter((block) -> block.getValue().registry().isBlockEntity()) // filter out map to not include
+                                                                                // non-block
+                .collect(Collectors.toMap(x -> x.getKey(), x -> x.getValue()))); // entities. see below for explanation
     }
 
     public ChunkData(BinaryReader reader) {
@@ -36,12 +40,15 @@ public record ChunkData(@NotNull NBTCompound heightmaps, byte @NotNull [] data,
         writer.writeVarInt(data.length);
         writer.writeBytes(data);
         // Block entities
-        writer.writeVarInt(blockEntities.size());
+        writer.writeVarInt(blockEntities.size()); // causes issues with blocks w/ custom handlers that aren't block
+                                                  // entities. solution: filter out these "fake" block entities prior
+                                                  // to this when the map is created
         for (var entry : blockEntities.entrySet()) {
             final int index = entry.getKey();
             final Block block = entry.getValue();
             final var registry = block.registry();
-            if (!registry.isBlockEntity()) continue;
+            if (!registry.isBlockEntity())
+                continue;
 
             final Point point = ChunkUtils.getBlockPosition(index, 0, 0);
 
@@ -49,7 +56,6 @@ public record ChunkData(@NotNull NBTCompound heightmaps, byte @NotNull [] data,
             writer.writeShort((short) point.blockY()); // y
 
             writer.writeVarInt(registry.blockEntityId());
-
 
             NBTCompound resultNbt;
             // Append handler tags


### PR DESCRIPTION
Current solution of writing to the ChunkData packet accidentally includes "fake" Block Entities to be counted in the blockEntities.size() var write. Causes issues with clients attempting to load chunks that include non-block entities with a custom handler. This solution proposes that these blocks get filtered out prior to the packet data being written, via a stream -> filter -> collection solution. Open to ideas on how to better solve this issue, as it is impossible to get logs of due to it being a client issue.

To replicate the original issue;

1. Create world containing a non-block entity block (ie; a cobweb) in the chunks where the player will spawn
2. Create BlockHandler for that type of block- example attached below

```java
public class CobwebHandler implements BlockHandler {
	private Random random = new Random();

	@OverRide
	public @NotNull NamespaceID getNamespaceId() {
		return NamespaceID.from("minecraft", "custom_cobweb");
	}

	@OverRide
	public boolean isTickable() {
		return true;
	}

	@OverRide
	public void tick(@NotNull Tick tick) { // super cool cobwebs that play the stepSound packet randomly
		if (tick.getInstance().getChunkAt(tick.getBlockPosition()).getViewers().size() == 0) return;
		if (tick.getInstance().getTime() % (50 + random.nextInt(35)) == 0) {
			EffectPacket stepSoundPacket = new EffectPacket(2001, tick.getBlockPosition(), tick.getBlock().stateId(),
					false);
			tick.getInstance().sendGroupedPacket(stepSoundPacket);
		}
	}
}
```

3. Register the handler as so;

```java
MinecraftServer.getBlockManager().registerHandler(NamespaceID.from("minecraft:cobweb"), CobwebHandler::new);
```

4. Connect to server. You should immediately disconnect with a `DecoderException: z: Loading NBT Data` error.


To validate solution, repeat the the above steps, but including the updated ChunkData class. You'll be able to connect normally and the BlockHandler will tick as normal.