### PR TITLE
Update FakePlayer.java

### DIFF
--- a/src/main/java/net/minestom/server/entity/fakeplayer/FakePlayer.java
+++ b/src/main/java/net/minestom/server/entity/fakeplayer/FakePlayer.java
@@ -6,6 +6,7 @@ import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.Player;
 import net.minestom.server.entity.pathfinding.NavigableEntity;
 import net.minestom.server.entity.pathfinding.Navigator;
+import net.minestom.server.event.Event;
 import net.minestom.server.event.EventListener;
 import net.minestom.server.event.player.PlayerSpawnEvent;
 import net.minestom.server.instance.Instance;
@@ -37,6 +38,8 @@ public class FakePlayer extends Player implements NavigableEntity {
 
     private final Navigator navigator = new Navigator(this);
 
+    private EventListener<PlayerSpawnEvent> spawnListener;
+
     /**
      * Initializes a new {@link FakePlayer} with the given {@code uuid}, {@code username} and {@code option}'s.
      *
@@ -54,17 +57,16 @@ public class FakePlayer extends Player implements NavigableEntity {
         this.fakePlayerController = new FakePlayerController(this);
 
         if (spawnCallback != null) {
-            // FIXME
-            MinecraftServer.getGlobalEventHandler().addListener(
-                    EventListener.builder(PlayerSpawnEvent.class)
-                            .expireCount(1)
-                            .handler(event -> {
-                                if (event.isFirstSpawn()) {
-                                    spawnCallback.accept(this);
-                                }
-                            }).build());
+            spawnListener = EventListener.builder(PlayerSpawnEvent.class)
+                    .handler(event -> {
+                        if (event.getPlayer().equals(this))
+                            if (event.isFirstSpawn()) {
+                                spawnCallback.accept(this);
+                                MinecraftServer.getGlobalEventHandler().removeListener(spawnListener);
+                            }
+                    }).build();
+            MinecraftServer.getGlobalEventHandler().addListener(spawnListener);
         }
-
         CONNECTION_MANAGER.startPlayState(this, option.isRegistered());
     }
 


### PR DESCRIPTION
Fixed problem with unresponsive spawnCallback

the following code block did not work, for example.

Because the old listener was deleted directly after a player was joined.
```java
      globalEventHandler.addListener(AddEntityToInstanceEvent.class, event -> {
            if(event.getEntity() instanceof FakePlayer) return;
            FakePlayer.initPlayer(UUID.randomUUID(), "Name", fakePlayer -> {
                Player player = (Player) event.getEntity();
                player.sendMessage("INTI!");
            });
        });
```