### PR TITLE
Velocity packet fix

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -596,8 +596,8 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
                         -gravityAcceleration * tps * (1 - gravityDragPerTick),
                         0
                 );
-                if (VELOCITY_UPDATE_INTERVAL > 0) {
-                    if (!isPlayer && !this.lastVelocityWasZero && this.ticks % VELOCITY_UPDATE_INTERVAL == 0) {
+                if (this.ticks % VELOCITY_UPDATE_INTERVAL == 0) {
+                    if (!isPlayer && !this.lastVelocityWasZero) {
                         sendPacketToViewers(getVelocityPacket());
                         this.lastVelocityWasZero = !hasVelocity;
                     }
@@ -628,8 +628,8 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
             updateVelocity(wasOnGround, flying, positionBeforeMove, newVelocity);
         }
         // Verify if velocity packet has to be sent
-        if (VELOCITY_UPDATE_INTERVAL > 0) {
-            if (!isPlayer && (hasVelocity || !lastVelocityWasZero) && this.ticks % VELOCITY_UPDATE_INTERVAL == 0) {
+        if (this.ticks % VELOCITY_UPDATE_INTERVAL == 0) {
+            if (!isPlayer && (hasVelocity || !lastVelocityWasZero)) {
                 sendPacketToViewers(getVelocityPacket());
                 this.lastVelocityWasZero = !hasVelocity;
             }
@@ -927,8 +927,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         EntityVelocityEvent entityVelocityEvent = new EntityVelocityEvent(this, velocity);
         EventDispatcher.callCancellable(entityVelocityEvent, () -> {
             this.velocity = entityVelocityEvent.getVelocity();
-            if (VELOCITY_UPDATE_INTERVAL > 0)
-                sendPacketToViewersAndSelf(getVelocityPacket());
+            sendPacketToViewersAndSelf(getVelocityPacket());
         });
     }
 

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -926,7 +926,8 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         EntityVelocityEvent entityVelocityEvent = new EntityVelocityEvent(this, velocity);
         EventDispatcher.callCancellable(entityVelocityEvent, () -> {
             this.velocity = entityVelocityEvent.getVelocity();
-            sendPacketToViewersAndSelf(getVelocityPacket());
+            if (this.getVelocityUpdateInterval() > 0)
+                sendPacketToViewersAndSelf(getVelocityPacket());
         });
     }
 

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -106,6 +106,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
 
     // Velocity
     protected Vec velocity = Vec.ZERO; // Movement in block per second
+    protected boolean lastVelocityWasZero = true;
     protected boolean hasPhysics = true;
 
     /**
@@ -593,7 +594,10 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
                         -gravityAcceleration * tps * (1 - gravityDragPerTick),
                         0
                 );
-                if (!isPlayer) sendPacketToViewers(getVelocityPacket());
+                if (!isPlayer && !this.lastVelocityWasZero) {
+                    sendPacketToViewers(getVelocityPacket());
+                    this.lastVelocityWasZero = !hasVelocity;
+                }
                 return;
             }
         }
@@ -620,8 +624,9 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
             updateVelocity(wasOnGround, flying, positionBeforeMove, newVelocity);
         }
         // Verify if velocity packet has to be sent
-        if (!isPlayer && (hasVelocity || gravityTickCount > 0)) {
+        if (!isPlayer && (hasVelocity || !lastVelocityWasZero)) {
             sendPacketToViewers(getVelocityPacket());
+            this.lastVelocityWasZero = !hasVelocity;
         }
     }
 

--- a/src/test/java/net/minestom/server/entity/EntityVelocityIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/EntityVelocityIntegrationTest.java
@@ -173,21 +173,18 @@ public class EntityVelocityIntegrationTest {
         entity.setInstance(instance, new Pos(0,40,0));
 
         AtomicInteger i = new AtomicInteger();
-        BooleanSupplier tickLoopCondition = () -> i.getAndIncrement() < VELOCITY_UPDATE_INTERVAL;
+        BooleanSupplier tickLoopCondition = () -> i.getAndIncrement() < Math.max(VELOCITY_UPDATE_INTERVAL, 1);
         viewerConnection.connect(instance, new Pos(1, 40, 1)).join();
 
         var tracker = viewerConnection.trackIncoming(EntityVelocityPacket.class);
         env.tickWhile(tickLoopCondition, null);
         tracker.assertEmpty(); // Verify no updates are sent while the entity is not moving
 
-        tracker = viewerConnection.trackIncoming(EntityVelocityPacket.class);
         entity.setVelocity(new Vec(0, 5, 0));
-        tracker.assertCount(VELOCITY_UPDATE_INTERVAL > 0 ? 1 : 0); // Verify the setVelocity method only sends an update when it should
-
         tracker = viewerConnection.trackIncoming(EntityVelocityPacket.class);
         i.set(0);
         env.tickWhile(tickLoopCondition, null);
-        tracker.assertCount(VELOCITY_UPDATE_INTERVAL > 0 ? 1 : 0); // Verify the update is only sent once, or never if interval is 0
+        tracker.assertCount(1); // Verify the update is only sent once
     }
 
     private void testMovement(Env env, Entity entity, Vec... sample) {

--- a/src/test/java/net/minestom/server/entity/EntityVelocityIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/EntityVelocityIntegrationTest.java
@@ -169,12 +169,12 @@ public class EntityVelocityIntegrationTest {
 
         var instance = env.createFlatInstance();
         var viewerConnection = env.createConnection();
+        viewerConnection.connect(instance, new Pos(1, 40, 1)).join();
         var entity = new Entity(EntityType.ZOMBIE);
-        entity.setInstance(instance, new Pos(0,40,0));
+        entity.setInstance(instance, new Pos(0,40,0)).join();
 
         AtomicInteger i = new AtomicInteger();
         BooleanSupplier tickLoopCondition = () -> i.getAndIncrement() < Math.max(VELOCITY_UPDATE_INTERVAL, 1);
-        viewerConnection.connect(instance, new Pos(1, 40, 1)).join();
 
         var tracker = viewerConnection.trackIncoming(EntityVelocityPacket.class);
         env.tickWhile(tickLoopCondition, null);


### PR DESCRIPTION
Aiming to fix the issue #1413 I pointed out about a week ago, here's what this PR does:

- When an entity has no velocity, and the latest sent velocity update corresponds to this same state, we no longer send another packet to notify the client of an inexistent change.
If however the entity has velocity, even if that velocity has not changed since the last update, we still send an update: this is because the client will predict a reduction of this velocity over time, so the fact that the velocity did not change is, in itself, a change.
- Adds an update interval for velocity. 1 by default, this lets minestom users define how often the velocity of their entity should be update, should they need to change it. As some entities like paintings cannot have velocity - at least on the client side, this also lets them disable the updates as a whole for that entity.
(It might be also worth noting that as of 1.19.2, the velocity packet does absolutely nothing on entities that are not projectiles, dynamic tiles, thrown items, or experience orbs: another reason to let people disable those updates if they so desire.)
- Tied to the point above, this also prevents the velocity update packet to be sent when Entity#setVelocity is invoked if the interval is set to 0 or lower. As the updates are disabled, no kind of velocity update whatsoever should be sent to the client for that entity, otherwise this could cause it to appear at a different location than it actually is if this entity falls into one of the categories mentioned above.

This does not alter any behavior whatsoever on the server's side. It only aims at reducing the amount of unnecessary packets sent to the client.