### PR TITLE
Add riptide spin attack to ItemUpdateStateEvent

### DIFF
--- a/src/main/java/net/minestom/server/event/item/ItemUpdateStateEvent.java
+++ b/src/main/java/net/minestom/server/event/item/ItemUpdateStateEvent.java
@@ -12,6 +12,7 @@ public class ItemUpdateStateEvent implements PlayerInstanceEvent, ItemEvent {
     private final Player.Hand hand;
     private final ItemStack itemStack;
     private boolean handAnimation;
+    private boolean riptideSpinAttack;
 
     public ItemUpdateStateEvent(@NotNull Player player, @NotNull Player.Hand hand, @NotNull ItemStack itemStack) {
         this.player = player;
@@ -24,12 +25,30 @@ public class ItemUpdateStateEvent implements PlayerInstanceEvent, ItemEvent {
         return hand;
     }
 
+    /**
+     * Sets whether the player should have a hand animation.
+     *
+     * @param handAnimation whether the player should have a hand animation
+     */
     public void setHandAnimation(boolean handAnimation) {
         this.handAnimation = handAnimation;
     }
 
     public boolean hasHandAnimation() {
         return handAnimation;
+    }
+
+    /**
+     * Sets whether the player should have a riptide spin attack animation.
+     *
+     * @param riptideSpinAttack whether the player should have a riptide spin attack animation
+     */
+    public void setRiptideSpinAttack(boolean riptideSpinAttack) {
+        this.riptideSpinAttack = riptideSpinAttack;
+    }
+
+    public boolean isRiptideSpinAttack() {
+        return riptideSpinAttack;
     }
 
     @Override

--- a/src/main/java/net/minestom/server/listener/PlayerDiggingListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerDiggingListener.java
@@ -138,7 +138,8 @@ public final class PlayerDiggingListener {
             player.refreshActiveHand(true, false, false);
         } else {
             final boolean isOffHand = itemUpdateStateEvent.getHand() == Player.Hand.OFF;
-            player.refreshActiveHand(itemUpdateStateEvent.hasHandAnimation(), isOffHand, false);
+            player.refreshActiveHand(itemUpdateStateEvent.hasHandAnimation(),
+                    isOffHand, itemUpdateStateEvent.isRiptideSpinAttack());
         }
     }
 

--- a/src/main/java/net/minestom/server/listener/UseItemListener.java
+++ b/src/main/java/net/minestom/server/listener/UseItemListener.java
@@ -41,7 +41,6 @@ public class UseItemListener {
         }
 
         PlayerItemAnimationEvent.ItemAnimationType itemAnimationType = null;
-        boolean riptideSpinAttack = false;
 
         boolean cancelAnimation = false;
 
@@ -68,7 +67,7 @@ public class UseItemListener {
         if (!cancelAnimation && itemAnimationType != null) {
             PlayerItemAnimationEvent playerItemAnimationEvent = new PlayerItemAnimationEvent(player, itemAnimationType, hand);
             EventDispatcher.callCancellable(playerItemAnimationEvent, () -> {
-                player.refreshActiveHand(true, hand == Player.Hand.OFF, riptideSpinAttack);
+                player.refreshActiveHand(true, hand == Player.Hand.OFF, false);
                 player.sendPacketToViewers(player.getMetadataPacket());
             });
         }


### PR DESCRIPTION
Setting the animation in the event listener had no effect before, because it was immediately undone by `PlayerDiggingListener`