### PR TITLE
Add commit info from JitPack into Minestom's jar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,13 +48,11 @@ tasks {
         val gitBranch = System.getenv("GIT_BRANCH")
         val group = System.getenv("GROUP")
         val artifact = System.getenv("ARTIFACT")
-        val version = System.getenv("VERSION")
 
         replaceToken("\"&COMMIT\"", if (gitCommit == null) "null" else "\"${gitCommit}\"", git)
         replaceToken("\"&BRANCH\"", if (gitBranch == null) "null" else "\"${gitBranch}\"", git)
         replaceToken("\"&GROUP\"", if (group == null) "null" else "\"${group}\"", git)
         replaceToken("\"&ARTIFACT\"", if (artifact == null) "null" else "\"${artifact}\"", git)
-        replaceToken("\"&VERSION\"", if (version == null) "null" else "\"${version}\"", git)
     }
 
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     `java-library`
     id("minestom.publishing-conventions")
     id("minestom.native-conventions")
+    alias(libs.plugins.blossom)
 }
 
 allprojects {
@@ -79,4 +80,18 @@ dependencies {
     // NBT parsing/manipulation/saving
     api("io.github.jglrxavpok.hephaistos:common:${libs.versions.hephaistos.get()}")
     api("io.github.jglrxavpok.hephaistos:gson:${libs.versions.hephaistos.get()}")
+}
+
+blossom {
+    val git = "src/main/java/net/minestom/server/Git.java"
+    val gitCommit = System.getenv("GIT_COMMIT") ?: null
+    replaceToken("&COMMIT", if (gitCommit == null) "null" else "\"${gitCommit}\"", git)
+    val gitBranch = System.getenv("GIT_BRANCH") ?: null
+    replaceToken("&BRANCH", if (gitBranch == null) "null" else "\"${gitBranch}\"", git)
+    val group = System.getenv("GROUP") ?: null
+    replaceToken("&GROUP", if (group == null) "null" else "\"${group}\"", git)
+    val artifact = System.getenv("ARTIFACT") ?: null
+    replaceToken("&ARTIFACT", if (artifact == null) "null" else "\"${artifact}\"", git)
+    val version = System.getenv("VERSION") ?: null
+    replaceToken("&VERSION", if (version == null) "null" else "\"${version}\"", git)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,15 +43,17 @@ tasks {
 
     blossom {
         val git = "src/main/java/net/minestom/server/Git.java"
-        val gitCommit = System.getenv("GIT_COMMIT") ?: null
+
+        val gitCommit = System.getenv("GIT_COMMIT")
+        val gitBranch = System.getenv("GIT_BRANCH")
+        val group = System.getenv("GROUP")
+        val artifact = System.getenv("ARTIFACT")
+        val version = System.getenv("VERSION")
+
         replaceToken("\"&COMMIT\"", if (gitCommit == null) "null" else "\"${gitCommit}\"", git)
-        val gitBranch = System.getenv("GIT_BRANCH") ?: null
         replaceToken("\"&BRANCH\"", if (gitBranch == null) "null" else "\"${gitBranch}\"", git)
-        val group = System.getenv("GROUP") ?: null
         replaceToken("\"&GROUP\"", if (group == null) "null" else "\"${group}\"", git)
-        val artifact = System.getenv("ARTIFACT") ?: null
         replaceToken("\"&ARTIFACT\"", if (artifact == null) "null" else "\"${artifact}\"", git)
-        val version = System.getenv("VERSION") ?: null
         replaceToken("\"&VERSION\"", if (version == null) "null" else "\"${version}\"", git)
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,21 @@ tasks {
     withType<Zip> {
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     }
+
+    blossom {
+        val git = "src/main/java/net/minestom/server/Git.java"
+        val gitCommit = System.getenv("GIT_COMMIT") ?: null
+        replaceToken("&COMMIT", if (gitCommit == null) "null" else "\"${gitCommit}\"", git)
+        val gitBranch = System.getenv("GIT_BRANCH") ?: null
+        replaceToken("&BRANCH", if (gitBranch == null) "null" else "\"${gitBranch}\"", git)
+        val group = System.getenv("GROUP") ?: null
+        replaceToken("&GROUP", if (group == null) "null" else "\"${group}\"", git)
+        val artifact = System.getenv("ARTIFACT") ?: null
+        replaceToken("&ARTIFACT", if (artifact == null) "null" else "\"${artifact}\"", git)
+        val version = System.getenv("VERSION") ?: null
+        replaceToken("&VERSION", if (version == null) "null" else "\"${version}\"", git)
+    }
+
 }
 
 dependencies {
@@ -82,16 +97,3 @@ dependencies {
     api("io.github.jglrxavpok.hephaistos:gson:${libs.versions.hephaistos.get()}")
 }
 
-blossom {
-    val git = "src/main/java/net/minestom/server/Git.java"
-    val gitCommit = System.getenv("GIT_COMMIT") ?: null
-    replaceToken("&COMMIT", if (gitCommit == null) "null" else "\"${gitCommit}\"", git)
-    val gitBranch = System.getenv("GIT_BRANCH") ?: null
-    replaceToken("&BRANCH", if (gitBranch == null) "null" else "\"${gitBranch}\"", git)
-    val group = System.getenv("GROUP") ?: null
-    replaceToken("&GROUP", if (group == null) "null" else "\"${group}\"", git)
-    val artifact = System.getenv("ARTIFACT") ?: null
-    replaceToken("&ARTIFACT", if (artifact == null) "null" else "\"${artifact}\"", git)
-    val version = System.getenv("VERSION") ?: null
-    replaceToken("&VERSION", if (version == null) "null" else "\"${version}\"", git)
-}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,15 +44,15 @@ tasks {
     blossom {
         val git = "src/main/java/net/minestom/server/Git.java"
         val gitCommit = System.getenv("GIT_COMMIT") ?: null
-        replaceToken("&COMMIT", if (gitCommit == null) "null" else "\"${gitCommit}\"", git)
+        replaceToken("\"&COMMIT\"", if (gitCommit == null) "null" else "\"${gitCommit}\"", git)
         val gitBranch = System.getenv("GIT_BRANCH") ?: null
-        replaceToken("&BRANCH", if (gitBranch == null) "null" else "\"${gitBranch}\"", git)
+        replaceToken("\"&BRANCH\"", if (gitBranch == null) "null" else "\"${gitBranch}\"", git)
         val group = System.getenv("GROUP") ?: null
-        replaceToken("&GROUP", if (group == null) "null" else "\"${group}\"", git)
+        replaceToken("\"&GROUP\"", if (group == null) "null" else "\"${group}\"", git)
         val artifact = System.getenv("ARTIFACT") ?: null
-        replaceToken("&ARTIFACT", if (artifact == null) "null" else "\"${artifact}\"", git)
+        replaceToken("\"&ARTIFACT\"", if (artifact == null) "null" else "\"${artifact}\"", git)
         val version = System.getenv("VERSION") ?: null
-        replaceToken("&VERSION", if (version == null) "null" else "\"${version}\"", git)
+        replaceToken("\"&VERSION\"", if (version == null) "null" else "\"${version}\"", git)
     }
 
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,9 @@ jmh = "1.35"
 # JCStress
 jcstress = "0.8"
 
+# Gradle plugins
+blossom = "1.3.0"
+
 [libraries]
 
 # Important Dependencies
@@ -104,3 +107,7 @@ flare = ["flare", "flare-fastutil"]
 adventure = ["adventure-api", "adventure-serializer-gson", "adventure-serializer-legacy", "adventure-serializer-plain", "adventure-text-logger-slf4j"]
 logging = ["tinylog-api", "tinylog-impl", "tinylog-slf4j"]
 terminal = ["jline", "jline-jansi"]
+
+[plugins]
+
+blossom = { id = "net.kyori.blossom", version.ref = "blossom" }

--- a/src/main/java/net/minestom/server/Git.java
+++ b/src/main/java/net/minestom/server/Git.java
@@ -6,5 +6,4 @@ public class Git {
 
     public static final String GROUP = "&GROUP";
     public static final String ARTIFACT = "&ARTIFACT";
-    public static final String VERSION = "&VERSION";
 }

--- a/src/main/java/net/minestom/server/Git.java
+++ b/src/main/java/net/minestom/server/Git.java
@@ -1,0 +1,10 @@
+package net.minestom.server;
+
+public class Git {
+    public static final String COMMIT = &COMMIT;
+    public static final String BRANCH = &BRANCH;
+
+    public static final String GROUP = &GROUP;
+    public static final String ARTIFACT = &ARTIFACT;
+    public static final String VERSION = &VERSION;
+}

--- a/src/main/java/net/minestom/server/Git.java
+++ b/src/main/java/net/minestom/server/Git.java
@@ -1,10 +1,10 @@
 package net.minestom.server;
 
 public class Git {
-    public static final String COMMIT = &COMMIT;
-    public static final String BRANCH = &BRANCH;
+    public static final String COMMIT = "&COMMIT";
+    public static final String BRANCH = "&BRANCH";
 
-    public static final String GROUP = &GROUP;
-    public static final String ARTIFACT = &ARTIFACT;
-    public static final String VERSION = &VERSION;
+    public static final String GROUP = "&GROUP";
+    public static final String ARTIFACT = "&ARTIFACT";
+    public static final String VERSION = "&VERSION";
 }

--- a/src/main/java/net/minestom/server/Git.java
+++ b/src/main/java/net/minestom/server/Git.java
@@ -1,6 +1,6 @@
 package net.minestom.server;
 
-public class Git {
+public final class Git {
     private static final String COMMIT = "&COMMIT";
     private static final String BRANCH = "&BRANCH";
 

--- a/src/main/java/net/minestom/server/Git.java
+++ b/src/main/java/net/minestom/server/Git.java
@@ -1,9 +1,17 @@
 package net.minestom.server;
 
 public class Git {
-    public static final String COMMIT = "&COMMIT";
-    public static final String BRANCH = "&BRANCH";
+    private static final String COMMIT = "&COMMIT";
+    private static final String BRANCH = "&BRANCH";
 
-    public static final String GROUP = "&GROUP";
-    public static final String ARTIFACT = "&ARTIFACT";
+    private static final String GROUP = "&GROUP";
+    private static final String ARTIFACT = "&ARTIFACT";
+
+
+
+    public String getCommit() { return COMMIT; }
+    public String getBranch() { return BRANCH; }
+
+    public String getGroup() { return GROUP; }
+    public String getArtifact() { return ARTIFACT; }
 }

--- a/src/main/java/net/minestom/server/Git.java
+++ b/src/main/java/net/minestom/server/Git.java
@@ -8,9 +8,9 @@ public final class Git {
     private static final String ARTIFACT = "&ARTIFACT";
 
 
-    public String commit() { return COMMIT; }
-    public String branch() { return BRANCH; }
+    public static String commit() { return COMMIT; }
+    public static String branch() { return BRANCH; }
 
-    public String group() { return GROUP; }
-    public String artifact() { return ARTIFACT; }
+    public static String group() { return GROUP; }
+    public static String artifact() { return ARTIFACT; }
 }

--- a/src/main/java/net/minestom/server/Git.java
+++ b/src/main/java/net/minestom/server/Git.java
@@ -8,10 +8,9 @@ public final class Git {
     private static final String ARTIFACT = "&ARTIFACT";
 
 
+    public String commit() { return COMMIT; }
+    public String branch() { return BRANCH; }
 
-    public String getCommit() { return COMMIT; }
-    public String getBranch() { return BRANCH; }
-
-    public String getGroup() { return GROUP; }
-    public String getArtifact() { return ARTIFACT; }
+    public String group() { return GROUP; }
+    public String artifact() { return ARTIFACT; }
 }


### PR DESCRIPTION
Adds a `Git` class holding information about the build from JitPack.
So any extension or server implementation would have access to these.

I took group and artifact fields too, so one can tell what fork of Minestom is used.
