### PR TITLE
Prevent invisible item when consumeBlock is false

### DIFF
--- a/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
+++ b/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
@@ -146,6 +146,9 @@ public class BlockPlacementListener {
             // Consume the block in the player's hand
             final ItemStack newUsedItem = usedItem.consume(1);
             playerInventory.setItemInHand(hand, newUsedItem);
+        } else {
+            // Prevent invisible item on client
+            playerInventory.update();   
         }
     }
 


### PR DESCRIPTION
Currently the client doesn't receive an update when the item isn't being consumed, causing a invisible item on the client.