### PR TITLE
Rename outdated LivingEntityMeta methods

### DIFF
--- a/src/main/java/net/minestom/server/entity/metadata/LivingEntityMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/LivingEntityMeta.java
@@ -76,10 +76,40 @@ public class LivingEntityMeta extends EntityMeta {
         super.metadata.setIndex(OFFSET + 4, Metadata.VarInt(value));
     }
 
+    /**
+     * @deprecated
+     * This returns the bee stinger count, not the absorption heart count
+     * Use {@link #getBeeStingerCount()} instead
+     * @return The number of bee stingers in this entity
+     */
+    @Deprecated
+    public int getHealthAddedByAbsorption() {
+        return super.metadata.getIndex(OFFSET + 5, 0);
+    }
+
+    /**
+     * @deprecated
+     * This sets the bee stinger count, not the absorption heart count
+     * Use {@link #setBeeStingerCount(int)} instead
+     * @param value The number of bee stingers for this entity to have
+     */
+    @Deprecated
+    public void setHealthAddedByAbsorption(int value) {
+        super.metadata.setIndex(OFFSET + 5, Metadata.VarInt(value));
+    }
+
+    /**
+     * Gets the amount of bee stingers in this entity
+     * @return The amount of bee stingers
+     */
     public int getBeeStingerCount() {
         return super.metadata.getIndex(OFFSET + 5, 0);
     }
 
+    /**
+     * Sets the amount of bee stingers in this entity
+     * @param value The amount of bee stingers to set, use 0 to clear all stingers
+     */
     public void setBeeStingerCount(int value) {
         super.metadata.setIndex(OFFSET + 5, Metadata.VarInt(value));
     }

--- a/src/main/java/net/minestom/server/entity/metadata/LivingEntityMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/LivingEntityMeta.java
@@ -76,11 +76,11 @@ public class LivingEntityMeta extends EntityMeta {
         super.metadata.setIndex(OFFSET + 4, Metadata.VarInt(value));
     }
 
-    public int getHealthAddedByAbsorption() {
+    public int getBeeStingerCount() {
         return super.metadata.getIndex(OFFSET + 5, 0);
     }
 
-    public void setHealthAddedByAbsorption(int value) {
+    public void setBeeStingerCount(int value) {
         super.metadata.setIndex(OFFSET + 5, Metadata.VarInt(value));
     }
 


### PR DESCRIPTION
Fixes #712 .

The absorption heart count was moved to PlayerMeta, and bee stinger count took the place of meta index 13, but these methods were never updated to match.

This PR renames the methods to solve the issue.