### PR TITLE
process chunk history based on actual history size

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -174,7 +174,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
 
     // Game state (https://wiki.vg/Protocol#Change_Game_State)
     private boolean enableRespawnScreen;
-    private final ChunkUpdateLimitChecker chunkUpdateLimitChecker = new ChunkUpdateLimitChecker(6);
+    private final ChunkUpdateLimitChecker chunkUpdateLimitChecker = new ChunkUpdateLimitChecker(5);
 
     // Experience orb pickup
     protected Cooldown experiencePickupCooldown = new Cooldown(Duration.of(10, TimeUnit.SERVER_TICK));
@@ -622,6 +622,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         if (updateChunks) {
             final int chunkX = spawnPosition.chunkX();
             final int chunkZ = spawnPosition.chunkZ();
+            chunkUpdateLimitChecker.addToHistory(ChunkUtils.getChunkIndex(chunkX, chunkZ));
             chunksLoadedByClient = new Vec(chunkX, chunkZ);
             sendPacket(new UpdateViewPositionPacket(chunkX, chunkZ));
             ChunkUtils.forChunksInRange(spawnPosition, MinecraftServer.getChunkViewDistance(), chunkAdder);
@@ -2033,7 +2034,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
     }
 
     protected void sendChunkUpdates(Chunk newChunk) {
-        if (chunkUpdateLimitChecker.addToHistory(newChunk)) {
+        if (chunkUpdateLimitChecker.addToHistory(ChunkUtils.getChunkIndex(newChunk))) {
             final int newX = newChunk.getChunkX();
             final int newZ = newChunk.getChunkZ();
             final Vec old = chunksLoadedByClient;

--- a/src/main/java/net/minestom/server/utils/chunk/ChunkUpdateLimitChecker.java
+++ b/src/main/java/net/minestom/server/utils/chunk/ChunkUpdateLimitChecker.java
@@ -5,31 +5,38 @@ import org.jetbrains.annotations.ApiStatus;
 
 @ApiStatus.Internal
 public final class ChunkUpdateLimitChecker {
-    private final int historySize;
+    private final int maxHistorySize;
     private final long[] chunkHistory;
+    private int historySize;
 
     public ChunkUpdateLimitChecker(int historySize) {
-        this.historySize = historySize;
-        this.chunkHistory = new long[historySize];
+        this.maxHistorySize = historySize;
+        this.chunkHistory = new long[historySize + 1];
+        this.historySize = 0;
     }
 
     /**
      * Adds the chunk to the history
      *
-     * @param chunk chunk to add
+     * @param index chunk index to add
      * @return {@code true} if it's a new chunk in the history
      */
-    public boolean addToHistory(Chunk chunk) {
-        final long index = ChunkUtils.getChunkIndex(chunk);
+    public boolean addToHistory(long index) {
         boolean result = true;
-        final int lastIndex = historySize - 1;
+        final int lastIndex = historySize;
         for (int i = 0; i < lastIndex; i++) {
             if (chunkHistory[i] == index) {
                 result = false;
+                break;
             }
-            chunkHistory[i] = chunkHistory[i + 1];
         }
         chunkHistory[lastIndex] = index;
+        if (historySize < maxHistorySize) {
+            historySize++;
+        }
+        else {
+            System.arraycopy(chunkHistory, 1, chunkHistory, 0, lastIndex);
+        }
         return result;
     }
 }


### PR DESCRIPTION
seems to fix #1187
the limit checker was zeroed initially, so it refused to send chunks with zero chunk key
in the integration test, this was mistaken for the chunk having already been added to the history (which it wasn't, so I now send it when the player spawns)