### PR TITLE
Added support for setting blocks without updating.

### DIFF
--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -99,7 +99,7 @@ public class InstanceContainer extends Instance {
                     "Tried to set a block to an unloaded chunk with auto chunk load disabled");
             chunk = loadChunk(getChunkCoordinate(x), getChunkCoordinate(z)).join();
         }
-        if (isLoaded(chunk)) UNSAFE_setBlock(chunk, x, y, z, block, null, null);
+        if (isLoaded(chunk)) UNSAFE_setBlock(chunk, x, y, z, block, null, null, resendChunk);
     }
 
     /**

--- a/src/test/java/net/minestom/server/instance/InstanceBlockPacketIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/InstanceBlockPacketIntegrationTest.java
@@ -96,4 +96,23 @@ public class InstanceBlockPacketIntegrationTest {
 
         assertEquals(block, instance.getBlock(blockPoint));
     }
+
+    @Test
+    public void setBlockOptionalUpdate(Env env) {
+        var instance = (InstanceContainer) env.createFlatInstance();
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+
+
+        // setting without update
+        var packetTracker = connection.trackIncoming(BlockChangePacket.class);
+        instance.setBlock(1, 42, 0, Block.AMETHYST_BLOCK, false);
+        packetTracker.assertEmpty();
+
+        // setting with update
+        packetTracker = connection.trackIncoming(BlockChangePacket.class);
+        var blockPos = new Vec(3, 42, 0);
+        instance.setBlock(blockPos.blockX(), blockPos.blockY(), blockPos.blockZ(), Block.ACACIA_WOOD);
+        packetTracker.assertSingle(change -> assertEquals(blockPos, change.blockPosition()));
+    }
 }


### PR DESCRIPTION
This can be used for example a clearer `Batch`, because the current batches just sets the blocks in the chunk and then resends the chunk, but when the blocks are getting setted, things like nearby block updates are ignored.