### PR TITLE
Fixed expanded bounding box

### DIFF
--- a/src/main/java/net/minestom/server/collision/BoundingBox.java
+++ b/src/main/java/net/minestom/server/collision/BoundingBox.java
@@ -18,7 +18,8 @@ public final class BoundingBox implements Shape {
     private final Point offset;
     private Point relativeEnd;
 
-    BoundingBox(double width, double height, double depth, Point offset) {
+    @ApiStatus.Internal
+    public BoundingBox(double width, double height, double depth, Point offset) {
         this.width = width;
         this.height = height;
         this.depth = depth;

--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -523,7 +523,10 @@ public class LivingEntity extends Entity implements EquipmentHandler {
     @Override
     public void setBoundingBox(double x, double y, double z) {
         super.setBoundingBox(x, y, z);
-        this.expandedBoundingBox = getBoundingBox().expand(1, 0.5f, 1);
+        final double width = getBoundingBox().width() + x;
+        final double height = getBoundingBox().height() + y;
+        final double depth = getBoundingBox().depth() + z;
+        this.expandedBoundingBox = new BoundingBox(width, height, depth, new Vec(-width / 2, -y, -depth / 2));
     }
 
     /**


### PR DESCRIPTION
Currently players can't pickup items on half-blocks or staircases, because their expanded bounding box still starts at entity's bottom Y and not lower.