### PR TITLE
Shut down tinylog during Minestom shutdown hook

### DIFF
--- a/src/main/java/net/minestom/server/ServerProcessImpl.java
+++ b/src/main/java/net/minestom/server/ServerProcessImpl.java
@@ -31,6 +31,7 @@ import net.minestom.server.world.biomes.BiomeManager;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.tinylog.provider.ProviderRegistry;
 
 import java.io.IOException;
 import java.net.SocketAddress;
@@ -245,6 +246,12 @@ final class ServerProcessImpl implements ServerProcess {
         MinestomTerminal.stop();
         dispatcher.shutdown();
         LOGGER.info("Minestom server stopped successfully.");
+        try {
+            ProviderRegistry.getLoggingProvider().shutdown();
+        } catch (InterruptedException exception) {
+            exception.printStackTrace();
+            System.out.println("WARNING: Tinylog was exited while trying to clean up resources.");
+        }
     }
 
     @Override

--- a/src/main/resources/tinylog.properties
+++ b/src/main/resources/tinylog.properties
@@ -1,4 +1,4 @@
-autoshutdown=true
+autoshutdown=false
 writer=console
 writer.level=info
 writer.format=[{thread}] [{date: HH:mm:ss}] ({class-name}.{method}) - {level} - {message}


### PR DESCRIPTION
For tinylog configurations that handle files, shutting down a Minestom server normally means the log file won't be able to write the output of the shutdown. This moves the shutdown hook for tinylog to Minestom's shutdown hook, shutting down the logger when Minestom is shut down.