### PR TITLE
Add javadocs for PlayerBlockIteractEvent#setBlockingItemUse

### DIFF
--- a/src/main/java/net/minestom/server/event/player/PlayerBlockInteractEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerBlockInteractEvent.java
@@ -48,6 +48,11 @@ public class PlayerBlockInteractEvent implements PlayerInstanceEvent, BlockEvent
         return blocksItemUse;
     }
 
+    /**
+     * Sets if the event should block the item use.
+     *
+     * @param blocks true if the item use should be blocked, false otherwise
+     */
     public void setBlockingItemUse(boolean blocks) {
         this.blocksItemUse = blocks;
     }


### PR DESCRIPTION
Adds missing javadocs for PlayerBlockIteractEvent#setBlockingItemUse. Docs are inferred from the isBlockingItemUse method.