### PR TITLE
Fix incorrect arrow no clip mask bit

### DIFF
--- a/src/main/java/net/minestom/server/entity/metadata/arrow/AbstractArrowMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/arrow/AbstractArrowMeta.java
@@ -10,7 +10,7 @@ public class AbstractArrowMeta extends EntityMeta {
     public static final byte MAX_OFFSET = OFFSET + 2;
 
     private final static byte CRITICAL_BIT = 0x01;
-    private final static byte NO_CLIP_BIT = 0x01;
+    private final static byte NO_CLIP_BIT = 0x02;
 
     protected AbstractArrowMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
         super(entity, metadata);


### PR DESCRIPTION
`NO_CLIP_BIT` in `AbstractArrowMeta` should be `0x02` but is currently `0x01`.