### PR TITLE
Add wildcard support to no-verifier hasPermission

### DIFF
--- a/src/main/java/net/minestom/server/permission/PermissionHandler.java
+++ b/src/main/java/net/minestom/server/permission/PermissionHandler.java
@@ -67,6 +67,15 @@ public interface PermissionHandler {
             if (permissionLoop.equals(permission)) {
                 return true;
             }
+
+            if (permissionLoop.getPermissionName().endsWith(".*")) {
+
+                // Remove (.*) from the end of the string
+                String permissionPrefix = permissionLoop.getPermissionName().substring(0, permission.getPermissionName().length() - 2);
+
+                if (permission.getPermissionName().startsWith(permissionPrefix))
+                    return true;
+            }
         }
         return false;
     }

--- a/src/test/java/net/minestom/server/permission/TestPermissions.java
+++ b/src/test/java/net/minestom/server/permission/TestPermissions.java
@@ -18,7 +18,7 @@ public class TestPermissions {
 
     private Player player;
 
-    private Permission permission1, permission2;
+    private Permission permission1, permission2, permission3;
 
     @BeforeEach
     public void init() {
@@ -42,6 +42,8 @@ public class TestPermissions {
         );
 
         permission2 = new Permission("perm.name2");
+
+        permission3 = new Permission("perm.test.*");
     }
 
     @Test
@@ -60,6 +62,15 @@ public class TestPermissions {
 
         player.addPermission(permission2);
         assertTrue(player.hasPermission(permission2));
+    }
+
+    @Test
+    public void hasPermissionWildcard() {
+        assertFalse(player.hasPermission(permission3));
+
+        player.addPermission(permission3);
+
+        assertTrue(player.hasPermission(permission3));
     }
 
     @Test


### PR DESCRIPTION
This adds wildcard support to the #hasPermission(Permission permission) method.

EX:

If a player has the permission `test.*`, `test.one` and `test.two` would count as valid permissions when passed through the above hasPermission method.

This is part of one of the two PRs (#401) to help bring better support for permission plugins.