### PR TITLE
Fix a harmful javadoc typo

### DIFF
--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -402,7 +402,7 @@ public class LivingEntity extends Entity implements EquipmentHandler {
     }
 
     /**
-     * Changes the entity health, kill it if {@code health} is &gt;= 0 and is not dead yet.
+     * Changes the entity health, kill it if {@code health} is &lt;= 0 and is not dead yet.
      *
      * @param health the new entity health
      */


### PR DESCRIPTION
Original: kill if health is **> (more)** or equal to 0 and is not yet dead