### PR TITLE
Load heightmaps from anvil files

### DIFF
--- a/src/main/java/net/minestom/server/instance/AnvilLoader.java
+++ b/src/main/java/net/minestom/server/instance/AnvilLoader.java
@@ -127,6 +127,9 @@ public class AnvilLoader implements IChunkLoader {
 
             // Block entities
             loadBlockEntities(chunk, chunkReader);
+
+            // Heightmaps
+            loadHeightmaps(chunk, mcaFile.getChunk(chunkX, chunkZ));
         }
         synchronized (perRegionLoadedChunks) {
             int regionX = CoordinatesKt.chunkToRegion(chunkX);
@@ -298,6 +301,18 @@ public class AnvilLoader implements IChunkLoader {
             final var finalBlock = mutableCopy.getSize() > 0 ?
                     block.withNbt(mutableCopy.toCompound()) : block;
             loadedChunk.setBlock(x, y, z, finalBlock);
+        }
+    }
+
+    private void loadHeightmaps(Chunk loadedChunk, ChunkColumn chunkColumn) {
+        final var motionBlocking = chunkColumn.getMotionBlockingHeightMap();
+        final var worldSurface = chunkColumn.getWorldSurfaceHeightMap();
+
+        for (int z = 0; z < 16; z++) {
+            for (int x = 0; x < 16; x++) {
+                loadedChunk.getMotionBlockingHeightmap().set(x, z, motionBlocking.get(x, z));
+                loadedChunk.getWorldSurfaceHeightmap().set(x, z, worldSurface.get(x, z));
+            }
         }
     }
 

--- a/src/main/java/net/minestom/server/instance/Chunk.java
+++ b/src/main/java/net/minestom/server/instance/Chunk.java
@@ -95,6 +95,10 @@ public abstract class Chunk implements Block.Getter, Block.Setter, Biome.Getter,
         return getSection(ChunkUtils.getChunkCoordinate(blockY));
     }
 
+    public abstract @NotNull Heightmap getMotionBlockingHeightmap();
+
+    public abstract @NotNull Heightmap getWorldSurfaceHeightmap();
+
     /**
      * Executes a chunk tick.
      * <p>

--- a/src/main/java/net/minestom/server/instance/Heightmap.java
+++ b/src/main/java/net/minestom/server/instance/Heightmap.java
@@ -1,0 +1,25 @@
+package net.minestom.server.instance;
+
+public class Heightmap {
+    private final int[] values;
+
+    public Heightmap() {
+        values = new int[16 * 16];
+    }
+
+    public int get(int x, int z) {
+        return values[index(x, z)];
+    }
+
+    public void set(int x, int z, int height) {
+        values[index(x, z)] = height;
+    }
+
+    private int index(int x, int z) {
+        return x + z * 16;
+    }
+
+    public int[] getValues() {
+        return values;
+    }
+}


### PR DESCRIPTION
Previously, heightmaps were hardcoded, which made it rain under surfaces:
![2023-08-01_16 48 17](https://github.com/Minestom/Minestom/assets/43483846/39cbf86f-32b1-408f-950c-7c074a9dbc0c)

With this change, heightmaps are read from anvil files and it no longer rains under surfaces:
![2023-08-01_16 46 08](https://github.com/Minestom/Minestom/assets/43483846/baea0b70-ecad-44b6-bc78-984d2b57f4c6)

In a future commit, the heightmaps will need to be updated on block placement.