### PR TITLE
Add support for relative teleportation

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -444,7 +444,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         setOnFire(false);
         refreshHealth();
         sendPacket(new RespawnPacket(getDimensionType().toString(), getDimensionType().getName().asString(),
-               0, gameMode, gameMode, false, levelFlat, true));
+                0, gameMode, gameMode, false, levelFlat, true));
 
         PlayerRespawnEvent respawnEvent = new PlayerRespawnEvent(this);
         EventDispatcher.call(respawnEvent);
@@ -1531,16 +1531,28 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         this.receivedTeleportId = receivedTeleportId;
     }
 
+    @Override
+    protected void synchronizePosition(boolean includeSelf) {
+        synchronizePosition(includeSelf, false);
+    }
+
     /**
-     * @see Entity#synchronizePosition(boolean)
+     * @see Entity#synchronizePosition(boolean, boolean)
      */
     @Override
     @ApiStatus.Internal
-    protected void synchronizePosition(boolean includeSelf) {
+    protected void synchronizePosition(boolean includeSelf, boolean relativePosition) {
         if (includeSelf) {
-            sendPacket(new PlayerPositionAndLookPacket(position, (byte) 0x00, getNextTeleportId(), false));
+            Pos pos = position;
+            byte flag = PlayerPositionAndLookPacket.FLAG_ABSOLUTE;
+            if (relativePosition) {
+                pos = position.sub(previousPosition)
+                        .withView(position.yaw() - previousPosition.yaw(), position.pitch() - previousPosition.pitch());
+                flag = PlayerPositionAndLookPacket.FLAG_RELATIVE;
+            }
+            sendPacket(new PlayerPositionAndLookPacket(pos, flag, getNextTeleportId(), false));
         }
-        super.synchronizePosition(includeSelf);
+        super.synchronizePosition(includeSelf, relativePosition);
     }
 
     /**

--- a/src/main/java/net/minestom/server/network/packet/server/play/PlayerPositionAndLookPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/PlayerPositionAndLookPacket.java
@@ -10,6 +10,24 @@ import static net.minestom.server.network.NetworkBuffer.*;
 
 public record PlayerPositionAndLookPacket(Pos position, byte flags, int teleportId,
                                           boolean dismountVehicle) implements ServerPacket {
+
+    // Bitfield from https://wiki.vg/Protocol#Synchronize_Player_Position
+    private static final byte FLAG_RELATIVE_X = 0x01;
+    private static final byte FLAG_RELATIVE_Y = 0x02;
+    private static final byte FLAG_RELATIVE_Z = 0x04;
+    private static final byte FLAG_RELATIVE_Y_ROT = 0x08;
+    private static final byte FLAG_RELATIVE_X_ROT = 0x10;
+    /**
+     * Used to declare that the given coordinates are relative to the player's position.
+     */
+    public static final byte FLAG_RELATIVE =
+            FLAG_RELATIVE_X | FLAG_RELATIVE_Y | FLAG_RELATIVE_Z | FLAG_RELATIVE_Y_ROT | FLAG_RELATIVE_X_ROT;
+    /**
+     * Used to declare that the given coordinates are absolute.
+     */
+    public static final byte FLAG_ABSOLUTE = 0x0;
+
+
     public PlayerPositionAndLookPacket(@NotNull NetworkBuffer reader) {
         this(new Pos(reader.read(DOUBLE), reader.read(DOUBLE), reader.read(DOUBLE), reader.read(FLOAT), reader.read(FLOAT)),
                 reader.read(BYTE), reader.read(VAR_INT), reader.read(BOOLEAN));


### PR DESCRIPTION
A different and simplified approach to #1273

This PR aims to provide a way to teleport an entity using relative coordinates, the true benefit is actually seen when used on players as setting the flags as relative (see https://wiki.vg/Protocol#Synchronize_Player_Position) has the additional effect of making the client retain its state such as its velocity as opposed to the typical teleportation which resets it.

This is a compromise of the original PR which in my opinion was a bit overcomplicated allowing full control of which coordinates should be considered relative/absolute, I do believe that in the typical use case you'd either decide to specify a position fully absolute or fully relative and not something mixed.

The internal method Entity#synchronizePosition(boolean includeSelf, boolean relativePosition) now has an additional parameter to switch to this new behavior, I'm not a fan but that's the way includeSelf was already handled (only Player actually makes use of it) so I followed along.