### PR TITLE
Fix block memory leak with properties function

### DIFF
--- a/src/main/java/net/minestom/server/instance/block/BlockImpl.java
+++ b/src/main/java/net/minestom/server/instance/block/BlockImpl.java
@@ -164,8 +164,8 @@ record BlockImpl(@NotNull Registry.BlockEntry registry,
     public @Unmodifiable @NotNull Map<String, String> properties() {
         final PropertyType[] propertyTypes = PROPERTIES_TYPE.get(id());
         assert propertyTypes != null;
-        if (propertyTypes.length == 0) return Collections.emptyMap();
         final int length = propertyTypes.length;
+        if (length == 0) return Map.of();
         String[] keys = new String[length];
         String[] values = new String[length];
         for (int i = 0; i < length; i++) {

--- a/src/main/java/net/minestom/server/instance/block/BlockImpl.java
+++ b/src/main/java/net/minestom/server/instance/block/BlockImpl.java
@@ -164,6 +164,7 @@ record BlockImpl(@NotNull Registry.BlockEntry registry,
     public @Unmodifiable @NotNull Map<String, String> properties() {
         final PropertyType[] propertyTypes = PROPERTIES_TYPE.get(id());
         assert propertyTypes != null;
+        if (propertyTypes.length == 0) return Collections.emptyMap();
         final int length = propertyTypes.length;
         String[] keys = new String[length];
         String[] values = new String[length];
@@ -172,7 +173,7 @@ record BlockImpl(@NotNull Registry.BlockEntry registry,
             keys[i] = property.key();
             values[i] = property.values().get(propertiesArray[i]);
         }
-        return Map.class.cast(Object2ObjectMaps.unmodifiable(new Object2ObjectArrayMap<>(keys, values, length)));
+        return Object2ObjectMaps.unmodifiable(new Object2ObjectArrayMap<>(keys, values, length));
     }
 
     @Override


### PR DESCRIPTION
### Description

Some blocks don't have any property types, yet the `BlockImpl#properties()` function doesn't check if the list is empty. This can cause thousands of 0 length `String[]`'s to be allocated in memory alongside some unnecessary overhead. We can fix this by returning an empty immutable map.

> Unsure if caching / precomputing the properties map would be another possible performance improvement? Given Minestom already depends on caffiene.