### PR TITLE
Add Maven publication for testing framework.

### DIFF
--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -1,5 +1,18 @@
 plugins {
     id("java-library")
+    `maven-publish`
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            groupId = "net.minestom.testing"
+            artifactId = "testing"
+            version = "1.0"
+
+            from(components["java"])
+        }
+    }
 }
 
 group = "net.minestom.testing"


### PR DESCRIPTION
This PR adds a maven publication to the `testing` module, which means that it can be imported using the following dependency notation:
`com.github.Minestom.Minestom:testing:<version>`
The produced JAR only includes the testing framework API (nothing from the main module).

Notably, the Jitpack build log now contains this (example from when I built it on my fork):
```
✅ Build artifacts:
com.github.BlueDragonMC.Minestom:testing:b5951e9cb2
com.github.BlueDragonMC.Minestom:Minestom:b5951e9cb2
```