### PR TITLE
Apply GameProfile to players when using Mojang Authenication

### DIFF
--- a/src/main/java/net/minestom/server/network/packet/client/login/EncryptionResponsePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/login/EncryptionResponsePacket.java
@@ -1,7 +1,9 @@
 package net.minestom.server.network.packet.client.login;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import net.kyori.adventure.text.Component;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.crypto.SaltSignaturePair;
 import net.minestom.server.crypto.SignatureValidator;
@@ -9,6 +11,7 @@ import net.minestom.server.extras.MojangAuth;
 import net.minestom.server.extras.mojangAuth.MojangCrypt;
 import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.packet.client.ClientPreplayPacket;
+import net.minestom.server.network.player.GameProfile;
 import net.minestom.server.network.player.PlayerConnection;
 import net.minestom.server.network.player.PlayerSocketConnection;
 import net.minestom.server.utils.Either;
@@ -25,7 +28,9 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 
 import static net.minestom.server.network.NetworkBuffer.*;
@@ -84,14 +89,22 @@ public record EncryptionResponsePacket(byte[] sharedSecret,
             client.sendAsync(request, HttpResponse.BodyHandlers.ofString()).whenComplete((response, throwable) -> {
                 if (throwable != null) {
                     MinecraftServer.getExceptionManager().handleException(throwable);
-                    //todo disconnect with reason
+                    if (socketConnection.getPlayer() != null) {
+                        socketConnection.getPlayer().kick(Component.text("Failed to contact Mojang's Session Servers (Are they down?)"));
+                    } else {
+                        socketConnection.disconnect();
+                    }
                     return;
                 }
                 try {
                     final JsonObject gameProfile = GSON.fromJson(response.body(), JsonObject.class);
                     if (gameProfile == null) {
                         // Invalid response
-                        //todo disconnect with reason
+                        if (socketConnection.getPlayer() != null) {
+                            socketConnection.getPlayer().kick(Component.text("Failed to get data from Mojang's Session Servers (Are they down?)"));
+                        } else {
+                            socketConnection.disconnect();
+                        }
                         return;
                     }
                     socketConnection.setEncryptionKey(getSecretKey());
@@ -101,6 +114,12 @@ public record EncryptionResponsePacket(byte[] sharedSecret,
 
                     MinecraftServer.LOGGER.info("UUID of player {} is {}", loginUsername, profileUUID);
                     CONNECTION_MANAGER.startPlayState(connection, profileUUID, profileName, true);
+                    List<GameProfile.Property> propertyList = new ArrayList<>();
+                    for (JsonElement element : gameProfile.get("properties").getAsJsonArray()) {
+                        JsonObject object = element.getAsJsonObject();
+                        propertyList.add(new GameProfile.Property(object.get("name").getAsString(), object.get("value").getAsString(), object.get("signature").getAsString()));
+                    }
+                    socketConnection.UNSAFE_setProfile(new GameProfile(profileUUID, profileName, propertyList));
                 } catch (Exception e) {
                     MinecraftServer.getExceptionManager().handleException(e);
                 }


### PR DESCRIPTION
Resolves #1695. 

Now applies the GameProfile to players when using Mojang Authentication, and cleans up a few todos.

~~Currently a draft PR as I have not tested this yet.~~

Testing complete, this now properly sets the Game Profile for players.