### PR TITLE
Include JCStress for stress tests in our concurrent models.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,8 @@ jNoise = "b93008e35e"
 # JMH
 jmh = "1.35"
 
-
+# JCStress
+jcstress = "0.8"
 
 [libraries]
 
@@ -91,6 +92,9 @@ jNoise = { group = "com.github.Articdive.JNoise", name = "jnoise-pipeline", vers
 # JMH
 jmh-core = { group = "org.openjdk.jmh", name = "jmh-core", version.ref = "jmh" }
 jmh-annotationprocessor = { group = "org.openjdk.jmh", name = "jmh-generator-annprocess", version.ref = "jmh" }
+
+# JCStress
+jcstress-core = { group = "org.openjdk.jcstress", name = "jcstress-core", version.ref = "jcstress" }
 
 [bundles]
 

--- a/jcstress-tests/build.gradle.kts
+++ b/jcstress-tests/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    id("io.github.reyerizo.gradle.jcstress") version "0.8.13"
+    id("minestom.common-conventions")
+}
+
+dependencies {
+    jcstressImplementation(rootProject)
+    jcstress(libs.jcstress.core)
+}

--- a/jcstress-tests/src/jcstress/java/net/minestom/server/ConstructorBasic.java
+++ b/jcstress-tests/src/jcstress/java/net/minestom/server/ConstructorBasic.java
@@ -1,0 +1,49 @@
+package net.minestom.server;
+
+import org.openjdk.jcstress.annotations.*;
+import org.openjdk.jcstress.infra.results.I_Result;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE_INTERESTING;
+
+@JCStressTest
+@Outcome(id = "-1", expect = ACCEPTABLE, desc = "Object has not been seen")
+@Outcome(id = {"4", "5"}, expect = ACCEPTABLE_INTERESTING, desc = "Object only partially initialized")
+@Outcome(id = "9", expect = ACCEPTABLE,  desc = "Object fully initialized")
+@State
+public class ConstructorBasic {
+    private SimpleClass value;
+
+    @Actor
+    public void actor1() {
+        value = new SimpleClass();
+    }
+
+    @Actor
+    public void actor2(I_Result r) {
+        SimpleClass current = this.value;
+        if (current != null) {
+            r.r1 = current.getX() + current.getY();
+        } else {
+            r.r1 = -1;
+        }
+    }
+
+    public static class SimpleClass {
+        private int x;
+        private int y;
+
+        SimpleClass() {
+            x = 4;
+            y = 5;
+        }
+
+        int getX() {
+            return x;
+        }
+
+        int getY() {
+            return y;
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,4 +19,5 @@ pluginManagement {
 rootProject.name = "Minestom"
 include("code-generators")
 include("jmh-benchmarks")
+include("jcstress-tests")
 include("demo")


### PR DESCRIPTION
Adds a new subproject in which we can include stress tests for concurrency.