### PR TITLE
Resetting player flying speed after changing gamemode

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -1252,6 +1252,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
                 this.flying = false;
             }
         }
+        this.flyingSpeed = 0.05f; // reset flying speed
     }
 
     /**

--- a/src/test/java/net/minestom/server/entity/player/PlayerIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerIntegrationTest.java
@@ -43,6 +43,11 @@ public class PlayerIntegrationTest {
         assertAbilities(player, false, false, false, false);
         player.setGameMode(GameMode.SURVIVAL);
         assertAbilities(player, false, false, false, false);
+
+        player.setGameMode(GameMode.SPECTATOR);
+        player.setFlyingSpeed(1.0f);
+        player.setGameMode(GameMode.CREATIVE);
+        assertEquals(player.getFlyingSpeed(), 0.05f);
     }
 
     private void assertAbilities(Player player, boolean isInvulnerable, boolean isFlying, boolean isAllowFlying,


### PR DESCRIPTION
Hello. Today I found a bug, that causes the player not to reset flying speed after changing the gamemode. So, I decided to fix it.