### PR TITLE
Checking that payload length is positive on packets reading

### DIFF
--- a/src/main/java/net/minestom/server/utils/PacketUtils.java
+++ b/src/main/java/net/minestom/server/utils/PacketUtils.java
@@ -172,6 +172,9 @@ public final class PacketUtils {
                 if (compressed) {
                     final int dataLength = readBuffer.readVarInt();
                     final int payloadLength = packetLength - (readBuffer.readerOffset() - readerStart);
+                    if (payloadLength < 0) {
+                        throw new DataFormatException("Negative payload length " + payloadLength);
+                    }
                     if (dataLength == 0) {
                         // Data is too small to be compressed, payload is following
                         decompressedSize = payloadLength;


### PR DESCRIPTION
```
> java.lang.IndexOutOfBoundsException: Range [42, 42 + -5) out of bounds for length 2097151
        at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
        at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckFromIndexSize(Preconditions.java:82)
        at java.base/jdk.internal.util.Preconditions.checkFromIndexSize(Preconditions.java:361)
        at java.base/java.util.Objects.checkFromIndexSize(Objects.java:411)
        at java.base/java.nio.DirectByteBuffer.slice(DirectByteBuffer.java:255)
        at java.base/java.nio.DirectByteBuffer.slice(DirectByteBuffer.java:40)
        at net.minestom.server.utils.binary.BinaryBuffer.asByteBuffer(BinaryBuffer.java:144)
        at net.minestom.server.utils.PacketUtils.readPackets(PacketUtils.java:183)
        at net.minestom.server.network.player.PlayerSocketConnection.processPackets(PlayerSocketConnection.java:106)
        at net.minestom.server.network.socket.Worker.lambda$run$0(Worker.java:79)
        at java.base/sun.nio.ch.SelectorImpl.processReadyEvents(SelectorImpl.java:294)
        at java.base/sun.nio.ch.EPollSelectorImpl.processEvents(EPollSelectorImpl.java:195)
        at java.base/sun.nio.ch.EPollSelectorImpl.doSelect(EPollSelectorImpl.java:135)
        at java.base/sun.nio.ch.SelectorImpl.lockAndDoSelect(SelectorImpl.java:129)
        at java.base/sun.nio.ch.SelectorImpl.select(SelectorImpl.java:161)
        at net.minestom.server.network.socket.Worker.run(Worker.java:59)
```