### PR TITLE
Inventory interaction fix for bad slots received from the client

### DIFF
--- a/src/main/java/net/minestom/server/inventory/PlayerInventory.java
+++ b/src/main/java/net/minestom/server/inventory/PlayerInventory.java
@@ -186,8 +186,11 @@ public non-sealed class PlayerInventory extends AbstractInventory implements Equ
     @Override
     public boolean leftClick(@NotNull Player player, int slot) {
         final int convertedSlot = convertPlayerInventorySlot(slot, OFFSET);
-        final ItemStack cursor = getCursorItem();
+        if (convertedSlot >= getSize()) {
+            return false;
+        }
         final ItemStack clicked = getItemStack(convertedSlot);
+        final ItemStack cursor = getCursorItem();
         final InventoryClickResult clickResult = clickProcessor.leftClick(player, this, convertedSlot, clicked, cursor);
         if (clickResult.isCancel()) {
             update();
@@ -202,8 +205,11 @@ public non-sealed class PlayerInventory extends AbstractInventory implements Equ
     @Override
     public boolean rightClick(@NotNull Player player, int slot) {
         final int convertedSlot = convertPlayerInventorySlot(slot, OFFSET);
-        final ItemStack cursor = getCursorItem();
+        if (convertedSlot >= getSize()) {
+            return false;
+        }
         final ItemStack clicked = getItemStack(convertedSlot);
+        final ItemStack cursor = getCursorItem();
         final InventoryClickResult clickResult = clickProcessor.rightClick(player, this, convertedSlot, clicked, cursor);
         if (clickResult.isCancel()) {
             update();
@@ -225,9 +231,17 @@ public non-sealed class PlayerInventory extends AbstractInventory implements Equ
     @Override
     public boolean drop(@NotNull Player player, boolean all, int slot, int button) {
         final int convertedSlot = convertPlayerInventorySlot(slot, OFFSET);
-        final ItemStack cursor = getCursorItem();
         final boolean outsideDrop = slot == -999;
-        final ItemStack clicked = outsideDrop ? ItemStack.AIR : getItemStack(convertedSlot);
+        final ItemStack clicked;
+        if (outsideDrop) {
+            clicked = ItemStack.AIR;
+        } else {
+            if (convertedSlot >= getSize()) {
+                return false;
+            }
+            clicked = getItemStack(convertedSlot);
+        }
+        final ItemStack cursor = getCursorItem();
         final InventoryClickResult clickResult = clickProcessor.drop(player, this,
                 all, convertedSlot, button, clicked, cursor);
         if (clickResult.isCancel()) {
@@ -245,8 +259,11 @@ public non-sealed class PlayerInventory extends AbstractInventory implements Equ
     @Override
     public boolean shiftClick(@NotNull Player player, int slot) {
         final int convertedSlot = convertPlayerInventorySlot(slot, OFFSET);
-        final ItemStack cursor = getCursorItem();
+        if (convertedSlot >= getSize()) {
+            return false;
+        }
         final ItemStack clicked = getItemStack(convertedSlot);
+        final ItemStack cursor = getCursorItem();
         final boolean hotBarClick = convertSlot(slot, OFFSET) < 9;
         final int start = hotBarClick ? 9 : 0;
         final int end = hotBarClick ? getSize() - 9 : 8;
@@ -270,6 +287,9 @@ public non-sealed class PlayerInventory extends AbstractInventory implements Equ
         final ItemStack cursorItem = getCursorItem();
         if (!cursorItem.isAir()) return false;
         final int convertedSlot = convertPlayerInventorySlot(slot, OFFSET);
+        if (convertedSlot >= getSize()) {
+            return false;
+        }
         final ItemStack heldItem = getItemStack(convertedKey);
         final ItemStack clicked = getItemStack(convertedSlot);
         final InventoryClickResult clickResult = clickProcessor.changeHeld(player, this, convertedSlot, convertedKey, clicked, heldItem);
@@ -285,10 +305,20 @@ public non-sealed class PlayerInventory extends AbstractInventory implements Equ
 
     @Override
     public boolean dragging(@NotNull Player player, int slot, int button) {
+        final int convertedSlot = convertPlayerInventorySlot(slot, OFFSET);
+        final boolean outside = slot == -999;
+        final ItemStack clicked;
+        if (outside) {
+            clicked = ItemStack.AIR;
+        } else {
+            if (convertedSlot >= getSize()) {
+                return false;
+            }
+            clicked = getItemStack(convertedSlot);
+        }
         final ItemStack cursor = getCursorItem();
-        final ItemStack clicked = slot != -999 ? getItemStackFromPacketSlot(slot) : ItemStack.AIR;
         final InventoryClickResult clickResult = clickProcessor.dragging(player, this,
-                convertPlayerInventorySlot(slot, OFFSET), button, clicked, cursor);
+                convertedSlot, button, clicked, cursor);
         if (clickResult == null || clickResult.isCancel()) {
             update();
             return false;
@@ -301,8 +331,11 @@ public non-sealed class PlayerInventory extends AbstractInventory implements Equ
     @Override
     public boolean doubleClick(@NotNull Player player, int slot) {
         final int convertedSlot = convertPlayerInventorySlot(slot, OFFSET);
-        final ItemStack cursor = getCursorItem();
+        if (convertedSlot >= getSize()) {
+            return false;
+        }
         final ItemStack clicked = getItemStack(convertedSlot);
+        final ItemStack cursor = getCursorItem();
         final InventoryClickResult clickResult = clickProcessor.doubleClick(this, this, player, convertedSlot, clicked, cursor);
         if (clickResult.isCancel()) {
             update();
@@ -311,15 +344,5 @@ public non-sealed class PlayerInventory extends AbstractInventory implements Equ
         setCursorItem(clickResult.getCursor());
         update(); // FIXME: currently not properly client-predicted
         return true;
-    }
-
-    private void setItemStackFromPacketSlot(int slot, @NotNull ItemStack itemStack) {
-        final int convertedSlot = convertPlayerInventorySlot(slot, OFFSET);
-        setItemStack(convertedSlot, itemStack);
-    }
-
-    private ItemStack getItemStackFromPacketSlot(int slot) {
-        final int convertedSlot = convertPlayerInventorySlot(slot, OFFSET);
-        return itemStacks[convertedSlot];
     }
 }


### PR DESCRIPTION
One of the exceptions:
```
> java.lang.ArrayIndexOutOfBoundsException: Index 47 out of bounds for length 46
        at java.base/java.lang.invoke.VarHandle$1.apply(VarHandle.java:2187)
        at java.base/java.lang.invoke.VarHandle$1.apply(VarHandle.java:2184)
        at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:177)
        at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:174)
        at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:62)
        at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
        at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
        at java.base/java.lang.invoke.VarHandleReferences$Array.getVolatile(VarHandleReferences.java:602)
        at net.minestom.server.inventory.AbstractInventory.getItemStack(AbstractInventory.java:185)
        at net.minestom.server.inventory.PlayerInventory.leftClick(PlayerInventory.java:190)
        at net.minestom.server.listener.WindowListener.clickWindowListener(WindowListener.java:41)
        at net.minestom.server.listener.manager.PacketListenerManager.processClientPacket(PacketListenerManager.java:89)
        at net.minestom.server.entity.Player.lambda$interpretPacketQueue$13(Player.java:1752)
        at org.jctools.queues.MpscUnboundedXaddArrayQueue.drain(MpscUnboundedXaddArrayQueue.java:312)
        at net.minestom.server.entity.Player.interpretPacketQueue(Player.java:1752)
        at net.minestom.server.entity.Player.update(Player.java:329)
        at sexy.kostya.aevium.entity.RpgPlayer.update(RpgPlayer.kt:511)
        at net.minestom.server.entity.Entity.tick(Entity.java:537)
        at net.minestom.server.thread.TickThread.tick(TickThread.java:66)
        at net.minestom.server.thread.TickThread.run(TickThread.java:41)
```