### PR TITLE
Item and experience orbs pickup fix

### DIFF
--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -203,11 +203,12 @@ public class LivingEntity extends Entity implements EquipmentHandler {
         // Items picking
         if (canPickupItem() && itemPickupCooldown.isReady(time)) {
             itemPickupCooldown.refreshLastUpdate(time);
+            final Point loweredPosition = position.sub(0, -.5, 0);
             this.instance.getEntityTracker().nearbyEntities(position, expandedBoundingBox.width(),
                     EntityTracker.Target.ITEMS, itemEntity -> {
                         if (this instanceof Player player && !itemEntity.isViewer(player)) return;
                         if (!itemEntity.isPickable()) return;
-                        if (expandedBoundingBox.intersectEntity(position, itemEntity)) {
+                        if (expandedBoundingBox.intersectEntity(loweredPosition, itemEntity)) {
                             PickupItemEvent pickupItemEvent = new PickupItemEvent(this, itemEntity);
                             EventDispatcher.callCancellable(pickupItemEvent, () -> {
                                 final ItemStack item = itemEntity.getItemStack();
@@ -524,7 +525,7 @@ public class LivingEntity extends Entity implements EquipmentHandler {
     @Override
     public void setBoundingBox(BoundingBox boundingBox) {
         super.setBoundingBox(boundingBox);
-        this.expandedBoundingBox = boundingBox.expand(1, 0.5f, 1);
+        this.expandedBoundingBox = boundingBox.expand(1, .5, 1);
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -333,9 +333,10 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         // Experience orb pickup
         if (experiencePickupCooldown.isReady(time)) {
             experiencePickupCooldown.refreshLastUpdate(time);
+            final Point loweredPosition = position.sub(0, -.5, 0);
             this.instance.getEntityTracker().nearbyEntities(position, expandedBoundingBox.width(),
                     EntityTracker.Target.EXPERIENCE_ORBS, experienceOrb -> {
-                        if (expandedBoundingBox.intersectEntity(position, experienceOrb)) {
+                        if (expandedBoundingBox.intersectEntity(loweredPosition, experienceOrb)) {
                             PickupExperienceEvent pickupExperienceEvent = new PickupExperienceEvent(this, experienceOrb);
                             EventDispatcher.callCancellable(pickupExperienceEvent, () -> {
                                 short experienceCount = pickupExperienceEvent.getExperienceCount(); // TODO give to player


### PR DESCRIPTION
No matter how you expand the bounding box on Y direction, it will always start at y=0 and end at y=height. Because of that, items and experience orbs can't be picked up if they fall lower than player position. For example, if an item goes into a stair lower half-block and there is no way for player to lower his own position to that height, he will never be able to pick it up.