### PR TITLE
Fix/mojang utils long name

### DIFF
--- a/src/main/java/net/minestom/server/utils/mojang/MojangUtils.java
+++ b/src/main/java/net/minestom/server/utils/mojang/MojangUtils.java
@@ -41,10 +41,15 @@ public final class MojangUtils {
                 final String response = URLUtils.getText(url);
                 // If our response is "", that means the url did not get a proper object from the url
                 // So the username or UUID was invalid, and therefore we return null
-                if(response.isEmpty()) {
+                if (response.isEmpty()) {
                     return null;
                 }
-                return JsonParser.parseString(response).getAsJsonObject();
+
+                JsonObject jsonObject = JsonParser.parseString(response).getAsJsonObject();
+                if (jsonObject.has("errorMessage")) {
+                    return null;
+                }
+                return jsonObject;
             } catch (IOException e) {
                 MinecraftServer.getExceptionManager().handleException(e);
                 throw new RuntimeException(e);

--- a/src/test/java/net/minestom/server/utils/TestMojangUtils.java
+++ b/src/test/java/net/minestom/server/utils/TestMojangUtils.java
@@ -18,4 +18,24 @@ public class TestMojangUtils {
         var result = MojangUtils.fromUsername("jfdsa84vvcxadubasdfcvn"); // Longer than 16, always invalid
         assertNull(result);
     }
+
+    @Test
+    public void testValidUuidWorks() {
+        var result = MojangUtils.fromUuid("853c80ef3c3749fdaa49938b674adae6");
+        assertNotNull(result);
+        assertEquals("jeb_", result.get("name").getAsString());
+        assertEquals("853c80ef3c3749fdaa49938b674adae6", result.get("id").getAsString());
+    }
+
+    @Test
+    public void testInvalidUuidReturnsNull() {
+        var result = MojangUtils.fromUuid("853c80ef3c3749fdaa49938b674adae6a"); // Longer than 32, always invalid
+        assertNull(result);
+    }
+
+    @Test
+    public void testNonExistentUuidReturnsNull() {
+        var result = MojangUtils.fromUuid("00000000-0000-0000-0000-000000000000");
+        assertNull(result);
+    }
 }


### PR DESCRIPTION
This fixes issues with tests failing and Minestom therefore not properly building in Actions.

There is another option to this change: return a richer data response that provides the error if there was one. For now, I've just gone with keeping the behaviour as intended (if a username is invalid or doesn't exist, return null).

Also added some more tests for the UUID methods and such.