### PR TITLE
Fix Maven Central Link

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -31,7 +31,7 @@ Minestom is not installed like Bukkit/Forge/Sponge.
 As Minestom is a Java library, it must be loaded the same way any other Java library may be loaded.
 This means you need to add Minestom as a dependency, add your code and compile by yourself.
 
-Minestom is available on [Maven Central](https://central.sonatype.com/artifact/net.minestom/minestom),
+Minestom is available on [Maven Central](https://central.sonatype.com/artifact/net.minestom/minestom-snapshots),
 and can be installed like the following (Gradle/Groovy):
 
 ```groovy


### PR DESCRIPTION
Just a simple change from https://central.sonatype.com/artifact/net.minestom/minestom to https://central.sonatype.com/artifact/net.minestom/minestom-snapshots