### PR TITLE
Another fix for EntityProjectile

### DIFF
--- a/src/main/java/net/minestom/server/entity/EntityProjectile.java
+++ b/src/main/java/net/minestom/server/entity/EntityProjectile.java
@@ -159,8 +159,9 @@ public class EntityProjectile extends Entity {
                         .map(entity -> (LivingEntity) entity)
                         .collect(Collectors.toSet());
             }
+            final Point currentPos = pos;
             Stream<LivingEntity> victimsStream = entities.stream()
-                    .filter(entity -> bb.intersectEntity(getPosition(), entity));
+                    .filter(entity -> bb.intersectEntity(currentPos, entity));
             /*
               We won't check collisions with a shooter for first ticks of arrow's life, because it spawns in him
               and will immediately deal damage.


### PR DESCRIPTION
I've discovered that for bounding box intersection I used projectile's final position and not the extrapolated one. In some circumstances it led to intersection losses.
Also adjusted test for that kind of cases.