### PR TITLE
Make SweepResult public

### DIFF
--- a/src/main/java/net/minestom/server/collision/SweepResult.java
+++ b/src/main/java/net/minestom/server/collision/SweepResult.java
@@ -3,7 +3,7 @@ package net.minestom.server.collision;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.instance.block.Block;
 
-final class SweepResult {
+public final class SweepResult {
     double res;
     double normalX, normalY, normalZ;
     Point collidedShapePosition;


### PR DESCRIPTION
Make SweepResult public to use the method intersectBoxSwept() from Shape I need that to get the block collision with block.registry().collisionShape() like this demo:

```java
      var shape = block.registry().collisionShape();
      var isHit = shape.intersectBoxSwept(context.start(), context.direction(), position, new BoundingBox(0.01, 0.01, 0.01), new SweepResult(100, 0, 0, 0));
```