### PR TITLE
Fix slow dimension changes

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -489,6 +489,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
      * Sends necessary packets to synchronize player data after a {@link RespawnPacket}
      */
     private void refreshClientStateAfterRespawn() {
+        sendPacket(new ServerDifficultyPacket(MinecraftServer.getDifficulty(), false));
         sendPacket(new UpdateHealthPacket(this.getHealth(), food, foodSaturation));
         sendPacket(new SetExperiencePacket(exp, level, 0));
         triggerStatus((byte) (24 + permissionLevel)); // Set permission level
@@ -653,7 +654,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
      */
     private void spawnPlayer(@NotNull Instance instance, @NotNull Pos spawnPosition,
                              boolean firstSpawn, boolean dimensionChange, boolean updateChunks) {
-        if (!firstSpawn) {
+        if (!firstSpawn && !dimensionChange) {
             // Player instance changed, clear current viewable collections
             if (updateChunks)
                 ChunkUtils.forChunksInRange(spawnPosition, MinecraftServer.getChunkViewDistance(), chunkRemover);
@@ -673,9 +674,16 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         }
 
         synchronizePosition(true); // So the player doesn't get stuck
+        sendPacket(new SpawnPositionPacket(spawnPosition, 0));
+
+        if (dimensionChange) {
+            instance.getWorldBorder().init(this);
+            sendPacket(new TimeUpdatePacket(instance.getWorldAge(), instance.getTime()));
+        }
 
         if (dimensionChange || firstSpawn) {
             this.inventory.update();
+            sendPacket(new HeldItemChangePacket(heldSlot));
         }
 
         EventDispatcher.call(new PlayerSpawnEvent(this, instance, firstSpawn));

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -674,9 +674,9 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         }
 
         synchronizePosition(true); // So the player doesn't get stuck
-        sendPacket(new SpawnPositionPacket(spawnPosition, 0));
 
         if (dimensionChange) {
+            sendPacket(new SpawnPositionPacket(spawnPosition, 0)); // Without this the client gets stuck on loading terrain for a while
             instance.getWorldBorder().init(this);
             sendPacket(new TimeUpdatePacket(instance.getWorldAge(), instance.getTime()));
         }


### PR DESCRIPTION
Fixes an issue where dimension changes cause the client to sit on the loading terrain screen for a very long time.

Cherry picked from https://github.com/hollow-cube/minestom-ce/commit/388dbf71b9d21c21e9fbd8d691c08ed1fe889665