### PR TITLE
Strong Ref for child EventNode

### DIFF
--- a/src/main/java/net/minestom/server/event/EventNodeImpl.java
+++ b/src/main/java/net/minestom/server/event/EventNodeImpl.java
@@ -21,8 +21,7 @@ non-sealed class EventNodeImpl<T extends Event> implements EventNode<T> {
 
     private final Map<Class, Handle<T>> handleMap = new ConcurrentHashMap<>();
     final Map<Class<? extends T>, ListenerEntry<T>> listenerMap = new ConcurrentHashMap<>();
-    final Set<EventNodeImpl<T>> children = Collections.newSetFromMap(Caffeine.newBuilder()
-            .weakKeys().<EventNodeImpl<T>, Boolean>build().asMap());
+    final Set<EventNodeImpl<T>> children = new CopyOnWriteArraySet<>();
     final Map<Object, EventNodeImpl<T>> mappedNodeCache = Caffeine.newBuilder()
             .weakKeys().weakValues().<Object, EventNodeImpl<T>>build().asMap();
     final Map<Object, EventNodeImpl<T>> registeredMappedNode = Caffeine.newBuilder()

--- a/src/test/java/net/minestom/server/event/EventNodeTest.java
+++ b/src/test/java/net/minestom/server/event/EventNodeTest.java
@@ -245,20 +245,20 @@ public class EventNodeTest {
         waitUntilCleared(ref);
     }
 
-    @Test
-    public void nodeChildGC() {
-        var node = EventNode.all("main");
-
-        var child = EventNode.all("child");
-        var ref = new WeakReference<>(child);
-        child.addListener(EventTest.class, event -> {
-        });
-        node.addChild(child);
-
-        //noinspection UnusedAssignment
-        child = null;
-        waitUntilCleared(ref);
-    }
+//    @Test
+//    public void nodeChildGC() {
+//        var node = EventNode.all("main");
+//
+//        var child = EventNode.all("child");
+//        var ref = new WeakReference<>(child);
+//        child.addListener(EventTest.class, event -> {
+//        });
+//        node.addChild(child);
+//
+//        //noinspection UnusedAssignment
+//        child = null;
+//        waitUntilCleared(ref);
+//    }
 
     @Test
     public void nodeMapGC() {


### PR DESCRIPTION
My implementation registers some custom `EventNode`-s to the global node and unregisters them when they are finished.
With the current weak parent-child ref, sometimes the child nodes are not even called.

Is it really important to change the child set to be a weak ref? If so, is there anyways to fix that the child nodes will always be called?