### PR TITLE
Improve PlayerChangeHeldSlotEvent

### DIFF
--- a/src/main/java/net/minestom/server/event/player/PlayerChangeHeldSlotEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerChangeHeldSlotEvent.java
@@ -3,6 +3,7 @@ package net.minestom.server.event.player;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.CancellableEvent;
 import net.minestom.server.event.trait.PlayerInstanceEvent;
+import net.minestom.server.item.ItemStack;
 import net.minestom.server.utils.MathUtils;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.NotNull;
@@ -13,22 +14,55 @@ import org.jetbrains.annotations.NotNull;
 public class PlayerChangeHeldSlotEvent implements PlayerInstanceEvent, CancellableEvent {
 
     private final Player player;
-    private byte slot;
+    private final byte oldSlot;
+    private byte newSlot;
 
     private boolean cancelled;
 
-    public PlayerChangeHeldSlotEvent(@NotNull Player player, byte slot) {
+    public PlayerChangeHeldSlotEvent(@NotNull Player player, byte oldSlot, byte newSlot) {
         this.player = player;
-        this.slot = slot;
+        this.oldSlot = oldSlot;
+        this.newSlot = newSlot;
     }
 
     /**
      * Gets the slot which the player will hold.
-     *
+     * @deprecated Use {@link #getNewSlot()} instead.
      * @return the future slot
      */
+    @Deprecated(forRemoval = true)
     public byte getSlot() {
-        return slot;
+        return newSlot;
+    }
+
+    /**
+     * Gets the slot number that the player is currently holding
+     *
+     * @return The slot index that the player currently is holding
+     */
+    public int getOldSlot() {
+        return oldSlot;
+    }
+
+    /**
+     * Gets the slot which the player will hold.
+     * @return the future slot
+     */
+    public byte getNewSlot() {
+        return newSlot;
+    }
+
+    /**
+     * Changes the final held slot of the player.
+     *
+     * @param slot the new held slot
+     * @deprecated Use {@link #setNewSlot(byte)} instead
+     * @throws IllegalArgumentException if <code>slot</code> is not between 0 and 8
+     */
+    @Deprecated(forRemoval = true)
+    public void setSlot(byte slot) {
+        Check.argCondition(!MathUtils.isBetween(slot, 0, 8), "The held slot needs to be between 0 and 8");
+        this.newSlot = slot;
     }
 
     /**
@@ -37,9 +71,25 @@ public class PlayerChangeHeldSlotEvent implements PlayerInstanceEvent, Cancellab
      * @param slot the new held slot
      * @throws IllegalArgumentException if <code>slot</code> is not between 0 and 8
      */
-    public void setSlot(byte slot) {
+    public void setNewSlot(byte slot) {
         Check.argCondition(!MathUtils.isBetween(slot, 0, 8), "The held slot needs to be between 0 and 8");
-        this.slot = slot;
+        this.newSlot = slot;
+    }
+
+    /**
+     * Gets the ItemStack in the player's currently held slot
+     * @return The ItemStack in the player's currently held slot
+     */
+    public ItemStack getItemInOldSlot() {
+        return player.getInventory().getItemStack(oldSlot);
+    }
+
+    /**
+     * Gets the ItemStack in the slot the player will hold
+     * @return The ItemStack in the final held slot of the player
+     */
+    public ItemStack getItemInNewSlot() {
+        return player.getInventory().getItemStack(newSlot);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/listener/PlayerHeldListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerHeldListener.java
@@ -15,15 +15,16 @@ public class PlayerHeldListener {
             return;
         }
 
-        final byte slot = (byte) packet.slot();
+        final byte newSlot = (byte) packet.slot();
+        final byte oldSlot = player.getHeldSlot();
 
-        PlayerChangeHeldSlotEvent changeHeldSlotEvent = new PlayerChangeHeldSlotEvent(player, slot);
+        PlayerChangeHeldSlotEvent changeHeldSlotEvent = new PlayerChangeHeldSlotEvent(player, oldSlot, newSlot);
         EventDispatcher.call(changeHeldSlotEvent);
 
         if (!changeHeldSlotEvent.isCancelled()) {
             // Event hasn't been canceled, process it
 
-            final byte resultSlot = changeHeldSlotEvent.getSlot();
+            final byte resultSlot = changeHeldSlotEvent.getNewSlot();
 
             // If the held slot has been changed by the event, send the change to the player
             if (resultSlot != slot) {
@@ -34,7 +35,7 @@ public class PlayerHeldListener {
             }
         } else {
             // Event has been canceled, send the last held slot to refresh the client
-            player.setHeldItemSlot(player.getHeldSlot());
+            player.setHeldItemSlot(oldSlot);
         }
 
         // Player is not using offhand, reset item use

--- a/src/main/java/net/minestom/server/listener/PlayerHeldListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerHeldListener.java
@@ -27,7 +27,7 @@ public class PlayerHeldListener {
             final byte resultSlot = changeHeldSlotEvent.getNewSlot();
 
             // If the held slot has been changed by the event, send the change to the player
-            if (resultSlot != oldSlot) {
+            if (resultSlot != newSlot) {
                 player.setHeldItemSlot(resultSlot);
             } else {
                 // Otherwise, simply refresh the player field

--- a/src/main/java/net/minestom/server/listener/PlayerHeldListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerHeldListener.java
@@ -27,7 +27,7 @@ public class PlayerHeldListener {
             final byte resultSlot = changeHeldSlotEvent.getNewSlot();
 
             // If the held slot has been changed by the event, send the change to the player
-            if (resultSlot != slot) {
+            if (resultSlot != oldSlot) {
                 player.setHeldItemSlot(resultSlot);
             } else {
                 // Otherwise, simply refresh the player field

--- a/src/test/java/net/minestom/server/entity/PlayerHeldIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/PlayerHeldIntegrationTest.java
@@ -45,7 +45,7 @@ public class PlayerHeldIntegrationTest {
         var listener = env.listen(PlayerChangeHeldSlotEvent.class);
         listener.followup(event -> {
             assertEquals(player, event.getPlayer());
-            assertEquals(1, event.getSlot());
+            assertEquals(1, event.getNewSlot());
         });
         player.interpretPacketQueue();
         assertEquals(ItemStack.of(Material.STONE), player.getItemInMainHand());

--- a/src/test/java/net/minestom/server/entity/PlayerHeldIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/PlayerHeldIntegrationTest.java
@@ -2,20 +2,22 @@ package net.minestom.server.entity;
 
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.event.player.PlayerChangeHeldSlotEvent;
+import net.minestom.server.event.player.PlayerPacketOutEvent;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
 import net.minestom.server.network.packet.client.play.ClientHeldItemChangePacket;
+import net.minestom.server.network.packet.server.play.HeldItemChangePacket;
 import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 @EnvTest
 public class PlayerHeldIntegrationTest {
 
     @Test
-    public void playerHeld(Env env) {
+    void playerHeld(Env env) {
         var instance = env.createFlatInstance();
         var connection = env.createConnection();
         var player = connection.connect(instance, new Pos(0, 40, 0));
@@ -32,7 +34,7 @@ public class PlayerHeldIntegrationTest {
     }
 
     @Test
-    public void playerHeldEvent(Env env) {
+    void playerHeldEvent(Env env) {
         var instance = env.createFlatInstance();
         var connection = env.createConnection();
         var player = connection.connect(instance, new Pos(0, 40, 0));
@@ -54,10 +56,10 @@ public class PlayerHeldIntegrationTest {
     }
 
     @Test
-    public void playerChangingSlots(Env env) {
+    void playerChangingSlots(Env env) {
         var instance = env.createFlatInstance();
         var connection = env.createConnection();
-        var player = connection.connect(instance, new Pos(0, 40, 0)).join();
+        var player = connection.connect(instance, new Pos(0, 40, 0));
 
         player.getInventory().setItemStack(1, ItemStack.of(Material.STONE));
         player.getInventory().setItemStack(3, ItemStack.of(Material.OAK_PLANKS));
@@ -82,5 +84,24 @@ public class PlayerHeldIntegrationTest {
             assertEquals(ItemStack.of(Material.OAK_PLANKS), event.getItemInNewSlot());
         });
         player.interpretPacketQueue();
+    }
+
+    @Test
+    void eventChangeIsReflectedOnClient(Env env) {
+        var instance = env.createFlatInstance();
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0, 40, 0));
+
+        player.eventNode().addListener(PlayerChangeHeldSlotEvent.class, event -> event.setNewSlot((byte) 0));
+
+        var listener = connection.trackIncoming(HeldItemChangePacket.class);
+        player.addPacketToQueue(new ClientHeldItemChangePacket((short) 0));
+        player.interpretPacketQueue();
+        listener.assertEmpty(); // Ensure we don't send an unneeded packet if there is no change
+
+        listener = connection.trackIncoming(HeldItemChangePacket.class); // Re-register listener
+        player.addPacketToQueue(new ClientHeldItemChangePacket((short) 3));
+        player.interpretPacketQueue();
+        listener.assertSingle(packet -> assertEquals((byte) 0, packet.slot())); // Ensure packet is sent
     }
 }


### PR DESCRIPTION
Changes the PlayerChangeHeldSlotEvent to better clarify what the getSlot methods will do, and add a couple of convenience methods.

Resolves #1257. 