### PR TITLE
Rewrite CommandParserImpl recursively (fix #1327)

### DIFF
--- a/src/main/java/net/minestom/server/command/CommandParserImpl.java
+++ b/src/main/java/net/minestom/server/command/CommandParserImpl.java
@@ -30,9 +30,9 @@ final class CommandParserImpl implements CommandParser {
 
     static final class Chain {
         CommandExecutor defaultExecutor = null;
-        final ArrayDeque<NodeResult> nodeResults = new ArrayDeque<>();
-        final List<CommandCondition> conditions = new ArrayList<>();
-        final List<CommandExecutor> globalListeners = new ArrayList<>();
+        ArrayDeque<NodeResult> nodeResults = new ArrayDeque<>();
+        List<CommandCondition> conditions = new ArrayList<>();
+        List<CommandExecutor> globalListeners = new ArrayList<>();
 
         void append(NodeResult result) {
             this.nodeResults.add(result);
@@ -76,68 +76,48 @@ final class CommandParserImpl implements CommandParser {
         List<Argument<?>> getArgs() {
             return nodeResults.stream().map(x -> x.node.argument()).collect(Collectors.toList());
         }
+
+        Chain() {}
+
+        Chain(CommandExecutor defaultExecutor,
+              ArrayDeque<NodeResult> nodeResults,
+              List<CommandCondition> conditions,
+              List<CommandExecutor> globalListeners) {
+            this.defaultExecutor = defaultExecutor;
+            this.nodeResults = nodeResults.clone();
+            this.conditions = new ArrayList<>(conditions);
+            this.globalListeners = new ArrayList<>(globalListeners);
+        }
+
+        Chain fork() {
+            return new Chain(defaultExecutor, nodeResults, conditions, globalListeners);
+        }
     }
 
     @Override
     public @NotNull CommandParser.Result parse(@NotNull Graph graph, @NotNull String input) {
         final CommandStringReader reader = new CommandStringReader(input);
-        final Chain chain = new Chain();
-        // Read from input
-        NodeResult result;
+        Chain chain = new Chain();
         Node parent = graph.root();
-        while ((result = parseChild(parent, reader)) != null) {
-            chain.append(result);
-            if (result.argumentResult instanceof ArgumentResult.SyntaxError<?> e) {
-                // Syntax error stop at this arg
-                final ArgumentCallback argumentCallback = parent.argument().getCallback();
-                if (argumentCallback == null && chain.defaultExecutor != null) {
-                    return ValidCommand.defaultExecutor(input, chain);
-                } else {
-                    return new InvalidCommand(input, chain.mergedConditions(),
-                            argumentCallback, e, chain.collectArguments(), chain.mergedGlobalExecutors(),
-                            chain.extractSuggestionCallback(), chain.getArgs());
-                }
-            }
-            parent = result.node;
+
+        NodeResult result = parseNode(parent, chain, reader);
+        chain = result.chain;
+        if (result.argumentResult instanceof ArgumentResult.Success<?>) {
+            NodeResult lastNodeResult = chain.nodeResults.peekLast();
+            Node lastNode = lastNodeResult.node;
+
+            return ValidCommand.executor(input, chain, lastNode.execution().executor());
         }
-        // Check children for arguments with default values
-        do {
-            Node tmp = parent;
-            parent = null;
-            for (Node child : tmp.next()) {
-                final Argument<?> argument = child.argument();
-                final Supplier<?> defaultSupplier = argument.getDefaultValue();
-                if (defaultSupplier != null) {
-                    final Object value = defaultSupplier.get();
-                    final ArgumentResult<Object> argumentResult = new ArgumentResult.Success<>(value, "");
-                    chain.append(new NodeResult(child, argumentResult, argument.getSuggestionCallback()));
-                    parent = child;
-                    break;
-                }
-            }
-        } while (parent != null);
-        // Check if any syntax has been found
-        final NodeResult lastNode = chain.nodeResults.peekLast();
-        if (lastNode == null) return UnknownCommandResult.INSTANCE;
-        // Verify syntax(s)
-        final CommandExecutor executor = nullSafeGetter(lastNode.node().execution(), Graph.Execution::executor);
-        if (executor == null) {
-            // Syntax error
-            if (chain.defaultExecutor != null) {
-                return ValidCommand.defaultExecutor(input, chain);
-            } else {
-                return InvalidCommand.invalid(input, chain);
-            }
+        // If here, then the command failed
+
+        // Look for a default executor, or give up if we got nowhere
+        NodeResult lastNode = chain.nodeResults.peekLast();
+        if (lastNode.node.equals(parent)) return UnknownCommandResult.INSTANCE;
+        if (chain.defaultExecutor != null) {
+            return ValidCommand.defaultExecutor(input, chain);
         }
-        if (reader.hasRemaining()) {
-            // Command had trailing data
-            if (chain.defaultExecutor != null) {
-                return ValidCommand.defaultExecutor(input, chain);
-            } else {
-                return InvalidCommand.invalid(input, chain);
-            }
-        }
-        return ValidCommand.executor(input, chain, executor);
+
+        return InvalidCommand.invalid(input, chain);
     }
 
     @Contract("null, _ -> null; !null, null -> fail; !null, !null -> _")
@@ -145,32 +125,80 @@ final class CommandParserImpl implements CommandParser {
         return obj == null ? null : getter.apply(obj);
     }
 
-    private static NodeResult parseChild(Node parent, CommandStringReader reader) {
-        if (!reader.hasRemaining()) return null;
-        for (Node child : parent.next()) {
-            final Argument<?> argument = child.argument();
-            final int start = reader.cursor();
-            final ArgumentResult<?> parse = parse(argument, reader);
-            if (parse instanceof ArgumentResult.Success<?> success) {
-                return new NodeResult(child, (ArgumentResult<Object>) success,
-                        argument.getSuggestionCallback());
-            } else if (parse instanceof ArgumentResult.SyntaxError<?> syntaxError) {
-                return new NodeResult(child, (ArgumentResult<Object>) syntaxError,
-                        argument.getSuggestionCallback());
+    private static NodeResult parseNode(Node node, Chain chain, CommandStringReader reader) {
+        chain = chain.fork();
+        Argument<?> argument = node.argument();
+        int start = reader.cursor();
+
+        if (reader.hasRemaining()) {
+            ArgumentResult<?> result = parseArgument(argument, reader);
+            NodeResult nodeResult = new NodeResult(node, chain, (ArgumentResult<Object>) result, argument.getSuggestionCallback());
+            chain.append(nodeResult);
+            if (node.argument().getId().equals("")) {
+                // This is isn't *great*
+                reader.cursor(start);
             } else {
-                // Reset cursor & try next
+                if (!(result instanceof ArgumentResult.Success<?>)) {
+                    reader.cursor(start);
+                    return nodeResult;
+                }
+            }
+        } else {
+            // Nothing left, yet we're still being asked to parse? There must be defaults then
+            Supplier<?> defaultSupplier = node.argument().getDefaultValue();
+            if (defaultSupplier != null) {
+                Object value = defaultSupplier.get();
+                ArgumentResult<Object> argumentResult = new ArgumentResult.Success<>(value, "");
+                chain.append(new NodeResult(node, chain, argumentResult, argument.getSuggestionCallback()));
+                // Add the default to the chain, and then carry on dealing with this node
+            } else {
+                // Still being asked to parse yet there's nothing left, syntax error.
+                return new NodeResult(
+                        node,
+                        chain,
+                        new ArgumentResult.SyntaxError<>("Not enough arguments","",-1),
+                        argument.getSuggestionCallback()
+                );
+            }
+        }
+        // Successfully matched this node's argument
+        start = reader.cursor();
+
+        for (Node child : node.next()) {
+            NodeResult childResult = parseNode(child, chain, reader);
+            if (childResult.argumentResult instanceof ArgumentResult.Success<Object>) {
+                // Assume that there is only one successful node for a given chain of arguments
+                return childResult;
+            } else {
                 reader.cursor(start);
             }
         }
-        for (Node node : parent.next()) {
-            final SuggestionCallback suggestionCallback = node.argument().getSuggestionCallback();
-            if (suggestionCallback != null) {
-                return new NodeResult(parent,
-                        new ArgumentResult.SyntaxError<>("None of the arguments were compatible, but a suggestion callback was found.", "", -1),
-                        suggestionCallback);
-            }
+        // None were successful. Either incompatible types, or syntax error. It doesn't matter to us, though
+
+        // Try to execute this node
+        CommandExecutor executor = nullSafeGetter(node.execution(), Graph.Execution::executor);
+        if (executor == null) {
+            // Stuck here with no executor, return
+            return new NodeResult(
+                    node,
+                    chain,
+                    new ArgumentResult.SyntaxError<>("None of the arguments were compatible", "", -1),
+                    argument.getSuggestionCallback()
+            );
         }
-        return null;
+
+        if (reader.hasRemaining()) {
+            // Trailing data is a syntax error
+            return new NodeResult(
+                    node,
+                    chain,
+                    new ArgumentResult.SyntaxError<>("Command has trailing data", "", -1),
+                    argument.getSuggestionCallback()
+            );
+        }
+
+        // Command was successful!
+        return chain.nodeResults.peekLast();
     }
 
     record UnknownCommandResult() implements Result.UnknownCommand {
@@ -324,7 +352,7 @@ final class CommandParserImpl implements CommandParser {
         static final ExecutableCommand.Result INVALID_SYNTAX = new ExecutionResultImpl(Type.INVALID_SYNTAX, null);
     }
 
-    private record NodeResult(Node node, ArgumentResult<Object> argumentResult, SuggestionCallback callback) {
+    private record NodeResult(Node node, Chain chain, ArgumentResult<Object> argumentResult, SuggestionCallback callback) {
         public String name() {
             return node.argument().getId();
         }
@@ -375,7 +403,7 @@ final class CommandParserImpl implements CommandParser {
 
     // ARGUMENT
 
-    private static <T> ArgumentResult<T> parse(Argument<T> argument, CommandStringReader reader) {
+    private static <T> ArgumentResult<T> parseArgument(Argument<T> argument, CommandStringReader reader) {
         // Handle specific type without loop
         try {
             // Single word argument

--- a/src/main/java/net/minestom/server/command/CommandParserImpl.java
+++ b/src/main/java/net/minestom/server/command/CommandParserImpl.java
@@ -165,7 +165,6 @@ final class CommandParserImpl implements CommandParser {
         start = reader.cursor();
         if (!reader.hasRemaining()) start--; // This is needed otherwise the reader throws an AssertionError
 
-        int i = 0;
         NodeResult error = null;
         for (Node child : node.next()) {
             NodeResult childResult = parseNode(child, chain, reader);
@@ -173,10 +172,12 @@ final class CommandParserImpl implements CommandParser {
                 // Assume that there is only one successful node for a given chain of arguments
                 return childResult;
             } else {
-                if (i == 0) {
-                    if (!(childResult.argumentResult instanceof ArgumentResult.IncompatibleType<?>)) {
+                if (error == null) {
+                    // If this is the base argument (e.g. "teleport" in /teleport) then
+                    // do not report an argument to be incompatible, since the more
+                    // correct thing would be to say that the command is unknown.
+                    if (!(childResult.chain.nodeResults.size() == 2 && childResult.argumentResult instanceof ArgumentResult.IncompatibleType<?>)) {
                         error = childResult;
-                        i++;
                     }
                 }
                 reader.cursor(start);

--- a/src/main/java/net/minestom/server/command/CommandParserImpl.java
+++ b/src/main/java/net/minestom/server/command/CommandParserImpl.java
@@ -69,7 +69,7 @@ final class CommandParserImpl implements CommandParser {
 
         Map<String, ArgumentResult<Object>> collectArguments() {
             return nodeResults.stream()
-                    .skip(1) // skip root
+                    .skip(2) // skip root node and command
                     .collect(Collectors.toUnmodifiableMap(NodeResult::name, NodeResult::argumentResult));
         }
 

--- a/src/main/java/net/minestom/server/command/CommandParserImpl.java
+++ b/src/main/java/net/minestom/server/command/CommandParserImpl.java
@@ -30,9 +30,9 @@ final class CommandParserImpl implements CommandParser {
 
     static final class Chain {
         CommandExecutor defaultExecutor = null;
-        ArrayDeque<NodeResult> nodeResults = new ArrayDeque<>();
-        List<CommandCondition> conditions = new ArrayList<>();
-        List<CommandExecutor> globalListeners = new ArrayList<>();
+        final ArrayDeque<NodeResult> nodeResults = new ArrayDeque<>();
+        final List<CommandCondition> conditions = new ArrayList<>();
+        final List<CommandExecutor> globalListeners = new ArrayList<>();
 
         void append(NodeResult result) {
             this.nodeResults.add(result);
@@ -84,9 +84,9 @@ final class CommandParserImpl implements CommandParser {
               List<CommandCondition> conditions,
               List<CommandExecutor> globalListeners) {
             this.defaultExecutor = defaultExecutor;
-            this.nodeResults = nodeResults.clone();
-            this.conditions = new ArrayList<>(conditions);
-            this.globalListeners = new ArrayList<>(globalListeners);
+            this.nodeResults.addAll(nodeResults);
+            this.conditions.addAll(conditions);
+            this.globalListeners.addAll(globalListeners);
         }
 
         Chain fork() {

--- a/src/main/java/net/minestom/server/command/GraphImpl.java
+++ b/src/main/java/net/minestom/server/command/GraphImpl.java
@@ -4,6 +4,8 @@ import net.minestom.server.command.builder.Command;
 import net.minestom.server.command.builder.CommandExecutor;
 import net.minestom.server.command.builder.CommandSyntax;
 import net.minestom.server.command.builder.arguments.Argument;
+import net.minestom.server.command.builder.arguments.ArgumentCommand;
+import net.minestom.server.command.builder.arguments.ArgumentLiteral;
 import net.minestom.server.command.builder.condition.CommandCondition;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -62,6 +64,12 @@ record GraphImpl(NodeImpl root) implements Graph {
     }
 
     record NodeImpl(Argument<?> argument, ExecutionImpl execution, List<Graph.Node> next) implements Graph.Node {
+        NodeImpl(Argument<?> argument, ExecutionImpl execution, List<Graph.Node> next) {
+            this.argument = argument;
+            this.execution = execution;
+            this.next = next.stream().sorted(nodePriority).toList();
+        }
+
         static NodeImpl fromBuilder(BuilderImpl builder) {
             final List<BuilderImpl> children = builder.children;
             Node[] nodes = new NodeImpl[children.size()];
@@ -75,6 +83,17 @@ record GraphImpl(NodeImpl root) implements Graph {
 
         static NodeImpl rootCommands(Collection<Command> commands) {
             return ConversionNode.rootConv(commands).toNode();
+        }
+
+        private static final java.util.Comparator<Node> nodePriority = (node1, node2) -> {
+            int node1Value = argumentValue(node1.argument());
+            int node2Value = argumentValue(node2.argument());
+            return Integer.compare(node1Value, node2Value);
+        };
+        private static int argumentValue(Argument<?> argument) {
+            if (argument.getClass() == ArgumentCommand.class) return -3000;
+            if (argument.getClass() == ArgumentLiteral.class) return -2000;
+            return -1000;
         }
     }
 

--- a/src/test/java/net/minestom/server/command/CommandSyntaxMultiTest.java
+++ b/src/test/java/net/minestom/server/command/CommandSyntaxMultiTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.String;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static net.minestom.server.command.builder.arguments.ArgumentType.Float;
@@ -25,6 +26,17 @@ public class CommandSyntaxMultiTest {
         );
         assertSyntax(args, "integer 5", ExpectedExecution.FIRST_SYNTAX, Map.of("integer", "integer", "number", 5));
         assertSyntax(args, "float 5.5", ExpectedExecution.SECOND_SYNTAX, Map.of("float", "float", "number", 5.5f));
+    }
+
+
+    @Test
+    public void similarArgs() {
+        List<List<Argument<?>>> args = List.of(
+                List.of(Word("a")),
+                List.of(Word("b"), Word("a"))
+        );
+        assertSyntax(args, "baz", ExpectedExecution.FIRST_SYNTAX);
+        assertSyntax(args, "bar baz", ExpectedExecution.SECOND_SYNTAX);
     }
 
     private static void assertSyntax(List<List<Argument<?>>> args, String input, ExpectedExecution expectedExecution, Map<String, Object> expectedValues) {

--- a/src/test/java/net/minestom/server/command/CommandSyntaxMultiTest.java
+++ b/src/test/java/net/minestom/server/command/CommandSyntaxMultiTest.java
@@ -28,6 +28,14 @@ public class CommandSyntaxMultiTest {
         assertSyntax(args, "float 5.5", ExpectedExecution.SECOND_SYNTAX, Map.of("float", "float", "number", 5.5f));
     }
 
+    @Test
+    public void argPriority() {
+        List<List<Argument<?>>> args = List.of(
+                List.of(Word("word")),
+                List.of(Literal("literal"))
+        );
+        assertSyntax(args, "literal", ExpectedExecution.SECOND_SYNTAX);
+    }
 
     @Test
     public void similarArgs() {


### PR DESCRIPTION
Fix for #1327 

Rewrites `CommandParserImpl.java` to work recursively. This allows it to backtrack, whereas previously it could not. (This caused the bug; it found an argument that was successful initially, but looking further ahead fails, and it does not recover)

This change needs way more testing before going in, and probably a serious look at what this changes and how it affects existing implementations. I do not know how performant it is, and it may be better to write this iteratively, but I don't think the impact should be too great (keeping in mind that the previous version was not a full/proper implementation)

TODO:
- [x] Fix test failures
- [x] Check compatibility
- [x] Check performance
- [x] Add test for bugs fixed