### PR TITLE
Fix yaw/pitch order in SpawnEntityPacket

### DIFF
--- a/src/main/java/net/minestom/server/network/packet/server/play/SpawnEntityPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/SpawnEntityPacket.java
@@ -29,8 +29,8 @@ public record SpawnEntityPacket(int entityId, @NotNull UUID uuid, int type,
         writer.writeDouble(position.y());
         writer.writeDouble(position.z());
 
-        writer.writeByte((byte) (position.yaw() * 256 / 360));
         writer.writeByte((byte) (position.pitch() * 256 / 360));
+        writer.writeByte((byte) (position.yaw() * 256 / 360));
         writer.writeByte((byte) (headRot * 256 / 360));
 
         writer.writeVarInt(data);


### PR DESCRIPTION
The order for yaw/pitch is different in the SpawnEntityPacket vs the TeleportEntityPacket.

See https://wiki.vg/Protocol#Spawn_Entity for the spec on the SpawnEntityPacket :)