### PR TITLE
Fix empty command chain causing NullPointerException

### DIFF
--- a/src/main/java/net/minestom/server/command/CommandParserImpl.java
+++ b/src/main/java/net/minestom/server/command/CommandParserImpl.java
@@ -101,18 +101,19 @@ final class CommandParserImpl implements CommandParser {
 
         NodeResult result = parseNode(parent, chain, reader);
         chain = result.chain;
-        if (result.argumentResult instanceof ArgumentResult.Success<?>) {
-            NodeResult lastNodeResult = chain.nodeResults.peekLast();
-            Node lastNode = lastNodeResult.node;
 
+        NodeResult lastNodeResult = chain.nodeResults.peekLast();
+        if (lastNodeResult == null) return UnknownCommandResult.INSTANCE;
+        Node lastNode = lastNodeResult.node;
+
+        if (result.argumentResult instanceof ArgumentResult.Success<?>) {
             CommandExecutor executor = nullSafeGetter(lastNode.execution(), Graph.Execution::executor);
             if (executor != null) return ValidCommand.executor(input, chain, executor);
         }
         // If here, then the command failed or didn't have an executor
 
         // Look for a default executor, or give up if we got nowhere
-        NodeResult lastNode = chain.nodeResults.peekLast();
-        if (lastNode.node.equals(parent)) return UnknownCommandResult.INSTANCE;
+        if (lastNode.equals(parent)) return UnknownCommandResult.INSTANCE;
         if (chain.defaultExecutor != null) {
             return ValidCommand.defaultExecutor(input, chain);
         }

--- a/src/test/java/net/minestom/server/command/CommandParseTest.java
+++ b/src/test/java/net/minestom/server/command/CommandParseTest.java
@@ -14,6 +14,12 @@ import static org.junit.jupiter.api.Assertions.*;
 public class CommandParseTest {
 
     @Test
+    public void emptyCommand() {
+        var graph = Graph.merge(Graph.builder(Literal("foo"), createExecutor(new AtomicBoolean())).build());
+        assertUnknown(graph, "");
+    }
+
+    @Test
     public void singleParameterlessCommand() {
         final AtomicBoolean b = new AtomicBoolean();
         var foo = Graph.merge(Graph.builder(Literal("foo"), createExecutor(b)).build());


### PR DESCRIPTION
May or may not have done an oopsie
(I think my panel was not submitting empty strings)

Running `/` causes a NullPointerException. This PR fixes it and instead returns `UnknownCommandResult`