### PR TITLE
Fix nullability for Player shoulder entity data

### DIFF
--- a/src/main/java/net/minestom/server/entity/metadata/PlayerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/PlayerMeta.java
@@ -6,6 +6,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jglrxavpok.hephaistos.nbt.NBT;
 
+import java.util.Map;
+
 public class PlayerMeta extends LivingEntityMeta {
     public static final byte OFFSET = LivingEntityMeta.MAX_OFFSET;
     public static final byte MAX_OFFSET = OFFSET + 1;
@@ -108,6 +110,8 @@ public class PlayerMeta extends LivingEntityMeta {
     }
 
     public void setLeftShoulderEntityData(@Nullable NBT value) {
+        if (value == null) value = NBT.Compound(Map.of());
+
         super.metadata.setIndex(OFFSET + 4, Metadata.NBT(value));
     }
 
@@ -117,6 +121,8 @@ public class PlayerMeta extends LivingEntityMeta {
     }
 
     public void setRightShoulderEntityData(@Nullable NBT value) {
+        if (value == null) value = NBT.Compound(Map.of());
+
         super.metadata.setIndex(OFFSET + 5, Metadata.NBT(value));
     }
 


### PR DESCRIPTION
Fixes #1442 

If a shoulder NBT is set to null, convert it to an empty NBT element as it cannot be null (or take null).