### PR TITLE
Fix Entity#lookAt(Pos) not correctly looking at the position

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -350,8 +350,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
      */
     public void lookAt(@NotNull Entity entity) {
         Check.argCondition(entity.instance != instance, "Entity can look at another entity that is within it's own instance");
-        double eyeHeightDifference = entity.getEyeHeight() - getEyeHeight();
-        lookAt(entity.position.withY(entity.position.y() + eyeHeightDifference));
+        lookAt(entity.position.withY(entity.position.y() + entity.getEyeHeight()));
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -339,7 +339,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
      * @param position the position to look at.
      */
     public void lookAt(@NotNull Pos position) {
-        final Pos newPosition = this.position.withLookAt(position);
+        final Pos newPosition = this.position.add(0, getEyeHeight(), 0).withLookAt(position);
         setView(newPosition.yaw(), newPosition.pitch());
     }
 

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -336,10 +336,10 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
      * Changes the view of the entity so that it looks in a direction to the given position if
      * it is different from the entity's current position.
      *
-     * @param position the position to look at.
+     * @param point the point to look at.
      */
-    public void lookAt(@NotNull Pos position) {
-        final Pos newPosition = this.position.add(0, getEyeHeight(), 0).withLookAt(position);
+    public void lookAt(@NotNull Point point) {
+        final Pos newPosition = this.position.add(0, getEyeHeight(), 0).withLookAt(point);
         setView(newPosition.yaw(), newPosition.pitch());
     }
 

--- a/src/test/java/net/minestom/server/entity/EntityViewDirectionIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/EntityViewDirectionIntegrationTest.java
@@ -53,12 +53,10 @@ public class EntityViewDirectionIntegrationTest {
         var entity = new Entity(EntityType.ZOMBIE);
         entity.setInstance(instance, new Pos(0, 40, 0)).join();
 
-        // look at itself, direction should not change
-        float prevYaw = entity.getPosition().yaw();
-        float prevPitch = entity.getPosition().pitch();
+        // look at its feet's position, it should look down
         entity.lookAt(entity.getPosition());
-        assertEquals(prevYaw, entity.getPosition().yaw());
-        assertEquals(prevPitch, entity.getPosition().pitch());
+        //looking vertically, not checking yaw
+        assertEquals(90f, entity.getPosition().pitch());
 
         entity.lookAt(new Pos(16, 41.6575, 16));
         assertEquals(-45f, entity.getPosition().yaw());

--- a/src/test/java/net/minestom/server/entity/EntityViewDirectionIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/EntityViewDirectionIntegrationTest.java
@@ -60,19 +60,19 @@ public class EntityViewDirectionIntegrationTest {
         assertEquals(prevYaw, entity.getPosition().yaw());
         assertEquals(prevPitch, entity.getPosition().pitch());
 
-        entity.lookAt(new Pos(16, 40, 16));
+        entity.lookAt(new Pos(16, 41.6575, 16));
         assertEquals(-45f, entity.getPosition().yaw());
         assertEquals(0f, entity.getPosition().pitch(), EPSILON);
 
-        entity.lookAt(new Pos(-16, 40, 56));
+        entity.lookAt(new Pos(-16, 41.6575, 56));
         assertEquals(15.94f, entity.getPosition().yaw(), EPSILON);
         assertEquals(0f, entity.getPosition().pitch(), EPSILON);
 
-        entity.lookAt(new Pos(48, 36, 48));
+        entity.lookAt(new Pos(48, 37.6575, 48));
         assertEquals(-45f, entity.getPosition().yaw(), EPSILON);
         assertEquals(4.76f, entity.getPosition().pitch(), EPSILON);
 
-        entity.lookAt(new Pos(48, 36, -17));
+        entity.lookAt(new Pos(48, 37.6575, -17));
         assertEquals(-109.50f, entity.getPosition().yaw(), EPSILON);
         // should have the same pitch as the previous position
         assertEquals(4.76f, entity.getPosition().pitch(), EPSILON);
@@ -81,7 +81,7 @@ public class EntityViewDirectionIntegrationTest {
         // looking from below, not checking the yaw
         assertEquals(-90f, entity.getPosition().pitch(), EPSILON);
 
-        entity.lookAt(new Pos(-25, 42, 4));
+        entity.lookAt(new Pos(-25, 43.6575, 4));
         assertEquals(80.90f, entity.getPosition().yaw(), EPSILON);
         assertEquals(-4.57f, entity.getPosition().pitch(), EPSILON);
     }

--- a/src/test/java/net/minestom/server/entity/EntityViewDirectionIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/EntityViewDirectionIntegrationTest.java
@@ -51,37 +51,39 @@ public class EntityViewDirectionIntegrationTest {
     public void lookAtPos(Env env) {
         var instance = env.createFlatInstance();
         var entity = new Entity(EntityType.ZOMBIE);
+        double eyeHeight = entity.getEyeHeight(); // adding this to some position Y coordinates, to look horizontally
+        
         entity.setInstance(instance, new Pos(0, 40, 0)).join();
 
-        // look at its feet's position, it should look down
+        // make it look at its feet's position, it should look down
         entity.lookAt(entity.getPosition());
-        //looking vertically, not checking yaw
+        // looking vertically, not checking yaw
         assertEquals(90f, entity.getPosition().pitch());
 
-        entity.lookAt(new Pos(16, 41.6575, 16));
+        entity.lookAt(new Pos(16, 40 + eyeHeight, 16));
         assertEquals(-45f, entity.getPosition().yaw());
         assertEquals(0f, entity.getPosition().pitch(), EPSILON);
 
-        entity.lookAt(new Pos(-16, 41.6575, 56));
+        entity.lookAt(new Pos(-16, 40 + eyeHeight, 56));
         assertEquals(15.94f, entity.getPosition().yaw(), EPSILON);
         assertEquals(0f, entity.getPosition().pitch(), EPSILON);
 
-        entity.lookAt(new Pos(48, 37.6575, 48));
+        entity.lookAt(new Pos(48, 36, 48));
         assertEquals(-45f, entity.getPosition().yaw(), EPSILON);
-        assertEquals(4.76f, entity.getPosition().pitch(), EPSILON);
+        assertEquals(6.72f, entity.getPosition().pitch(), EPSILON);
 
-        entity.lookAt(new Pos(48, 37.6575, -17));
+        entity.lookAt(new Pos(48, 36, -17));
         assertEquals(-109.50f, entity.getPosition().yaw(), EPSILON);
         // should have the same pitch as the previous position
-        assertEquals(4.76f, entity.getPosition().pitch(), EPSILON);
+        assertEquals(6.72f, entity.getPosition().pitch(), EPSILON);
 
         entity.lookAt(new Pos(0, 87, 0));
         // looking from below, not checking the yaw
         assertEquals(-90f, entity.getPosition().pitch(), EPSILON);
 
-        entity.lookAt(new Pos(-25, 43.6575, 4));
+        entity.lookAt(new Pos(-25, 42, 4));
         assertEquals(80.90f, entity.getPosition().yaw(), EPSILON);
-        assertEquals(-4.57f, entity.getPosition().pitch(), EPSILON);
+        assertEquals(-0.78f, entity.getPosition().pitch(), EPSILON);
     }
 
     @Test


### PR DESCRIPTION
This PR fixes `Entity#lookAt(pos)`. The current implementation makes the `Entity`'s feet's position look at the desired position. The problem is exactly here: it is not looking from the eyes of the entity. This makes the entity look above the desired position. To fix this, I have added the entity's height to the calculation in `lookAt()` method, and I have also modified the method's signature to accept `Point` instead of `Pos`, as there is no reason to limit the method parameter to `Pos` (only the x, y, z coordinates are used).

This also modifies `Entity#lookAt(Entity)`, and an associated test, namely `EntityViewDirectionIntegrationTest` to correctly query the values.