### PR TITLE
Add missing enum values to Biome.Category

### DIFF
--- a/src/main/java/net/minestom/server/world/biomes/Biome.java
+++ b/src/main/java/net/minestom/server/world/biomes/Biome.java
@@ -121,13 +121,14 @@ public final class Biome {
     }
 
     public enum Precipitation {
-        RAIN, NONE, SNOW;
+        NONE, RAIN, SNOW;
     }
 
     public enum Category {
         NONE, TAIGA, EXTREME_HILLS, JUNGLE, MESA, PLAINS,
         SAVANNA, ICY, THE_END, BEACH, FOREST, OCEAN,
-        DESERT, RIVER, SWAMP, MUSHROOM, NETHER;
+        DESERT, RIVER, SWAMP, MUSHROOM, NETHER, UNDERGROUND,
+        MOUNTAIN;
     }
 
     public enum TemperatureModifier {


### PR DESCRIPTION
Also re-orders values of Biome.Precipitation to match vanilla Minecraft.

I was attempting to recreate the full set of vanilla biomes, only to discover that some of the biome categories were missing. Since the Biome class is final, this pull request is necessary as there is no way to work around this issue.