### PR TITLE
Move reflect fields in Extension to ExtensionClassLoader

### DIFF
--- a/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
+++ b/src/main/java/net/minestom/server/extensions/DiscoveredExtension.java
@@ -116,7 +116,7 @@ public final class DiscoveredExtension {
     void createClassLoader() {
         Check.stateCondition(classLoader != null, "Extension classloader has already been created");
         final URL[] urls = this.files.toArray(new URL[0]);
-        classLoader = new ExtensionClassLoader(this.getName(), urls);
+        classLoader = new ExtensionClassLoader(this.getName(), urls, this);
     }
 
     @NotNull

--- a/src/main/java/net/minestom/server/extensions/Extension.java
+++ b/src/main/java/net/minestom/server/extensions/Extension.java
@@ -17,16 +17,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 public abstract class Extension {
-    // Set by reflection
-    @SuppressWarnings("unused")
-    private DiscoveredExtension origin;
-    // Set by reflection
-    @SuppressWarnings("unused")
-    private Logger logger;
-    // Set by reflection
-    @SuppressWarnings("unused")
-    private EventNode<Event> eventNode;
-
     /**
      * List of extensions that depend on this extension.
      */
@@ -56,9 +46,16 @@ public abstract class Extension {
 
     }
 
+    ExtensionClassLoader getExtensionClassLoader() {
+        if (getClass().getClassLoader() instanceof ExtensionClassLoader extensionClassLoader) {
+            return extensionClassLoader;
+        }
+        throw new IllegalStateException("Extension class loader is not an ExtensionClassLoader");
+    }
+
     @NotNull
     public DiscoveredExtension getOrigin() {
-        return origin;
+        return getExtensionClassLoader().getDiscoveredExtension();
     }
 
     /**
@@ -68,11 +65,11 @@ public abstract class Extension {
      */
     @NotNull
     public Logger getLogger() {
-        return logger;
+        return getExtensionClassLoader().getLogger();
     }
 
     public @NotNull EventNode<Event> getEventNode() {
-        return eventNode;
+        return getExtensionClassLoader().getEventNode();
     }
 
     public @NotNull Path getDataDirectory() {


### PR DESCRIPTION
This fixes an NPE when an author use `getDataDirectory`, `getOrigin`, `getLogger` on their class fields like this (by "polluting" `ExtensionClassLoader`):
```java
public class TestExtension extends Extension {
    private final Path configPath = getDataDirectory();
    private final EventNode<Event> node = getEventNode();

    @Override
    public void initialize() {
        getLogger().info(configPath == null ? "Config path is null" : "Config path: " + configPath);
    }
    // ...
}
```
The current Minestom will throw an exception when instantiating the extension:
```
ERROR [2022-10-25 16:30:04] - While instantiating the main class 'me.hsgamer.minestomskinsrestorer.MinestomSkinsRestorer' in 'MinestomSkinsRestorer' an exception was thrown.: java.lang.NullPointerException: Cannot invoke "net.minestom.server.extensions.DiscoveredExtension.getDataDirectory()" because the return value of "net.minestom.server.extensions.Extension.getOrigin()" is null
        at net.minestom.server.extensions.Extension.getDataDirectory(Extension.java:79)
        at Ext_MinestomSkinsRestorer//me.hsgamer.minestomskinsrestorer.MinestomSkinsRestorer.<init>(MinestomSkinsRestorer.java:17)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
        at net.minestom.server.extensions.ExtensionManager.loadExtension(ExtensionManager.java:309)
        at net.minestom.server.extensions.ExtensionManager.loadExtensions(ExtensionManager.java:241)
        at net.minestom.server.extensions.ExtensionManager.start(ExtensionManager.java:115)
        at net.minestom.server.ServerProcessImpl.start(ServerProcessImpl.java:211)
        at net.minestom.server.MinecraftServer.start(MinecraftServer.java:323)
        at net.minestom.server.MinecraftServer.start(MinecraftServer.java:328)
        at me.hsgamer.flexegames.GameServer.start(GameServer.java:114)
        at me.hsgamer.flexegames.FlexEGames.main(FlexEGames.java:10)
```
After the fix:
```
2022-10-25 16:36:01 [main] net.minestom.server.ServerProcessImpl.start()
INFO: Starting Minestom server.
2022-10-25 16:36:01 [main] me.hsgamer.minestomskinsrestorer.MinestomSkinsRestorer.initialize()
INFO: Config path: extensions/MinestomSkinsRestorer
2022-10-25 16:36:01 [main] net.minestom.server.ServerProcessImpl.start()
INFO: Minestom server started successfully.
```