### PR TITLE
Make PermissionHandler independent instance in Entity / ConsoleSender

### DIFF
--- a/src/main/java/net/minestom/server/command/ConsoleSender.java
+++ b/src/main/java/net/minestom/server/command/ConsoleSender.java
@@ -4,23 +4,22 @@ import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
-import net.minestom.server.permission.Permission;
+import net.minestom.server.permission.ForwardingPermissionHandler;
+import net.minestom.server.permission.PermissionHandler;
+import net.minestom.server.permission.PermissionHandlerImpl;
 import net.minestom.server.tag.TagHandler;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
-
 /**
  * Represents the console when sending a command to the server.
  */
-public class ConsoleSender implements CommandSender {
+public class ConsoleSender implements CommandSender, ForwardingPermissionHandler {
     private static final PlainTextComponentSerializer PLAIN_SERIALIZER = PlainTextComponentSerializer.plainText();
     private static final Logger LOGGER = LoggerFactory.getLogger(ConsoleSender.class);
 
-    private final Set<Permission> permissions = new CopyOnWriteArraySet<>();
+    private PermissionHandler permissionHandler = new PermissionHandlerImpl();
     private final TagHandler tagHandler = TagHandler.newHandler();
 
     @Override
@@ -34,10 +33,13 @@ public class ConsoleSender implements CommandSender {
         this.sendMessage(PLAIN_SERIALIZER.serialize(message));
     }
 
-    @NotNull
     @Override
-    public Set<Permission> getAllPermissions() {
-        return permissions;
+    public @NotNull PermissionHandler getPermissionHandler() {
+        return this.permissionHandler;
+    }
+
+    public void setPermissionHandler(@NotNull PermissionHandler permissionHandler) {
+        this.permissionHandler = permissionHandler;
     }
 
     @Override

--- a/src/main/java/net/minestom/server/permission/ForwardingPermissionHandler.java
+++ b/src/main/java/net/minestom/server/permission/ForwardingPermissionHandler.java
@@ -1,0 +1,59 @@
+package net.minestom.server.permission;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Set;
+
+/**
+ * A permission handler that wraps another permission handler
+ * ForwardingPermissionHandler is designed to easily allow users or implementations wrap an existing PermissionHandler
+ *
+ * @see net.minestom.server.permission.PermissionHandler
+ */
+public interface ForwardingPermissionHandler extends PermissionHandler {
+
+    @NotNull PermissionHandler getPermissionHandler();
+
+    @Override
+    default @NotNull Set<Permission> getAllPermissions() {
+        return this.getPermissionHandler().getAllPermissions();
+    }
+
+    @Override
+    default void addPermission(@NotNull Permission permission) {
+        this.getPermissionHandler().addPermission(permission);
+    }
+
+    @Override
+    default void removePermission(@NotNull Permission permission) {
+        this.getPermissionHandler().removePermission(permission);
+    }
+
+    @Override
+    default void removePermission(@NotNull String permissionName) {
+        this.getPermissionHandler().removePermission(permissionName);
+    }
+
+    @Override
+    default boolean hasPermission(@NotNull String permissionName) {
+        return this.getPermissionHandler().hasPermission(permissionName);
+    }
+
+    @Override
+    default boolean hasPermission(@NotNull Permission permission) {
+        return this.getPermissionHandler().hasPermission(permission);
+    }
+
+    @Override
+    default boolean hasPermission(@NotNull String permissionName, @Nullable PermissionVerifier permissionVerifier) {
+        return this.getPermissionHandler().hasPermission(permissionName, permissionVerifier);
+    }
+
+    @Override
+    @Nullable
+    default Permission getPermission(@NotNull String permissionName) {
+        return this.getPermissionHandler().getPermission(permissionName);
+    }
+
+}

--- a/src/main/java/net/minestom/server/permission/PermissionHandlerImpl.java
+++ b/src/main/java/net/minestom/server/permission/PermissionHandlerImpl.java
@@ -1,0 +1,21 @@
+package net.minestom.server.permission;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * The very basic implementation for PermissionHandler
+ *
+ * @see net.minestom.server.permission.PermissionHandler
+ */
+public class PermissionHandlerImpl implements PermissionHandler {
+
+    private final Set<Permission> permissions = ConcurrentHashMap.newKeySet();
+
+    @Override
+    public @NotNull Set<Permission> getAllPermissions() {
+        return permissions;
+    }
+}


### PR DESCRIPTION
This allows users to create their own custom permission handler implementation by Entity#setPermissionHandler() and ConsoleSender#setPermissionHandler()
Allowing more flexibility for users to create their own permission system