### PR TITLE
Add onGround to PlayerMoveEvent

### DIFF
--- a/src/main/java/net/minestom/server/event/player/PlayerMoveEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerMoveEvent.java
@@ -14,12 +14,14 @@ public class PlayerMoveEvent implements PlayerEvent, EntityInstanceEvent, Cancel
 
     private final Player player;
     private Pos newPosition;
+    private final boolean onGround;
 
     private boolean cancelled;
 
-    public PlayerMoveEvent(@NotNull Player player, @NotNull Pos newPosition) {
+    public PlayerMoveEvent(@NotNull Player player, @NotNull Pos newPosition, boolean onGround) {
         this.player = player;
         this.newPosition = newPosition;
+        this.onGround = onGround;
     }
 
     /**
@@ -38,6 +40,15 @@ public class PlayerMoveEvent implements PlayerEvent, EntityInstanceEvent, Cancel
      */
     public void setNewPosition(@NotNull Pos newPosition) {
         this.newPosition = newPosition;
+    }
+
+    /**
+     * Gets if the player is now on the ground.
+     *
+     * @return onGround
+     */
+    public boolean isOnGround() {
+        return onGround;
     }
 
     @Override

--- a/src/main/java/net/minestom/server/event/player/PlayerMoveEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerMoveEvent.java
@@ -44,6 +44,8 @@ public class PlayerMoveEvent implements PlayerEvent, EntityInstanceEvent, Cancel
 
     /**
      * Gets if the player is now on the ground.
+     * This is the original value that the client sent,
+     * and is not modified by setting the new position.
      *
      * @return onGround
      */

--- a/src/main/java/net/minestom/server/listener/PlayerPositionListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerPositionListener.java
@@ -54,7 +54,7 @@ public class PlayerPositionListener {
             return;
         }
 
-        PlayerMoveEvent playerMoveEvent = new PlayerMoveEvent(player, packetPosition);
+        PlayerMoveEvent playerMoveEvent = new PlayerMoveEvent(player, packetPosition, onGround);
         EventDispatcher.call(playerMoveEvent);
         if (!currentPosition.equals(player.getPosition())) {
             // Player has been teleported in the event


### PR DESCRIPTION
It is not possible to just use `Player#isOnGround()` because the field is updated after the event call.