### PR TITLE
Null verifier wildcard fix

### DIFF
--- a/src/main/java/net/minestom/server/permission/PermissionHandler.java
+++ b/src/main/java/net/minestom/server/permission/PermissionHandler.java
@@ -112,15 +112,17 @@ public interface PermissionHandler {
      * @return true if the handler has the permission, false otherwise
      */
     default boolean hasPermission(@NotNull String permissionName, @Nullable PermissionVerifier permissionVerifier) {
-        final Permission permission = getPermission(permissionName);
+        Permission permission = getPermission(permissionName);
 
-        if (permission != null) {
-            // If no permission verifier, hand off to no-verifier hasPermission for wildcard support
-            if(permissionVerifier == null) { return hasPermission(permission); }
-            // Verify using the permission verifier
-            return permissionVerifier == null || permissionVerifier.isValid(permission.getNBTData());
+        if (permission == null && permissionVerifier == null) {
+            permission = new Permission(permissionName, null);
+        } else if (permission == null) {
+            return false;
         }
-        return false;
+        // If no permission verifier, hand off to no-verifier hasPermission for wildcard support
+        if(permissionVerifier == null) { return hasPermission(permission); }
+        // Verify using the permission verifier
+        return permissionVerifier.isValid(permission.getNBTData());
     }
 
     /**

--- a/src/test/java/net/minestom/server/permission/TestPermissions.java
+++ b/src/test/java/net/minestom/server/permission/TestPermissions.java
@@ -85,6 +85,8 @@ public class TestPermissions {
         Permission permission = new Permission("foo.b*r.baz");
         Permission match = new Permission("foo.baaar.baz");
         Permission match2 = new Permission("foo.br.baz");
+        String match3 = "foo.br.baz";
+        String match4 = "foo.baaar.baz";
         Permission nomatch = new Permission("foo.br.bz");
         Permission nomatch2 = new Permission("foo.b.baz");
         assertFalse(player.hasPermission(match));
@@ -96,6 +98,8 @@ public class TestPermissions {
 
         assertTrue(player.hasPermission(match));
         assertTrue(player.hasPermission(match2));
+        assertTrue(player.hasPermission(match3));
+        assertTrue(player.hasPermission(match4));
         assertFalse(player.hasPermission(nomatch));
         assertFalse(player.hasPermission(nomatch2));
     }
@@ -105,6 +109,8 @@ public class TestPermissions {
         Permission permission = new Permission("foo.b*");
         Permission match = new Permission("foo.baaar.baz");
         Permission match2 = new Permission("foo.b");
+        String match3 = "foo.b";
+        String match4 = "foo.baaar.baz";
         Permission nomatch = new Permission("foo.");
         Permission nomatch2 = new Permission("foo/b");
         assertFalse(player.hasPermission(match));
@@ -116,6 +122,8 @@ public class TestPermissions {
 
         assertTrue(player.hasPermission(match));
         assertTrue(player.hasPermission(match2));
+        assertTrue(player.hasPermission(match3));
+        assertTrue(player.hasPermission(match4));
         assertFalse(player.hasPermission(nomatch));
         assertFalse(player.hasPermission(nomatch2));
     }


### PR DESCRIPTION
refactored the code to use hasPermission(Permission) when verifier is null, and to not rely on getPermission

fixes wildcards not working for hasPermission(String)

includes test cases