### PR TITLE
Use toUpperCase(Locale.ROOT) instead of toLowerCase

### DIFF
--- a/src/main/java/net/minestom/server/extensions/ExtensionManager.java
+++ b/src/main/java/net/minestom/server/extensions/ExtensionManager.java
@@ -167,7 +167,7 @@ public final class ExtensionManager {
         for (ExtensionDescriptor extension : extensionsByName.values()) {
             for (Dependency dependency : extension.dependencies()) {
                 if (dependency instanceof Dependency.Extension extensionDependency) {
-                    ExtensionDescriptor dependencyExtension = extensionsByName.get(extensionDependency.id().toLowerCase());
+                    ExtensionDescriptor dependencyExtension = extensionsByName.get(extensionDependency.id().toUpperCase(Locale.ROOT));
                     if (dependencyExtension == null) {
                         if (extensionDependency.isOptional()) {
                             LOGGER.debug("Optional extension {} (for {}) was not found.", extensionDependency.id(), extension.name());

--- a/src/main/java/net/minestom/server/extensions/ExtensionManager.java
+++ b/src/main/java/net/minestom/server/extensions/ExtensionManager.java
@@ -329,7 +329,7 @@ public final class ExtensionManager {
         // Load child and get classloader
         HierarchyClassLoader dependencyClassLoader = null;
         if (dep instanceof Dependency.Extension dependency) {
-            ExtensionDescriptor descriptor = extensionsById.get(dependency.id().toLowerCase());
+            ExtensionDescriptor descriptor = extensionsById.get(dependency.id().toUpperCase(Locale.ROOT));
             //todo what happens if extension does not exist?
             boolean loaded = loadExtension(descriptor, extensionsById);
             if (!loaded) return false;


### PR DESCRIPTION
Loading dependencies if they arent uppercase doesn't work. This PR fixes that issue.

For example, if you had the dependency "Test", the code would expect "TEST" but it instead would transform it to "test".