### PR TITLE
Add a way to override hasPermission method

### DIFF
--- a/src/main/java/net/minestom/server/event/player/PlayerCheckPermissionEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerCheckPermissionEvent.java
@@ -1,0 +1,42 @@
+package net.minestom.server.event.player;
+
+import net.minestom.server.entity.Player;
+import net.minestom.server.event.trait.PlayerEvent;
+import net.minestom.server.permission.Permission;
+import org.jetbrains.annotations.NotNull;
+
+public class PlayerCheckPermissionEvent implements PlayerEvent {
+
+    private final Player player;
+    private final Permission permission;
+    private final String permissionName;
+    private boolean hasPermission;
+
+    public PlayerCheckPermissionEvent(Player player, Permission permission, String permissionName, boolean hasPermission) {
+        this.player = player;
+        this.permission = permission;
+        this.permissionName = permissionName;
+        this.hasPermission = hasPermission;
+    }
+
+    @Override
+    public @NotNull Player getPlayer() {
+        return this.player;
+    }
+
+    public Permission getPermission() {
+        return permission;
+    }
+
+    public String getPermissionName() {
+        return permissionName;
+    }
+
+    public boolean hasPermission() {
+        return hasPermission;
+    }
+
+    public void setHasPermission(boolean hasPermission) {
+        this.hasPermission = hasPermission;
+    }
+}


### PR DESCRIPTION
Permission manager plugins needs to override hasPermission method.

Can be used like any other events:

```java
	public void handlePlayerCheckPermissionEvent(PlayerCheckPermissionEvent event) {
		boolean hasPermission = event.hasPermission();

		if (hasPermission)
			return;
		
		final Player player = event.getPlayer();

		// Your behavior

		event.setHasPermission(/* true or false */);
	}
```