### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -93,7 +93,7 @@ Commands are the simplest way of communication between clients and server. Since
 * The [contributors](https://github.com/Minestom/Minestom/graphs/contributors) of the project
 * [The Minecraft Coalition](https://wiki.vg/) and [`#mcdevs`](https://github.com/mcdevs) -
    protocol and file formats research.
-* [The Minecraft Wiki](https://minecraft.gamepedia.com/Minecraft_Wiki) for all their useful info
+* [The Minecraft Wiki](https://minecraft.wiki) for all their useful info
 * [JProfiler](https://www.ej-technologies.com/products/jprofiler/overview.html) for their amazing Java profiler
 
 # Contributing

--- a/demo/src/main/java/net/minestom/demo/commands/GamemodeCommand.java
+++ b/demo/src/main/java/net/minestom/demo/commands/GamemodeCommand.java
@@ -20,7 +20,7 @@ import java.util.Locale;
  * Command that make a player change gamemode, made in
  * the style of the vanilla /gamemode command.
  *
- * @see <a href="https://minecraft.fandom.com/wiki/Commands/gamemode">...</a>
+ * @see <a href="https://minecraft.wiki/w/Commands/gamemode">...</a>
  */
 public class GamemodeCommand extends Command {
 

--- a/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentEntity.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentEntity.java
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
 
 /**
  * Represents the target selector argument.
- * https://minecraft.gamepedia.com/Commands#Target_selectors
+ * https://minecraft.wiki/w/Target_selectors
  */
 public class ArgumentEntity extends Argument<EntityFinder> {
 

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -979,7 +979,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
      *
      * @param gravityDragPerTick  the gravity drag per tick in block
      * @param gravityAcceleration the gravity acceleration in block
-     * @see <a href="https://minecraft.gamepedia.com/Entity#Motion_of_entities">Entities motion</a>
+     * @see <a href="https://minecraft.wiki/w/Entity#Motion_of_entities">Entities motion</a>
      */
     public void setGravity(double gravityDragPerTick, double gravityAcceleration) {
         this.gravityDragPerTick = gravityDragPerTick;

--- a/src/main/java/net/minestom/server/instance/block/BlockHandler.java
+++ b/src/main/java/net/minestom/server/instance/block/BlockHandler.java
@@ -67,7 +67,7 @@ public interface BlockHandler {
      * Specifies which block entity tags should be sent to the player.
      *
      * @return The list of tags from this block's block entity that should be sent to the player
-     * @see <a href="https://minecraft.fandom.com/wiki/Block_entity">Block entity on Minecraft fandom wiki</a>
+     * @see <a href="https://minecraft.wiki/w/Block_entity">Block entity on the Minecraft wiki</a>
      */
     default @NotNull Collection<Tag<?>> getBlockEntityTags() {
         return List.of();

--- a/src/main/java/net/minestom/server/map/MapColors.java
+++ b/src/main/java/net/minestom/server/map/MapColors.java
@@ -120,7 +120,7 @@ public enum MapColors {
         this.blue = blue;
     }
 
-    // From the wiki: https://minecraft.gamepedia.com/Map_item_format
+    // From the wiki: https://minecraft.wiki/w/Map_item_format
     // Map Color ID 	Multiply R,G,B By 	= Multiplier
     //Base Color ID*4 + 0 	180 	0.71
     //Base Color ID*4 + 1 	220 	0.86

--- a/src/main/java/net/minestom/server/utils/NamespaceID.java
+++ b/src/main/java/net/minestom/server/utils/NamespaceID.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 
 /**
  * Represents a namespaced ID
- * https://minecraft.gamepedia.com/Namespaced_ID
+ * https://minecraft.wiki/w/Namespaced_ID
  */
 public final class NamespaceID implements CharSequence, Key {
     private static final String legalLetters = "[0123456789abcdefghijklmnopqrstuvwxyz_-]+";

--- a/src/main/java/net/minestom/server/world/DimensionType.java
+++ b/src/main/java/net/minestom/server/world/DimensionType.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * https://minecraft.gamepedia.com/Custom_dimension
+ * https://minecraft.wiki/w/Custom_dimension
  */
 public class DimensionType {
 


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.