### PR TITLE
Create AbsoluteBlockBatch#getAffectedChunks()

### DIFF
--- a/src/main/java/net/minestom/server/instance/batch/AbsoluteBlockBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/AbsoluteBlockBatch.java
@@ -49,6 +49,17 @@ public class AbsoluteBlockBatch implements Batch<Runnable> {
         this.options = options;
     }
 
+    /**
+     * Returns a long array, containing the chunk indexes of
+     * every affected chunk so far.
+     * @return the chunk indexes
+     * 
+     * @see ChunkUtils#getChunkIndex(int, int)
+     */
+    public long[] getAffectedChunks() {
+        return chunkBatchesMap.keySet().toLongArray();
+    }
+
     @Override
     public void setBlock(int x, int y, int z, @NotNull Block block) {
         final int chunkX = ChunkUtils.getChunkCoordinate(x);


### PR DESCRIPTION
This PR creates a new method in AbsoluteBlockBatch, that returns the chunk indexes that will be affected by this `AbsoluteBlockBatch`. This is useful in combination with `ChunkUtils.optionalLoadAll(Instance, long[], ChunkCallback)`, to ensure that all chunks that will be affected, are loaded at the time of calling `AbsoluteBlockBatch#apply(Instance)`.

Inspired by #1263