### PR TITLE
Add Point#isPointWithinRange for range checks

### DIFF
--- a/src/main/java/net/minestom/server/coordinate/Point.java
+++ b/src/main/java/net/minestom/server/coordinate/Point.java
@@ -227,13 +227,28 @@ public sealed interface Point permits Vec, Pos {
     }
 
     /**
-     * Checks it two points have similar (x/y/z).
+     * Checks if two points have similar (x/y/z).
      *
      * @param point the point to compare
      * @return true if the two positions are similar
      */
     default boolean samePoint(@NotNull Point point) {
         return samePoint(point.x(), point.y(), point.z());
+    }
+
+    default boolean isWithin(double x, double y, double z, double range) {
+        return distanceSquared(x, y, z) <= range * range;
+    }
+
+    /**
+     * Checks if two points are within a given distance range from each other.
+     *
+     * @param point the other point
+     * @param range the maximum distance
+     * @return true if within range, false otherwise
+     */
+    default boolean isWithin(@NotNull Point point, double range) {
+        return isWithin(point.x(), point.y(), point.z(), range);
     }
 
     /**

--- a/src/main/java/net/minestom/server/coordinate/Point.java
+++ b/src/main/java/net/minestom/server/coordinate/Point.java
@@ -236,7 +236,7 @@ public sealed interface Point permits Vec, Pos {
         return samePoint(point.x(), point.y(), point.z());
     }
 
-    default boolean isWithin(double x, double y, double z, double range) {
+    default boolean isPointWithinRange(double x, double y, double z, double range) {
         return distanceSquared(x, y, z) <= range * range;
     }
 
@@ -247,8 +247,8 @@ public sealed interface Point permits Vec, Pos {
      * @param range the maximum distance
      * @return true if within range, false otherwise
      */
-    default boolean isWithin(@NotNull Point point, double range) {
-        return isWithin(point.x(), point.y(), point.z(), range);
+    default boolean isPointWithinRange(@NotNull Point point, double range) {
+        return isPointWithinRange(point.x(), point.y(), point.z(), range);
     }
 
     /**


### PR DESCRIPTION
This PR adds 2 util methods to the interface Point.
Motivation:
Distance checks, at least from experience, are mostly used to check if some position is within (or outside) a given range from another position.
Adding a dedicated method would not only make code more readable 
```java
if(playerPos.isWithin(spawnPos, 10)){
   // Stuff
}
```
as opposed to
```java
if(playerPos.distanceSquared(spawnPos) <= 10*10){
   // Stuff
}
```
But it would also have a performance benefit since it would be internally using distanceSquared() instead of distance() which is one of the most common "mistakes" made by beginners that don't know the performance implications of distance()

Other possible names for such a method that I could think of are isNearby, isClose, isInRange.