### PR TITLE
Add convenience playSound method in PacketGroupingAudience class

### DIFF
--- a/src/main/java/net/minestom/server/adventure/audience/PacketGroupingAudience.java
+++ b/src/main/java/net/minestom/server/adventure/audience/PacketGroupingAudience.java
@@ -11,6 +11,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.title.TitlePart;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.adventure.AdventurePacketConvertor;
+import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Player;
 import net.minestom.server.message.ChatPosition;
 import net.minestom.server.message.Messenger;
@@ -94,6 +95,15 @@ public interface PacketGroupingAudience extends ForwardingAudience {
     @Override
     default void hideBossBar(@NotNull BossBar bar) {
         MinecraftServer.getBossBarManager().removeBossBar(this.getPlayers(), bar);
+    }
+
+    /**
+     * Plays a {@link Sound} at a given point
+     * @param sound The sound to play
+     * @param point The point in this instance at which to play the sound
+     */
+    default void playSound(@NotNull Sound sound, @NotNull Point point) {
+        playSound(sound, point.x(), point.y(), point.z());
     }
 
     @Override

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -3,7 +3,6 @@ package net.minestom.server.instance;
 import it.unimi.dsi.fastutil.objects.ObjectArraySet;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.pointer.Pointers;
-import net.kyori.adventure.sound.Sound;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.ServerProcess;
 import net.minestom.server.Tickable;
@@ -692,15 +691,6 @@ public abstract class Instance implements Block.Getter, Block.Setter,
      */
     public void setExplosionSupplier(@Nullable ExplosionSupplier supplier) {
         this.explosionSupplier = supplier;
-    }
-
-    /**
-     * Plays a {@link Sound} at a given point
-     * @param sound The sound to play
-     * @param point The point in this instance at which to play the sound
-     */
-    public void playSound(@NotNull Sound sound, @NotNull Point point) {
-        playSound(sound, point.x(), point.y(), point.z());
     }
 
     /**

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -3,6 +3,7 @@ package net.minestom.server.instance;
 import it.unimi.dsi.fastutil.objects.ObjectArraySet;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.pointer.Pointers;
+import net.kyori.adventure.sound.Sound;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.ServerProcess;
 import net.minestom.server.Tickable;
@@ -691,6 +692,15 @@ public abstract class Instance implements Block.Getter, Block.Setter,
      */
     public void setExplosionSupplier(@Nullable ExplosionSupplier supplier) {
         this.explosionSupplier = supplier;
+    }
+
+    /**
+     * Plays a {@link Sound} at a given point
+     * @param sound The sound to play
+     * @param point The point in this instance at which to play the sound
+     */
+    public void playSound(@NotNull Sound sound, @NotNull Point point) {
+        playSound(sound, point.x(), point.y(), point.z());
     }
 
     /**


### PR DESCRIPTION
This PR adds a convenience method to the Instance class so it is quicker to play sounds in that instance.