### PR TITLE
Standardization start logic for providers

### DIFF
--- a/src/main/java/net/minestom/server/MinecraftServer.java
+++ b/src/main/java/net/minestom/server/MinecraftServer.java
@@ -355,7 +355,19 @@ public final class MinecraftServer {
      * Starts the server.
      * <p>
      * It should be called after {@link #init()} and probably your own initialization code.
-     *
+     * <br>
+     * Can be controlled/overridden via jvm properties.<br>
+     * <strong>Unix</strong><br>
+     * -Dunix=/var/run/minestom/minestom.sock
+     * <br>
+     * <strong>Host and Port</strong><br>
+     * -Dhost=127.0.0.1<br>
+     * -Dport=255565<br>
+     *<br>
+     * <strong>Full commandline example</strong><br>
+     * java -Dhost=127.0.0.1 -Dport=25565 -jar minestom.jar<br>
+     * or <br>
+     * java -Dunix=/var/run/minestom/minestom.sock -jar minestom.jar<br>
      * @param address the server address
      * @throws IllegalStateException if called before {@link #init()} or if the server is already running
      */

--- a/src/main/java/net/minestom/server/ServerProcessImpl.java
+++ b/src/main/java/net/minestom/server/ServerProcessImpl.java
@@ -1,6 +1,10 @@
 package net.minestom.server;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+
+import java.net.InetSocketAddress;
+import java.net.UnixDomainSocketAddress;
+
 import net.minestom.server.advancements.AdvancementManager;
 import net.minestom.server.adventure.bossbar.BossBarManager;
 import net.minestom.server.command.CommandManager;
@@ -222,7 +226,17 @@ final class ServerProcessImpl implements ServerProcess {
 
         // Init server
         try {
-            server.init(socketAddress);
+            var address = socketAddress;
+            var unixPath = System.getProperty("unix");
+            if (unixPath != null) {
+                address = UnixDomainSocketAddress.of(unixPath);
+            }
+            String host = System.getProperty("host");
+            String port = System.getProperty("port");
+            if (host != null && port != null) {
+                address = new InetSocketAddress(host, Integer.parseInt(port));
+            }
+            server.init(address);
         } catch (IOException e) {
             exception.handleException(e);
             throw new RuntimeException(e);


### PR DESCRIPTION
This allows to provider to override via environment variables port and host.
Also to use unix socket paths. 
Documentation describes how it works