### PR TITLE
Add namespace id to instance

### DIFF
--- a/demo/src/main/java/net/minestom/demo/PlayerInit.java
+++ b/demo/src/main/java/net/minestom/demo/PlayerInit.java
@@ -1,5 +1,6 @@
 package net.minestom.demo;
 
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.adventure.audience.Audiences;
@@ -29,6 +30,7 @@ import net.minestom.server.item.metadata.BundleMeta;
 import net.minestom.server.monitoring.BenchmarkManager;
 import net.minestom.server.monitoring.TickMonitor;
 import net.minestom.server.utils.MathUtils;
+import net.minestom.server.utils.NamespaceID;
 import net.minestom.server.utils.chunk.ChunkUtils;
 import net.minestom.server.utils.time.TimeUnit;
 import net.minestom.server.world.DimensionType;
@@ -121,7 +123,7 @@ public class PlayerInit {
     static {
         InstanceManager instanceManager = MinecraftServer.getInstanceManager();
 
-        InstanceContainer instanceContainer = instanceManager.createInstanceContainer(DimensionType.OVERWORLD);
+        InstanceContainer instanceContainer = instanceManager.createInstanceContainer(DimensionType.OVERWORLD, NamespaceID.from("minestom", "world"));
         instanceContainer.setGenerator(unit -> unit.modifier().fillHeight(0, 40, Block.STONE));
 
         if (false) {

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -70,6 +70,7 @@ import net.minestom.server.snapshot.SnapshotUpdater;
 import net.minestom.server.statistic.PlayerStatistic;
 import net.minestom.server.timer.Scheduler;
 import net.minestom.server.utils.MathUtils;
+import net.minestom.server.utils.NamespaceID;
 import net.minestom.server.utils.PacketUtils;
 import net.minestom.server.utils.async.AsyncUtils;
 import net.minestom.server.utils.chunk.ChunkUtils;
@@ -239,11 +240,16 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
     public CompletableFuture<Void> UNSAFE_init(@NotNull Instance spawnInstance) {
         this.dimensionType = spawnInstance.getDimensionType();
 
+        List<String> availableInstances = MinecraftServer.getInstanceManager().getInstances().stream()
+                .map(Instance::getId)
+                .map(NamespaceID::asString)
+                .toList();
+
         NBTCompound nbt = NBT.Compound(Map.of(
                 "minecraft:dimension_type", MinecraftServer.getDimensionTypeManager().toNBT(),
                 "minecraft:worldgen/biome", MinecraftServer.getBiomeManager().toNBT()));
         final JoinGamePacket joinGamePacket = new JoinGamePacket(getEntityId(), false, gameMode, null,
-                List.of("minestom:world"), nbt, dimensionType.toNBT(), dimensionType.getName().asString(),
+                availableInstances, nbt, dimensionType.toNBT(), dimensionType.getName().asString(),
                 0, 0, MinecraftServer.getChunkViewDistance(), MinecraftServer.getChunkViewDistance(),
                 false, true, false, levelFlat);
         sendPacket(joinGamePacket);

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -2,6 +2,7 @@ package net.minestom.server.instance;
 
 import it.unimi.dsi.fastutil.objects.ObjectArraySet;
 import net.kyori.adventure.identity.Identity;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.pointer.Pointers;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.ServerProcess;
@@ -31,6 +32,7 @@ import net.minestom.server.thread.ThreadDispatcher;
 import net.minestom.server.timer.Schedulable;
 import net.minestom.server.timer.Scheduler;
 import net.minestom.server.utils.ArrayUtils;
+import net.minestom.server.utils.NamespaceID;
 import net.minestom.server.utils.PacketUtils;
 import net.minestom.server.utils.chunk.ChunkCache;
 import net.minestom.server.utils.chunk.ChunkUtils;
@@ -87,6 +89,7 @@ public abstract class Instance implements Block.Getter, Block.Setter,
 
     // the uuid of this instance
     protected UUID uniqueId;
+    protected final NamespaceID id;
 
     // instance custom data
     private final TagHandler tagHandler = TagHandler.newHandler();
@@ -107,10 +110,24 @@ public abstract class Instance implements Block.Getter, Block.Setter,
      *
      * @param uniqueId      the {@link UUID} of the instance
      * @param dimensionType the {@link DimensionType} of the instance
+     * @deprecated use {@link #Instance(UUID, DimensionType, NamespaceID)} instead.
      */
+    @Deprecated
     public Instance(@NotNull UUID uniqueId, @NotNull DimensionType dimensionType) {
+        this(uniqueId, dimensionType, NamespaceID.from("minestom", "world"));
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param uniqueId      the {@link UUID} of the instance
+     * @param dimensionType the {@link DimensionType} of the instance
+     * @param id           the {@link Key} of the instance
+     */
+    public Instance(@NotNull UUID uniqueId, @NotNull DimensionType dimensionType, @NotNull NamespaceID id) {
         Check.argCondition(!dimensionType.isRegistered(),
                 "The dimension " + dimensionType.getName() + " is not registered! Please use DimensionTypeManager#addDimension");
+        this.id = id;
         this.uniqueId = uniqueId;
         this.dimensionType = dimensionType;
 
@@ -584,6 +601,15 @@ public abstract class Instance implements Block.Getter, Block.Setter,
      */
     public @NotNull UUID getUniqueId() {
         return uniqueId;
+    }
+
+    /**
+     * Get the instance name.
+     *
+     * @return the instance name
+     */
+    public @NotNull NamespaceID getId() {
+        return id;
     }
 
     /**

--- a/src/main/java/net/minestom/server/instance/SharedInstance.java
+++ b/src/main/java/net/minestom/server/instance/SharedInstance.java
@@ -5,6 +5,7 @@ import net.minestom.server.entity.Player;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockHandler;
 import net.minestom.server.instance.generator.Generator;
+import net.minestom.server.utils.NamespaceID;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -19,8 +20,14 @@ import java.util.concurrent.CompletableFuture;
 public class SharedInstance extends Instance {
     private final InstanceContainer instanceContainer;
 
+    @Deprecated
     public SharedInstance(@NotNull UUID uniqueId, @NotNull InstanceContainer instanceContainer) {
-        super(uniqueId, instanceContainer.getDimensionType());
+        super(uniqueId, instanceContainer.getDimensionType(), NamespaceID.from("minestom", "world"));
+        this.instanceContainer = instanceContainer;
+    }
+
+    public SharedInstance(@NotNull UUID uniqueId, @NotNull InstanceContainer instanceContainer, @NotNull NamespaceID id) {
+        super(uniqueId, instanceContainer.getDimensionType(), id);
         this.instanceContainer = instanceContainer;
     }
 

--- a/src/test/java/net/minestom/server/entity/player/PlayerIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerIntegrationTest.java
@@ -1,5 +1,6 @@
 package net.minestom.server.entity.player;
 
+import net.kyori.adventure.key.Key;
 import net.minestom.server.api.Collector;
 import net.minestom.server.api.Env;
 import net.minestom.server.api.EnvTest;
@@ -91,7 +92,7 @@ public class PlayerIntegrationTest {
         env.process().dimension().addDimension(testDimension);
 
         var instance = env.createFlatInstance();
-        var instance2 = env.process().instance().createInstanceContainer(testDimension);
+        var instance2 = env.process().instance().createInstanceContainer(testDimension, NamespaceID.from("minestom", "world"));
 
         var connection = env.createConnection();
         var player = connection.connect(instance, new Pos(0, 42, 0)).join();

--- a/src/test/java/net/minestom/server/instance/ChunkViewerIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/ChunkViewerIntegrationTest.java
@@ -5,6 +5,7 @@ import net.minestom.server.api.Env;
 import net.minestom.server.api.EnvTest;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.network.packet.server.play.ChunkDataPacket;
+import net.minestom.server.utils.NamespaceID;
 import net.minestom.server.utils.chunk.ChunkUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -23,7 +24,7 @@ public class ChunkViewerIntegrationTest {
             // Chunks get their viewers from the instance
             // Ensuring that the system works with shared instances is therefore important
             var manager = env.process().instance();
-            instance = manager.createSharedInstance((InstanceContainer) instance);
+            instance = manager.createSharedInstance((InstanceContainer) instance, NamespaceID.from("minestom", "world"));
         }
 
         var chunk = instance.loadChunk(0, 0).join();

--- a/src/test/java/net/minestom/server/instance/InstanceUnregisterIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/InstanceUnregisterIntegrationTest.java
@@ -4,6 +4,7 @@ import net.minestom.server.api.Env;
 import net.minestom.server.api.EnvTest;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.event.player.PlayerTickEvent;
+import net.minestom.server.utils.NamespaceID;
 import org.junit.jupiter.api.Test;
 
 import java.lang.ref.WeakReference;
@@ -18,7 +19,7 @@ public class InstanceUnregisterIntegrationTest {
         // Ensure that unregistering a shared instance does not unload the container chunks
         var instanceManager = env.process().instance();
         var instance = instanceManager.createInstanceContainer();
-        var shared1 = instanceManager.createSharedInstance(instance);
+        var shared1 = instanceManager.createSharedInstance(instance, NamespaceID.from("minestom", "world"));
         var connection = env.createConnection();
         var player = connection.connect(shared1, new Pos(0, 40, 0)).join();
 
@@ -26,7 +27,7 @@ public class InstanceUnregisterIntegrationTest {
         listener.followup();
         env.tick();
 
-        player.setInstance(instanceManager.createSharedInstance(instance)).join();
+        player.setInstance(instanceManager.createSharedInstance(instance, NamespaceID.from("minestom", "world"))).join();
         listener.followup();
         env.tick();
 


### PR DESCRIPTION
This PR adds a namespace id to each instance and instance container. The reason to include this is that the client needs to know all available worlds to support proper command completion. Additionally each instance can be identified (e.g. by an extension) using the given namespace id and making it easier to save and load instances for custom minestom implementations.