### PR TITLE
Fix: FakePlayer is not registered in connection player map

### DIFF
--- a/demo/src/main/java/net/minestom/demo/Main.java
+++ b/demo/src/main/java/net/minestom/demo/Main.java
@@ -75,6 +75,8 @@ public class Main {
         commandManager.register(new SetEntityType());
         commandManager.register(new RelightCommand());
         commandManager.register(new KillCommand());
+        commandManager.register(new KickCommand());
+        commandManager.register(new FakePlayerCommand());
 
         commandManager.setUnknownCommandCallback((sender, command) -> sender.sendMessage(Component.text("Unknown command", NamedTextColor.RED)));
 

--- a/demo/src/main/java/net/minestom/demo/commands/FakePlayerCommand.java
+++ b/demo/src/main/java/net/minestom/demo/commands/FakePlayerCommand.java
@@ -1,0 +1,32 @@
+package net.minestom.demo.commands;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.minestom.server.command.builder.Command;
+import net.minestom.server.command.builder.arguments.ArgumentType;
+import net.minestom.server.command.builder.condition.Conditions;
+import net.minestom.server.entity.Player;
+import net.minestom.server.entity.fakeplayer.FakePlayer;
+import net.minestom.server.entity.fakeplayer.FakePlayerOption;
+
+import java.util.UUID;
+
+public class FakePlayerCommand extends Command {
+
+    public FakePlayerCommand() {
+        super("fakeplayer");
+        setCondition(Conditions::playerOnly);
+        var usernameArg = ArgumentType.String("username");
+        setDefaultExecutor((sender, context) -> sender.sendMessage("Usage: /" + getName() + " <" + usernameArg.getId() + ">"));
+        addSyntax((sender, context) -> {
+            Player p = (Player) sender;
+            String username = context.get(usernameArg);
+            FakePlayer.initPlayer(
+                    UUID.randomUUID(), username,
+                    new FakePlayerOption().setInTabList(true).setRegistered(true),
+                    fp -> p.sendMessage(Component.text(fp.getUsername() + " spawned!", NamedTextColor.GREEN))
+            );
+        }, usernameArg);
+    }
+
+}

--- a/demo/src/main/java/net/minestom/demo/commands/KickCommand.java
+++ b/demo/src/main/java/net/minestom/demo/commands/KickCommand.java
@@ -1,0 +1,51 @@
+package net.minestom.demo.commands;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.minestom.server.command.builder.Command;
+import net.minestom.server.command.builder.arguments.ArgumentType;
+import net.minestom.server.command.builder.suggestion.SuggestionEntry;
+import net.minestom.server.entity.Player;
+import net.minestom.server.utils.entity.EntityFinder;
+
+public class KickCommand extends Command {
+
+    public KickCommand() {
+        super("kick");
+        setDefaultExecutor((sender, context) -> sender.sendMessage(Component.text("Usage: /kick <player> [reason]")));
+
+        var playerArg = ArgumentType.Entity("player").onlyPlayers(true);
+        var reasonArg = ArgumentType.StringArray("reason");
+
+        reasonArg.setSuggestionCallback((sender, context, suggestion) -> {
+            if (suggestion.getInput().isBlank()) {
+                suggestion.addEntry(new SuggestionEntry("<reason>"));
+            }
+        });
+
+        addSyntax((sender, context) -> {
+            EntityFinder finder = context.get("player");
+            Component reason = Component.text("You have been kicked from this server");
+            finder.find(sender).stream().filter(e -> e instanceof Player).map(e -> (Player) e).forEach(p -> {
+                p.kick(reason);
+                sender.sendMessage(Component.text("Kicked " + p.getUsername(), NamedTextColor.GREEN));
+            });
+        }, playerArg);
+
+        addSyntax((sender, context) -> {
+            EntityFinder finder = context.get("player");
+            Component reason = Component.text(String.join(" ", context.get(reasonArg)));
+            finder.find(sender).stream().filter(e -> e instanceof Player).map(e -> (Player) e).forEach(p -> {
+                p.kick(reason);
+                sender.sendMessage(Component.join(
+                        JoinConfiguration.separator(Component.space()),
+                        Component.text("Kicked " + p.getUsername() + ":", NamedTextColor.GREEN),
+                        reason
+                ));
+            });
+        }, playerArg, reasonArg);
+
+    }
+
+}

--- a/src/main/java/net/minestom/server/network/ConnectionManager.java
+++ b/src/main/java/net/minestom/server/network/ConnectionManager.java
@@ -218,6 +218,10 @@ public final class ConnectionManager {
         return AsyncUtils.runAsync(() -> {
             final PlayerConnection playerConnection = player.getPlayerConnection();
 
+            // Map the connection to the player provided if no mapping currently exists (fallback)
+            if (!connectionPlayerMap.containsKey(playerConnection))
+                connectionPlayerMap.put(playerConnection, player);
+
             // Compression
             if (playerConnection instanceof PlayerSocketConnection socketConnection) {
                 final int threshold = MinecraftServer.getCompressionThreshold();

--- a/src/test/java/net/minestom/server/entity/player/FakePlayerIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/player/FakePlayerIntegrationTest.java
@@ -1,0 +1,71 @@
+package net.minestom.server.entity.player;
+
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.entity.fakeplayer.FakePlayer;
+import net.minestom.server.entity.fakeplayer.FakePlayerOption;
+import net.minestom.server.event.player.AsyncPlayerConfigurationEvent;
+import net.minestom.testing.Env;
+import net.minestom.testing.EnvTest;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@EnvTest
+public class FakePlayerIntegrationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(FakePlayerIntegrationTest.class);
+
+    @Test
+    public void removalTest(Env env) {
+        var instance = env.createFlatInstance();
+
+        env.listen(AsyncPlayerConfigurationEvent.class).followup(event -> {
+            // Spawning instance is required to be set in configuration event
+            event.setSpawningInstance(instance);
+            log.info("Spawning instance set for {}", event.getPlayer().getUsername());
+        });
+
+        FakePlayer player = initializeFakePlayer(env, UUID.randomUUID(), "FakePlayer");
+
+        assertTrue(player.isOnline(), "The FakePlayer should currently be considered as online");
+        assertEquals(1, MinecraftServer.getConnectionManager().getOnlinePlayerCount(), "Should only be 1 player online (the FakePlayer)");
+
+        // One extra tick just in case something is missed
+        env.tick();
+
+        // Disconnects the FakePlayer
+        player.remove();
+
+        // FakePlayer should be removed after two ticks
+        env.tick();
+        env.tick();
+
+        assertFalse(player.isOnline(), "The FakePlayer should currently be considered as offline");
+        assertEquals(0, MinecraftServer.getConnectionManager().getOnlinePlayerCount(), "There should be no players online");
+    }
+
+    private FakePlayer initializeFakePlayer(Env env, UUID uuid, String username) {
+        return initializeFakePlayer(env, uuid, username, new FakePlayerOption().setInTabList(true).setRegistered(true));
+    }
+
+    private FakePlayer initializeFakePlayer(Env env, UUID uuid, String username, FakePlayerOption options) {
+        log.info("Initializing new FakePlayer: {}", username);
+        AtomicReference<FakePlayer> reference = new AtomicReference<>();
+        FakePlayer.initPlayer(uuid, username, options, fp -> {
+            log.info("Spawn callback called for {}", fp.getUsername());
+            reference.set(fp);
+        });
+        env.tickWhile(() -> Objects.isNull(reference.get()), Duration.ofSeconds(15));
+        FakePlayer fp = reference.get();
+        assertNotNull(fp, "No FakePlayer spawned");
+        return fp;
+    }
+
+}


### PR DESCRIPTION
FakePlayers, when initialized, have no mapping in `connectionPlayerMap` in `ConnectionManager` because it looks like `ConnectionManager#createPlayer` is not being called. This commit adds a fallback to connection manager where if a player is being transitioned from login to config and no connection <-> player map exists, set it as a fallback. The map needs to be set because if the FakePlayer is disconnected, it causes inaccurate player online counts and issues for duplicate FakePlayers with the same username.

To see the issue, comment out the fallback fix in ConnectionManager. Then run the commands:
- `/fakeplayer Test`
- `/kick Test`
- `/fakeplayer Test`

The 2nd FakePlayer remains online and is not disconnected. Also, after the first player is kicked, the online player count becomes inaccurate.

I also added a test for checking when a FakePlayer is initialized and disconnected.
