### PR TITLE
Fix native images not detecting MinestomConsoleWriter

### DIFF
--- a/src/main/resources/META-INF/native-image/minestom/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/minestom/reflect-config.json
@@ -115,6 +115,10 @@
   "fields":[{"name":"parked"}]
 },
 {
+  "name": "net.minestom.server.terminal.MinestomConsoleWriter",
+  "methods": [{"name":"<init>","parameterTypes":["java.util.Map"] }]
+},
+{
   "name":"org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields",
   "fields":[{"name":"producerLimit"}]
 },


### PR DESCRIPTION
When the change was made to using MinestomConsoleWriter it was never added to the reflect-config causing it to fail to load and no console output to appear. This fixes that by adding the MinestomConsoleWriter to the reflect-config.