### PR TITLE
Support dynamic selection of a port using '0'

### DIFF
--- a/src/main/java/net/minestom/server/network/socket/Server.java
+++ b/src/main/java/net/minestom/server/network/socket/Server.java
@@ -63,6 +63,10 @@ public final class Server {
         server.register(selector, SelectionKey.OP_ACCEPT);
         this.serverSocket = server;
         this.socketAddress = address;
+
+        if (address instanceof InetSocketAddress && port == 0) {
+            port = server.socket().getLocalPort();
+        }
     }
 
     @ApiStatus.Internal

--- a/src/test/java/net/minestom/server/network/socket/ServerAddressTest.java
+++ b/src/test/java/net/minestom/server/network/socket/ServerAddressTest.java
@@ -14,12 +14,25 @@ public class ServerAddressTest {
 
     @Test
     public void inetAddressTest() throws IOException {
-        InetSocketAddress address = new InetSocketAddress("localhost", 0);
+        InetSocketAddress address = new InetSocketAddress("localhost", 25565);
         var server = new Server(new PacketProcessor());
         server.init(address);
         assertSame(address, server.socketAddress());
         assertEquals(address.getHostString(), server.getAddress());
         assertEquals(address.getPort(), server.getPort());
+
+        assertDoesNotThrow(server::start);
+        assertDoesNotThrow(server::stop);
+    }
+
+    @Test
+    public void inetAddressDynamicTest() throws IOException {
+        InetSocketAddress address = new InetSocketAddress("localhost", 0);
+        var server = new Server(new PacketProcessor());
+        server.init(address);
+        assertSame(address, server.socketAddress());
+        assertEquals(address.getHostString(), server.getAddress());
+        assertNotEquals(address.getPort(), server.getPort());
 
         assertDoesNotThrow(server::start);
         assertDoesNotThrow(server::stop);


### PR DESCRIPTION
> A port number of zero will let the system pick up an ephemeral port in a bind operation.  

Since minestom just saves the port before the binding process this possibility will never affect the port value, thus the actual port and the saved port are not the same.