### PR TITLE
Add getPath function to the anvilloader

### DIFF
--- a/src/main/java/net/minestom/server/instance/AnvilLoader.java
+++ b/src/main/java/net/minestom/server/instance/AnvilLoader.java
@@ -361,7 +361,7 @@ public class AnvilLoader implements IChunkLoader {
         return blockStateId2ObjectCacheTLS.get().computeIfAbsent(block.stateId(), _unused -> new BlockState(block.name(), block.properties()));
     }
 
-    private Path getPath() {
+    public Path getPath() {
         return this.path;
     }
 

--- a/src/main/java/net/minestom/server/instance/AnvilLoader.java
+++ b/src/main/java/net/minestom/server/instance/AnvilLoader.java
@@ -361,6 +361,10 @@ public class AnvilLoader implements IChunkLoader {
         return blockStateId2ObjectCacheTLS.get().computeIfAbsent(block.stateId(), _unused -> new BlockState(block.name(), block.properties()));
     }
 
+    private Path getPath() {
+        return this.path;
+    }
+
     private void save(Chunk chunk, ChunkWriter chunkWriter) {
         final int minY = chunk.getMinSection() * Chunk.CHUNK_SECTION_SIZE;
         final int maxY = chunk.getMaxSection() * Chunk.CHUNK_SECTION_SIZE - 1;

--- a/src/main/java/net/minestom/server/instance/AnvilLoader.java
+++ b/src/main/java/net/minestom/server/instance/AnvilLoader.java
@@ -361,6 +361,7 @@ public class AnvilLoader implements IChunkLoader {
         return blockStateId2ObjectCacheTLS.get().computeIfAbsent(block.stateId(), _unused -> new BlockState(block.name(), block.properties()));
     }
 
+    @NotNull
     public Path getPath() {
         return this.path;
     }


### PR DESCRIPTION
You can now get the path from the anvilloader. This mean that when you set an anvilloader to an instance, you can get the path from the "world" everytime you want.