### PR TITLE
Minor Property Tweaks

### DIFF
--- a/src/main/java/net/minestom/server/extensions/ExtensionManager.java
+++ b/src/main/java/net/minestom/server/extensions/ExtensionManager.java
@@ -37,7 +37,7 @@ public class ExtensionManager {
     private final Map<String, Extension> extensions = new LinkedHashMap<>();
     private final Map<String, Extension> immutableExtensions = Collections.unmodifiableMap(extensions);
 
-    private final File extensionFolder = new File(PropertyUtils.getString("minestom.extension.folder", "extensions"));
+    private final File extensionFolder = new File(System.getProperty("minestom.extension.folder", "extensions"));
     private final File dependenciesFolder = new File(extensionFolder, ".libs");
     private Path extensionDataRoot = extensionFolder.toPath();
 

--- a/src/main/java/net/minestom/server/extensions/ExtensionManager.java
+++ b/src/main/java/net/minestom/server/extensions/ExtensionManager.java
@@ -5,7 +5,6 @@ import net.minestom.dependencies.DependencyGetter;
 import net.minestom.dependencies.ResolvedDependency;
 import net.minestom.dependencies.maven.MavenRepository;
 import net.minestom.server.ServerProcess;
-import net.minestom.server.utils.PropertyUtils;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/net/minestom/server/instance/WorldBorder.java
+++ b/src/main/java/net/minestom/server/instance/WorldBorder.java
@@ -27,7 +27,7 @@ public class WorldBorder {
     private long lerpStartTime;
 
     private long speed;
-    private int portalTeleportBoundary;
+    private final int portalTeleportBoundary;
     private int warningTime;
     private int warningBlocks;
 
@@ -39,8 +39,7 @@ public class WorldBorder {
 
         this.speed = 0;
 
-        this.portalTeleportBoundary = 29999984;
-
+        this.portalTeleportBoundary = Integer.getInteger("minestom.world-border-size", 29999984);
     }
 
     /**

--- a/src/main/java/net/minestom/server/utils/PropertyUtils.java
+++ b/src/main/java/net/minestom/server/utils/PropertyUtils.java
@@ -1,9 +1,6 @@
 package net.minestom.server.utils;
 
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
 public final class PropertyUtils {

--- a/src/main/java/net/minestom/server/utils/PropertyUtils.java
+++ b/src/main/java/net/minestom/server/utils/PropertyUtils.java
@@ -1,6 +1,9 @@
 package net.minestom.server.utils;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
 public final class PropertyUtils {
@@ -14,5 +17,10 @@ public final class PropertyUtils {
         } catch (IllegalArgumentException | NullPointerException ignored) {
         }
         return result;
+    }
+
+    @Contract("_, null -> null; _, !null -> !null")
+    public static String getString(@NotNull String name, @Nullable String defaultValue) {
+        return System.getProperty(name, defaultValue);
     }
 }

--- a/src/main/java/net/minestom/server/utils/PropertyUtils.java
+++ b/src/main/java/net/minestom/server/utils/PropertyUtils.java
@@ -18,15 +18,4 @@ public final class PropertyUtils {
         }
         return result;
     }
-
-    @Contract("_, null -> null; _, !null -> !null")
-    public static String getString(@NotNull String name, @Nullable String defaultValue) {
-        final String value = System.getProperty(name);
-
-        if (value == null) {
-            return defaultValue;
-        } else {
-            return value;
-        }
-    }
 }


### PR DESCRIPTION
This PR:

- Adds the ability to customize the maximum border with a System Property (`minestom.world-border-size`)
- Changes the properties call in ExtensionManager, as there is a native Java method to supply a default value when retrieving a System Property
- Changes the `getString` method in PropertyUtils to use the native Java method.



Closes #1171. 