### PR TITLE
Add automatic module name

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,11 @@ java {
 }
 
 tasks {
+    jar {
+        manifest {
+            attributes("Automatic-Module-Name" to "net.minestom.server")
+        }
+    }
     withType<Javadoc> {
         (options as? StandardJavadocDocletOptions)?.apply {
             encoding = "UTF-8"


### PR DESCRIPTION
Minestom is currently not modular, resulting in an assigned module name derived from the JAR name. However, this name is often not a valid Java identifier.
![module name](https://github.com/Minestom/Minestom/assets/87631423/2fc9d71f-b3d8-47eb-8bfe-52b239e5d0ac)

This PR assigns a stable module name to the server JAR.