### PR TITLE
Fix player dimension packages

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -251,7 +251,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
                 "minecraft:dimension_type", MinecraftServer.getDimensionTypeManager().toNBT(),
                 "minecraft:worldgen/biome", MinecraftServer.getBiomeManager().toNBT()));
         final JoinGamePacket joinGamePacket = new JoinGamePacket(getEntityId(), false, gameMode, null,
-                List.of("minestom:world"), nbt, dimensionType.toString(), "minestom:world",
+                List.of(dimensionType.getName().asString()), nbt, dimensionType.toString(), dimensionType.getName().asString(),
                 0, 0, MinecraftServer.getChunkViewDistance(), MinecraftServer.getChunkViewDistance(),
                 false, true, false, levelFlat);
         sendPacket(joinGamePacket);
@@ -964,7 +964,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         final PlayerInfoPacket removePlayerPacket = getRemovePlayerToList();
         final PlayerInfoPacket addPlayerPacket = getAddPlayerToList();
 
-        RespawnPacket respawnPacket = new RespawnPacket(getDimensionType().toString(), "minestom:world",
+        RespawnPacket respawnPacket = new RespawnPacket(getDimensionType().toString(), getDimensionType().getName().asString(),
                 0, gameMode, gameMode, false, levelFlat, true);
 
         sendPacket(removePlayerPacket);
@@ -1337,7 +1337,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         Check.argCondition(dimensionType.equals(getDimensionType()),
                 "The dimension needs to be different than the current one!");
         this.dimensionType = dimensionType;
-        sendPacket(new RespawnPacket(dimensionType.toString(), "minestom:world",
+        sendPacket(new RespawnPacket(dimensionType.toString(), getDimensionType().getName().asString(),
                 0, gameMode, gameMode, false, levelFlat, true));
         refreshClientStateAfterRespawn();
     }


### PR DESCRIPTION
The initial setup did not work due to the fact that the server, when changing the instance, transmitted a dimension named `"minestom:world"`, which is most likely why the client simply ignored the new information. I don't know if this is correct, but considering that dimension `"minecraft:overworld"` (`DimensionType.OVERWORLD`) is used by default, then using `"minestom:world"` looks wrong.

Initially, I asked a question in discussions (#1615), but I didn't get an answer. Later I realized it was still a bug and opened the problem. No special activity was noticed, so I had to find out for myself why this was happening. And here I am. This is fix #1619.