### PR TITLE
Improve consistency of team packets

### DIFF
--- a/src/main/java/net/minestom/server/network/packet/server/play/TeamsPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/TeamsPacket.java
@@ -170,7 +170,7 @@ public record TeamsPacket(String teamName, Action action) implements ComponentHo
         }
     }
 
-    public record AddEntitiesToTeamAction(Collection<String> entities) implements Action {
+    public record AddEntitiesToTeamAction(@NotNull Collection<@NotNull String> entities) implements Action {
         public AddEntitiesToTeamAction {
             entities = List.copyOf(entities);
         }
@@ -190,7 +190,7 @@ public record TeamsPacket(String teamName, Action action) implements ComponentHo
         }
     }
 
-    public record RemoveEntitiesToTeamAction(@NotNull List<@NotNull String> entities) implements Action {
+    public record RemoveEntitiesToTeamAction(@NotNull Collection<@NotNull String> entities) implements Action {
         public RemoveEntitiesToTeamAction {
             entities = List.copyOf(entities);
         }

--- a/src/main/java/net/minestom/server/scoreboard/Team.java
+++ b/src/main/java/net/minestom/server/scoreboard/Team.java
@@ -103,13 +103,26 @@ public class Team implements PacketGroupingAudience {
     /**
      * Adds a member to the {@link Team}.
      * <br>
-     * This member can be a {@link Player} or an {@link LivingEntity}.
+     * This member collection can contain {@link Player} or {@link LivingEntity}.
+     * For players use their username, for entities use their UUID
      *
      * @param member The member to be added
      */
     public void addMember(@NotNull String member) {
+        addMembers(List.of(member));
+    }
+
+    /**
+     * Adds a members to the {@link Team}.
+     * <br>
+     * This member collection can contain {@link Player} or {@link LivingEntity}.
+     * For players use their username, for entities use their UUID
+     *
+     * @param members The members to be added
+     */
+    public void addMembers(@NotNull Collection<@NotNull String> members) {
         // Adds a new member to the team
-        this.members.add(member);
+        this.members.addAll(members);
 
         // Initializes add player packet
         final TeamsPacket addPlayerPacket = new TeamsPacket(teamName,
@@ -123,18 +136,33 @@ public class Team implements PacketGroupingAudience {
 
     /**
      * Removes a member from the {@link Team}.
+     * <br>
+     * This member collection can contain {@link Player} or {@link LivingEntity}.
+     * For players use their username, for entities use their UUID
      *
      * @param member The member to be removed
      */
     public void removeMember(@NotNull String member) {
+        removeMembers(List.of(member));
+    }
+
+    /**
+     * Removes members from the {@link Team}.
+     * <br>
+     * This member collection can contain {@link Player} or {@link LivingEntity}.
+     * For players use their username, for entities use their UUID
+     *
+     * @param members The members to be removed
+     */
+    public void removeMembers(@NotNull Collection<@NotNull String> members) {
         // Initializes remove player packet
         final TeamsPacket removePlayerPacket = new TeamsPacket(teamName,
-                new TeamsPacket.RemoveEntitiesToTeamAction(List.of(member)));
-        // Sends to all online player teh remove player packet
+                new TeamsPacket.RemoveEntitiesToTeamAction(members));
+        // Sends to all online player the remove player packet
         PacketUtils.broadcastPacket(removePlayerPacket);
 
         // Removes the member from the team
-        this.members.remove(member);
+        this.members.removeAll(members);
 
         // invalidate player members
         this.isPlayerMembersUpToDate = false;

--- a/src/main/java/net/minestom/server/scoreboard/Team.java
+++ b/src/main/java/net/minestom/server/scoreboard/Team.java
@@ -118,15 +118,15 @@ public class Team implements PacketGroupingAudience {
      * This member collection can contain {@link Player} or {@link LivingEntity}.
      * For players use their username, for entities use their UUID
      *
-     * @param members The members to be added
+     * @param toAdd The members to be added
      */
-    public void addMembers(@NotNull Collection<@NotNull String> members) {
+    public void addMembers(@NotNull Collection<@NotNull String> toAdd) {
         // Adds a new member to the team
-        this.members.addAll(members);
+        this.members.addAll(toAdd);
 
         // Initializes add player packet
         final TeamsPacket addPlayerPacket = new TeamsPacket(teamName,
-                new TeamsPacket.AddEntitiesToTeamAction(members));
+                new TeamsPacket.AddEntitiesToTeamAction(toAdd));
         // Sends to all online players the add player packet
         PacketUtils.broadcastPacket(addPlayerPacket);
 
@@ -152,17 +152,17 @@ public class Team implements PacketGroupingAudience {
      * This member collection can contain {@link Player} or {@link LivingEntity}.
      * For players use their username, for entities use their UUID
      *
-     * @param members The members to be removed
+     * @param toRemove The members to be removed
      */
-    public void removeMembers(@NotNull Collection<@NotNull String> members) {
+    public void removeMembers(@NotNull Collection<@NotNull String> toRemove) {
         // Initializes remove player packet
         final TeamsPacket removePlayerPacket = new TeamsPacket(teamName,
-                new TeamsPacket.RemoveEntitiesToTeamAction(members));
+                new TeamsPacket.RemoveEntitiesToTeamAction(toRemove));
         // Sends to all online player the remove player packet
         PacketUtils.broadcastPacket(removePlayerPacket);
 
         // Removes the member from the team
-        this.members.removeAll(members);
+        this.members.removeAll(toRemove);
 
         // invalidate player members
         this.isPlayerMembersUpToDate = false;


### PR DESCRIPTION
- Add a way to add/remove multiple entities from teams
- Reduce packet size of `TeamsPacket.AddEntitiesToTeamAction`