### PR TITLE
Limit chunk update packets

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -1381,11 +1381,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
             // Entity moved in a new chunk
             final Chunk newChunk = instance.getChunk(newChunkX, newChunkZ);
             Check.notNull(newChunk, "The entity {0} tried to move in an unloaded chunk at {1}", getEntityId(), newPosition);
-            if (this instanceof Player player) { // Update visible chunks
-                player.sendPacket(new UpdateViewPositionPacket(newChunkX, newChunkZ));
-                ChunkUtils.forDifferingChunksInRange(newChunkX, newChunkZ, lastChunkX, lastChunkZ,
-                        MinecraftServer.getChunkViewDistance(), player.chunkAdder, player.chunkRemover);
-            }
+            if (this instanceof Player player) player.sendChunkUpdates(newChunk);
             refreshCurrentChunk(newChunk);
         }
     }

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -2040,7 +2040,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
             sendPacket(new UpdateViewPositionPacket(newX, newZ));
             ChunkUtils.forDifferingChunksInRange(newX, newZ, (int) old.x(), (int) old.z(),
                     MinecraftServer.getChunkViewDistance(), chunkAdder, chunkRemover);
-            chunksLoadedByClient = new Vec(newX, newZ);
+            this.chunksLoadedByClient = new Vec(newX, newZ);
         }
     }
 

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -174,7 +174,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
 
     // Game state (https://wiki.vg/Protocol#Change_Game_State)
     private boolean enableRespawnScreen;
