### PR TITLE
Add optional outgoing packet manipulation

### DIFF
--- a/src/main/java/net/minestom/server/event/player/PlayerPacketOutEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerPacketOutEvent.java
@@ -1,26 +1,32 @@
 package net.minestom.server.event.player;
 
+import net.minestom.server.Viewable;
+import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.CancellableEvent;
 import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.network.packet.server.SendablePacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
 /**
  * Listen to outgoing packets asynchronously.
  * <p>
- * Currently, do not support viewable packets.
+ * Currently, this does not fully support viewable packets. For more information see {@link net.minestom.server.utils.PacketUtils#prepareViewablePacket(Viewable, ServerPacket, Entity) packet controlling}.
  */
 @ApiStatus.Experimental
-public class PlayerPacketOutEvent implements PlayerEvent, CancellableEvent {
+public class PlayerPacketOutEvent implements PlayerEvent {
 
     private final Player player;
-    private boolean updated = false;
-    private ServerPacket packet;
-    private boolean cancelled = false;
+    private final ServerPacket packet;
+    private final List<SendablePacket> appendix = new ArrayList<>();
+    private boolean discarded = false;
 
-    public PlayerPacketOutEvent(Player player, ServerPacket packet) {
+    public PlayerPacketOutEvent(@NotNull Player player, @NotNull ServerPacket packet) {
         this.player = player;
         this.packet = packet;
     }
@@ -38,41 +44,57 @@ public class PlayerPacketOutEvent implements PlayerEvent, CancellableEvent {
     }
 
     /**
-     * Sets a new packet that should be sent instead.
+     * Discards the original packet.
      *
-     * @param packet the new packet.
+     * @return The event instance.
      */
-    public void setPacket(@NotNull ServerPacket packet) {
-        this.packet = packet;
-        this.updated = true;
+    @NotNull
+    public PlayerPacketOutEvent discardPacket() {
+        discarded = true;
+        return this;
     }
 
     /**
-     * Indicates if the event has been cancelled.
+     * Appends a packet to the appendix which will be sent additionally to the original packet if it has not been discarded.
      *
-     * @return true if the event has been cancelled.
+     * @param packet The packet to add to the appendix.
+     * @return The event instance.
      */
-    @Override
-    public boolean isCancelled() {
-        return cancelled;
+    @NotNull
+    public PlayerPacketOutEvent append(@NotNull ServerPacket packet) {
+        appendix.add(packet);
+        return this;
     }
 
     /**
-     * Cancels the event.
+     * Discards the packet and appends the given packet to the appendix.
      *
-     * @param cancel true if the event should be cancelled, false otherwise.
+     * @param packet The replacement packet.
      */
-    @Override
-    public void setCancelled(boolean cancel) {
-        cancelled = cancel;
+    public void replace(@NotNull ServerPacket packet) {
+        discardPacket().append(packet);
     }
 
     /**
-     * Indicates if the packet has been updated.
-     *
-     * @return true if the packet was updated.
+     * @return The original appendix instance to allow later modifications from extensions.
      */
-    public boolean isUpdated() {
-        return updated;
+    @NotNull
+    public List<SendablePacket> getAppendix() {
+        return appendix;
+    }
+
+    /**
+     * @param consumer The consumer which consumes all packets.
+     */
+    public void usePackets(@NotNull Consumer<SendablePacket> consumer) {
+        if (!isDiscarded()) consumer.accept(packet);
+        appendix.forEach(consumer);
+    }
+
+    /**
+     * @return true if the packet was discarded.
+     */
+    public boolean isDiscarded() {
+        return discarded;
     }
 }

--- a/src/main/java/net/minestom/server/event/player/PlayerPacketOutEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerPacketOutEvent.java
@@ -1,6 +1,7 @@
 package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
+import net.minestom.server.event.trait.CancellableEvent;
 import net.minestom.server.event.trait.PlayerEvent;
 import net.minestom.server.network.packet.server.ServerPacket;
 import org.jetbrains.annotations.ApiStatus;
@@ -12,10 +13,12 @@ import org.jetbrains.annotations.NotNull;
  * Currently, do not support viewable packets.
  */
 @ApiStatus.Experimental
-public class PlayerPacketOutEvent implements PlayerEvent {
+public class PlayerPacketOutEvent implements PlayerEvent, CancellableEvent {
 
     private final Player player;
-    private final ServerPacket packet;
+    private boolean updated = false;
+    private ServerPacket packet;
+    private boolean cancelled = false;
 
     public PlayerPacketOutEvent(Player player, ServerPacket packet) {
         this.player = player;
@@ -27,7 +30,49 @@ public class PlayerPacketOutEvent implements PlayerEvent {
         return player;
     }
 
+    /**
+     * @return The current packet.
+     */
     public @NotNull ServerPacket getPacket() {
         return packet;
+    }
+
+    /**
+     * Sets a new packet that should be sent instead.
+     *
+     * @param packet the new packet.
+     */
+    public void setPacket(@NotNull ServerPacket packet) {
+        this.packet = packet;
+        this.updated = true;
+    }
+
+    /**
+     * Indicates if the event has been cancelled.
+     *
+     * @return true if the event has been cancelled.
+     */
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    /**
+     * Cancels the event.
+     *
+     * @param cancel true if the event should be cancelled, false otherwise.
+     */
+    @Override
+    public void setCancelled(boolean cancel) {
+        cancelled = cancel;
+    }
+
+    /**
+     * Indicates if the packet has been updated.
+     *
+     * @return true if the packet was updated.
+     */
+    public boolean isUpdated() {
+        return updated;
     }
 }

--- a/src/main/java/net/minestom/server/network/player/PlayerSocketConnection.java
+++ b/src/main/java/net/minestom/server/network/player/PlayerSocketConnection.java
@@ -344,7 +344,10 @@ public class PlayerSocketConnection extends PlayerConnection {
         // Outgoing event
         if (player != null && outgoing.hasListener()) {
             final ServerPacket serverPacket = SendablePacket.extractServerPacket(packet);
-            outgoing.call(new PlayerPacketOutEvent(player, serverPacket));
+            PlayerPacketOutEvent event = new PlayerPacketOutEvent(player, serverPacket);
+            outgoing.call(event);
+            if (event.isCancelled()) return;
+            if (event.isUpdated()) packet = event.getPacket();
         }
         // Write packet
         if (packet instanceof ServerPacket serverPacket) {

--- a/src/main/java/net/minestom/server/network/player/PlayerSocketConnection.java
+++ b/src/main/java/net/minestom/server/network/player/PlayerSocketConnection.java
@@ -346,9 +346,14 @@ public class PlayerSocketConnection extends PlayerConnection {
             final ServerPacket serverPacket = SendablePacket.extractServerPacket(packet);
             PlayerPacketOutEvent event = new PlayerPacketOutEvent(player, serverPacket);
             outgoing.call(event);
-            if (event.isCancelled()) return;
-            if (event.isUpdated()) packet = event.getPacket();
+
+            event.usePackets(p -> writeAbstractPacketSync(p, compressed));
+        } else {
+            writeAbstractPacketSync(packet, compressed);
         }
+    }
+
+    private void writeAbstractPacketSync(SendablePacket packet, boolean compressed) {
         // Write packet
         if (packet instanceof ServerPacket serverPacket) {
             writeServerPacketSync(serverPacket, compressed);


### PR DESCRIPTION
Sometimes it's necessary to either block or replace packets. With the current API it's possible to see when a packet is about to be sent but it could not be intercepted.