### PR TITLE
Prioritise errors by chain length, build subcommands first (fix #1934)

### DIFF
--- a/src/main/java/net/minestom/server/command/CommandParserImpl.java
+++ b/src/main/java/net/minestom/server/command/CommandParserImpl.java
@@ -74,6 +74,10 @@ final class CommandParserImpl implements CommandParser {
             return nodeResults.stream().map(x -> x.node.argument()).collect(Collectors.toList());
         }
 
+        int size() {
+            return nodeResults.size();
+        }
+
         Chain() {}
 
         Chain(CommandExecutor defaultExecutor,
@@ -137,7 +141,7 @@ final class CommandParserImpl implements CommandParser {
             NodeResult nodeResult = new NodeResult(node, chain, (ArgumentResult<Object>) result, suggestionCallback);
             chain.append(nodeResult);
             if (suggestionCallback != null) chain.suggestionCallback = suggestionCallback;
-            if (chain.nodeResults.size() == 1) { // If this is the root node (usually "Literal<>")
+            if (chain.size() == 1) { // If this is the root node (usually "Literal<>")
                 reader.cursor(start);
             } else {
                 if (!(result instanceof ArgumentResult.Success<?>)) {
@@ -174,11 +178,11 @@ final class CommandParserImpl implements CommandParser {
                 // Assume that there is only one successful node for a given chain of arguments
                 return childResult;
             } else {
-                if (error == null) {
+                if (error == null || error.chain.size() < childResult.chain.size()) {
                     // If this is the base argument (e.g. "teleport" in /teleport) then
                     // do not report an argument to be incompatible, since the more
                     // correct thing would be to say that the command is unknown.
-                    if (!(childResult.chain.nodeResults.size() == 2 && childResult.argumentResult instanceof ArgumentResult.IncompatibleType<?>)) {
+                    if (!(childResult.chain.size() == 2 && childResult.argumentResult instanceof ArgumentResult.IncompatibleType<?>)) {
                         error = childResult;
                     }
                 }

--- a/src/main/java/net/minestom/server/command/CommandParserImpl.java
+++ b/src/main/java/net/minestom/server/command/CommandParserImpl.java
@@ -101,18 +101,19 @@ final class CommandParserImpl implements CommandParser {
 
         NodeResult result = parseNode(parent, chain, reader);
         chain = result.chain;
-        if (result.argumentResult instanceof ArgumentResult.Success<?>) {
-            NodeResult lastNodeResult = chain.nodeResults.peekLast();
-            Node lastNode = lastNodeResult.node;
 
+        NodeResult lastNodeResult = chain.nodeResults.peekLast();
+        if (lastNodeResult == null) return UnknownCommandResult.INSTANCE;
+        Node lastNode = lastNodeResult.node;
+
+        if (result.argumentResult instanceof ArgumentResult.Success<?>) {
             CommandExecutor executor = nullSafeGetter(lastNode.execution(), Graph.Execution::executor);
             if (executor != null) return ValidCommand.executor(input, chain, executor);
         }
         // If here, then the command failed or didn't have an executor
 
         // Look for a default executor, or give up if we got nowhere
-        NodeResult lastNode = chain.nodeResults.peekLast();
-        if (lastNode.node.equals(parent)) return UnknownCommandResult.INSTANCE;
+        if (lastNode.equals(parent)) return UnknownCommandResult.INSTANCE;
         if (chain.defaultExecutor != null) {
             return ValidCommand.defaultExecutor(input, chain);
         }

--- a/src/main/java/net/minestom/server/command/GraphImpl.java
+++ b/src/main/java/net/minestom/server/command/GraphImpl.java
@@ -156,6 +156,10 @@ record GraphImpl(NodeImpl root) implements Graph {
 
         static ConversionNode fromCommand(Command command) {
             ConversionNode root = new ConversionNode(commandToArgument(command), ExecutionImpl.fromCommand(command));
+            // Subcommands
+            for (Command subcommand : command.getSubcommands()) {
+                root.nextMap.put(commandToArgument(subcommand), fromCommand(subcommand));
+            }
             // Syntaxes
             for (CommandSyntax syntax : command.getSyntaxes()) {
                 ConversionNode syntaxNode = root;
@@ -165,10 +169,6 @@ record GraphImpl(NodeImpl root) implements Graph {
                     syntaxNode = syntaxNode.nextMap.computeIfAbsent(arg, argument -> new ConversionNode(argument, ex));
                     if (syntaxNode.execution == null) syntaxNode.execution = ex;
                 }
-            }
-            // Subcommands
-            for (Command subcommand : command.getSubcommands()) {
-                root.nextMap.put(commandToArgument(subcommand), fromCommand(subcommand));
             }
             return root;
         }

--- a/src/test/java/net/minestom/server/command/CommandParseTest.java
+++ b/src/test/java/net/minestom/server/command/CommandParseTest.java
@@ -14,6 +14,12 @@ import static org.junit.jupiter.api.Assertions.*;
 public class CommandParseTest {
 
     @Test
+    public void emptyCommand() {
+        var graph = Graph.merge(Graph.builder(Literal("foo"), createExecutor(new AtomicBoolean())).build());
+        assertUnknown(graph, "");
+    }
+
+    @Test
     public void singleParameterlessCommand() {
         final AtomicBoolean b = new AtomicBoolean();
         var foo = Graph.merge(Graph.builder(Literal("foo"), createExecutor(b)).build());

--- a/src/test/java/net/minestom/server/command/CommandSuggestionIntegrationTest.java
+++ b/src/test/java/net/minestom/server/command/CommandSuggestionIntegrationTest.java
@@ -95,9 +95,7 @@ public class CommandSuggestionIntegrationTest {
 
         subCommand.addSyntax((sender, context) -> {}, wordArg1, wordArg2);
 
-        command.addSyntax((sender,context)->{
-
-        }, Literal("literal"), wordArg2);
+        command.addSyntax((sender,context)->{}, Literal("literal"), wordArg2);
 
         command.addSubcommand(subCommand);
 
@@ -109,6 +107,36 @@ public class CommandSuggestionIntegrationTest {
 
         listener.assertSingle(tabCompletePacket -> {
             assertEquals(List.of(new TabCompletePacket.Match("suggestionA", null)), tabCompletePacket.matches());
+        });
+    }
+
+    @Test
+    public void suggestionWithTwoLiterals(Env env) {
+        var instance = env.createFlatInstance();
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+
+        var command = new Command("foo");
+
+        var wordArg1 = Word("wordArg1").setSuggestionCallback((sender, context, suggestion) -> {
+            suggestion.addEntry(new SuggestionEntry("suggestionA"));
+        });
+        var wordArg2 = Word("wordArg2").setSuggestionCallback((sender, context, suggestion) -> {
+            suggestion.addEntry(new SuggestionEntry("suggestionB"));
+        });
+
+        command.addSyntax((sender,context)->{}, Literal("literal1"), wordArg1);
+
+        command.addSyntax((sender,context)->{}, Literal("literal2"), wordArg2);
+
+        env.process().command().register(command);
+
+        var listener = connection.trackIncoming(TabCompletePacket.class);
+        player.addPacketToQueue(new ClientTabCompletePacket(1, "foo literal2 "));
+        player.interpretPacketQueue();
+
+        listener.assertSingle(tabCompletePacket -> {
+            assertEquals(List.of(new TabCompletePacket.Match("suggestionB", null)), tabCompletePacket.matches());
         });
     }
 

--- a/src/test/java/net/minestom/server/command/GraphConversionTest.java
+++ b/src/test/java/net/minestom/server/command/GraphConversionTest.java
@@ -85,6 +85,10 @@ public class GraphConversionTest {
         final Command main = new Command("main");
         final Command sub = new Command("sub");
 
+        var baz = Literal("baz");
+
+        main.addSyntax(GraphConversionTest::dummyExecutor, baz); // Check that subcommands are added to graph first
+
         var bar = Literal("bar");
         var number = Integer("number");
 
@@ -97,6 +101,7 @@ public class GraphConversionTest {
         var graph = Graph.builder(Literal("main"))
                 .append(Literal("sub"), builder ->
                         builder.append(bar, builder1 -> builder1.append(number)))
+                .append(Literal("baz"))
                 .build();
         assertEqualsGraph(graph, main);
     }


### PR DESCRIPTION
More discussion of fixes found at #1934.

Despite #1893 adding priority to nodes, the graph converter converts command arguments (as subcommands) to literals before they reach the node. This is fixed by converting the subcommands before the syntaxes.
On top of that, a variation of the issue can be created by having two literals instead of a literal and subcommand. The error returned will depend on the order of addSyntax. This is wrong, and is fixed by returning the error with the longest chain length.

I would like to add a test to check that commands are always processed before literals, but I don't know how to do this given the current test utils. It doesn't fit in `CommandSyntaxMultiTest`, perhaps `CommandParseTest`? If someone who has better experience with the testing could give some feedback that would be great.

If anyone has code that relies on the errors reported, please test this - it works fine internally but I can't predict how it will affect stuff like that.

ps: ignore the first commit. I think the squash merge did some funky stuff with git and now it's still there.