### PR TITLE
Update libary versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,13 +17,13 @@ jline = "3.23.0"
 
 # Performance / Data Structures
 caffeine = "3.1.6"
-fastutil = "8.5.9"
+fastutil = "8.5.12"
 flare = "2.0.1"
 gson = "2.10.1"
 jcTools = "4.0.1"
 
 # Test
-junit-jupiter = "5.10.0-M1"
+junit-jupiter = "5.9.3"
 junit-platform = "1.8.2"
 mockito = "5.3.1"
 
@@ -34,10 +34,10 @@ javaPoet = "1.13.0"
 jNoise = "b93008e35e"
 
 # JMH
-jmh = "1.35"
+jmh = "1.36"
 
 # JCStress
-jcstress = "0.8"
+jcstress = "0.16"
 
 # Gradle plugins
 blossom = "1.3.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ kotlin = "1.8.22"
 hydrazine = "1.7.2"
 dependencyGetter = "v1.0.1"
 minestomData = "ddde11056e"
-hephaistos = "2.5.3"
+hephaistos = "2.6.1"
 jetbrainsAnnotations = "24.0.1"
 
 # Terminal / Logging

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,29 +3,29 @@ metadata.format.version = "1.1"
 [versions]
 
 # Important dependencies
-adventure = "4.12.0"
-kotlin = "1.7.22"
+adventure = "4.14.0"
+kotlin = "1.8.22"
 hydrazine = "1.7.2"
 dependencyGetter = "v1.0.1"
 minestomData = "ddde11056e"
 hephaistos = "2.5.3"
-jetbrainsAnnotations = "23.0.0"
+jetbrainsAnnotations = "24.0.1"
 
 # Terminal / Logging
 tinylog = "2.5.0"
-jline = "3.21.0"
+jline = "3.23.0"
 
 # Performance / Data Structures
-caffeine = "3.1.2"
+caffeine = "3.1.6"
 fastutil = "8.5.9"
 flare = "2.0.1"
-gson = "2.9.1"
+gson = "2.10.1"
 jcTools = "4.0.1"
 
 # Test
-junit-jupiter = "5.8.2"
+junit-jupiter = "5.10.0-M1"
 junit-platform = "1.8.2"
-mockito = "4.2.0"
+mockito = "5.3.1"
 
 # Code Generation
 javaPoet = "1.13.0"


### PR DESCRIPTION
I took the trouble to update the following libraries:

- adventure (4.12.0) -> 4.14.0 
- kotlin (1.7.22) -> 1.8.22
- jetbrainsAnnotations (23.0.0) -> 24.0.1
- jLine (3.21.0) ->3.23.0
- caffeine (3.1.2) -> 3.1.6
- gson (2.9.1) -> gson (2.10.1)
- junit-jupiter (5.8.2) -> 5.10-0-M1
- mockito (4.2.0) -> 5.3.1

I checked all updates with the changelogs and was able to build local without errors. This pull request fixes some vulnerabilities. https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-37533