### PR TITLE
Fix server sending unnecessary CloseWindowPacket

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -1443,6 +1443,40 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
     }
 
     /**
+     * Called to properly set the state of the server when a client sends a CloseWindowPacket
+     * Generally, you should use {@link #closeInventory()} instead of this function
+     * @param id The id of the window to close
+     */
+    public void closeInventoryFromClient(byte id) {
+        if(id == 0) {
+            // Player inventory closing
+            ItemStack cursorItem = getInventory().getCursorItem();
+            getInventory().setCursorItem(ItemStack.AIR);
+            if(!cursorItem.isAir()) {
+                boolean canAdd = getInventory().addItemStack(cursorItem);
+                if(!canAdd) {
+                    dropItem(cursorItem);
+                }
+            }
+        } else {
+            if(getOpenInventory() != null && getOpenInventory().getWindowId() == id) {
+                ItemStack cursorItem = getOpenInventory().getCursorItem(this);
+                if (!cursorItem.isAir()) {
+                    // Add item to inventory if unable to drop
+                    if (!dropItem(cursorItem)) {
+                        getInventory().addItemStack(cursorItem);
+                    }
+                }
+                openInventory.removeViewer(this);
+                this.openInventory = null;
+            }
+            // If our check failed, disregard, since we received an invalid close window request
+        }
+        inventory.update();
+        this.didCloseInventory = true;
+    }
+
+    /**
      * Used internally to prevent an inventory click to be processed
      * when the inventory listeners closed the inventory.
      * <p>

--- a/src/main/java/net/minestom/server/listener/WindowListener.java
+++ b/src/main/java/net/minestom/server/listener/WindowListener.java
@@ -90,7 +90,7 @@ public class WindowListener {
         InventoryCloseEvent inventoryCloseEvent = new InventoryCloseEvent(player.getOpenInventory(), player);
         EventDispatcher.call(inventoryCloseEvent);
 
-        player.closeInventory();
+        player.closeInventoryFromClient(packet.windowId());
 
         Inventory newInventory = inventoryCloseEvent.getNewInventory();
         if (newInventory != null)


### PR DESCRIPTION
Fixes #713 

This PR adds an additional method to the player class, and uses that set the proper state server-side upon the server receiving a ClientCloseWindowPacket.