### PR TITLE
Item metadata fixes

### DIFF
--- a/src/main/java/net/minestom/server/item/metadata/CrossbowMeta.java
+++ b/src/main/java/net/minestom/server/item/metadata/CrossbowMeta.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 public record CrossbowMeta(TagReadable readable) implements ItemMetaView<CrossbowMeta.Builder> {
     private static final Tag<List<ItemStack>> PROJECTILES = Tag.ItemStack("ChargedProjectiles").list();
-    private static final Tag<Boolean> CHARGED = Tag.Boolean("Charged");
+    private static final Tag<Boolean> CHARGED = Tag.Boolean("Charged").defaultValue(false);
 
     public @NotNull List<ItemStack> getProjectiles() {
         return getTag(PROJECTILES);

--- a/src/main/java/net/minestom/server/item/metadata/CrossbowMeta.java
+++ b/src/main/java/net/minestom/server/item/metadata/CrossbowMeta.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.UnknownNullability;
 import java.util.List;
 
 public record CrossbowMeta(TagReadable readable) implements ItemMetaView<CrossbowMeta.Builder> {
-    private static final Tag<List<ItemStack>> PROJECTILES = Tag.ItemStack("ChargedProjectiles").list();
+    private static final Tag<List<ItemStack>> PROJECTILES = Tag.ItemStack("ChargedProjectiles").list().defaultValue(List.of());
     private static final Tag<Boolean> CHARGED = Tag.Boolean("Charged").defaultValue(false);
 
     public @NotNull List<ItemStack> getProjectiles() {

--- a/src/main/java/net/minestom/server/item/metadata/FireworkMeta.java
+++ b/src/main/java/net/minestom/server/item/metadata/FireworkMeta.java
@@ -7,6 +7,7 @@ import net.minestom.server.tag.TagHandler;
 import net.minestom.server.tag.TagReadable;
 import net.minestom.server.tag.TagSerializer;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
 
 import java.util.List;
@@ -17,11 +18,11 @@ public record FireworkMeta(TagReadable readable) implements ItemMetaView<Firewor
             .path("Fireworks").list().defaultValue(List.of());
     private static final Tag<Byte> FLIGHT_DURATION = Tag.Byte("Flight").path("Fireworks");
 
-    public List<FireworkEffect> getEffects() {
+    public @NotNull List<FireworkEffect> getEffects() {
         return getTag(EFFECTS);
     }
 
-    public byte getFlightDuration() {
+    public @Nullable Byte getFlightDuration() {
         return getTag(FLIGHT_DURATION);
     }
 

--- a/src/main/java/net/minestom/server/item/metadata/PlayerHeadMeta.java
+++ b/src/main/java/net/minestom/server/item/metadata/PlayerHeadMeta.java
@@ -42,7 +42,7 @@ public record PlayerHeadMeta(TagReadable readable) implements ItemMetaView<Playe
         }
     }).path("SkullOwner");
 
-    public UUID getSkullOwner() {
+    public @Nullable UUID getSkullOwner() {
         return getTag(SKULL_OWNER);
     }
 

--- a/src/main/java/net/minestom/server/item/metadata/PotionMeta.java
+++ b/src/main/java/net/minestom/server/item/metadata/PotionMeta.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.UnknownNullability;
 import java.util.List;
 
 public record PotionMeta(TagReadable readable) implements ItemMetaView<PotionMeta.Builder> {
-    private static final Tag<PotionType> POTION_TYPE = Tag.String("Potion").map(PotionType::fromNamespaceId, ProtocolObject::name);
+    private static final Tag<PotionType> POTION_TYPE = Tag.String("Potion").map(PotionType::fromNamespaceId, ProtocolObject::name).defaultValue(PotionType.EMPTY);
     private static final Tag<List<CustomPotionEffect>> CUSTOM_POTION_EFFECTS = Tag.Structure("CustomPotionEffects", new TagSerializer<CustomPotionEffect>() {
         @Override
         public @Nullable CustomPotionEffect read(@NotNull TagReadable reader) {
@@ -41,15 +41,15 @@ public record PotionMeta(TagReadable readable) implements ItemMetaView<PotionMet
     }).list().defaultValue(List.of());
     private static final Tag<Color> CUSTOM_POTION_COLOR = Tag.Integer("CustomPotionColor").path("display").map(Color::new, Color::asRGB);
 
-    public PotionType getPotionType() {
+    public @NotNull PotionType getPotionType() {
         return getTag(POTION_TYPE);
     }
 
-    public List<CustomPotionEffect> getCustomPotionEffects() {
+    public @NotNull List<CustomPotionEffect> getCustomPotionEffects() {
         return getTag(CUSTOM_POTION_EFFECTS);
     }
 
-    public Color getColor() {
+    public @Nullable Color getColor() {
         return getTag(CUSTOM_POTION_COLOR);
     }
 

--- a/src/main/java/net/minestom/server/item/metadata/WrittenBookMeta.java
+++ b/src/main/java/net/minestom/server/item/metadata/WrittenBookMeta.java
@@ -23,7 +23,7 @@ public record WrittenBookMeta(TagReadable readable) implements ItemMetaView<Writ
                     textComponent -> LegacyComponentSerializer.legacySection().serialize(textComponent))
             .list().defaultValue(List.of());
 
-    public boolean isResolved() {
+    public @Nullable Boolean isResolved() {
         return getTag(RESOLVED);
     }
 

--- a/src/main/java/net/minestom/server/item/metadata/WrittenBookMeta.java
+++ b/src/main/java/net/minestom/server/item/metadata/WrittenBookMeta.java
@@ -14,7 +14,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public record WrittenBookMeta(TagReadable readable) implements ItemMetaView<WrittenBookMeta.Builder> {
-    private static final Tag<Boolean> RESOLVED = Tag.Boolean("resolved");
+    private static final Tag<Boolean> RESOLVED = Tag.Boolean("resolved").defaultValue(false);
     private static final Tag<WrittenBookGeneration> GENERATION = Tag.Integer("resolved").map(integer -> WrittenBookGeneration.values()[integer], Enum::ordinal);
     private static final Tag<String> AUTHOR = Tag.String("author");
     private static final Tag<String> TITLE = Tag.String("title");
@@ -23,7 +23,7 @@ public record WrittenBookMeta(TagReadable readable) implements ItemMetaView<Writ
                     textComponent -> LegacyComponentSerializer.legacySection().serialize(textComponent))
             .list().defaultValue(List.of());
 
-    public @Nullable Boolean isResolved() {
+    public boolean isResolved() {
         return getTag(RESOLVED);
     }
 

--- a/src/main/java/net/minestom/server/tag/Tag.java
+++ b/src/main/java/net/minestom/server/tag/Tag.java
@@ -106,7 +106,11 @@ public class Tag<T> {
         return new Tag<>(index, key, readMap,
                 new Serializers.Entry<>(readFunction, writeFunction),
                 // Default value
-                () -> readMap.apply(createDefault()),
+                () -> {
+                    T defaultValue = createDefault();
+                    if (defaultValue == null) return null;
+                    return readMap.apply(defaultValue);
+                },
                 path, null, listScope);
     }
 

--- a/src/test/java/net/minestom/server/tag/TagMapTest.java
+++ b/src/test/java/net/minestom/server/tag/TagMapTest.java
@@ -3,6 +3,7 @@ package net.minestom.server.tag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TagMapTest {
 

--- a/src/test/java/net/minestom/server/tag/TagMapTest.java
+++ b/src/test/java/net/minestom/server/tag/TagMapTest.java
@@ -26,11 +26,17 @@ public class TagMapTest {
         var intTag = Tag.Integer("key");
         var tag = intTag.map(Entry::new, Entry::value);
 
-        assertNull(handler.getTag(tag));
         assertEquals(new Entry(1), handler.getTag(tag.defaultValue(new Entry(1))));
 
         handler.setTag(tag, new Entry(2));
         assertEquals(2, handler.getTag(intTag));
         assertEquals(new Entry(2), handler.getTag(tag));
+    }
+
+    @Test
+    public void mapDefaultAbsent() {
+        var handler = TagHandler.newHandler();
+        var tag = Tag.Integer("key").map(Entry::new, Entry::value);
+        assertNull(handler.getTag(tag));
     }
 }

--- a/src/test/java/net/minestom/server/tag/TagMapTest.java
+++ b/src/test/java/net/minestom/server/tag/TagMapTest.java
@@ -26,6 +26,7 @@ public class TagMapTest {
         var intTag = Tag.Integer("key");
         var tag = intTag.map(Entry::new, Entry::value);
 
+        assertNull(handler.getTag(tag));
         assertEquals(new Entry(1), handler.getTag(tag.defaultValue(new Entry(1))));
 
         handler.setTag(tag, new Entry(2));

--- a/src/test/java/net/minestom/server/tag/TagTest.java
+++ b/src/test/java/net/minestom/server/tag/TagTest.java
@@ -79,7 +79,7 @@ public class TagTest {
 
     @Test
     public void defaultMapped() {
-        var mapped = Tag.Int("key").map(String::valueOf, Integer::parseInt);
+        var mapped = Tag.Integer("key").map(String::valueOf, Integer::parseInt);
         var handler = TagHandler.newHandler();
         assertNull(handler.getTag(mapped));
     }

--- a/src/test/java/net/minestom/server/tag/TagTest.java
+++ b/src/test/java/net/minestom/server/tag/TagTest.java
@@ -78,13 +78,6 @@ public class TagTest {
     }
 
     @Test
-    public void defaultMapped() {
-        var mapped = Tag.Integer("key").map(String::valueOf, Integer::parseInt);
-        var handler = TagHandler.newHandler();
-        assertNull(handler.getTag(mapped));
-    }
-
-    @Test
     public void invalidType() {
         var tag1 = Tag.Integer("key");
         var tag2 = Tag.String("key");

--- a/src/test/java/net/minestom/server/tag/TagTest.java
+++ b/src/test/java/net/minestom/server/tag/TagTest.java
@@ -78,6 +78,13 @@ public class TagTest {
     }
 
     @Test
+    public void defaultMapped() {
+        var mapped = Tag.Int("key").map(String::valueOf, Integer::parseInt);
+        var handler = TagHandler.newHandler();
+        assertNull(handler.getTag(mapped));
+    }
+
+    @Test
     public void invalidType() {
         var tag1 = Tag.Integer("key");
         var tag2 = Tag.String("key");


### PR DESCRIPTION
This pull request fixes a few issues with item metadata and tags:
- Default values for primitive and always present metadata
- Nullable annotation for optional metadata
- Exception when reading a mapped tag with default value null