### PR TITLE
Corrected the incorrect warning message

### DIFF
--- a/src/main/java/net/minestom/server/instance/block/BlockManager.java
+++ b/src/main/java/net/minestom/server/instance/block/BlockManager.java
@@ -44,7 +44,7 @@ public final class BlockManager {
         if (handler == null) {
             if (dummyWarning.add(namespace)) {
                 LOGGER.warn("""
-                        Block {} does not have any corresponding handler, default to dummy.
+                        Block Entity {} does not have any corresponding handler, default to dummy.
                         You may want to register a handler for this namespace to prevent any data loss.""", namespace);
             }
             handler = BlockHandler.Dummy.get(namespace);


### PR DESCRIPTION
For example,when i entered my server with a oak sign block without handler,it tips me that Block minecraft:sign doesn't have corresponding handler.However,there is no "sign" block,there is only "oak sign" block and "sign" block entity.So I think we should change the message.