### PR TITLE
Fixed nullpointer when unloading a dependent extention

### DIFF
--- a/src/main/java/net/minestom/server/extensions/ExtensionManager.java
+++ b/src/main/java/net/minestom/server/extensions/ExtensionManager.java
@@ -715,8 +715,10 @@ public class ExtensionManager {
 
         for (String dependentID : dependents) {
             Extension dependentExt = extensions.get(dependentID.toLowerCase());
-            LOGGER.info("Unloading dependent extension {} (because it depends on {})", dependentID, extensionName);
-            unload(dependentExt);
+            if ( dependentExt != null ) { // check if extension isn't already unloaded.
+                LOGGER.info("Unloading dependent extension {} (because it depends on {})", dependentID, extensionName);
+                unload(dependentExt);
+            }
         }
 
         LOGGER.info("Unloading extension {}", extensionName);


### PR DESCRIPTION
This PR fixes the following error.
 It appears during the shutdown process, when extension A depends on extension B and extension A is unloaded before extension B. Before unloading B, all dependants will be unloaded but since A is already unloaded it tries to unload null.

```
[12:57:39] - INFO  - ExtensionManager    : Unloading extension brickchat
[12:57:39] - INFO  - BrickChat           : Disabled BrickChat v1.0.0.
[12:57:39] - INFO  - ExtensionManager    : Unloading dependent extension BrickChat (because it depends on brickplaceholders)
java.lang.NullPointerException: Cannot invoke "net.minestom.server.extensions.Extension.preTerminate()" because "ext" is null
        at net.minestom.server.extensions.ExtensionManager.unload(ExtensionManager.java:728)
        at net.minestom.server.extensions.ExtensionManager.unloadExtension(ExtensionManager.java:720)
        at net.minestom.server.extensions.ExtensionManager.shutdown(ExtensionManager.java:703)
        at net.minestom.server.ServerProcessImpl.stop(ServerProcessImpl.java:259)
        at net.minestom.server.MinecraftServer.stopCleanly(MinecraftServer.java:418)
        at com.gufli.brick.commands.StopCommand.stop(StopCommand.java:23)
        at com.gufli.brick.commands.StopCommand.lambda$new$1(StopCommand.java:19)
        at net.minestom.server.command.builder.ParsedCommand.execute(ParsedCommand.java:67)
        at net.minestom.server.command.builder.CommandDispatcher.execute(CommandDispatcher.java:94)
        at net.minestom.server.command.CommandManager.execute(CommandManager.java:110)
        at com.gufli.brick.terminal.BrickTerminalConsole.runCommand(BrickTerminalConsole.java:27)
        at net.minecrell.terminalconsole.SimpleTerminalConsole.processInput(SimpleTerminalConsole.java:87)
        at net.minecrell.terminalconsole.SimpleTerminalConsole.readCommands(SimpleTerminalConsole.java:181)
        at net.minecrell.terminalconsole.SimpleTerminalConsole.start(SimpleTerminalConsole.java:143)
        at com.gufli.brick.Main.main(Main.java:66)
```