### PR TITLE
Add a getBlock() method to Batches

### DIFF
--- a/src/main/java/net/minestom/server/instance/batch/AbsoluteBlockBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/AbsoluteBlockBatch.java
@@ -3,6 +3,7 @@ package net.minestom.server.instance.batch;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMaps;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import net.minestom.server.coordinate.Point;
 import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.InstanceContainer;

--- a/src/main/java/net/minestom/server/instance/batch/AbsoluteBlockBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/AbsoluteBlockBatch.java
@@ -64,6 +64,22 @@ public class AbsoluteBlockBatch implements Batch<Runnable> {
         final int relativeZ = z - (chunkZ * Chunk.CHUNK_SIZE_Z);
         chunkBatch.setBlock(relativeX, y, relativeZ, block);
     }
+    
+    @Override
+    public Block getBlock(int x, int y, int z, @NotNull Condition condition) {
+        final int chunkX = ChunkUtils.getChunkCoordinate(x);
+        final int chunkZ = ChunkUtils.getChunkCoordinate(z);
+        final long chunkIndex = ChunkUtils.getChunkIndex(chunkX, chunkZ);
+        
+        final ChunkBatch chunkBatch;
+        synchronized (chunkBatchesMap) {
+            chunkBatch = chunkBatchesMap.computeIfAbsent(chunkIndex, i -> new ChunkBatch(this.options));
+        }
+        
+        final int relativeX = x - (chunkX * Chunk.CHUNK_SIZE_X);
+        final int relativeZ = z - (chunkZ * Chunk.CHUNK_SIZE_Z);
+        return chunkBatch.getBlock(relativeX, y, relativeZ);
+    }
 
     @Override
     public void clear() {

--- a/src/main/java/net/minestom/server/instance/batch/AbsoluteBlockBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/AbsoluteBlockBatch.java
@@ -80,6 +80,16 @@ public class AbsoluteBlockBatch implements Batch<Runnable> {
         final int relativeZ = z - (chunkZ * Chunk.CHUNK_SIZE_Z);
         return chunkBatch.getBlock(relativeX, y, relativeZ);
     }
+    
+    @Override
+    public @Nullable Block getBlock(int x, int y, int z) {
+        return getBlock(x, y, z, Condition.NONE);
+    }
+    
+    @Override
+    public @Nullable Block getBlock(Point point) {
+        return getBlock(point, Condition.NONE);
+    }
 
     @Override
     public void clear() {

--- a/src/main/java/net/minestom/server/instance/batch/Batch.java
+++ b/src/main/java/net/minestom/server/instance/batch/Batch.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ForkJoinPool;
  * @see AbsoluteBlockBatch
  * @see RelativeBlockBatch
  */
-public interface Batch<C> extends Block.Setter {
+public interface Batch<C> extends Block.Setter, Block.Getter {
 
     ExecutorService BLOCK_BATCH_POOL = ForkJoinPool.commonPool();
 

--- a/src/main/java/net/minestom/server/instance/batch/ChunkBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/ChunkBatch.java
@@ -67,6 +67,16 @@ public class ChunkBatch implements Batch<ChunkCallback> {
             return this.blocks.get(index);
         }
     }
+    
+    @Override
+    public @Nullable Block getBlock(int x, int y, int z) {
+        return getBlock(x, y, z, Condition.NONE);
+    }
+    
+    @Override
+    public @Nullable Block getBlock(Point point) {
+        return getBlock(point, Condition.NONE);
+    }
 
     @Override
     public void clear() {

--- a/src/main/java/net/minestom/server/instance/batch/ChunkBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/ChunkBatch.java
@@ -59,6 +59,14 @@ public class ChunkBatch implements Batch<ChunkCallback> {
             this.blocks.put(index, block);
         }
     }
+    
+    @Override
+    public Block getBlock(int x, int y, int z, @NotNull Condition condition) {
+        final int index = ChunkUtils.getBlockIndex(x, y, z);
+        synchronized (blocks) {
+            return this.blocks.get(index);
+        }
+    }
 
     @Override
     public void clear() {

--- a/src/main/java/net/minestom/server/instance/batch/ChunkBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/ChunkBatch.java
@@ -4,6 +4,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntArraySet;
 import it.unimi.dsi.fastutil.ints.IntSet;
+import net.minestom.server.coordinate.Point;
 import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.InstanceContainer;

--- a/src/main/java/net/minestom/server/instance/batch/RelativeBlockBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/RelativeBlockBatch.java
@@ -108,6 +108,16 @@ public class RelativeBlockBatch implements Batch<Runnable> {
             return this.blockIdMap.get(pos);
         }
     }
+    
+    @Override
+    public @Nullable Block getBlock(int x, int y, int z) {
+        return getBlock(x, y, z, Condition.NONE);
+    }
+    
+    @Override
+    public @Nullable Block getBlock(Point point) {
+        return getBlock(point, Condition.NONE);
+    }
 
     @Override
     public void clear() {

--- a/src/main/java/net/minestom/server/instance/batch/RelativeBlockBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/RelativeBlockBatch.java
@@ -78,6 +78,36 @@ public class RelativeBlockBatch implements Batch<Runnable> {
             this.blockIdMap.put(pos, block);
         }
     }
+    
+    @Override
+    public Block getBlock(int x, int y, int z, @NotNull Condition condition) {
+        // Save the offsets if it is the first entry
+        if (firstEntry) {
+            this.firstEntry = false;
+
+            this.offsetX = x;
+            this.offsetY = y;
+            this.offsetZ = z;
+        }
+        
+        // Subtract offset
+        x -= offsetX;
+        y -= offsetY;
+        z -= offsetZ;
+
+        // Verify that blocks are not too far from each other
+        Check.argCondition(Math.abs(x) > Short.MAX_VALUE, "Relative x position may not be more than 16 bits long.");
+        Check.argCondition(Math.abs(y) > Short.MAX_VALUE, "Relative y position may not be more than 16 bits long.");
+        Check.argCondition(Math.abs(z) > Short.MAX_VALUE, "Relative z position may not be more than 16 bits long.");
+
+        long pos = Short.toUnsignedLong((short)x);
+        pos = (pos << 16) | Short.toUnsignedLong((short)y);
+        pos = (pos << 16) | Short.toUnsignedLong((short)z);
+
+        synchronized (blockIdMap) {
+            return this.blockIdMap.get(pos);
+        }
+    }
 
     @Override
     public void clear() {


### PR DESCRIPTION
This PR adds the `getBlock(x, y, z)` methods from `Block.Getter` to Batches, thus letting one query changed blocks from the block map. This is useful if you would like to pre-process batches before applying them to an instance. According to the default behavior of the internal maps, the methods return `null` if the position is not changed in the Batch.