### PR TITLE
Resetting player flying speed after changing gamemode

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -1252,6 +1252,10 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
                 this.flying = false;
             }
         }
+        // Make sure that the player is in the PLAY state and synchronize their flight speed.
+        if (isActive()) {
+            refreshAbilities();
+        }
     }
 
     /**


### PR DESCRIPTION
Hi. This is an improved version of my PR #707. This PR contains a fix, that resets the player's speed after changing the gamemode.