### PR TITLE
Allow listening for packets sent in the LOGIN and STATUS states

### DIFF
--- a/src/main/java/net/minestom/server/listener/manager/PreplayPacketListenerConsumer.java
+++ b/src/main/java/net/minestom/server/listener/manager/PreplayPacketListenerConsumer.java
@@ -1,0 +1,14 @@
+package net.minestom.server.listener.manager;
+
+import net.minestom.server.network.packet.client.ClientPreplayPacket;
+import net.minestom.server.network.player.PlayerConnection;
+
+/**
+ * Small convenient interface to use method references with {@link PacketListenerManager#setListener(Class, PreplayPacketListenerConsumer)}.
+ *
+ * @param <T> the packet type
+ */
+@FunctionalInterface
+public interface PreplayPacketListenerConsumer<T extends ClientPreplayPacket> {
+    void accept(T packet, PlayerConnection connection);
+}

--- a/src/main/java/net/minestom/server/network/PacketProcessor.java
+++ b/src/main/java/net/minestom/server/network/PacketProcessor.java
@@ -1,5 +1,6 @@
 package net.minestom.server.network;
 
+import net.minestom.server.MinecraftServer;
 import net.minestom.server.entity.Player;
 import net.minestom.server.network.packet.client.ClientPacket;
 import net.minestom.server.network.packet.client.ClientPacketsHandler;
@@ -44,7 +45,7 @@ public record PacketProcessor(@NotNull ClientPacketsHandler statusHandler,
     public ClientPacket process(@NotNull PlayerConnection connection, int packetId, ByteBuffer body) {
         final ClientPacket packet = create(connection.getConnectionState(), packetId, body);
         if (packet instanceof ClientPreplayPacket prePlayPacket) {
-            prePlayPacket.process(connection);
+            MinecraftServer.getPacketListenerManager().processClientPrePlayPacket(prePlayPacket, connection);
         } else {
             final Player player = connection.getPlayer();
             assert player != null;


### PR DESCRIPTION
Minestom packet listeners currently have no effect for subclasses of `ClientPreplayPacket` (likely because a `Player` object does not exist at the time these packets are received). This PR adds the ability to listen to these packets, and uses it for the default listeners similarly to other PLAY packets. Also, the `process` method of each packet has been moved to its own listener class (thank you @Eoghanmc22 for the suggestion!)

My usecase for this feature is listening to every `LoginPluginResponsePacket` to receive information from a proxy before the player logs in to the server. I have not used the testing framework yet, but if tests are needed I will definitely implement those.

See corresponding discussion: #1394