### PR TITLE
Fix incorrect lectern inventory size

### DIFF
--- a/src/main/java/net/minestom/server/inventory/InventoryType.java
+++ b/src/main/java/net/minestom/server/inventory/InventoryType.java
@@ -21,7 +21,7 @@ public enum InventoryType {
     FURNACE(3),
     GRINDSTONE(3),
     HOPPER(5),
-    LECTERN(0),
+    LECTERN(1),
     LOOM(4),
     MERCHANT(3),
     SHULKER_BOX(27),


### PR DESCRIPTION
Fixes incorrect lectern inventory size.
This additional slot is a hidden "book" slot, holding the book that is open in the lectern.
This slot exists according to recent MC source code, and to wiki.vg & Spigot.
