### PR TITLE
Add playerblockhit event

### DIFF
--- a/src/main/java/net/minestom/server/event/player/PlayerBlockHitEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerBlockHitEvent.java
@@ -1,0 +1,77 @@
+package net.minestom.server.event.player;
+
+import net.minestom.server.coordinate.Point;
+import net.minestom.server.entity.Player;
+import net.minestom.server.event.trait.BlockEvent;
+import net.minestom.server.event.trait.CancellableEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
+import net.minestom.server.instance.block.Block;
+import net.minestom.server.instance.block.BlockFace;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called when a {@link Player} hits a block (left-click).
+ * <p>
+ * It's called right before {@link PlayerStartDiggingEvent} or {@link PlayerBlockBreakEvent}
+ * if the player is in Creative mode.
+ */
+public class PlayerBlockHitEvent implements PlayerInstanceEvent, BlockEvent, CancellableEvent {
+
+    private final Player player;
+    private final Block block;
+    private final Point blockPosition;
+    private final BlockFace blockFace;
+
+    private boolean cancelled;
+
+    public PlayerBlockHitEvent(@NotNull Player player, @NotNull Block block, @NotNull Point blockPosition,
+                               @NotNull BlockFace blockFace) {
+        this.player = player;
+        this.block = block;
+        this.blockPosition = blockPosition;
+        this.blockFace = blockFace;
+    }
+
+    /**
+     * Gets the block which is being hit.
+     *
+     * @return the block
+     */
+    @Override
+    public @NotNull Block getBlock() {
+        return block;
+    }
+
+    /**
+     * Gets the block position.
+     *
+     * @return the block position
+     */
+    public @NotNull Point getBlockPosition() {
+        return blockPosition;
+    }
+
+    /**
+     * Gets the face you are hitting
+     *
+     * @return the block face
+     */
+    public @NotNull BlockFace getBlockFace() {
+        return blockFace;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public @NotNull Player getPlayer() {
+        return player;
+    }
+}

--- a/src/main/java/net/minestom/server/listener/PlayerDiggingListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerDiggingListener.java
@@ -7,6 +7,7 @@ import net.minestom.server.entity.Player;
 import net.minestom.server.entity.metadata.PlayerMeta;
 import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.item.ItemUpdateStateEvent;
+import net.minestom.server.event.player.PlayerBlockHitEvent;
 import net.minestom.server.event.player.PlayerStartDiggingEvent;
 import net.minestom.server.event.player.PlayerSwapItemEvent;
 import net.minestom.server.instance.Instance;
@@ -55,6 +56,12 @@ public final class PlayerDiggingListener {
     private static DiggingResult startDigging(Player player, Instance instance, Point blockPosition, BlockFace blockFace) {
         final Block block = instance.getBlock(blockPosition);
         final GameMode gameMode = player.getGameMode();
+
+        PlayerBlockHitEvent playerBlockHitEvent = new PlayerBlockHitEvent(player, block, blockPosition, blockFace);
+        EventDispatcher.call(playerBlockHitEvent);
+        if (playerBlockHitEvent.isCancelled()) {
+            return new DiggingResult(block, false);
+        }
 
         // Prevent spectators and check players in adventure mode
         if (shouldPreventBreaking(player, block)) {

--- a/src/main/java/net/minestom/server/listener/PlayerDiggingListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerDiggingListener.java
@@ -57,14 +57,14 @@ public final class PlayerDiggingListener {
         final Block block = instance.getBlock(blockPosition);
         final GameMode gameMode = player.getGameMode();
 
-        PlayerBlockHitEvent playerBlockHitEvent = new PlayerBlockHitEvent(player, block, blockPosition, blockFace);
-        EventDispatcher.call(playerBlockHitEvent);
-        if (playerBlockHitEvent.isCancelled()) {
+        // Prevent spectators and check players in adventure mode
+        if (shouldPreventBreaking(player, block)) {
             return new DiggingResult(block, false);
         }
 
-        // Prevent spectators and check players in adventure mode
-        if (shouldPreventBreaking(player, block)) {
+        PlayerBlockHitEvent playerBlockHitEvent = new PlayerBlockHitEvent(player, block, blockPosition, blockFace);
+        EventDispatcher.call(playerBlockHitEvent);
+        if (playerBlockHitEvent.isCancelled()) {
             return new DiggingResult(block, false);
         }
 


### PR DESCRIPTION
Adds a new event fired when a player hits a block (left click).

Currently PlayerBlockInteractEvent only handles right clicks, to listen to left clicks one should use PlayerStartDiggingEvent, however, that event is only fired when players don't have instant break (i.e. creative).
There are then 2 workarounds for this:
1 - Listen for PlayerBlockInteractEvent and PlayerBlockBreakEvent checking for instabreak
2 - Create your own packet listener and intercept the packet and fire a custom event from your extension

This PR aims to simplify this process and simply handle everything with a PlayerBlockHitEvent that is structured similarly to PlayerStartDiggingEvent (same fields) but that has a more precise name and is fired before everything else.

Use cases could be for example WorldEdit using left click interactions to manage selections