### PR TITLE
Add HeadPlacementRule and include ItemMeta in BlockPlacementRule

### DIFF
--- a/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java
+++ b/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java
@@ -1,10 +1,11 @@
 package net.minestom.server.instance.block.rule;
 
+import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Player;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockFace;
-import net.minestom.server.coordinate.Point;
+import net.minestom.server.item.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -38,6 +39,23 @@ public abstract class BlockPlacementRule {
     public abstract @Nullable Block blockPlace(@NotNull Instance instance,
                                                @NotNull Block block, @NotNull BlockFace blockFace, @NotNull Point blockPosition,
                                                @NotNull Player pl);
+
+    /**
+     * Called when the block is placed.
+     *
+     * @param instance      the instance of the block
+     * @param usedItemMeta  the meta of the item placed
+     * @param block         the block placed
+     * @param blockFace     the block face
+     * @param blockPosition the block position
+     * @param pl            the player who placed the block
+     * @return the block to place, {@code null} to cancel
+     */
+    public @Nullable Block blockPlace(@NotNull Instance instance, ItemMeta usedItemMeta,
+                                      @NotNull Block block, @NotNull BlockFace blockFace, @NotNull Point blockPosition,
+                                      @NotNull Player pl) {
+        return blockPlace(instance, block, blockFace, blockPosition, pl);
+    }
 
     public @NotNull Block getBlock() {
         return block;

--- a/src/main/java/net/minestom/server/instance/block/rule/vanilla/HeadPlacementRule.java
+++ b/src/main/java/net/minestom/server/instance/block/rule/vanilla/HeadPlacementRule.java
@@ -1,0 +1,107 @@
+package net.minestom.server.instance.block.rule.vanilla;
+
+import net.minestom.server.coordinate.Point;
+import net.minestom.server.entity.Player;
+import net.minestom.server.entity.PlayerSkin;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.instance.block.Block;
+import net.minestom.server.instance.block.BlockFace;
+import net.minestom.server.instance.block.rule.BlockPlacementRule;
+import net.minestom.server.item.ItemMeta;
+import net.minestom.server.item.metadata.PlayerHeadMeta;
+import net.minestom.server.tag.Tag;
+import net.minestom.server.utils.NamespaceID;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jglrxavpok.hephaistos.nbt.NBT;
+import org.jglrxavpok.hephaistos.nbt.NBTType;
+
+import java.util.UUID;
+
+public class HeadPlacementRule extends BlockPlacementRule {
+
+    public HeadPlacementRule(@NotNull Block block) {
+        super(block);
+    }
+
+    @Override
+    public @NotNull Block blockUpdate(@NotNull Instance instance, @NotNull Point blockPosition, @NotNull Block block) {
+        return block;
+    }
+
+    @Override
+    public Block blockPlace(@NotNull Instance instance,
+                            @NotNull Block block, @NotNull BlockFace blockFace, @NotNull Point blockPosition,
+                            @NotNull Player pl) {
+        return block;
+    }
+
+    @Override
+    public @Nullable Block blockPlace(@NotNull Instance instance, ItemMeta usedItemMeta, @NotNull Block block,
+                                      @NotNull BlockFace blockFace, @NotNull Point blockPosition, @NotNull Player pl) {
+
+        if (blockFace == BlockFace.TOP || blockFace == BlockFace.BOTTOM) {
+            float yaw = pl.getPosition().yaw() + 360;
+            int rotation = (int) (Math.round(yaw / 22.5d) % 16);
+
+            return withSkin(usedItemMeta, block)
+                    .withProperty("rotation", String.valueOf(rotation));
+        }
+
+        return withSkin(usedItemMeta, toWallBlock(block))
+                .withProperty("facing", blockFace.name().toLowerCase());
+    }
+
+    /**
+     * Convert the given head/skull block into its wall variant.
+     *
+     * @param block the block to convert
+     * @return the wall variant of the block
+     */
+    private Block toWallBlock(Block block) {
+        // Is there a better way to do this?
+        String name = block.namespace().value();
+
+        // player_head -> player
+        String rawName = name.substring(0, name.indexOf("_"));
+        // player_head -> _head
+        String rawType = name.substring(rawName.length());
+
+        return Block.fromNamespaceId(NamespaceID.from(block.namespace().domain(), rawName + "_wall" + rawType));
+    }
+
+    /**
+     * Include the head skin tags if present.
+     *
+     * @param meta  the original head meta
+     * @param block the block
+     * @return the block with the skin tags
+     */
+    private Block withSkin(ItemMeta meta, Block block) {
+        UUID skullOwner = meta.getTag(PlayerHeadMeta.SKULL_OWNER);
+        if (skullOwner == null) return block;
+
+        PlayerSkin skin = meta.getTag(PlayerHeadMeta.SKIN);
+        if (skin == null) return block;
+
+        String textures = skin.textures();
+        if (textures == null) return block;
+
+        /*
+            SkullOwner (Compound)
+                |_ Id (UUID)
+                |_ Properties (Compound)
+                    |_ textures (Compound List)
+                        |_ Value (String)
+
+            See https://minecraft.fandom.com/wiki/Head#Block_data
+         */
+        return block.withTag(Tag.NBT("SkullOwner"), NBT.Compound(tag -> {
+            Tag.UUID("Id").write(tag, skullOwner);
+            tag.set("Properties", NBT.Compound(propTag ->
+                    propTag.set("textures", NBT.List(NBTType.TAG_Compound,
+                            NBT.Compound(txTag -> txTag.setString("Value", textures))))));
+        }));
+    }
+
+}

--- a/src/main/java/net/minestom/server/instance/block/rule/vanilla/HeadPlacementRule.java
+++ b/src/main/java/net/minestom/server/instance/block/rule/vanilla/HeadPlacementRule.java
@@ -63,7 +63,7 @@ public class HeadPlacementRule extends BlockPlacementRule {
         String name = block.namespace().value();
 
         // player_head -> player
-        String rawName = name.substring(0, name.indexOf("_"));
+        String rawName = name.substring(0, name.lastIndexOf("_"));
         // player_head -> _head
         String rawType = name.substring(rawName.length());
 

--- a/src/main/java/net/minestom/server/item/metadata/PlayerHeadMeta.java
+++ b/src/main/java/net/minestom/server/item/metadata/PlayerHeadMeta.java
@@ -17,9 +17,9 @@ import java.util.Objects;
 import java.util.UUID;
 
 public record PlayerHeadMeta(TagReadable readable) implements ItemMetaView<PlayerHeadMeta.Builder> {
-    private static final Tag<UUID> SKULL_OWNER = Tag.UUID("Id").path("SkullOwner");
-    private static final Tag<PlayerSkin> SKIN = Tag.Structure("Properties", new TagSerializer<PlayerSkin>() {
-        private static final Tag<NBT> TEXTURES = Tag.NBT("textures");
+    public static final Tag<UUID> SKULL_OWNER = Tag.UUID("Id").path("SkullOwner");
+    public static final Tag<PlayerSkin> SKIN = Tag.Structure("Properties", new TagSerializer<PlayerSkin>() {
+        public static final Tag<NBT> TEXTURES = Tag.NBT("textures");
 
         @Override
         public @Nullable PlayerSkin read(@NotNull TagReadable reader) {

--- a/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
+++ b/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
@@ -118,7 +118,7 @@ public class BlockPlacementListener {
             // Client also doesn't predict placement of blocks on entities, but we need to refresh for cases where bounding boxes on the server don't match the client
             if (collisionEntity != player)
                 refresh(player, chunk);
-            
+
             return;
         }
 
@@ -136,7 +136,7 @@ public class BlockPlacementListener {
         final BlockPlacementRule blockPlacementRule = BLOCK_MANAGER.getBlockPlacementRule(resultBlock);
         if (blockPlacementRule != null) {
             // Get id from block placement rule instead of the event
-            resultBlock = blockPlacementRule.blockPlace(instance, resultBlock, blockFace, blockPosition, player);
+            resultBlock = blockPlacementRule.blockPlace(instance, usedItem.meta(), resultBlock, blockFace, blockPosition, player);
         }
         if (resultBlock == null) {
             refresh(player, chunk);
@@ -153,7 +153,7 @@ public class BlockPlacementListener {
             playerInventory.setItemInHand(hand, newUsedItem);
         } else {
             // Prevent invisible item on client
-            playerInventory.update();   
+            playerInventory.update();
         }
     }
 


### PR DESCRIPTION
This PR adds placement support for heads and skulls as well as player skin support for player heads.

Notable changes:
 - The Tags in PlayerHeadMeta were exposed (private->public) so that they could be reused here
 - In order to access the skin data a new blockPlace was added to include the usedItem ItemMeta, this will also be used in a future PR for Banner placement rules
