### PR TITLE
Return Block.AIR instead of throwing NPE for Instance getBlock

### DIFF
--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -533,7 +533,7 @@ public abstract class Instance implements Block.Getter, Block.Setter,
     @Override
     public @Nullable Block getBlock(int x, int y, int z, @NotNull Condition condition) {
         final Block block = blockRetriever.getBlock(x, y, z, condition);
-        if (block == null) throw new NullPointerException("Unloaded chunk at " + x + "," + y + "," + z);
+        if (block == null) return Block.AIR;
         return block;
     }
 


### PR DESCRIPTION
This change means that, if `Instance#getBlock` is called on a block in an unloaded chunk, the method simply returns Block.AIR, instead of throwing a `NullPointerException`.

This behaviour is in line with `Chunk#getBlock`, and also in line with vanilla behaviour.

### Motivation

Currently, if you try to get a block in an unloaded chunk using `Instance#getBlock`, it will throw a `NullPointerException`. This behaviour is very annoying for several reasons:

* It is not documented anywhere. It is not at all obvious from any documentation anywhere that this is the case.
* This is not something you should expect this method to do, especially consdering the overridden signature is `@Nullable`, when it can actually never return null because of the NPE behaviour.
* It means that you either have to check if the chunk is loaded, or use a try catch around `getBlock`, catching a `NullPointerException`, every time you get a block from an `Instance`. Both of these are undesirable, and the latter is bad practice.

This aims to completely eliminate the possibility of encountering a `NullPointerException` when using `Instance#getBlock`, therefore avoiding confusion, saving inevitable debugging time, and moving the API in line with its `Chunk` counterpart.