### PR TITLE
Fix issue #534

### DIFF
--- a/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
+++ b/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
@@ -92,10 +92,11 @@ public class BlockPlacementListener {
         final Point placementPosition = blockPosition.add(offsetX, offsetY, offsetZ);
 
         if (!canPlaceBlock) {
-            // Send a block change with AIR as block to keep the client in sync,
+            // Send a block change with the real block in the instance to keep the client in sync,
             // using refreshChunk results in the client not being in sync
             // after rapid invalid block placements
-            player.getPlayerConnection().sendPacket(new BlockChangePacket(placementPosition, Block.AIR));
+            final Block block = interactedChunk.getBlock(placementPosition);
+            player.getPlayerConnection().sendPacket(new BlockChangePacket(placementPosition, block));
             return;
         }
 

--- a/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
+++ b/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
@@ -95,7 +95,7 @@ public class BlockPlacementListener {
             // Send a block change with the real block in the instance to keep the client in sync,
             // using refreshChunk results in the client not being in sync
             // after rapid invalid block placements
-            final Block block = interactedChunk.getBlock(placementPosition);
+            final Block block = instance.getBlock(placementPosition);
             player.getPlayerConnection().sendPacket(new BlockChangePacket(placementPosition, block));
             return;
         }


### PR DESCRIPTION
This PR fixes issue #534 

The client was always being sent air blocks to "keep them in sync", when this often wouldn't keep them in sync. This PR changes that to send the block actually in the instance.