-    private final ChunkUpdateLimitChecker chunkUpdateLimitChecker = new ChunkUpdateLimitChecker(4);
+    private final ChunkUpdateLimitChecker chunkUpdateLimitChecker = new ChunkUpdateLimitChecker(6);
 
     // Experience orb pickup
     protected Cooldown experiencePickupCooldown = new Cooldown(Duration.of(10, TimeUnit.SERVER_TICK));

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -620,7 +620,10 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         super.setInstance(instance, spawnPosition);
 
         if (updateChunks) {
-            sendPacket(new UpdateViewPositionPacket(spawnPosition.chunkX(), spawnPosition.chunkZ()));
+            final int chunkX = spawnPosition.chunkX();
+            final int chunkZ = spawnPosition.chunkZ();
+            chunksLoadedByClient = new Vec(chunkX, chunkZ);
+            sendPacket(new UpdateViewPositionPacket(chunkX, chunkZ));
             ChunkUtils.forChunksInRange(spawnPosition, MinecraftServer.getChunkViewDistance(), chunkAdder);
         }
 

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -2031,11 +2031,13 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
 
     protected void sendChunkUpdates(Chunk newChunk) {
         if (chunkUpdateLimitChecker.addToHistory(newChunk)) {
-            sendPacket(new UpdateViewPositionPacket(newChunk.getChunkX(), newChunk.getChunkZ()));
-            ChunkUtils.forDifferingChunksInRange(newChunk.getChunkX(), newChunk.getChunkZ(),
-                    (int) chunksLoadedByClient.x(), (int) chunksLoadedByClient.z(),
+            final int newX = newChunk.getChunkX();
+            final int newZ = newChunk.getChunkZ();
+            final Vec old = chunksLoadedByClient;
+            sendPacket(new UpdateViewPositionPacket(newX, newZ));
+            ChunkUtils.forDifferingChunksInRange(newX, newZ, (int) old.x(), (int) old.z(),
                     MinecraftServer.getChunkViewDistance(), chunkAdder, chunkRemover);
-            chunksLoadedByClient = new Vec(newChunk.getChunkX(), newChunk.getChunkZ());
+            chunksLoadedByClient = new Vec(newX, newZ);
         }
     }
 

--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -339,7 +339,6 @@ public class InstanceContainer extends Instance {
                     MinecraftServer.getExceptionManager().handleException(e);
                 } finally {
                     // End generation
-                    chunk.sendChunk();
                     refreshLastBlockChangeTime();
                     resultFuture.complete(chunk);
                 }

--- a/src/main/java/net/minestom/server/utils/chunk/ChunkUpdateLimitChecker.java
+++ b/src/main/java/net/minestom/server/utils/chunk/ChunkUpdateLimitChecker.java
@@ -1,17 +1,16 @@
 package net.minestom.server.utils.chunk;
 
 import net.minestom.server.instance.Chunk;
+import org.jetbrains.annotations.ApiStatus;
 
-import java.util.ArrayDeque;
-import java.util.Queue;
-
-public class ChunkUpdateLimitChecker {
+@ApiStatus.Internal
+public final class ChunkUpdateLimitChecker {
     private final int historySize;
-    private final Queue<Chunk> chunkHistory;
+    private final long[] chunkHistory;
 
     public ChunkUpdateLimitChecker(int historySize) {
         this.historySize = historySize;
-        this.chunkHistory = new ArrayDeque<>(historySize);
+        this.chunkHistory = new long[historySize];
     }
 
     /**
@@ -21,11 +20,16 @@ public class ChunkUpdateLimitChecker {
      * @return {@code true} if it's a new chunk in the history
      */
     public boolean addToHistory(Chunk chunk) {
-        boolean result = !chunkHistory.contains(chunk);
-        if (chunkHistory.size() == historySize) {
-            chunkHistory.remove();
+        final long index = ChunkUtils.getChunkIndex(chunk);
+        boolean result = true;
+        int lastIndex = historySize-1;
+        for (int i = 0; i < lastIndex; i++) {
+            if (chunkHistory[i] == index) {
+                result = false;
+            }
+            chunkHistory[i] = chunkHistory[i+1];
         }
-        chunkHistory.offer(chunk);
+        chunkHistory[lastIndex] = index;
         return result;
     }
 }

--- a/src/main/java/net/minestom/server/utils/chunk/ChunkUpdateLimitChecker.java
+++ b/src/main/java/net/minestom/server/utils/chunk/ChunkUpdateLimitChecker.java
@@ -1,0 +1,31 @@
+package net.minestom.server.utils.chunk;
+
+import net.minestom.server.instance.Chunk;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+public class ChunkUpdateLimitChecker {
+    private final int historySize;
+    private final Queue<Chunk> chunkHistory;
+
+    public ChunkUpdateLimitChecker(int historySize) {
+        this.historySize = historySize;
+        this.chunkHistory = new ArrayDeque<>(historySize);
+    }
+
+    /**
+     * Adds the chunk to the history
+     *
+     * @param chunk chunk to add
+     * @return {@code true} if it's a new chunk in the history
+     */
+    public boolean addToHistory(Chunk chunk) {
+        boolean result = !chunkHistory.contains(chunk);
+        if (chunkHistory.size() == historySize) {
+            chunkHistory.remove();
+        }
+        chunkHistory.offer(chunk);
+        return result;
+    }
+}

--- a/src/main/java/net/minestom/server/utils/chunk/ChunkUpdateLimitChecker.java
+++ b/src/main/java/net/minestom/server/utils/chunk/ChunkUpdateLimitChecker.java
@@ -22,12 +22,12 @@ public final class ChunkUpdateLimitChecker {
     public boolean addToHistory(Chunk chunk) {
         final long index = ChunkUtils.getChunkIndex(chunk);
         boolean result = true;
-        int lastIndex = historySize-1;
+        final int lastIndex = historySize - 1;
         for (int i = 0; i < lastIndex; i++) {
             if (chunkHistory[i] == index) {
                 result = false;
             }
-            chunkHistory[i] = chunkHistory[i+1];
+            chunkHistory[i] = chunkHistory[i + 1];
         }
         chunkHistory[lastIndex] = index;
         return result;

--- a/src/main/java/net/minestom/server/utils/chunk/ChunkUtils.java
+++ b/src/main/java/net/minestom/server/utils/chunk/ChunkUtils.java
@@ -195,7 +195,7 @@ public final class ChunkUtils {
             if (!currentChunks.contains(newChunk)) newCallback.accept(getChunkCoordX(newChunk), getChunkCoordZ(newChunk));
         }
         for (long currentChunk : currentChunks) {
-            if (!newChunks.contains(currentChunk)) newCallback.accept(getChunkCoordX(currentChunk), getChunkCoordZ(currentChunk));
+            if (!newChunks.contains(currentChunk)) oldCallback.accept(getChunkCoordX(currentChunk), getChunkCoordZ(currentChunk));
         }
     }
 

--- a/src/main/java/net/minestom/server/utils/chunk/ChunkUtils.java
+++ b/src/main/java/net/minestom/server/utils/chunk/ChunkUtils.java
@@ -1,5 +1,7 @@
 package net.minestom.server.utils.chunk;
 
+import it.unimi.dsi.fastutil.longs.LongArraySet;
+import it.unimi.dsi.fastutil.longs.LongSet;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.Chunk;
@@ -183,6 +185,18 @@ public final class ChunkUtils {
 
     public static void forChunksInRange(@NotNull Point point, int range, IntegerBiConsumer consumer) {
         forChunksInRange(point.chunkX(), point.chunkZ(), range, consumer);
+    }
+
+    public static void forDifferingChunks(LongSet currentChunks, int newChunkX, int newChunkZ, int range,
+                                          @NotNull IntegerBiConsumer newCallback, @NotNull IntegerBiConsumer oldCallback) {
+        final LongArraySet newChunks = new LongArraySet();
+        forChunksInRange(newChunkX, newChunkZ, range, (x, z) -> newChunks.add(getChunkIndex(x, z)));
+        for (long newChunk : newChunks) {
+            if (!currentChunks.contains(newChunk)) newCallback.accept(getChunkCoordX(newChunk), getChunkCoordZ(newChunk));
+        }
+        for (long currentChunk : currentChunks) {
+            if (!newChunks.contains(currentChunk)) newCallback.accept(getChunkCoordX(currentChunk), getChunkCoordZ(currentChunk));
+        }
     }
 
     /**

--- a/src/main/java/net/minestom/server/utils/chunk/ChunkUtils.java
+++ b/src/main/java/net/minestom/server/utils/chunk/ChunkUtils.java
@@ -1,12 +1,9 @@
 package net.minestom.server.utils.chunk;
 
-import it.unimi.dsi.fastutil.longs.LongArraySet;
-import it.unimi.dsi.fastutil.longs.LongSet;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.Instance;
-import net.minestom.server.utils.MathUtils;
 import net.minestom.server.utils.callback.OptionalCallback;
 import net.minestom.server.utils.function.IntegerBiConsumer;
 import org.jetbrains.annotations.ApiStatus;
@@ -186,24 +183,6 @@ public final class ChunkUtils {
 
     public static void forChunksInRange(@NotNull Point point, int range, IntegerBiConsumer consumer) {
         forChunksInRange(point.chunkX(), point.chunkZ(), range, consumer);
-    }
-
-    public static void forDifferingChunks(LongSet currentChunks, int newChunkX, int newChunkZ, int range,
-                                          @NotNull IntegerBiConsumer newCallback, @NotNull IntegerBiConsumer oldCallback) {
-        final int minX = newChunkX - range, minZ = newChunkZ - range;
-        final int maxX = newChunkX + range, maxZ = newChunkZ + range;
-        for (int x = minX; x <= maxX; x++) {
-            outer: for (int z = minZ; z <= maxZ; z++) {
-                final long newChunk = ChunkUtils.getChunkIndex(x, z);
-                for (long currentChunk : currentChunks) if (currentChunk == newChunk) continue outer;
-                newCallback.accept(x, z);
-            }
-        }
-        for (long currentChunk : currentChunks) {
-            final int x = ChunkUtils.getChunkCoordX(currentChunk);
-            final int z = ChunkUtils.getChunkCoordZ(currentChunk);
-            if (x < minX || x > maxX || z < minZ || z > maxZ) oldCallback.accept(x, z);
-        }
     }
 
     /**

--- a/src/test/java/net/minestom/server/api/Collector.java
+++ b/src/test/java/net/minestom/server/api/Collector.java
@@ -27,7 +27,7 @@ public interface Collector<T> {
 
     default void assertCount(int count) {
         List<T> elements = collect();
-        assertEquals(count, elements.size(), "Expected " + count + " element(s), got " + elements);
+        assertEquals(count, elements.size(), "Expected " + count + " element(s), got " + elements.size() + ": " + elements);
     }
 
     default void assertSingle() {

--- a/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
@@ -58,7 +58,7 @@ public class PlayerMovementIntegrationTest {
     }
 
     @Test
-    public void chunkUpdateDebounceTest(Env env) {
+    public void chunkUpdateDebounceTest(Env env) throws InterruptedException {
         final Instance flatInstance = env.createFlatInstance();
         final TestConnection connection = env.createConnection();
         final CompletableFuture<@NotNull Player> future = connection.connect(flatInstance, new Pos(0.5, 40, 0.5));
@@ -73,30 +73,35 @@ public class PlayerMovementIntegrationTest {
         chunkDataPacketCollector = connection.trackIncoming(ChunkDataPacket.class);
         player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(-0.5, 40, 0.5), true));
         player.interpretPacketQueue();
+        Thread.sleep(1000);
         chunkDataPacketCollector.assertCount(viewDiameter);
 
         // Move to next chunk
         chunkDataPacketCollector = connection.trackIncoming(ChunkDataPacket.class);
         player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(-0.5, 40, -0.5), true));
         player.interpretPacketQueue();
+        Thread.sleep(1000);
         chunkDataPacketCollector.assertCount(viewDiameter);
 
         // Move to next chunk
         chunkDataPacketCollector = connection.trackIncoming(ChunkDataPacket.class);
         player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(0.5, 40, -0.5), true));
         player.interpretPacketQueue();
+        Thread.sleep(1000);
         chunkDataPacketCollector.assertCount(viewDiameter);
 
         // Move to next chunk
         chunkDataPacketCollector = connection.trackIncoming(ChunkDataPacket.class);
         player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(0.5, 40, 0.5), true));
         player.interpretPacketQueue();
+        Thread.sleep(1000);
         chunkDataPacketCollector.assertEmpty();
 
         // Move to next chunk
         chunkDataPacketCollector = connection.trackIncoming(ChunkDataPacket.class);
         player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(0.5, 40, -0.5), true));
         player.interpretPacketQueue();
+        Thread.sleep(1000);
         chunkDataPacketCollector.assertEmpty();
 
         // Move to next chunk
@@ -104,6 +109,7 @@ public class PlayerMovementIntegrationTest {
         // Abuse the fact that there is no delta check
         player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(16.5, 40, -16.5), true));
         player.interpretPacketQueue();
+        Thread.sleep(1000);
         chunkDataPacketCollector.assertCount(viewDiameter * 2 - 1);
     }
 }

--- a/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
@@ -8,16 +8,22 @@ import net.minestom.server.api.TestConnection;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Player;
+import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.network.packet.client.play.ClientPlayerPositionPacket;
 import net.minestom.server.network.packet.client.play.ClientTeleportConfirmPacket;
 import net.minestom.server.network.packet.server.play.ChunkDataPacket;
 import net.minestom.server.network.packet.server.play.EntityPositionPacket;
 import net.minestom.server.utils.MathUtils;
+import net.minestom.server.utils.chunk.ChunkUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -58,14 +64,17 @@ public class PlayerMovementIntegrationTest {
     }
 
     @Test
-    public void chunkUpdateDebounceTest(Env env) throws InterruptedException {
+    public void chunkUpdateDebounceTest(Env env) {
         final Instance flatInstance = env.createFlatInstance();
+        final int viewDiameter = MinecraftServer.getChunkViewDistance() * 2 + 1;
+        // Preload all possible chunks to avoid issues due to async loading
+        Set<CompletableFuture<Chunk>> chunks = new HashSet<>();
+        ChunkUtils.forChunksInRange(0, 0, viewDiameter+2, (x, z) -> chunks.add(flatInstance.loadChunk(x, z)));
+        CompletableFuture.allOf(chunks.toArray(CompletableFuture[]::new)).join();
         final TestConnection connection = env.createConnection();
         final CompletableFuture<@NotNull Player> future = connection.connect(flatInstance, new Pos(0.5, 40, 0.5));
         Collector<ChunkDataPacket> chunkDataPacketCollector = connection.trackIncoming(ChunkDataPacket.class);
         final Player player = future.join();
-        final int viewDiameter = MinecraftServer.getChunkViewDistance() * 2 + 1;
-        final int sleep = 100;
         // Initial join
         chunkDataPacketCollector.assertCount(MathUtils.square(viewDiameter));
         player.addPacketToQueue(new ClientTeleportConfirmPacket(player.getLastSentTeleportId()));
@@ -74,35 +83,30 @@ public class PlayerMovementIntegrationTest {
         chunkDataPacketCollector = connection.trackIncoming(ChunkDataPacket.class);
         player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(-0.5, 40, 0.5), true));
         player.interpretPacketQueue();
-        Thread.sleep(sleep);
         chunkDataPacketCollector.assertCount(viewDiameter);
 
         // Move to next chunk
         chunkDataPacketCollector = connection.trackIncoming(ChunkDataPacket.class);
         player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(-0.5, 40, -0.5), true));
         player.interpretPacketQueue();
-        Thread.sleep(sleep);
         chunkDataPacketCollector.assertCount(viewDiameter);
 
         // Move to next chunk
         chunkDataPacketCollector = connection.trackIncoming(ChunkDataPacket.class);
         player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(0.5, 40, -0.5), true));
         player.interpretPacketQueue();
-        Thread.sleep(sleep);
         chunkDataPacketCollector.assertCount(viewDiameter);
 
         // Move to next chunk
         chunkDataPacketCollector = connection.trackIncoming(ChunkDataPacket.class);
         player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(0.5, 40, 0.5), true));
         player.interpretPacketQueue();
-        Thread.sleep(sleep);
         chunkDataPacketCollector.assertEmpty();
 
         // Move to next chunk
         chunkDataPacketCollector = connection.trackIncoming(ChunkDataPacket.class);
         player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(0.5, 40, -0.5), true));
         player.interpretPacketQueue();
-        Thread.sleep(sleep);
         chunkDataPacketCollector.assertEmpty();
 
         // Move to next chunk
@@ -110,7 +114,6 @@ public class PlayerMovementIntegrationTest {
         // Abuse the fact that there is no delta check
         player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(16.5, 40, -16.5), true));
         player.interpretPacketQueue();
-        Thread.sleep(sleep);
         chunkDataPacketCollector.assertCount(viewDiameter * 2 - 1);
     }
 }

--- a/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
@@ -65,6 +65,7 @@ public class PlayerMovementIntegrationTest {
         Collector<ChunkDataPacket> chunkDataPacketCollector = connection.trackIncoming(ChunkDataPacket.class);
         final Player player = future.join();
         final int viewDiameter = MinecraftServer.getChunkViewDistance() * 2 + 1;
+        final int sleep = 100;
         // Initial join
         chunkDataPacketCollector.assertCount(MathUtils.square(viewDiameter));
         player.addPacketToQueue(new ClientTeleportConfirmPacket(player.getLastSentTeleportId()));
@@ -73,35 +74,35 @@ public class PlayerMovementIntegrationTest {
         chunkDataPacketCollector = connection.trackIncoming(ChunkDataPacket.class);
         player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(-0.5, 40, 0.5), true));
         player.interpretPacketQueue();
-        Thread.sleep(1000);
+        Thread.sleep(sleep);
         chunkDataPacketCollector.assertCount(viewDiameter);
 
         // Move to next chunk
         chunkDataPacketCollector = connection.trackIncoming(ChunkDataPacket.class);
         player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(-0.5, 40, -0.5), true));
         player.interpretPacketQueue();
-        Thread.sleep(1000);
+        Thread.sleep(sleep);
         chunkDataPacketCollector.assertCount(viewDiameter);
 
         // Move to next chunk
         chunkDataPacketCollector = connection.trackIncoming(ChunkDataPacket.class);
         player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(0.5, 40, -0.5), true));
         player.interpretPacketQueue();
-        Thread.sleep(1000);
+        Thread.sleep(sleep);
         chunkDataPacketCollector.assertCount(viewDiameter);
 
         // Move to next chunk
         chunkDataPacketCollector = connection.trackIncoming(ChunkDataPacket.class);
         player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(0.5, 40, 0.5), true));
         player.interpretPacketQueue();
-        Thread.sleep(1000);
+        Thread.sleep(sleep);
         chunkDataPacketCollector.assertEmpty();
 
         // Move to next chunk
         chunkDataPacketCollector = connection.trackIncoming(ChunkDataPacket.class);
         player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(0.5, 40, -0.5), true));
         player.interpretPacketQueue();
-        Thread.sleep(1000);
+        Thread.sleep(sleep);
         chunkDataPacketCollector.assertEmpty();
 
         // Move to next chunk
@@ -109,7 +110,7 @@ public class PlayerMovementIntegrationTest {
         // Abuse the fact that there is no delta check
         player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(16.5, 40, -16.5), true));
         player.interpretPacketQueue();
-        Thread.sleep(1000);
+        Thread.sleep(sleep);
         chunkDataPacketCollector.assertCount(viewDiameter * 2 - 1);
     }
 }

--- a/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
@@ -63,29 +63,28 @@ public class PlayerMovementIntegrationTest {
         final TestConnection connection = env.createConnection();
         final CompletableFuture<@NotNull Player> future = connection.connect(flatInstance, new Pos(0.5, 40, 0.5));
         final Collector<ChunkDataPacket> chunkDataPacketCollector = connection.trackIncoming(ChunkDataPacket.class);
-        future.thenAccept(player -> {
-            final int viewDiameter = MinecraftServer.getChunkViewDistance() * 2;
-            int totalUpdatePackets = MathUtils.square(viewDiameter);
-            chunkDataPacketCollector.assertCount(totalUpdatePackets);
-            player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(-0.5, 40, 0.5), true));
-            player.interpretPacketQueue();
-            chunkDataPacketCollector.assertCount(totalUpdatePackets += viewDiameter);
-            player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(-0.5, 40, -0.5), true));
-            player.interpretPacketQueue();
-            chunkDataPacketCollector.assertCount(totalUpdatePackets += viewDiameter);
-            player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(0.5, 40, -0.5), true));
-            player.interpretPacketQueue();
-            chunkDataPacketCollector.assertCount(totalUpdatePackets += viewDiameter);
-            player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(0.5, 40, 0.5), true));
-            player.interpretPacketQueue();
-            chunkDataPacketCollector.assertCount(totalUpdatePackets);
-            player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(0.5, 40, -0.5), true));
-            player.interpretPacketQueue();
-            chunkDataPacketCollector.assertCount(totalUpdatePackets);
-            // Abuse the fact that there is no delta check
-            player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(16.5, 40, -16.5), true));
-            player.interpretPacketQueue();
-            chunkDataPacketCollector.assertCount(totalUpdatePackets + (viewDiameter * 2 - 1));
-        });
+        final Player player = future.join();
+        final int viewDiameter = MinecraftServer.getChunkViewDistance() * 2;
+        int totalUpdatePackets = MathUtils.square(viewDiameter);
+        chunkDataPacketCollector.assertCount(totalUpdatePackets);
+        player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(-0.5, 40, 0.5), true));
+        player.interpretPacketQueue();
+        chunkDataPacketCollector.assertCount(totalUpdatePackets += viewDiameter);
+        player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(-0.5, 40, -0.5), true));
+        player.interpretPacketQueue();
+        chunkDataPacketCollector.assertCount(totalUpdatePackets += viewDiameter);
+        player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(0.5, 40, -0.5), true));
+        player.interpretPacketQueue();
+        chunkDataPacketCollector.assertCount(totalUpdatePackets += viewDiameter);
+        player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(0.5, 40, 0.5), true));
+        player.interpretPacketQueue();
+        chunkDataPacketCollector.assertCount(totalUpdatePackets);
+        player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(0.5, 40, -0.5), true));
+        player.interpretPacketQueue();
+        chunkDataPacketCollector.assertCount(totalUpdatePackets);
+        // Abuse the fact that there is no delta check
+        player.addPacketToQueue(new ClientPlayerPositionPacket(new Vec(16.5, 40, -16.5), true));
+        player.interpretPacketQueue();
+        chunkDataPacketCollector.assertCount(totalUpdatePackets + (viewDiameter * 2 - 1));
     }
 }

--- a/src/test/java/net/minestom/server/utils/ChunkUtilsTest.java
+++ b/src/test/java/net/minestom/server/utils/ChunkUtilsTest.java
@@ -1,0 +1,51 @@
+package net.minestom.server.utils;
+
+import net.minestom.server.utils.chunk.ChunkUtils;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+public class ChunkUtilsTest {
+
+    @ParameterizedTest
+    @MethodSource("testForDifferingChunksInRangeParams")
+    public void testForDifferingChunksInRange(int nx, int nz, int ox, int oz, int r) {
+        final Set<ChunkCoordinate> n = new HashSet<>();
+        final Set<ChunkCoordinate> o = new HashSet<>();
+        ChunkUtils.forChunksInRange(nx, nz, r, (x, z) -> n.add(new ChunkCoordinate(x, z)));
+        ChunkUtils.forChunksInRange(ox, oz, r, (x, z) -> o.add(new ChunkCoordinate(x, z)));
+
+        final List<ChunkCoordinate> actualNew = new ArrayList<>();
+        final List<ChunkCoordinate> actualOld = new ArrayList<>();
+        ChunkUtils.forDifferingChunksInRange(nx, nz, ox, oz, r, ((x, z) -> actualNew.add(new ChunkCoordinate(x, z))),
+                ((x, z) -> actualOld.add(new ChunkCoordinate(x, z))));
+
+        final Comparator<ChunkCoordinate> sorter = Comparator.comparingInt(ChunkCoordinate::x).thenComparingInt(ChunkCoordinate::z);
+        final List<ChunkCoordinate> expectedNew = n.stream().filter(x -> !o.contains(x)).sorted(sorter).toList();
+        final List<ChunkCoordinate> expectedOld = o.stream().filter(x -> !n.contains(x)).sorted(sorter).toList();
+
+        Assertions.assertIterableEquals(expectedNew, actualNew.stream().sorted(sorter).toList());
+        Assertions.assertIterableEquals(expectedOld, actualOld.stream().sorted(sorter).toList());
+    }
+
+    private static Stream<Arguments> testForDifferingChunksInRangeParams() {
+        return Stream.of(
+                Arguments.of(1, 0, 0, 0, 16),
+                Arguments.of(1, 1, 0, 0, 16),
+                Arguments.of(3, 1, 1, 0, 16),
+                Arguments.of(10, 1, 3, 5, 16),
+                Arguments.of(10, 10, -10, -10, 16),
+                Arguments.of(1, 0, 0, 0, 3),
+                Arguments.of(1, 1, 0, 0, 3),
+                Arguments.of(3, 1, 1, 0, 3),
+                Arguments.of(10, 1, 3, 5, 3),
+                Arguments.of(10, 10, -10, -10, 3)
+        );
+    }
+
+    private record ChunkCoordinate(int x, int z) {}
+}


### PR DESCRIPTION
Malicious players can generate huge amount of traffic by moving in a small circle at the edge of four chunks which will result in chunk updates being sent out every time they cross a border resulting in 3000+ packets per second, 15+ MBps outbound traffic on a relatively simple map, this pr prevents that by introducing a history of visited chunks.