### PR TITLE
Prevent unsafe velocity packet

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -1528,10 +1528,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     }
 
     protected @NotNull Vec getVelocityForPacket() {
-        return this.velocity.mul(8000f / MinecraftServer.TICK_PER_SECOND)
-                .withX(x -> MathUtils.clamp(x, Short.MIN_VALUE, Short.MAX_VALUE))
-                .withY(y -> MathUtils.clamp(y, Short.MIN_VALUE, Short.MAX_VALUE))
-                .withZ(z -> MathUtils.clamp(z, Short.MIN_VALUE, Short.MAX_VALUE));
+        return this.velocity.mul(8000f / MinecraftServer.TICK_PER_SECOND);
     }
 
     protected @NotNull EntityVelocityPacket getVelocityPacket() {

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -51,6 +51,7 @@ import net.minestom.server.timer.Schedulable;
 import net.minestom.server.timer.Scheduler;
 import net.minestom.server.timer.TaskSchedule;
 import net.minestom.server.utils.ArrayUtils;
+import net.minestom.server.utils.MathUtils;
 import net.minestom.server.utils.PacketUtils;
 import net.minestom.server.utils.async.AsyncUtils;
 import net.minestom.server.utils.block.BlockIterator;
@@ -1527,7 +1528,10 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     }
 
     protected @NotNull Vec getVelocityForPacket() {
-        return this.velocity.mul(8000f / MinecraftServer.TICK_PER_SECOND);
+        return this.velocity.mul(8000f / MinecraftServer.TICK_PER_SECOND)
+                .withX(x -> MathUtils.clamp(x, Short.MIN_VALUE, Short.MAX_VALUE))
+                .withY(y -> MathUtils.clamp(y, Short.MIN_VALUE, Short.MAX_VALUE))
+                .withZ(z -> MathUtils.clamp(z, Short.MIN_VALUE, Short.MAX_VALUE));
     }
 
     protected @NotNull EntityVelocityPacket getVelocityPacket() {

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -51,7 +51,6 @@ import net.minestom.server.timer.Schedulable;
 import net.minestom.server.timer.Scheduler;
 import net.minestom.server.timer.TaskSchedule;
 import net.minestom.server.utils.ArrayUtils;
-import net.minestom.server.utils.MathUtils;
 import net.minestom.server.utils.PacketUtils;
 import net.minestom.server.utils.async.AsyncUtils;
 import net.minestom.server.utils.block.BlockIterator;

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityVelocityPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityVelocityPacket.java
@@ -1,9 +1,11 @@
 package net.minestom.server.network.packet.server.play;
 
+import net.minestom.server.MinecraftServer;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.MathUtils;
 import org.jetbrains.annotations.NotNull;
 
 import static net.minestom.server.network.NetworkBuffer.SHORT;
@@ -11,13 +13,17 @@ import static net.minestom.server.network.NetworkBuffer.VAR_INT;
 
 public record EntityVelocityPacket(int entityId, short velocityX, short velocityY,
                                    short velocityZ) implements ServerPacket {
-
     public EntityVelocityPacket(@NotNull NetworkBuffer reader) {
         this(reader.read(VAR_INT), reader.read(SHORT), reader.read(SHORT), reader.read(SHORT));
     }
 
     public EntityVelocityPacket(int entityId, Point velocity) {
-        this(entityId, (short) velocity.x(), (short) velocity.y(), (short) velocity.z());
+        this(
+                entityId,
+                (short) MathUtils.clamp(velocity.x(), Short.MIN_VALUE, Short.MAX_VALUE),
+                (short) MathUtils.clamp(velocity.y(), Short.MIN_VALUE, Short.MAX_VALUE),
+                (short) MathUtils.clamp(velocity.z(), Short.MIN_VALUE, Short.MAX_VALUE)
+        );
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityVelocityPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityVelocityPacket.java
@@ -4,33 +4,28 @@ import net.minestom.server.coordinate.Point;
 import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
-import net.minestom.server.utils.MathUtils;
 import org.jetbrains.annotations.NotNull;
 
 import static net.minestom.server.network.NetworkBuffer.SHORT;
 import static net.minestom.server.network.NetworkBuffer.VAR_INT;
 
-public record EntityVelocityPacket(int entityId, int velocityX, int velocityY, int velocityZ) implements ServerPacket {
-    public EntityVelocityPacket {
-        velocityX = MathUtils.clamp(velocityX, Short.MIN_VALUE, Short.MAX_VALUE);
-        velocityY = MathUtils.clamp(velocityY, Short.MIN_VALUE, Short.MAX_VALUE);
-        velocityZ = MathUtils.clamp(velocityZ, Short.MIN_VALUE, Short.MAX_VALUE);
-    }
+public record EntityVelocityPacket(int entityId, short velocityX, short velocityY,
+                                   short velocityZ) implements ServerPacket {
 
     public EntityVelocityPacket(@NotNull NetworkBuffer reader) {
-        this(reader.read(VAR_INT), (int) reader.read(SHORT), (int) reader.read(SHORT), (int) reader.read(SHORT));
+        this(reader.read(VAR_INT), reader.read(SHORT), reader.read(SHORT), reader.read(SHORT));
     }
 
     public EntityVelocityPacket(int entityId, Point velocity) {
-        this(entityId, (int) velocity.x(), (int) velocity.y(), (int) velocity.z());
+        this(entityId, (short) velocity.x(), (short) velocity.y(), (short) velocity.z());
     }
 
     @Override
     public void write(@NotNull NetworkBuffer writer) {
         writer.write(VAR_INT, entityId);
-        writer.write(SHORT, (short) velocityX);
-        writer.write(SHORT, (short) velocityY);
-        writer.write(SHORT, (short) velocityZ);
+        writer.write(SHORT, velocityX);
+        writer.write(SHORT, velocityY);
+        writer.write(SHORT, velocityZ);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityVelocityPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityVelocityPacket.java
@@ -4,27 +4,33 @@ import net.minestom.server.coordinate.Point;
 import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
+import net.minestom.server.utils.MathUtils;
 import org.jetbrains.annotations.NotNull;
 
 import static net.minestom.server.network.NetworkBuffer.SHORT;
 import static net.minestom.server.network.NetworkBuffer.VAR_INT;
 
-public record EntityVelocityPacket(int entityId, short velocityX, short velocityY,
-                                   short velocityZ) implements ServerPacket {
+public record EntityVelocityPacket(int entityId, int velocityX, int velocityY, int velocityZ) implements ServerPacket {
+    public EntityVelocityPacket {
+        velocityX = MathUtils.clamp(velocityX, Short.MIN_VALUE, Short.MAX_VALUE);
+        velocityY = MathUtils.clamp(velocityY, Short.MIN_VALUE, Short.MAX_VALUE);
+        velocityZ = MathUtils.clamp(velocityZ, Short.MIN_VALUE, Short.MAX_VALUE);
+    }
+
     public EntityVelocityPacket(@NotNull NetworkBuffer reader) {
         this(reader.read(VAR_INT), reader.read(SHORT), reader.read(SHORT), reader.read(SHORT));
     }
 
     public EntityVelocityPacket(int entityId, Point velocity) {
-        this(entityId, (short) velocity.x(), (short) velocity.y(), (short) velocity.z());
+        this(entityId, (int) velocity.x(), (int) velocity.y(), (int) velocity.z());
     }
 
     @Override
     public void write(@NotNull NetworkBuffer writer) {
         writer.write(VAR_INT, entityId);
-        writer.write(SHORT, velocityX);
-        writer.write(SHORT, velocityY);
-        writer.write(SHORT, velocityZ);
+        writer.write(SHORT, (short) velocityX);
+        writer.write(SHORT, (short) velocityY);
+        writer.write(SHORT, (short) velocityZ);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityVelocityPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityVelocityPacket.java
@@ -1,6 +1,5 @@
 package net.minestom.server.network.packet.server.play;
 
-import net.minestom.server.MinecraftServer;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.packet.server.ServerPacket;

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityVelocityPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityVelocityPacket.java
@@ -18,7 +18,7 @@ public record EntityVelocityPacket(int entityId, int velocityX, int velocityY, i
     }
 
     public EntityVelocityPacket(@NotNull NetworkBuffer reader) {
-        this(reader.read(VAR_INT), reader.read(SHORT), reader.read(SHORT), reader.read(SHORT));
+        this(reader.read(VAR_INT), (int) reader.read(SHORT), (int) reader.read(SHORT), (int) reader.read(SHORT));
     }
 
     public EntityVelocityPacket(int entityId, Point velocity) {


### PR DESCRIPTION
Changed "short" params to "int" to have a safe constructor. Limiting to a short minimum and maximum will help us to prevent unsafe values after surpassing the short minimum and maximum.

Tested with the default game environment and everything works well. (passed all tests from EntityVelocityIntegrationTest except knockback tests which shouldn't be that predictable, IMO.)
![image](https://user-images.githubusercontent.com/45916622/204843756-b10a58ea-ff11-4d7b-b038-bd623384028f.png)