### PR TITLE
Fix respawning players falling into the void

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -131,7 +131,6 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         // Load new chunks
         this.instance.loadOptionalChunk(chunkX, chunkZ).thenAccept(chunk -> {
             try {
-                System.out.println("Sending chunk " + chunkX + ", " + chunkZ);
                 if (chunk != null) {
                     chunk.sendChunk(this);
                     EventDispatcher.call(new PlayerChunkLoadEvent(this, chunkX, chunkZ));

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -442,7 +442,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         Pos respawnPosition = respawnEvent.getRespawnPosition();
         // Client unloads chunks upon respawn, call unload event, but don't send unnecessary unload packets or create unload events for chunks the player will be loading
         ChunkUtils.forDifferingChunksInRange(respawnPosition.chunkX(), respawnPosition.chunkZ(),
-                this.position.chunkX(), this.position.chunkZ(), MinecraftServer.getChunkViewDistance(), (chunkX, chunkZ) -> EventDispatcher.call(new PlayerChunkUnloadEvent(this, chunkX, chunkZ)));
+                this.position.chunkX(), this.position.chunkZ(), MinecraftServer.getChunkViewDistance(), (chunkX, chunkZ) -> {}, (chunkX, chunkZ) -> EventDispatcher.call(new PlayerChunkUnloadEvent(this, chunkX, chunkZ)));
 
         ChunkUtils.forChunksInRange(respawnPosition, MinecraftServer.getChunkViewDistance(), chunkAdder);
         chunksLoadedByClient = new Vec(respawnPosition.chunkX(), respawnPosition.chunkZ());

--- a/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkTest.java
@@ -3,11 +3,20 @@ package net.minestom.server.entity.player;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.Player;
+import net.minestom.server.event.player.PlayerChunkLoadEvent;
+import net.minestom.server.event.player.PlayerChunkUnloadEvent;
+import net.minestom.server.network.packet.client.play.ClientStatusPacket;
 import net.minestom.server.network.packet.server.play.ChunkDataPacket;
 import net.minestom.server.network.packet.server.play.UnloadChunkPacket;
+import net.minestom.server.utils.chunk.ChunkUtils;
 import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @EnvTest
@@ -38,7 +47,59 @@ public class PlayerRespawnChunkTest {
         player.setHealth(0);
         player.respawn();
         // Player should have all their chunks reloaded
-        int chunkLoads = (int) Math.pow(MinecraftServer.getChunkViewDistance() * 2 + 1, 2);
+        int chunkLoads = ChunkUtils.getChunkCount(MinecraftServer.getChunkViewDistance());
         loadChunkTracker.assertCount(chunkLoads);
+    }
+
+    @Test
+    public void testPlayerTryRespawn(Env env) {
+        var instance = env.createFlatInstance();
+        var connection = env.createConnection();
+        Player player = connection.connect(instance, new Pos(0, 40, 0)).join();
+
+        player.eventNode().addListener(PlayerChunkLoadEvent.class, playerChunkLoadEvent -> {
+            // We should only load chunks around the spawnpoint
+            assertTrue(Math.abs(playerChunkLoadEvent.getChunkX()) <= MinecraftServer.getChunkViewDistance() && Math.abs(playerChunkLoadEvent.getChunkZ()) <= MinecraftServer.getChunkViewDistance());
+        });
+        player.setHealth(0);
+        player.addPacketToQueue(new ClientStatusPacket(ClientStatusPacket.Action.PERFORM_RESPAWN));
+        player.interpretPacketQueue();
+    }
+
+    @Test
+    public void testPlayerUnloadChunkEventOnRespawn(Env env) {
+        var instance = env.createFlatInstance();
+        var connection = env.createConnection();
+        Player player = connection.connect(instance, new Pos(0, 40, 0)).join();
+        player.setInstance(instance).join(); // TODO: REMOVE
+
+
+        // Get a list from -8 to 8, since we will be unloading
+        ArrayList<Integer> chunkZList = new ArrayList<>();
+        for(int i = -MinecraftServer.getChunkViewDistance(); i <= MinecraftServer.getChunkViewDistance(); i++) {
+            chunkZList.add(i);
+        }
+        ArrayList<Integer> chunkZListCopy = new ArrayList<>(chunkZList);
+
+        var listener = env.listen(PlayerChunkUnloadEvent.class);
+        // We will now trigger a bunch of chunk unloads from moving - ensure they are done properly
+        listener.followup(event -> {
+            assertEquals(-MinecraftServer.getChunkViewDistance(), event.getChunkX());
+            assertTrue(chunkZList.contains(event.getChunkZ()));
+            chunkZList.remove(Integer.valueOf(event.getChunkZ()));
+        });
+        // Trigger chunk unloading from movement
+        player.teleport(new Pos(16, 40, 0)).join();
+        assertTrue(chunkZList.isEmpty());
+        // We will now trigger another round of chunk unloads because we have shifted positions from the respawn
+        listener.followup(event -> {
+            assertEquals(MinecraftServer.getChunkViewDistance() + 1, event.getChunkX());
+            assertTrue(chunkZListCopy.contains(event.getChunkZ()));
+            chunkZListCopy.remove(Integer.valueOf(event.getChunkZ()));
+        });
+        player.setHealth(0);
+        player.addPacketToQueue(new ClientStatusPacket(ClientStatusPacket.Action.PERFORM_RESPAWN));
+        player.interpretPacketQueue();
+        assertTrue(chunkZListCopy.isEmpty());
     }
 }

--- a/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkTest.java
@@ -19,7 +19,6 @@ public class PlayerRespawnChunkTest {
         var instance = env.createFlatInstance();
         var connection = env.createConnection();
         Player player = connection.connect(instance, new Pos(0, 40, 0)).join();
-        player.setInstance(instance).join();
         player.teleport(new Pos(32, 40, 32)).join();
 
         var unloadChunkTracker = connection.trackIncoming(UnloadChunkPacket.class);
@@ -34,7 +33,6 @@ public class PlayerRespawnChunkTest {
         var instance = env.createFlatInstance();
         var connection = env.createConnection();
         Player player = connection.connect(instance, new Pos(0, 40, 0)).join();
-        player.setInstance(instance).join();
 
         var loadChunkTracker = connection.trackIncoming(ChunkDataPacket.class);
         player.setHealth(0);

--- a/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkTest.java
@@ -1,0 +1,46 @@
+package net.minestom.server.entity.player;
+
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.Player;
+import net.minestom.server.network.packet.server.play.ChunkDataPacket;
+import net.minestom.server.network.packet.server.play.UnloadChunkPacket;
+import net.minestom.testing.Env;
+import net.minestom.testing.EnvTest;
+import org.junit.jupiter.api.Test;
+
+
+@EnvTest
+public class PlayerRespawnChunkTest {
+
+
+    @Test
+    public void testChunkUnloadsOnRespawn(Env env) {
+        var instance = env.createFlatInstance();
+        var connection = env.createConnection();
+        Player player = connection.connect(instance, new Pos(0, 40, 0)).join();
+        player.setInstance(instance).join();
+        player.teleport(new Pos(32, 40, 32)).join();
+
+        var unloadChunkTracker = connection.trackIncoming(UnloadChunkPacket.class);
+        player.setHealth(0);
+        player.respawn();
+        // Since client unloads the chunks, we shouldn't receive any unload packets
+        unloadChunkTracker.assertCount(0);
+    }
+
+    @Test
+    public void testChunkReloadCount(Env env) {
+        var instance = env.createFlatInstance();
+        var connection = env.createConnection();
+        Player player = connection.connect(instance, new Pos(0, 40, 0)).join();
+        player.setInstance(instance).join();
+
+        var loadChunkTracker = connection.trackIncoming(ChunkDataPacket.class);
+        player.setHealth(0);
+        player.respawn();
+        // Player should have all their chunks reloaded
+        int chunkLoads = (int) Math.pow(MinecraftServer.getChunkViewDistance() * 2 + 1, 2);
+        loadChunkTracker.assertCount(chunkLoads);
+    }
+}

--- a/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkTest.java
@@ -5,6 +5,7 @@ import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.player.PlayerChunkLoadEvent;
 import net.minestom.server.event.player.PlayerChunkUnloadEvent;
+import net.minestom.server.event.player.PlayerPacketOutEvent;
 import net.minestom.server.network.packet.client.play.ClientStatusPacket;
 import net.minestom.server.network.packet.server.play.ChunkDataPacket;
 import net.minestom.server.network.packet.server.play.UnloadChunkPacket;
@@ -57,47 +58,14 @@ public class PlayerRespawnChunkTest {
         var connection = env.createConnection();
         Player player = connection.connect(instance, new Pos(0, 40, 0)).join();
 
-        player.eventNode().addListener(PlayerChunkLoadEvent.class, playerChunkLoadEvent -> {
-            // We should only load chunks around the spawnpoint
-            assertTrue(Math.abs(playerChunkLoadEvent.getChunkX()) <= MinecraftServer.getChunkViewDistance() && Math.abs(playerChunkLoadEvent.getChunkZ()) <= MinecraftServer.getChunkViewDistance());
+        player.eventNode().addListener(PlayerPacketOutEvent.class, playerPacketOutEvent -> {
+            if(playerPacketOutEvent.getPacket() instanceof ChunkDataPacket chunkDataPacket) {
+                // We should only load chunks around the spawnpoint
+                assertTrue(Math.abs(chunkDataPacket.chunkX()) <= MinecraftServer.getChunkViewDistance() && Math.abs(chunkDataPacket.chunkZ()) <= MinecraftServer.getChunkViewDistance());
+            }
         });
         player.setHealth(0);
         player.addPacketToQueue(new ClientStatusPacket(ClientStatusPacket.Action.PERFORM_RESPAWN));
         player.interpretPacketQueue();
-    }
-
-    @Test
-    public void testPlayerUnloadChunkEventOnRespawn(Env env) {
-        var instance = env.createFlatInstance();
-        var connection = env.createConnection();
-        Player player = connection.connect(instance, new Pos(0, 40, 0)).join();
-
-        // Get a list from -8 to 8, since we will be unloading
-        ArrayList<Integer> chunkZList = new ArrayList<>();
-        for(int i = -MinecraftServer.getChunkViewDistance(); i <= MinecraftServer.getChunkViewDistance(); i++) {
-            chunkZList.add(i);
-        }
-        ArrayList<Integer> chunkZListCopy = new ArrayList<>(chunkZList);
-
-        var listener = env.listen(PlayerChunkUnloadEvent.class);
-        // We will now trigger a bunch of chunk unloads from moving - ensure they are done properly
-        listener.followup(event -> {
-            assertEquals(-MinecraftServer.getChunkViewDistance(), event.getChunkX());
-            assertTrue(chunkZList.contains(event.getChunkZ()));
-            chunkZList.remove(Integer.valueOf(event.getChunkZ()));
-        });
-        // Trigger chunk unloading from movement
-        player.teleport(new Pos(16, 40, 0)).join();
-        assertTrue(chunkZList.isEmpty());
-        // We will now trigger another round of chunk unloads because we have shifted positions from the respawn
-        listener.followup(event -> {
-            assertEquals(MinecraftServer.getChunkViewDistance() + 1, event.getChunkX());
-            assertTrue(chunkZListCopy.contains(event.getChunkZ()));
-            chunkZListCopy.remove(Integer.valueOf(event.getChunkZ()));
-        });
-        player.setHealth(0);
-        player.addPacketToQueue(new ClientStatusPacket(ClientStatusPacket.Action.PERFORM_RESPAWN));
-        player.interpretPacketQueue();
-        assertTrue(chunkZListCopy.isEmpty());
     }
 }

--- a/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkTest.java
@@ -71,8 +71,6 @@ public class PlayerRespawnChunkTest {
         var instance = env.createFlatInstance();
         var connection = env.createConnection();
         Player player = connection.connect(instance, new Pos(0, 40, 0)).join();
-        player.setInstance(instance).join(); // TODO: REMOVE
-
 
         // Get a list from -8 to 8, since we will be unloading
         ArrayList<Integer> chunkZList = new ArrayList<>();


### PR DESCRIPTION
As documented in [wiki.vg's Respawn Packet](https://wiki.vg/Protocol#Respawn), the client automatically unloads chunks when sending a respawn packet to the server.

However, Minestom was not properly updating their chunks when respawning them. The client unloaded their chunks, but Minestom did not send chunk packets back to the client, so the client started falling endlessly into the void.

This PR rectifies this issue by properly handling the chunk unload, and then reloading the chunks for the player before teleporting them.