### PR TITLE
MultipleItemEvent

### DIFF
--- a/src/main/java/net/minestom/server/event/inventory/InventoryClickEvent.java
+++ b/src/main/java/net/minestom/server/event/inventory/InventoryClickEvent.java
@@ -3,6 +3,7 @@ package net.minestom.server.event.inventory;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.EntityInstanceEvent;
 import net.minestom.server.event.trait.InventoryEvent;
+import net.minestom.server.event.trait.MultipleItemEvent;
 import net.minestom.server.event.trait.PlayerEvent;
 import net.minestom.server.inventory.Inventory;
 import net.minestom.server.inventory.click.ClickType;
@@ -14,14 +15,13 @@ import org.jetbrains.annotations.Nullable;
  * Called after {@link InventoryPreClickEvent}, this event cannot be cancelled and items related to the click
  * are already moved.
  */
-public class InventoryClickEvent implements InventoryEvent, PlayerEvent, EntityInstanceEvent {
+public class InventoryClickEvent implements MultipleItemEvent, InventoryEvent, PlayerEvent, EntityInstanceEvent {
 
     private final Inventory inventory;
     private final Player player;
     private final int slot;
     private final ClickType clickType;
-    private final ItemStack clickedItem;
-    private final ItemStack cursorItem;
+    private final ItemStack[] itemStacks;
 
     public InventoryClickEvent(@Nullable Inventory inventory, @NotNull Player player,
                                int slot, @NotNull ClickType clickType,
@@ -30,8 +30,7 @@ public class InventoryClickEvent implements InventoryEvent, PlayerEvent, EntityI
         this.player = player;
         this.slot = slot;
         this.clickType = clickType;
-        this.clickedItem = clicked;
-        this.cursorItem = cursor;
+        this.itemStacks = new ItemStack[]{ clicked, cursor };
     }
 
     /**
@@ -70,7 +69,7 @@ public class InventoryClickEvent implements InventoryEvent, PlayerEvent, EntityI
      */
     @NotNull
     public ItemStack getClickedItem() {
-        return clickedItem;
+        return itemStacks[0];
     }
 
     /**
@@ -80,11 +79,14 @@ public class InventoryClickEvent implements InventoryEvent, PlayerEvent, EntityI
      */
     @NotNull
     public ItemStack getCursorItem() {
-        return cursorItem;
+        return itemStacks[1];
     }
 
     @Override
     public @Nullable Inventory getInventory() {
         return inventory;
     }
+
+    @Override
+    public @NotNull ItemStack[] getItemStacks() { return itemStacks; }
 }

--- a/src/main/java/net/minestom/server/event/inventory/InventoryItemChangeEvent.java
+++ b/src/main/java/net/minestom/server/event/inventory/InventoryItemChangeEvent.java
@@ -1,6 +1,7 @@
 package net.minestom.server.event.inventory;
 
 import net.minestom.server.event.trait.InventoryEvent;
+import net.minestom.server.event.trait.MultipleItemEvent;
 import net.minestom.server.event.trait.RecursiveEvent;
 import net.minestom.server.inventory.AbstractInventory;
 import net.minestom.server.inventory.Inventory;
@@ -15,19 +16,17 @@ import org.jetbrains.annotations.Nullable;
  * @see PlayerInventoryItemChangeEvent
  */
 @SuppressWarnings("JavadocReference")
-public class InventoryItemChangeEvent implements InventoryEvent, RecursiveEvent {
+public class InventoryItemChangeEvent implements MultipleItemEvent, InventoryEvent, RecursiveEvent {
 
     private final Inventory inventory;
     private final int slot;
-    private final ItemStack previousItem;
-    private final ItemStack newItem;
+    private final ItemStack[] itemStacks;
 
     public InventoryItemChangeEvent(@Nullable Inventory inventory, int slot,
                                     @NotNull ItemStack previousItem, @NotNull ItemStack newItem) {
         this.inventory = inventory;
         this.slot = slot;
-        this.previousItem = previousItem;
-        this.newItem = newItem;
+        this.itemStacks = new ItemStack[]{ previousItem, newItem };
     }
 
     /**
@@ -45,7 +44,7 @@ public class InventoryItemChangeEvent implements InventoryEvent, RecursiveEvent 
      * @return a previous item that was on changed slot.
      */
     public @NotNull ItemStack getPreviousItem() {
-        return previousItem;
+        return itemStacks[0];
     }
 
     /**
@@ -54,11 +53,14 @@ public class InventoryItemChangeEvent implements InventoryEvent, RecursiveEvent 
      * @return a new item on a changed slot.
      */
     public @NotNull ItemStack getNewItem() {
-        return newItem;
+        return itemStacks[1];
     }
 
     @Override
     public @Nullable Inventory getInventory() {
         return inventory;
     }
+
+    @Override
+    public @NotNull ItemStack[] getItemStacks() { return itemStacks; }
 }

--- a/src/main/java/net/minestom/server/event/inventory/InventoryPreClickEvent.java
+++ b/src/main/java/net/minestom/server/event/inventory/InventoryPreClickEvent.java
@@ -1,10 +1,7 @@
 package net.minestom.server.event.inventory;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.InventoryEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.*;
 import net.minestom.server.inventory.Inventory;
 import net.minestom.server.inventory.click.ClickType;
 import net.minestom.server.item.ItemStack;
@@ -14,14 +11,13 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Called before {@link InventoryClickEvent}, used to potentially cancel the click.
  */
-public class InventoryPreClickEvent implements InventoryEvent, PlayerEvent, EntityInstanceEvent, CancellableEvent {
+public class InventoryPreClickEvent implements MultipleItemEvent, InventoryEvent, PlayerEvent, EntityInstanceEvent, CancellableEvent {
 
     private final Inventory inventory;
     private final Player player;
     private final int slot;
     private final ClickType clickType;
-    private ItemStack clickedItem;
-    private ItemStack cursorItem;
+    private final ItemStack[] itemStacks;
 
     private boolean cancelled;
 
@@ -33,8 +29,7 @@ public class InventoryPreClickEvent implements InventoryEvent, PlayerEvent, Enti
         this.player = player;
         this.slot = slot;
         this.clickType = clickType;
-        this.clickedItem = clicked;
-        this.cursorItem = cursor;
+        this.itemStacks = new ItemStack[] { clicked, cursor };
     }
 
     /**
@@ -73,7 +68,7 @@ public class InventoryPreClickEvent implements InventoryEvent, PlayerEvent, Enti
      */
     @NotNull
     public ItemStack getClickedItem() {
-        return clickedItem;
+        return itemStacks[0];
     }
 
     /**
@@ -82,7 +77,7 @@ public class InventoryPreClickEvent implements InventoryEvent, PlayerEvent, Enti
      * @param clickedItem the clicked item
      */
     public void setClickedItem(@NotNull ItemStack clickedItem) {
-        this.clickedItem = clickedItem;
+        this.itemStacks[0] = clickedItem;
     }
 
     /**
@@ -91,18 +86,14 @@ public class InventoryPreClickEvent implements InventoryEvent, PlayerEvent, Enti
      * @return the cursor item
      */
     @NotNull
-    public ItemStack getCursorItem() {
-        return cursorItem;
-    }
+    public ItemStack getCursorItem() { return itemStacks[1]; }
 
     /**
      * Changes the cursor item.
      *
      * @param cursorItem the cursor item
      */
-    public void setCursorItem(@NotNull ItemStack cursorItem) {
-        this.cursorItem = cursorItem;
-    }
+    public void setCursorItem(@NotNull ItemStack cursorItem) { this.itemStacks[1] = cursorItem; }
 
     @Override
     public boolean isCancelled() {
@@ -118,4 +109,7 @@ public class InventoryPreClickEvent implements InventoryEvent, PlayerEvent, Enti
     public @Nullable Inventory getInventory() {
         return inventory;
     }
+
+    @Override
+    public @NotNull ItemStack[] getItemStacks() { return itemStacks; }
 }

--- a/src/main/java/net/minestom/server/event/player/PlayerSwapItemEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerSwapItemEvent.java
@@ -3,6 +3,7 @@ package net.minestom.server.event.player;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.CancellableEvent;
 import net.minestom.server.event.trait.EntityInstanceEvent;
+import net.minestom.server.event.trait.MultipleItemEvent;
 import net.minestom.server.event.trait.PlayerEvent;
 import net.minestom.server.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -10,18 +11,16 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Called when a player is trying to swap his main and off hand item.
  */
-public class PlayerSwapItemEvent implements PlayerEvent, EntityInstanceEvent, CancellableEvent {
+public class PlayerSwapItemEvent implements MultipleItemEvent, PlayerEvent, EntityInstanceEvent, CancellableEvent {
 
     private final Player player;
-    private ItemStack mainHandItem;
-    private ItemStack offHandItem;
+    private final ItemStack[] itemStacks;
 
     private boolean cancelled;
 
     public PlayerSwapItemEvent(@NotNull Player player, @NotNull ItemStack mainHandItem, @NotNull ItemStack offHandItem) {
         this.player = player;
-        this.mainHandItem = mainHandItem;
-        this.offHandItem = offHandItem;
+        this.itemStacks = new ItemStack[] { mainHandItem, offHandItem };
     }
 
     /**
@@ -30,18 +29,14 @@ public class PlayerSwapItemEvent implements PlayerEvent, EntityInstanceEvent, Ca
      * @return the item in main hand
      */
     @NotNull
-    public ItemStack getMainHandItem() {
-        return mainHandItem;
-    }
+    public ItemStack getMainHandItem() { return itemStacks[0]; }
 
     /**
      * Changes the item which will be in the player main hand.
      *
      * @param mainHandItem the main hand item
      */
-    public void setMainHandItem(@NotNull ItemStack mainHandItem) {
-        this.mainHandItem = mainHandItem;
-    }
+    public void setMainHandItem(@NotNull ItemStack mainHandItem) { this.itemStacks[0] = mainHandItem; }
 
     /**
      * Gets the item which will be in player off hand after the event.
@@ -49,18 +44,14 @@ public class PlayerSwapItemEvent implements PlayerEvent, EntityInstanceEvent, Ca
      * @return the item in off hand
      */
     @NotNull
-    public ItemStack getOffHandItem() {
-        return offHandItem;
-    }
+    public ItemStack getOffHandItem() { return itemStacks[1]; }
 
     /**
      * Changes the item which will be in the player off hand.
      *
      * @param offHandItem the off hand item
      */
-    public void setOffHandItem(@NotNull ItemStack offHandItem) {
-        this.offHandItem = offHandItem;
-    }
+    public void setOffHandItem(@NotNull ItemStack offHandItem) { this.itemStacks[1] = offHandItem; }
 
     @Override
     public boolean isCancelled() {
@@ -76,4 +67,7 @@ public class PlayerSwapItemEvent implements PlayerEvent, EntityInstanceEvent, Ca
     public @NotNull Player getPlayer() {
         return player;
     }
+
+    @Override
+    public @NotNull ItemStack[] getItemStacks() { return itemStacks; }
 }

--- a/src/main/java/net/minestom/server/event/trait/MultipleItemEvent.java
+++ b/src/main/java/net/minestom/server/event/trait/MultipleItemEvent.java
@@ -1,0 +1,20 @@
+package net.minestom.server.event.trait;
+
+import net.minestom.server.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+public interface MultipleItemEvent extends ItemEvent {
+
+    @NotNull ItemStack[] getItemStacks();
+
+    /**
+     * @return returns the first itemstack from the itemstack array
+     * @deprecated please use provided getters from the actual event
+     */
+    @Override
+    @Deprecated
+    default @NotNull ItemStack getItemStack() {
+        return getItemStacks()[0];
+    }
+
+}


### PR DESCRIPTION
This adds support for `EventFilter.ITEM` for Events with more than one ItemStack.

before, even:

```java
EventNode.event("multipleItemEventTestlol", EventFilter.ITEM, itemEvent -> {
        return test(itemEvent.getItemStack());
});
```
wasn't possible when using multiple item events like PlayerSwapItemEvent.

now, with this Pull Request, this is possible:

```java
EventNode.event("multipleItemEventTestlol", EventFilter.ITEM, itemEvent -> {
        if(!(itemEvent instanceof MultipleItemEvent)) return test(itemEvent.getItemStack());
        boolean valid = false;
        for (ItemStack item : ((MultipleItemEvent)itemEvent).getItemStacks()) {
                if(test(item)) {
                        valid = true;
                        break;
                }
        }
        return valid;
});
```

This fixes #950 

Feedback welcome - Thanks 😃 