### PR TITLE
Change assert in NamespacedID.from() to throw IllegalArgumentException instead

### DIFF
--- a/src/main/java/net/minestom/server/utils/NamespaceID.java
+++ b/src/main/java/net/minestom/server/utils/NamespaceID.java
@@ -49,9 +49,15 @@ public final class NamespaceID implements CharSequence, Key {
         this.full = full;
         this.domain = domain;
         this.path = path;
-        assert !domain.contains(".") && !domain.contains("/") : "Domain cannot contain a dot nor a slash character (" + full + ")";
-        assert domain.matches(legalLetters) : "Illegal character in domain (" + full + "). Must match " + legalLetters;
-        assert path.matches(legalPathLetters) : "Illegal character in path (" + full + "). Must match " + legalPathLetters;
+        if(domain.contains(".") || domain.contains("/")) {
+            throw new IllegalArgumentException("Domain cannot contain a dot nor a slash character (" + full + ")");
+        }
+        if(!domain.matches(legalLetters)) {
+            throw new IllegalArgumentException("Illegal character in domain (" + full + "). Must match " + legalLetters);
+        }
+        if(!path.matches(legalPathLetters)) {
+            throw new IllegalArgumentException("Illegal character in path (" + full + "). Must match " + legalPathLetters);
+        }
     }
 
     public @NotNull String domain() {

--- a/src/test/java/net/minestom/server/utils/NamespaceIDTest.java
+++ b/src/test/java/net/minestom/server/utils/NamespaceIDTest.java
@@ -30,35 +30,35 @@ public class NamespaceIDTest {
 
     @Test
     public void atMostOneColon() {
-        assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft:block:wool"));
+        assertThrows(IllegalArgumentException.class, () -> NamespaceID.from("minecraft:block:wool"));
     }
 
     @Test
     public void noSlashInDomain() {
-        assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft/java_edition:any"));
+        assertThrows(IllegalArgumentException.class, () -> NamespaceID.from("minecraft/java_edition:any"));
     }
 
     @Test
     public void noDotInDomain() {
-        assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft.java:game"));
+        assertThrows(IllegalArgumentException.class, () -> NamespaceID.from("minecraft.java:game"));
     }
 
     @Test
     public void noUppercase() {
-        assertThrows(AssertionError.class, () -> NamespaceID.from("Minecraft:any"));
-        assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft:Any"));
+        assertThrows(IllegalArgumentException.class, () -> NamespaceID.from("Minecraft:any"));
+        assertThrows(IllegalArgumentException.class, () -> NamespaceID.from("minecraft:Any"));
     }
 
     @Test
     public void noSpace() {
-        assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft:a n y"));
+        assertThrows(IllegalArgumentException.class, () -> NamespaceID.from("minecraft:a n y"));
     }
 
     @Test
     public void onlyLatinLowercase() {
-        assertThrows(AssertionError.class, () -> NamespaceID.from("Minecraft:voilà"));
-        assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft:où_ça"));
-        assertThrows(AssertionError.class, () -> NamespaceID.from("minecraft:schrödingers_var"));
+        assertThrows(IllegalArgumentException.class, () -> NamespaceID.from("Minecraft:voilà"));
+        assertThrows(IllegalArgumentException.class, () -> NamespaceID.from("minecraft:où_ça"));
+        assertThrows(IllegalArgumentException.class, () -> NamespaceID.from("minecraft:schrödingers_var"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #1097.

Java programs have assertions turned off by default, and therefore you can register invalid namespaces with Minestom if you do not have assertions on.

This PR fixes it by replacing the assertions with exceptions instead.