### PR TITLE
Replace char literal with unicode literal

### DIFF
--- a/src/main/java/net/minestom/server/scoreboard/Sidebar.java
+++ b/src/main/java/net/minestom/server/scoreboard/Sidebar.java
@@ -317,7 +317,7 @@ public class Sidebar implements Scoreboard {
          * Creates a new {@link SidebarTeam}
          */
         private void createTeam() {
-            this.entityName = ((char) 0xA7) + Integer.toHexString(colorName);
+            this.entityName = '\u00A7' + Integer.toHexString(colorName);
 
             this.sidebarTeam = new SidebarTeam(teamName, content, Component.empty(), entityName);
         }


### PR DESCRIPTION
Replaces the char literal in the Sidebar class with a unicode literal

The current implementation isn't broken, but this looks a bit cleaner.