### PR TITLE
Fix client not finding recipe serializer for minecraft:stonecutter

### DIFF
--- a/src/main/java/net/minestom/server/network/packet/server/play/DeclareRecipesPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/DeclareRecipesPacket.java
@@ -26,7 +26,7 @@ public record DeclareRecipesPacket(@NotNull List<DeclaredRecipe> recipes) implem
                 case "blasting" -> new DeclaredBlastingRecipe(reader);
                 case "smoking" -> new DeclaredSmokingRecipe(reader);
                 case "campfire_cooking" -> new DeclaredCampfireCookingRecipe(reader);
-                case "stonecutter" -> new DeclaredStonecutterRecipe(reader);
+                case "stonecutting" -> new DeclaredStonecutterRecipe(reader);
                 case "smithing" -> new DeclaredSmithingRecipe(reader);
                 default -> throw new UnsupportedOperationException("Unrecognized type: " + type);
             };
@@ -235,7 +235,7 @@ public record DeclareRecipesPacket(@NotNull List<DeclaredRecipe> recipes) implem
 
         @Override
         public @NotNull String type() {
-            return "stonecutter";
+            return "stonecutting";
         }
     }
 


### PR DESCRIPTION
When creating a StonecutterRecipe and registering that to the recipe manager, whenever a client joins and that recipe gets sent to them, they get kicked with the following message:

![image](https://user-images.githubusercontent.com/74827262/226174650-4f753116-2f94-494e-98c1-2200e8262734.png)

So i changed `DeclareRecipesPacket$DeclaredStonecutterRecipe#type` and the `DeclareRecipesPacket` constructor to return and accept `"stonecutting"` instead of `"stonecutter"`. This makes the client able to understand the recipe and to join the game.

Code that disallowed the client from joining when working with `"stonecutter"` and works fine now:

![image](https://user-images.githubusercontent.com/74827262/226175104-490119b3-d241-48da-b8dd-9518a7b20fc3.png)
