### PR TITLE
Add lightEmission to BlockEntry

### DIFF
--- a/src/main/java/net/minestom/server/registry/Registry.java
+++ b/src/main/java/net/minestom/server/registry/Registry.java
@@ -169,6 +169,7 @@ public final class Registry {
         private final boolean air;
         private final boolean solid;
         private final boolean liquid;
+        private final int lightEmission;
         private final String blockEntity;
         private final int blockEntityId;
         private final Supplier<Material> materialSupplier;
@@ -189,6 +190,7 @@ public final class Registry {
             this.air = main.getBoolean("air", false);
             this.solid = main.getBoolean("solid");
             this.liquid = main.getBoolean("liquid", false);
+            this.lightEmission = main.getInt("lightEmission", 0);
             {
                 Properties blockEntity = main.section("blockEntity");
                 if (blockEntity != null) {
@@ -255,6 +257,10 @@ public final class Registry {
 
         public boolean isLiquid() {
             return liquid;
+        }
+
+        public int lightEmission() {
+            return lightEmission;
         }
 
         public boolean isBlockEntity() {


### PR DESCRIPTION
There is currently no way to get the `lightEmission` value from the current implementation of `BlockEntry` from what I've seen.
