### PR TITLE
Improve PlacementRules

### DIFF
--- a/src/main/java/net/minestom/server/extras/PlacementRules.java
+++ b/src/main/java/net/minestom/server/extras/PlacementRules.java
@@ -10,6 +10,13 @@ import net.minestom.server.instance.block.rule.vanilla.WallPlacementRule;
 
 public final class PlacementRules {
 
+    /**
+     * Register all the block placement rules supported:
+     * - axis blocks (logs, hay block, etc)
+     * - stairs
+     * - walls
+     * - redstone dust
+     */
     public static void init() {
         initAxisBlocks();
         initStairs();
@@ -17,6 +24,10 @@ public final class PlacementRules {
         initRedstone();
     }
 
+    /**
+     * Register all the blocks that support axis placement (logs, hay block, etc)
+     * using {@link AxisPlacementRule}.
+     */
     public static void initAxisBlocks() {
         BlockManager blockManager = MinecraftServer.getBlockManager();
         for (Block block : Block.values()) {
@@ -26,6 +37,9 @@ public final class PlacementRules {
         }
     }
 
+    /**
+     * Register all the stairs blocks using {@link StairsPlacementRule}.
+     */
     public static void initStairs() {
         BlockManager blockManager = MinecraftServer.getBlockManager();
         for (Block block : Block.values()) {
@@ -35,6 +49,9 @@ public final class PlacementRules {
         }
     }
 
+    /**
+     * Register all the wall blocks using {@link WallPlacementRule}.
+     */
     public static void initWalls() {
         BlockManager blockManager = MinecraftServer.getBlockManager();
         for (Block block : Block.values()) {
@@ -45,6 +62,9 @@ public final class PlacementRules {
         }
     }
 
+    /**
+     * Register the {@link RedstonePlacementRule}.
+     */
     public static void initRedstone() {
         BlockManager blockManager = MinecraftServer.getBlockManager();
         blockManager.registerBlockPlacementRule(new RedstonePlacementRule());

--- a/src/main/java/net/minestom/server/extras/PlacementRules.java
+++ b/src/main/java/net/minestom/server/extras/PlacementRules.java
@@ -39,7 +39,7 @@ public final class PlacementRules {
         BlockManager blockManager = MinecraftServer.getBlockManager();
         for (Block block : Block.values()) {
             String namespace = block.namespace().value();
-            if (namespace.endsWith("wall") || namespace.endsWith("fence")) {
+            if (namespace.endsWith("wall")) {
                 blockManager.registerBlockPlacementRule(new WallPlacementRule(block));
             }
         }

--- a/src/main/java/net/minestom/server/extras/PlacementRules.java
+++ b/src/main/java/net/minestom/server/extras/PlacementRules.java
@@ -5,50 +5,48 @@ import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockManager;
 import net.minestom.server.instance.block.rule.vanilla.AxisPlacementRule;
 import net.minestom.server.instance.block.rule.vanilla.RedstonePlacementRule;
+import net.minestom.server.instance.block.rule.vanilla.StairsPlacementRule;
 import net.minestom.server.instance.block.rule.vanilla.WallPlacementRule;
 
 public final class PlacementRules {
 
-	public static void init() {
-		BlockManager blockManager = MinecraftServer.getBlockManager();
-		blockManager.registerBlockPlacementRule(new RedstonePlacementRule());
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.BONE_BLOCK));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.HAY_BLOCK));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.OAK_LOG));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.SPRUCE_LOG));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.BIRCH_LOG));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.JUNGLE_LOG));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.ACACIA_LOG));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.DARK_OAK_LOG));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.CRIMSON_STEM));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.WARPED_STEM));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.STRIPPED_OAK_LOG));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.STRIPPED_SPRUCE_LOG));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.STRIPPED_BIRCH_LOG));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.STRIPPED_JUNGLE_LOG));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.STRIPPED_ACACIA_LOG));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.STRIPPED_DARK_OAK_LOG));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.STRIPPED_CRIMSON_STEM));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.STRIPPED_WARPED_STEM));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.PURPUR_PILLAR));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.QUARTZ_PILLAR));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.OAK_WOOD));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.SPRUCE_WOOD));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.BIRCH_WOOD));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.JUNGLE_WOOD));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.ACACIA_WOOD));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.DARK_OAK_WOOD));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.CRIMSON_STEM));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.WARPED_STEM));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.STRIPPED_OAK_WOOD));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.STRIPPED_SPRUCE_WOOD));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.STRIPPED_BIRCH_WOOD));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.STRIPPED_JUNGLE_WOOD));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.STRIPPED_ACACIA_WOOD));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.STRIPPED_DARK_OAK_WOOD));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.STRIPPED_CRIMSON_STEM));
-		blockManager.registerBlockPlacementRule(new AxisPlacementRule(Block.STRIPPED_WARPED_STEM));
-		blockManager.registerBlockPlacementRule(new WallPlacementRule(Block.COBBLESTONE_WALL));
-		blockManager.registerBlockPlacementRule(new WallPlacementRule(Block.MOSSY_COBBLESTONE_WALL));
-	}
+    public static void init() {
+        initAxisBlocks();
+        initStairs();
+        initWalls();
+        initRedstone();
+    }
+
+    public static void initAxisBlocks() {
+        BlockManager blockManager = MinecraftServer.getBlockManager();
+        for (Block block : Block.values()) {
+            if (block.getProperty("axis") != null) {
+                blockManager.registerBlockPlacementRule(new AxisPlacementRule(block));
+            }
+        }
+    }
+
+    public static void initStairs() {
+        BlockManager blockManager = MinecraftServer.getBlockManager();
+        for (Block block : Block.values()) {
+            if (block.namespace().value().endsWith("stairs")) {
+                blockManager.registerBlockPlacementRule(new StairsPlacementRule(block));
+            }
+        }
+    }
+
+    public static void initWalls() {
+        BlockManager blockManager = MinecraftServer.getBlockManager();
+        for (Block block : Block.values()) {
+            String namespace = block.namespace().value();
+            if (namespace.endsWith("wall") || namespace.endsWith("fence")) {
+                blockManager.registerBlockPlacementRule(new WallPlacementRule(block));
+            }
+        }
+    }
+
+    public static void initRedstone() {
+        BlockManager blockManager = MinecraftServer.getBlockManager();
+        blockManager.registerBlockPlacementRule(new RedstonePlacementRule());
+    }
 }


### PR DESCRIPTION
This PR removes the explicit and manual registration of various placement rules for blocks in the utility class PlacementRules and instead registers all the blocks iteratively providing a more complete and accurate result.

It also separates the placement rule types in different methods so that they can be enabled separately  (i.e. only stairs, only walls, etc)
This PR does not provide the implementation of the various placement rules, just their registration.