### PR TITLE
Add PlayerInstanceEvent

### DIFF
--- a/src/main/java/net/minestom/server/event/book/EditBookEvent.java
+++ b/src/main/java/net/minestom/server/event/book/EditBookEvent.java
@@ -1,16 +1,15 @@
 package net.minestom.server.event.book;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
 import net.minestom.server.event.trait.ItemEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public class EditBookEvent implements PlayerEvent, EntityInstanceEvent, ItemEvent {
+public class EditBookEvent implements PlayerInstanceEvent, ItemEvent {
 
     private final Player player;
     private final ItemStack itemStack;

--- a/src/main/java/net/minestom/server/event/inventory/InventoryClickEvent.java
+++ b/src/main/java/net/minestom/server/event/inventory/InventoryClickEvent.java
@@ -1,9 +1,8 @@
 package net.minestom.server.event.inventory;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
 import net.minestom.server.event.trait.InventoryEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.inventory.Inventory;
 import net.minestom.server.inventory.click.ClickType;
 import net.minestom.server.item.ItemStack;
@@ -14,7 +13,7 @@ import org.jetbrains.annotations.Nullable;
  * Called after {@link InventoryPreClickEvent}, this event cannot be cancelled and items related to the click
  * are already moved.
  */
-public class InventoryClickEvent implements InventoryEvent, PlayerEvent, EntityInstanceEvent {
+public class InventoryClickEvent implements InventoryEvent, PlayerInstanceEvent {
 
     private final Inventory inventory;
     private final Player player;

--- a/src/main/java/net/minestom/server/event/inventory/InventoryCloseEvent.java
+++ b/src/main/java/net/minestom/server/event/inventory/InventoryCloseEvent.java
@@ -1,9 +1,8 @@
 package net.minestom.server.event.inventory;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
 import net.minestom.server.event.trait.InventoryEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.inventory.Inventory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -11,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Called when an {@link Inventory} is closed by a player.
  */
-public class InventoryCloseEvent implements InventoryEvent, PlayerEvent, EntityInstanceEvent {
+public class InventoryCloseEvent implements InventoryEvent, PlayerInstanceEvent {
 
     private final Inventory inventory;
     private final Player player;

--- a/src/main/java/net/minestom/server/event/inventory/InventoryOpenEvent.java
+++ b/src/main/java/net/minestom/server/event/inventory/InventoryOpenEvent.java
@@ -2,9 +2,8 @@ package net.minestom.server.event.inventory;
 
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.EntityInstanceEvent;
 import net.minestom.server.event.trait.InventoryEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.inventory.Inventory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -14,7 +13,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>
  * Executed by {@link Player#openInventory(Inventory)}.
  */
-public class InventoryOpenEvent implements InventoryEvent, PlayerEvent, EntityInstanceEvent, CancellableEvent {
+public class InventoryOpenEvent implements InventoryEvent, PlayerInstanceEvent, CancellableEvent {
 
     private Inventory inventory;
     private final Player player;

--- a/src/main/java/net/minestom/server/event/inventory/InventoryPreClickEvent.java
+++ b/src/main/java/net/minestom/server/event/inventory/InventoryPreClickEvent.java
@@ -2,9 +2,8 @@ package net.minestom.server.event.inventory;
 
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.EntityInstanceEvent;
 import net.minestom.server.event.trait.InventoryEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.inventory.Inventory;
 import net.minestom.server.inventory.click.ClickType;
 import net.minestom.server.item.ItemStack;
@@ -14,7 +13,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Called before {@link InventoryClickEvent}, used to potentially cancel the click.
  */
-public class InventoryPreClickEvent implements InventoryEvent, PlayerEvent, EntityInstanceEvent, CancellableEvent {
+public class InventoryPreClickEvent implements InventoryEvent, PlayerInstanceEvent, CancellableEvent {
 
     private final Inventory inventory;
     private final Player player;

--- a/src/main/java/net/minestom/server/event/inventory/PlayerInventoryItemChangeEvent.java
+++ b/src/main/java/net/minestom/server/event/inventory/PlayerInventoryItemChangeEvent.java
@@ -1,8 +1,7 @@
 package net.minestom.server.event.inventory;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.inventory.AbstractInventory;
 import net.minestom.server.inventory.PlayerInventory;
 import net.minestom.server.item.ItemStack;
@@ -16,7 +15,7 @@ import org.jetbrains.annotations.NotNull;
  * listen only for an ancestor event and check whether it is an instance of that class.
  */
 @SuppressWarnings("JavadocReference")
-public class PlayerInventoryItemChangeEvent extends InventoryItemChangeEvent implements PlayerEvent, EntityInstanceEvent {
+public class PlayerInventoryItemChangeEvent extends InventoryItemChangeEvent implements PlayerInstanceEvent {
 
     private final Player player;
 

--- a/src/main/java/net/minestom/server/event/item/EntityEquipEvent.java
+++ b/src/main/java/net/minestom/server/event/item/EntityEquipEvent.java
@@ -2,13 +2,12 @@ package net.minestom.server.event.item;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.EquipmentSlot;
-import net.minestom.server.event.trait.EntityEvent;
 import net.minestom.server.event.trait.EntityInstanceEvent;
 import net.minestom.server.event.trait.ItemEvent;
 import net.minestom.server.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-public class EntityEquipEvent implements EntityEvent, EntityInstanceEvent, ItemEvent {
+public class EntityEquipEvent implements EntityInstanceEvent, ItemEvent {
 
     private final Entity entity;
     private ItemStack equippedItem;

--- a/src/main/java/net/minestom/server/event/item/ItemDropEvent.java
+++ b/src/main/java/net/minestom/server/event/item/ItemDropEvent.java
@@ -2,13 +2,12 @@ package net.minestom.server.event.item;
 
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.EntityInstanceEvent;
 import net.minestom.server.event.trait.ItemEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-public class ItemDropEvent implements PlayerEvent, EntityInstanceEvent, ItemEvent, CancellableEvent {
+public class ItemDropEvent implements PlayerInstanceEvent, ItemEvent, CancellableEvent {
 
     private final Player player;
     private final ItemStack itemStack;

--- a/src/main/java/net/minestom/server/event/item/ItemUpdateStateEvent.java
+++ b/src/main/java/net/minestom/server/event/item/ItemUpdateStateEvent.java
@@ -1,13 +1,12 @@
 package net.minestom.server.event.item;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
 import net.minestom.server.event.trait.ItemEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-public class ItemUpdateStateEvent implements PlayerEvent, EntityInstanceEvent, ItemEvent {
+public class ItemUpdateStateEvent implements PlayerInstanceEvent, ItemEvent {
 
     private final Player player;
     private final Player.Hand hand;

--- a/src/main/java/net/minestom/server/event/item/PickupExperienceEvent.java
+++ b/src/main/java/net/minestom/server/event/item/PickupExperienceEvent.java
@@ -3,11 +3,10 @@ package net.minestom.server.event.item;
 import net.minestom.server.entity.ExperienceOrb;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
-public class PickupExperienceEvent implements CancellableEvent, PlayerEvent, EntityInstanceEvent {
+public class PickupExperienceEvent implements CancellableEvent, PlayerInstanceEvent {
 
     private final Player player;
     private final ExperienceOrb experienceOrb;

--- a/src/main/java/net/minestom/server/event/item/PickupItemEvent.java
+++ b/src/main/java/net/minestom/server/event/item/PickupItemEvent.java
@@ -4,13 +4,12 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.ItemEntity;
 import net.minestom.server.entity.LivingEntity;
 import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.EntityEvent;
 import net.minestom.server.event.trait.EntityInstanceEvent;
 import net.minestom.server.event.trait.ItemEvent;
 import net.minestom.server.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-public class PickupItemEvent implements EntityEvent, EntityInstanceEvent, ItemEvent, CancellableEvent {
+public class PickupItemEvent implements EntityInstanceEvent, ItemEvent, CancellableEvent {
 
     private final LivingEntity livingEntity;
     private final ItemEntity itemEntity;

--- a/src/main/java/net/minestom/server/event/player/AdvancementTabEvent.java
+++ b/src/main/java/net/minestom/server/event/player/AdvancementTabEvent.java
@@ -2,15 +2,14 @@ package net.minestom.server.event.player;
 
 import net.minestom.server.advancements.AdvancementAction;
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when a {@link Player} opens the advancement screens or switch the tab
  * and when he closes the screen.
  */
-public class AdvancementTabEvent implements PlayerEvent, EntityInstanceEvent {
+public class AdvancementTabEvent implements PlayerInstanceEvent {
 
     private final Player player;
     private final AdvancementAction action;

--- a/src/main/java/net/minestom/server/event/player/PlayerBlockBreakEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerBlockBreakEvent.java
@@ -4,12 +4,11 @@ import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.BlockEvent;
 import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.instance.block.Block;
 import org.jetbrains.annotations.NotNull;
 
-public class PlayerBlockBreakEvent implements PlayerEvent, EntityInstanceEvent, BlockEvent, CancellableEvent {
+public class PlayerBlockBreakEvent implements PlayerInstanceEvent, BlockEvent, CancellableEvent {
 
     private final Player player;
     private final Block block;

--- a/src/main/java/net/minestom/server/event/player/PlayerBlockInteractEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerBlockInteractEvent.java
@@ -4,8 +4,7 @@ import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.BlockEvent;
 import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockFace;
 import org.jetbrains.annotations.NotNull;
@@ -14,7 +13,7 @@ import org.jetbrains.annotations.NotNull;
  * Called when a player interacts with a block (right-click).
  * This is also called when a block is placed.
  */
-public class PlayerBlockInteractEvent implements PlayerEvent, EntityInstanceEvent, BlockEvent, CancellableEvent {
+public class PlayerBlockInteractEvent implements PlayerInstanceEvent, BlockEvent, CancellableEvent {
 
     private final Player player;
     private final Player.Hand hand;

--- a/src/main/java/net/minestom/server/event/player/PlayerBlockPlaceEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerBlockPlaceEvent.java
@@ -4,8 +4,7 @@ import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.BlockEvent;
 import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockFace;
 import org.jetbrains.annotations.NotNull;
@@ -13,7 +12,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Called when a player tries placing a block.
  */
-public class PlayerBlockPlaceEvent implements PlayerEvent, EntityInstanceEvent, BlockEvent, CancellableEvent {
+public class PlayerBlockPlaceEvent implements PlayerInstanceEvent, BlockEvent, CancellableEvent {
 
     private final Player player;
     private Block block;

--- a/src/main/java/net/minestom/server/event/player/PlayerChangeHeldSlotEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerChangeHeldSlotEvent.java
@@ -2,8 +2,7 @@ package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.utils.MathUtils;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.NotNull;
@@ -11,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Called when a player change his held slot (by pressing 1-9 keys).
  */
-public class PlayerChangeHeldSlotEvent implements PlayerEvent, EntityInstanceEvent, CancellableEvent {
+public class PlayerChangeHeldSlotEvent implements PlayerInstanceEvent, CancellableEvent {
 
     private final Player player;
     private byte slot;

--- a/src/main/java/net/minestom/server/event/player/PlayerChatEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerChatEvent.java
@@ -3,8 +3,7 @@ package net.minestom.server.event.player;
 import net.kyori.adventure.text.Component;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -17,7 +16,7 @@ import java.util.function.Supplier;
  * Called every time a {@link Player} write and send something in the chat.
  * The event can be cancelled to do not send anything, and the format can be changed.
  */
-public class PlayerChatEvent implements PlayerEvent, EntityInstanceEvent, CancellableEvent {
+public class PlayerChatEvent implements PlayerInstanceEvent, CancellableEvent {
 
     private final Player player;
     private final Collection<Player> recipients;

--- a/src/main/java/net/minestom/server/event/player/PlayerChunkLoadEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerChunkLoadEvent.java
@@ -1,14 +1,13 @@
 package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when a player receive a new chunk data.
  */
-public class PlayerChunkLoadEvent implements PlayerEvent, EntityInstanceEvent {
+public class PlayerChunkLoadEvent implements PlayerInstanceEvent {
 
     private final Player player;
     private final int chunkX, chunkZ;

--- a/src/main/java/net/minestom/server/event/player/PlayerChunkUnloadEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerChunkUnloadEvent.java
@@ -1,8 +1,7 @@
 package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -10,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
  * <p>
  * Could be used to unload the chunk internally in order to save memory.
  */
-public class PlayerChunkUnloadEvent implements PlayerEvent, EntityInstanceEvent {
+public class PlayerChunkUnloadEvent implements PlayerInstanceEvent {
 
     private final Player player;
     private final int chunkX, chunkZ;

--- a/src/main/java/net/minestom/server/event/player/PlayerCommandEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerCommandEvent.java
@@ -2,14 +2,13 @@ package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Called every time a player send a message starting by '/'.
  */
-public class PlayerCommandEvent implements PlayerEvent, EntityInstanceEvent, CancellableEvent {
+public class PlayerCommandEvent implements PlayerInstanceEvent, CancellableEvent {
 
     private final Player player;
     private String command;

--- a/src/main/java/net/minestom/server/event/player/PlayerDeathEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerDeathEvent.java
@@ -2,15 +2,14 @@ package net.minestom.server.event.player;
 
 import net.kyori.adventure.text.Component;
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * Called when a player die in {@link Player#kill()}.
  */
-public class PlayerDeathEvent implements PlayerEvent, EntityInstanceEvent {
+public class PlayerDeathEvent implements PlayerInstanceEvent {
 
     private final Player player;
     private Component deathText;

--- a/src/main/java/net/minestom/server/event/player/PlayerDisconnectEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerDisconnectEvent.java
@@ -1,14 +1,13 @@
 package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when a player disconnect.
  */
-public class PlayerDisconnectEvent implements PlayerEvent, EntityInstanceEvent {
+public class PlayerDisconnectEvent implements PlayerInstanceEvent {
 
     private final Player player;
 

--- a/src/main/java/net/minestom/server/event/player/PlayerEatEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerEatEvent.java
@@ -1,16 +1,15 @@
 package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
 import net.minestom.server.event.trait.ItemEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when a player is finished eating.
  */
-public class PlayerEatEvent implements ItemEvent, PlayerEvent, EntityInstanceEvent {
+public class PlayerEatEvent implements ItemEvent, PlayerInstanceEvent {
 
     private final Player player;
     private final ItemStack foodItem;

--- a/src/main/java/net/minestom/server/event/player/PlayerEntityInteractEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerEntityInteractEvent.java
@@ -2,14 +2,13 @@ package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when a {@link Player} interacts (right-click) with an {@link Entity}.
  */
-public class PlayerEntityInteractEvent implements PlayerEvent, EntityInstanceEvent {
+public class PlayerEntityInteractEvent implements PlayerInstanceEvent {
 
     private final Player player;
     private final Entity entityTarget;

--- a/src/main/java/net/minestom/server/event/player/PlayerHandAnimationEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerHandAnimationEvent.java
@@ -2,14 +2,13 @@ package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when the player swings his hand.
  */
-public class PlayerHandAnimationEvent implements PlayerEvent, EntityInstanceEvent, CancellableEvent {
+public class PlayerHandAnimationEvent implements PlayerInstanceEvent, CancellableEvent {
 
     private final Player player;
     private final Player.Hand hand;

--- a/src/main/java/net/minestom/server/event/player/PlayerItemAnimationEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerItemAnimationEvent.java
@@ -2,8 +2,7 @@ package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -11,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
  *
  * @see ItemAnimationType
  */
-public class PlayerItemAnimationEvent implements PlayerEvent, EntityInstanceEvent, CancellableEvent {
+public class PlayerItemAnimationEvent implements PlayerInstanceEvent, CancellableEvent {
 
     private final Player player;
     private final ItemAnimationType itemAnimationType;

--- a/src/main/java/net/minestom/server/event/player/PlayerMoveEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerMoveEvent.java
@@ -3,14 +3,13 @@ package net.minestom.server.event.player;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when a player is modifying his position.
  */
-public class PlayerMoveEvent implements PlayerEvent, EntityInstanceEvent, CancellableEvent {
+public class PlayerMoveEvent implements PlayerInstanceEvent, CancellableEvent {
 
     private final Player player;
     private Pos newPosition;

--- a/src/main/java/net/minestom/server/event/player/PlayerPacketEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerPacketEvent.java
@@ -2,12 +2,11 @@ package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.network.packet.client.ClientPacket;
 import org.jetbrains.annotations.NotNull;
 
-public class PlayerPacketEvent implements PlayerEvent, EntityInstanceEvent, CancellableEvent {
+public class PlayerPacketEvent implements PlayerInstanceEvent, CancellableEvent {
 
     private final Player player;
     private final ClientPacket packet;

--- a/src/main/java/net/minestom/server/event/player/PlayerPluginMessageEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerPluginMessageEvent.java
@@ -1,14 +1,13 @@
 package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when a player send {@link net.minestom.server.network.packet.client.play.ClientPluginMessagePacket}.
  */
-public class PlayerPluginMessageEvent implements PlayerEvent, EntityInstanceEvent {
+public class PlayerPluginMessageEvent implements PlayerInstanceEvent {
 
     private final Player player;
     private final String identifier;

--- a/src/main/java/net/minestom/server/event/player/PlayerPreEatEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerPreEatEvent.java
@@ -2,9 +2,8 @@ package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.EntityInstanceEvent;
 import net.minestom.server.event.trait.ItemEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
@@ -13,7 +12,7 @@ import org.jetbrains.annotations.NotNull;
  * or to cancel its processing, cancelling the event means that the player will
  * continue the animation indefinitely.
  */
-public class PlayerPreEatEvent implements ItemEvent, PlayerEvent, EntityInstanceEvent, CancellableEvent {
+public class PlayerPreEatEvent implements ItemEvent, PlayerInstanceEvent, CancellableEvent {
 
     private final Player player;
     private final ItemStack foodItem;

--- a/src/main/java/net/minestom/server/event/player/PlayerStartDiggingEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerStartDiggingEvent.java
@@ -4,8 +4,7 @@ import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.BlockEvent;
 import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.instance.block.Block;
 import org.jetbrains.annotations.NotNull;
 
@@ -17,7 +16,7 @@ import org.jetbrains.annotations.NotNull;
  * (could be because of high latency or a modified client) so cancelling {@link PlayerBlockBreakEvent} is also necessary.
  * Could be fixed in future Minestom version.
  */
-public class PlayerStartDiggingEvent implements PlayerEvent, EntityInstanceEvent, BlockEvent, CancellableEvent {
+public class PlayerStartDiggingEvent implements PlayerInstanceEvent, BlockEvent, CancellableEvent {
 
     private final Player player;
     private final Block block;

--- a/src/main/java/net/minestom/server/event/player/PlayerStartFlyingEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerStartFlyingEvent.java
@@ -1,14 +1,13 @@
 package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when a player start flying.
  */
-public class PlayerStartFlyingEvent implements PlayerEvent, EntityInstanceEvent {
+public class PlayerStartFlyingEvent implements PlayerInstanceEvent {
 
     private final Player player;
 

--- a/src/main/java/net/minestom/server/event/player/PlayerStartFlyingWithElytraEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerStartFlyingWithElytraEvent.java
@@ -1,11 +1,10 @@
 package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
-public class PlayerStartFlyingWithElytraEvent implements PlayerEvent, EntityInstanceEvent {
+public class PlayerStartFlyingWithElytraEvent implements PlayerInstanceEvent {
 
     private final Player player;
 

--- a/src/main/java/net/minestom/server/event/player/PlayerStartSneakingEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerStartSneakingEvent.java
@@ -1,14 +1,13 @@
 package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when a player starts sneaking.
  */
-public class PlayerStartSneakingEvent implements PlayerEvent, EntityInstanceEvent {
+public class PlayerStartSneakingEvent implements PlayerInstanceEvent {
 
     private final Player player;
 

--- a/src/main/java/net/minestom/server/event/player/PlayerStartSprintingEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerStartSprintingEvent.java
@@ -1,14 +1,13 @@
 package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when a player starts sprinting.
  */
-public class PlayerStartSprintingEvent implements PlayerEvent, EntityInstanceEvent {
+public class PlayerStartSprintingEvent implements PlayerInstanceEvent {
 
     private final Player player;
 

--- a/src/main/java/net/minestom/server/event/player/PlayerStopFlyingEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerStopFlyingEvent.java
@@ -1,14 +1,13 @@
 package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when a player stop flying.
  */
-public class PlayerStopFlyingEvent implements PlayerEvent, EntityInstanceEvent {
+public class PlayerStopFlyingEvent implements PlayerInstanceEvent {
 
     private final Player player;
 

--- a/src/main/java/net/minestom/server/event/player/PlayerStopFlyingWithElytraEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerStopFlyingWithElytraEvent.java
@@ -1,11 +1,10 @@
 package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
-public class PlayerStopFlyingWithElytraEvent implements PlayerEvent, EntityInstanceEvent {
+public class PlayerStopFlyingWithElytraEvent implements PlayerInstanceEvent {
 
     private final Player player;
 

--- a/src/main/java/net/minestom/server/event/player/PlayerStopSneakingEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerStopSneakingEvent.java
@@ -1,14 +1,13 @@
 package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when a player stops sneaking.
  */
-public class PlayerStopSneakingEvent implements PlayerEvent, EntityInstanceEvent {
+public class PlayerStopSneakingEvent implements PlayerInstanceEvent {
 
     private final Player player;
 

--- a/src/main/java/net/minestom/server/event/player/PlayerStopSprintingEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerStopSprintingEvent.java
@@ -1,14 +1,13 @@
 package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when a player stops sprinting.
  */
-public class PlayerStopSprintingEvent implements PlayerEvent, EntityInstanceEvent {
+public class PlayerStopSprintingEvent implements PlayerInstanceEvent {
 
     private final Player player;
 

--- a/src/main/java/net/minestom/server/event/player/PlayerSwapItemEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerSwapItemEvent.java
@@ -2,15 +2,14 @@ package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Called when a player is trying to swap his main and off hand item.
  */
-public class PlayerSwapItemEvent implements PlayerEvent, EntityInstanceEvent, CancellableEvent {
+public class PlayerSwapItemEvent implements PlayerInstanceEvent, CancellableEvent {
 
     private final Player player;
     private ItemStack mainHandItem;

--- a/src/main/java/net/minestom/server/event/player/PlayerTickEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerTickEvent.java
@@ -1,14 +1,13 @@
 package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Called at each player tick.
  */
-public class PlayerTickEvent implements PlayerEvent, EntityInstanceEvent {
+public class PlayerTickEvent implements PlayerInstanceEvent {
 
     private final Player player;
 

--- a/src/main/java/net/minestom/server/event/player/PlayerUseItemEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerUseItemEvent.java
@@ -2,16 +2,15 @@ package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.EntityInstanceEvent;
 import net.minestom.server.event.trait.ItemEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Event when an item is used without clicking on a block.
  */
-public class PlayerUseItemEvent implements PlayerEvent, EntityInstanceEvent, ItemEvent, CancellableEvent {
+public class PlayerUseItemEvent implements PlayerInstanceEvent, ItemEvent, CancellableEvent {
 
     private final Player player;
     private final Player.Hand hand;

--- a/src/main/java/net/minestom/server/event/player/PlayerUseItemOnBlockEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerUseItemOnBlockEvent.java
@@ -2,9 +2,8 @@ package net.minestom.server.event.player;
 
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.EntityInstanceEvent;
 import net.minestom.server.event.trait.ItemEvent;
-import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -12,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Used when a player is clicking on a block with an item (but is not a block in item form).
  */
-public class PlayerUseItemOnBlockEvent implements PlayerEvent, EntityInstanceEvent, ItemEvent {
+public class PlayerUseItemOnBlockEvent implements PlayerInstanceEvent, ItemEvent {
 
     private final Player player;
     private final Player.Hand hand;

--- a/src/main/java/net/minestom/server/event/trait/PlayerInstanceEvent.java
+++ b/src/main/java/net/minestom/server/event/trait/PlayerInstanceEvent.java
@@ -1,0 +1,15 @@
+package net.minestom.server.event.trait;
+
+import net.minestom.server.entity.Player;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Represents an {@link PlayerEvent} which happen in {@link Player#getInstance()}.
+ * Useful if you need to listen to player events happening in its instance.
+ * <p>
+ * Be aware that the player's instance must be non-null.
+ */
+@ApiStatus.Internal
+@ApiStatus.Experimental
+public interface PlayerInstanceEvent extends PlayerEvent, EntityInstanceEvent {
+}


### PR DESCRIPTION
Replace the combination of `PlayerEvent, EntityInstanceEvent` with a new `PlayerInstanceEvent`. Useful if you need to listen to player events happening in its instance.