### PR TITLE
Fix Spawn Location of projectiles in RangedAttackGoal

### DIFF
--- a/src/main/java/net/minestom/server/entity/ai/goal/RangedAttackGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/RangedAttackGoal.java
@@ -109,7 +109,7 @@ public class RangedAttackGoal extends GoalSelector {
                         projectileGenerator = shooter -> new EntityProjectile(shooter, EntityType.ARROW);
                     }
                     EntityProjectile projectile = projectileGenerator.apply(this.entityCreature);
-                    projectile.setInstance(this.entityCreature.getInstance(), this.entityCreature.getPosition());
+                    projectile.setInstance(this.entityCreature.getInstance(), this.entityCreature.getPosition().add(0D, this.entityCreature.getEyeHeight(), 0D));
 
                     projectile.shoot(to, this.power, this.spread);
                     this.lastShot = time;


### PR DESCRIPTION
Currently, a projectile will spawn at the entityCreature's position (their feet position).

This PR will make them spawn at the eye position instead.