### PR TITLE
BungeeCordProxy: skip if the name is not textures or the value & signature does not exist

### DIFF
--- a/src/main/java/net/minestom/server/extras/bungee/BungeeCordProxy.java
+++ b/src/main/java/net/minestom/server/extras/bungee/BungeeCordProxy.java
@@ -40,14 +40,14 @@ public final class BungeeCordProxy {
         for (JsonElement element : array) {
             JsonObject jsonObject = element.getAsJsonObject();
             JsonElement name = jsonObject.get("name");
-            if (name != null && name.getAsString().equals("textures")) {
-                JsonElement value = jsonObject.get("value");
-                JsonElement signature = jsonObject.get("signature");
-                if (value == null || signature == null) continue;
+            if (name == null || !name.getAsString().equals("textures")) continue;
 
-                skinTexture = value.getAsString();
-                skinSignature = signature.getAsString();
-            }
+            JsonElement value = jsonObject.get("value");
+            JsonElement signature = jsonObject.get("signature");
+            if (value == null || signature == null) continue;
+
+            skinTexture = value.getAsString();
+            skinSignature = signature.getAsString();
         }
 
         if (skinTexture != null && skinSignature != null) {

--- a/src/main/java/net/minestom/server/extras/bungee/BungeeCordProxy.java
+++ b/src/main/java/net/minestom/server/extras/bungee/BungeeCordProxy.java
@@ -8,7 +8,7 @@ import net.minestom.server.entity.PlayerSkin;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * BungeeCord forwarding support. This does not count as a security feature and you will still be required to manage your firewall.
+ * BungeeCord forwarding support. This does not count as a security feature, and you will still be required to manage your firewall.
  * <p>
  * Please consider using {@link net.minestom.server.extras.velocity.VelocityProxy} instead.
  */
@@ -39,15 +39,15 @@ public final class BungeeCordProxy {
 
         for (JsonElement element : array) {
             JsonObject jsonObject = element.getAsJsonObject();
-            final String name = jsonObject.get("name").getAsString();
-            final String value = jsonObject.get("value").getAsString();
-            final String signature = jsonObject.get("signature").getAsString();
+            JsonElement name = jsonObject.get("name");
+            if (name != null && name.getAsString().equals("textures")) {
+                JsonElement value = jsonObject.get("value");
+                JsonElement signature = jsonObject.get("signature");
+                if (value == null || signature == null) continue;
 
-            if (name.equals("textures")) {
-                skinTexture = value;
-                skinSignature = signature;
+                skinTexture = value.getAsString();
+                skinSignature = signature.getAsString();
             }
-
         }
 
         if (skinTexture != null && skinSignature != null) {


### PR DESCRIPTION
We do not need to parse `value` and `signature` if the `name` is not `textures`.

Also, I got an NPE on `signature` lately, so there is a `null` check for that.