### PR TITLE
Exclude world folder created by saving in the demo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ gradle-app.setting
 # Incase people are using IntelliJ to run the server, this will exclude extensions from any folder.
 /demo/extensions
 /extensions
+
+# When saving the world in the demo we generate the world folder
+# Incase people are using IntelliJ to run the server, this will exclude the world folder.
+/demo/world


### PR DESCRIPTION
When running the demo project directly from IntelliJ and saving the world, world folder gets added to git. This fixes that.