### PR TITLE
Fix bad conversion of block index using negative Y

### DIFF
--- a/src/main/java/net/minestom/server/utils/chunk/ChunkUtils.java
+++ b/src/main/java/net/minestom/server/utils/chunk/ChunkUtils.java
@@ -238,7 +238,7 @@ public final class ChunkUtils {
      * @return the chunk position Y of the specified index
      */
     public static int blockIndexToChunkPositionY(int index) {
-        int y = index >>> 4 & 0xFF;
+        int y = (index & 0x07FFFFF0) >>> 4;
         if(((index >>> 27) & 1) == 1) y = -y; // Sign bit set, invert sign
         return y; // 4-28 bits
     }

--- a/src/main/java/net/minestom/server/utils/chunk/ChunkUtils.java
+++ b/src/main/java/net/minestom/server/utils/chunk/ChunkUtils.java
@@ -216,9 +216,7 @@ public final class ChunkUtils {
      */
     public static @NotNull Point getBlockPosition(int index, int chunkX, int chunkZ) {
         final int x = blockIndexToChunkPositionX(index) + Chunk.CHUNK_SIZE_X * chunkX;
-        int y = index >>> 4 & 0xFF;
-        if(((index >>> 27) & 1) == 1) y = -y; // Sign bit set, invert sign
-
+        final int y = blockIndexToChunkPositionY(index);
         final int z = blockIndexToChunkPositionZ(index) + Chunk.CHUNK_SIZE_Z * chunkZ;
         return new Vec(x, y, z);
     }
@@ -240,7 +238,9 @@ public final class ChunkUtils {
      * @return the chunk position Y of the specified index
      */
     public static int blockIndexToChunkPositionY(int index) {
-        return (index >> 4) & 0x0FFFFFF; // 4-28 bits
+        int y = index >>> 4 & 0xFF;
+        if(((index >>> 27) & 1) == 1) y = -y; // Sign bit set, invert sign
+        return y; // 4-28 bits
     }
 
     /**

--- a/src/main/java/net/minestom/server/utils/chunk/ChunkUtils.java
+++ b/src/main/java/net/minestom/server/utils/chunk/ChunkUtils.java
@@ -198,7 +198,12 @@ public final class ChunkUtils {
         z = z % Chunk.CHUNK_SIZE_Z;
 
         int index = x & 0xF; // 4 bits
-        index |= (y << 4) & 0x0FFFFFF0; // 24 bits
+        if(y > 0) {
+            index |= (y << 4) & 0x07FFFFF0; // 23 bits (24th bit is always 0 because y is positive)
+        } else {
+            index |= ((-y) << 4) & 0x7FFFFF0; // Make positive and use 23 bits
+            index |= 1 << 27; // Set negative sign at 24th bit
+        }
         index |= (z << 28) & 0xF0000000; // 4 bits
         return index;
     }
@@ -211,7 +216,9 @@ public final class ChunkUtils {
      */
     public static @NotNull Point getBlockPosition(int index, int chunkX, int chunkZ) {
         final int x = blockIndexToChunkPositionX(index) + Chunk.CHUNK_SIZE_X * chunkX;
-        final int y = index >>> 4 & 0xFF;
+        int y = index >>> 4 & 0xFF;
+        if(((index >>> 27) & 1) == 1) y = -y; // Sign bit set, invert sign
+
         final int z = blockIndexToChunkPositionZ(index) + Chunk.CHUNK_SIZE_Z * chunkZ;
         return new Vec(x, y, z);
     }

--- a/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
+++ b/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
@@ -1,5 +1,7 @@
 package net.minestom.server.coordinate;
 
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
 import net.minestom.server.instance.Chunk;
 import net.minestom.server.utils.chunk.ChunkUtils;
 import org.junit.jupiter.api.Test;
@@ -126,7 +128,7 @@ public class CoordinateTest {
                 new Vec(0, -8_388_607, 0)
         );
 
-        for(Vec vec : tempEquals) {
+        for (Vec vec : tempEquals) {
             assertEquals(getBlockPosition(getBlockIndex(vec.blockX(), vec.blockY(), vec.blockZ()),
                     vec.chunkX(), vec.chunkZ()), vec);
         }
@@ -141,10 +143,29 @@ public class CoordinateTest {
                 new Vec(0, -8_388_608, 0)
         );
 
-        for(Vec vec : tempNotEquals) {
+        for (Vec vec : tempNotEquals) {
             assertNotEquals(getBlockPosition(getBlockIndex(vec.blockX(), vec.blockY(), vec.blockZ()),
                     vec.chunkX(), vec.chunkZ()), vec);
         }
     }
 
+    @Test
+    public void blockIndexDuplicate() {
+        LongSet temp = new LongOpenHashSet();
+
+        for (int x = 0; x < Chunk.CHUNK_SIZE_X; x++) {
+            for (int z = 0; z < Chunk.CHUNK_SIZE_Z; z++) {
+                for (int y = -64; y < 364; y++) {
+                    var vec = new Vec(x, y, z);
+                    var index = getBlockIndex(vec.blockX(), vec.blockY(), vec.blockZ());
+                    assertTrue(temp.add(index), "Duplicate block index found: " + index + " " + vec);
+                    assertEquals(getBlockPosition(index, vec.chunkX(), vec.chunkZ()), vec);
+
+                    assertEquals(blockIndexToChunkPositionX(index), x);
+                    assertEquals(blockIndexToChunkPositionY(index), y);
+                    assertEquals(blockIndexToChunkPositionZ(index), z);
+                }
+            }
+        }
+    }
 }

--- a/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
+++ b/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
@@ -100,4 +100,18 @@ public class CoordinateTest {
         assertEquals(0, ChunkUtils.toSectionRelativeCoordinate(32));
         assertEquals(1, ChunkUtils.toSectionRelativeCoordinate(33));
     }
+
+    @Test
+    public void testBlockIndex() {
+        // Positive Y coordinate
+        Pos posPositive = new Pos(124, 16, 116);
+        assertEquals(getBlockPosition(getBlockIndex(posPositive.blockX(), posPositive.blockY(), posPositive.blockZ()),
+                        posPositive.chunkX(), posPositive.chunkZ()), posPositive.asVec());
+
+        // Negative Y coordinate
+        Pos posNegative = new Pos(124, -16, 116);
+        assertEquals(getBlockPosition(getBlockIndex(posNegative.blockX(), posNegative.blockY(), posNegative.blockZ()),
+                posNegative.chunkX(), posNegative.chunkZ()), posNegative.asVec());
+    }
+
 }


### PR DESCRIPTION
Fixes issue #808.

We got the same problem and I debugged everything.
I found out that the NBT is sent right but the X/Y/Z coordinates inside the ChunkData packet is wrong:
![image](https://user-images.githubusercontent.com/3356015/161448610-70fe56ba-a972-43c8-af15-ffea1682df2e.png)

The expected coordinates for this would be -72 -42 -10.

I found out that the block index does not respect negative values (I think because it was missed during 1.18 Minestom update). It did work pre-1.18 because there weren't any tile entities on Y < 0, right?

But now when there are negative integers, the two-complement value does not convert back from the block index the right way.

I am no expert at binary arithmetics but I tried
* to use the 28th bit of the index to make a negative flag
* use the other bits to store the absolute value of Y and
* check for the negative flag in the `getBlockPosition` function to negate the value again.

I have tested it and it works fine now (signs appear again on negative Y values).

I don't know if this is the best solution for this problem, so I appreciate some hints to do it better. :)