### PR TITLE
Fix enchantment registry reading

### DIFF
--- a/src/main/java/net/minestom/server/registry/Registry.java
+++ b/src/main/java/net/minestom/server/registry/Registry.java
@@ -402,10 +402,10 @@ public final class Registry {
                     main.getInt("id"),
                     main.getString("translationKey"),
                     main.getDouble("maxLevel"),
-                    main.getBoolean("isCursed", false),
-                    main.getBoolean("isDiscoverable", true),
-                    main.getBoolean("isTradeable", true),
-                    main.getBoolean("isTreasureOnly", false),
+                    main.getBoolean("curse", false),
+                    main.getBoolean("discoverable", true),
+                    main.getBoolean("tradeable", true),
+                    main.getBoolean("treasureOnly", false),
                     custom);
         }
     }


### PR DESCRIPTION
The data generation code generates the `curse`, `discoverable`, `tradeable`, and `treasureOnly` fields, but the registry reader reads them as, respectively, `isCursed`, `isDiscoverable`, `isTradeable`, and `isTreasureOnly`, making the registry use the default value for each. This PR fixes this issue.

This registry feature used to be fine, but it was broken [here](https://github.com/Minestom/Minestom/commit/0743759eed0c956556f86f5247c5ec11cb181698) on 4 February 2022 due to what is presumably a mistake while manually updating code.