### PR TITLE
Serverside entity's hasNoGravity check doesn't rely on it's metadata anymore

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -107,6 +107,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     // Velocity
     protected Vec velocity = Vec.ZERO; // Movement in block per second
     protected boolean hasPhysics = true;
+    protected boolean hasNoGravity = false;
 
     /**
      * The amount of drag applied on the Y axle.
@@ -1265,7 +1266,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
      * @return true if the entity ignore gravity, false otherwise
      */
     public boolean hasNoGravity() {
-        return this.entityMeta.isHasNoGravity();
+        return this.hasNoGravity;
     }
 
     /**
@@ -1274,6 +1275,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
      * @param noGravity should the entity ignore gravity
      */
     public void setNoGravity(boolean noGravity) {
+        this.hasNoGravity = noGravity;
         this.entityMeta.setHasNoGravity(noGravity);
     }
 


### PR DESCRIPTION
Accessing entity's metadata is expensive, especially in it's `velocityTick()`: metadata is stored in synchronized map, therefore when amount of entities reach certain point, you could see that blocked monitors consume a lot of CPU for no objective reason:
![image](https://user-images.githubusercontent.com/3867723/178118713-78a8ae2f-6dc4-485b-8003-459098c247f0.png)
