### PR TITLE
BlockCollision#canPlaceBlockAt player check fix

### DIFF
--- a/src/main/java/net/minestom/server/collision/BlockCollision.java
+++ b/src/main/java/net/minestom/server/collision/BlockCollision.java
@@ -293,7 +293,7 @@ final class BlockCollision {
                 continue;
 
             final boolean intersects;
-            if (type == EntityType.PLAYER) {
+            if (entity instanceof Player) {
                 // Ignore spectators
                 if (((Player) entity).getGameMode() == GameMode.SPECTATOR)
                     continue;


### PR DESCRIPTION
I have custom entities of type `PLAYER` that don't extend `Player` class and catching the following exception:
```
> java.lang.ClassCastException: class sexy.kostya.aevium.entity.RpgNpcImpl cannot be cast to class net.minestom.server.entity.Player (sexy.kostya.aevium.entity.RpgNpcImpl and net.minestom.server.entity.Player are in unnamed module of loader 'app')
        at net.minestom.server.collision.BlockCollision.canPlaceBlockAt(BlockCollision.java:298)
        at net.minestom.server.collision.CollisionUtils.canPlaceBlockAt(CollisionUtils.java:85)
        at net.minestom.server.listener.BlockPlacementListener.listener(BlockPlacementListener.java:109)
        at net.minestom.server.listener.manager.PacketListenerManager.processClientPacket(PacketListenerManager.java:89)
        at net.minestom.server.entity.Player.lambda$interpretPacketQueue$13(Player.java:1752)
        at org.jctools.queues.MpscUnboundedXaddArrayQueue.drain(MpscUnboundedXaddArrayQueue.java:312)
        at net.minestom.server.entity.Player.interpretPacketQueue(Player.java:1752)
        at net.minestom.server.entity.Player.update(Player.java:329)
        at sexy.kostya.aevium.entity.RpgPlayer.update(RpgPlayer.kt:511)
        at net.minestom.server.entity.Entity.tick(Entity.java:537)
```