### PR TITLE
Fix entities vanishing upon respawn

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -455,7 +455,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         Pos respawnPosition = respawnEvent.getRespawnPosition();
 
         // The client unloads chunks when respawning, so resend all chunks next to spawn
-        ChunkUtils.forChunksInRange(respawnPosition, settings.getViewDistance(), (chunkX, chunkZ) ->
+        ChunkUtils.forChunksInRange(respawnPosition, Math.min(MinecraftServer.getChunkViewDistance(), settings.getViewDistance()), (chunkX, chunkZ) ->
                 this.instance.loadOptionalChunk(chunkX, chunkZ).thenAccept(chunk -> {
                     try {
                         if (chunk != null) {
@@ -467,7 +467,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
                 }));
         chunksLoadedByClient = new Vec(respawnPosition.chunkX(), respawnPosition.chunkZ());
         // Client also needs all entities resent to them, since those are unloaded as well
-        this.instance.getEntityTracker().nearbyEntitiesByChunkRange(respawnPosition, settings.getViewDistance(),
+        this.instance.getEntityTracker().nearbyEntitiesByChunkRange(respawnPosition, Math.min(MinecraftServer.getChunkViewDistance(), settings.getViewDistance()),
                 EntityTracker.Target.ENTITIES, entity -> {
                     // Skip refreshing self with a new viewer
                     if (!entity.getUuid().equals(uuid)) {
@@ -2182,7 +2182,8 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         public void refresh(String locale, byte viewDistance, ChatMessageType chatMessageType, boolean chatColors,
                             byte displayedSkinParts, MainHand mainHand, boolean enableTextFiltering, boolean allowServerListings) {
             this.locale = locale;
-            this.viewDistance = viewDistance;
+            // Clamp viewDistance to valid bounds
+            this.viewDistance = (byte) MathUtils.clamp(viewDistance, 2, 32);
             this.chatMessageType = chatMessageType;
             this.chatColors = chatColors;
             this.displayedSkinParts = displayedSkinParts;

--- a/src/main/java/net/minestom/server/listener/SettingsListener.java
+++ b/src/main/java/net/minestom/server/listener/SettingsListener.java
@@ -8,8 +8,8 @@ import net.minestom.server.network.packet.client.play.ClientSettingsPacket;
 public final class SettingsListener {
     public static void listener(ClientSettingsPacket packet, Player player) {
         Player.PlayerSettings settings = player.getSettings();
-        final byte viewDistance = (byte) Math.abs(packet.viewDistance());
-        settings.refresh(packet.locale(), viewDistance, packet.chatMessageType(), packet.chatColors(), packet.displayedSkinParts(), packet.mainHand(), packet.enableTextFiltering(), packet.allowsListing());
+        // Since viewDistance bounds checking is performed in the refresh function, it is not necessary to check it here
+        settings.refresh(packet.locale(), packet.viewDistance(), packet.chatMessageType(), packet.chatColors(), packet.displayedSkinParts(), packet.mainHand(), packet.enableTextFiltering(), packet.allowsListing());
         EventDispatcher.call(new PlayerSettingsChangeEvent(player));
     }
 }

--- a/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkIntegrationTest.java
@@ -1,5 +1,6 @@
 package net.minestom.server.entity.player;
 
+import net.minestom.server.MinecraftServer;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.Player;
 import net.minestom.server.network.packet.client.play.ClientStatusPacket;
@@ -44,7 +45,7 @@ public class PlayerRespawnChunkIntegrationTest {
         player.setHealth(0);
         player.respawn();
         // Player should have all their chunks reloaded
-        int chunkLoads = ChunkUtils.getChunkCount(player.getSettings().getViewDistance());
+        int chunkLoads = ChunkUtils.getChunkCount(Math.min(MinecraftServer.getChunkViewDistance(), player.getSettings().getViewDistance()));
         loadChunkTracker.assertCount(chunkLoads);
     }
 
@@ -60,12 +61,13 @@ public class PlayerRespawnChunkIntegrationTest {
         player.interpretPacketQueue();
         List<ChunkDataPacket> dataPacketList = loadChunkTracker.collect();
         Set<ChunkDataPacket> duplicateCheck = new HashSet<>();
-        int chunkLoads = ChunkUtils.getChunkCount(player.getSettings().getViewDistance());
+        int actualViewDistance = Math.min(MinecraftServer.getChunkViewDistance(), player.getSettings().getViewDistance());
+        int chunkLoads = ChunkUtils.getChunkCount(actualViewDistance);
         loadChunkTracker.assertCount(chunkLoads);
         for (ChunkDataPacket packet : dataPacketList) {
             assertFalse(duplicateCheck.contains(packet));
             duplicateCheck.add(packet);
-            assertTrue(Math.abs(packet.chunkX()) <= player.getSettings().getViewDistance() && Math.abs(packet.chunkZ()) <= player.getSettings().getViewDistance());
+            assertTrue(Math.abs(packet.chunkX()) <= actualViewDistance && Math.abs(packet.chunkZ()) <= actualViewDistance);
         }
     }
 }

--- a/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkIntegrationTest.java
@@ -1,6 +1,5 @@
 package net.minestom.server.entity.player;
 
-import net.minestom.server.MinecraftServer;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.Player;
 import net.minestom.server.network.packet.client.play.ClientStatusPacket;
@@ -45,7 +44,7 @@ public class PlayerRespawnChunkIntegrationTest {
         player.setHealth(0);
         player.respawn();
         // Player should have all their chunks reloaded
-        int chunkLoads = ChunkUtils.getChunkCount(MinecraftServer.getChunkViewDistance());
+        int chunkLoads = ChunkUtils.getChunkCount(player.getSettings().getViewDistance());
         loadChunkTracker.assertCount(chunkLoads);
     }
 
@@ -61,12 +60,12 @@ public class PlayerRespawnChunkIntegrationTest {
         player.interpretPacketQueue();
         List<ChunkDataPacket> dataPacketList = loadChunkTracker.collect();
         Set<ChunkDataPacket> duplicateCheck = new HashSet<>();
-        int chunkLoads = ChunkUtils.getChunkCount(MinecraftServer.getChunkViewDistance());
+        int chunkLoads = ChunkUtils.getChunkCount(player.getSettings().getViewDistance());
         loadChunkTracker.assertCount(chunkLoads);
         for (ChunkDataPacket packet : dataPacketList) {
             assertFalse(duplicateCheck.contains(packet));
             duplicateCheck.add(packet);
-            assertTrue(Math.abs(packet.chunkX()) <= MinecraftServer.getChunkViewDistance() && Math.abs(packet.chunkZ()) <= MinecraftServer.getChunkViewDistance());
+            assertTrue(Math.abs(packet.chunkX()) <= player.getSettings().getViewDistance() && Math.abs(packet.chunkZ()) <= player.getSettings().getViewDistance());
         }
     }
 }


### PR DESCRIPTION
Due what I suspect is the client unloading entities when respawning, current Minestom will see all other entities vanish upon respawning.

This PR resolves this by resending the entities when respawning, and also makes a minor fix to some surrounding code to use the Player's chunk render distance instead of the server default render distance.

Closes #1480 .