### PR TITLE
Advanced teleportation API

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -310,7 +310,9 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         Check.stateCondition(instance == null, "You need to use Entity#setInstance before teleporting an entity!");
         final Runnable endCallback = () -> {
             this.previousPosition = this.position;
-            this.position = position;
+            this.position = position
+                    .withYaw(Arrays.stream(flags).anyMatch(flag -> flag == RelativeTeleportFlag.YAW) ? this.position.yaw() : position.yaw())
+                    .withPitch(Arrays.stream(flags).anyMatch(flag -> flag == RelativeTeleportFlag.PITCH) ? this.position.pitch() : position.pitch());
             refreshCoordinate(position);
 
             if (this instanceof Player player) player.synchronizePosition(true, flags); // Allow relative teleportation to occur

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -1513,6 +1513,26 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
     }
 
     /**
+     * @see Entity#synchronizePosition(boolean)
+     *
+     * @param includeSelf whether the packet should be sent to the player
+     * @param flags       flags telling the client which co-ordinates are relative, can be empty
+     */
+    @ApiStatus.Internal
+    @ApiStatus.Experimental
+    protected void synchronizePosition(boolean includeSelf, @NotNull RelativeTeleportFlag... flags) {
+        if (includeSelf) {
+            sendPacket(new PlayerPositionAndLookPacket(
+                    position.sub(previousPosition).withPitch(position.pitch()-previousPosition.pitch()).withYaw(position.yaw()-previousPosition.yaw()),
+                    RelativeTeleportFlag.pack(flags),
+                    getNextTeleportId(),
+                    false
+            ));
+        }
+        super.synchronizePosition(includeSelf);
+    }
+
+    /**
      * Gets the player permission level.
      *
      * @return the player permission level

--- a/src/main/java/net/minestom/server/entity/RelativeTeleportFlag.java
+++ b/src/main/java/net/minestom/server/entity/RelativeTeleportFlag.java
@@ -1,0 +1,44 @@
+package net.minestom.server.entity;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+@ApiStatus.Experimental
+public enum RelativeTeleportFlag {
+
+    X(0),
+    Y(1),
+    Z(2),
+    YAW(3),
+    PITCH(4);
+
+    private final int shift;
+
+    RelativeTeleportFlag(int shift) {
+        this.shift = shift;
+    }
+
+    private int getMask() {
+        return 1 << this.shift;
+    }
+
+    private boolean isSet(int mask) {
+        return (mask & this.getMask()) == this.getMask();
+    }
+
+    public static @NotNull Set<RelativeTeleportFlag> unpack(byte mask) {
+        Set<RelativeTeleportFlag> set = EnumSet.noneOf(RelativeTeleportFlag.class);
+        for (RelativeTeleportFlag flag : values()) if (flag.isSet(mask)) set.add(flag);
+        return set;
+    }
+
+    public static byte pack(@NotNull RelativeTeleportFlag... flags) {
+        byte i = 0;
+        for (RelativeTeleportFlag flag : flags) i |= flag.getMask();
+        return i;
+    }
+
+}


### PR DESCRIPTION
This PR adds support for the [Synchronize Player Position](https://wiki.vg/Protocol#Synchronize_Player_Position) packet's `Flag` field. This field allows for relative teleportation, meaning the client's velocity, pitch and yaw can be preserved when teleported.

All new methods are labelled as experimental until tested properly.