### PR TITLE
Only increment arrow count if the projectile is an arrow

### DIFF
--- a/src/main/java/net/minestom/server/entity/EntityProjectile.java
+++ b/src/main/java/net/minestom/server/entity/EntityProjectile.java
@@ -178,7 +178,9 @@ public class EntityProjectile extends Entity {
                     .findAny();
             if (victimOptional.isPresent()) {
                 LivingEntity victim = (LivingEntity) victimOptional.get();
-                victim.setArrowCount(victim.getArrowCount() + 1);
+                if(entityType == EntityTypes.ARROW || entityType == EntityTypes.SPECTRAL_ARROW) {
+                    victim.setArrowCount(victim.getArrowCount() + 1);
+                }
                 EventDispatcher.call(new EntityAttackEvent(this, victim));
                 remove();
                 return super.onGround;


### PR DESCRIPTION
Currently, Minestom will always add an arrow upon EntityProjectile collide

This PR fixes this behavior by first ensuring that an arrow has collided with the target before incrementing the count.