### PR TITLE
General improvement for code readability

### DIFF
--- a/src/main/java/net/minestom/server/recipe/PacketDeclaration.java
+++ b/src/main/java/net/minestom/server/recipe/PacketDeclaration.java
@@ -1,0 +1,104 @@
+package net.minestom.server.recipe;
+
+import net.minestom.server.network.packet.server.play.DeclareRecipesPacket;
+import org.jetbrains.annotations.NotNull;
+
+interface PacketDeclaration {
+
+    @NotNull
+    static DeclareRecipesPacket.DeclaredShapelessCraftingRecipe create(@NotNull ShapelessRecipe shapelessRecipe) {
+        return new DeclareRecipesPacket.DeclaredShapelessCraftingRecipe(shapelessRecipe.getRecipeId(),
+                shapelessRecipe.getGroup(),
+                shapelessRecipe.getCategory(),
+                shapelessRecipe.getIngredients(),
+                shapelessRecipe.getResult());
+    }
+
+    @NotNull
+    static DeclareRecipesPacket.DeclaredShapedCraftingRecipe create(@NotNull ShapedRecipe shapedRecipe) {
+        return new DeclareRecipesPacket.DeclaredShapedCraftingRecipe(shapedRecipe.getRecipeId(),
+                shapedRecipe.getGroup(),
+                shapedRecipe.getCategory(),
+                shapedRecipe.getWidth(),
+                shapedRecipe.getHeight(),
+                shapedRecipe.getIngredients(),
+                shapedRecipe.getResult(),
+                shapedRecipe.getShowNotification());
+    }
+
+    @NotNull
+    static DeclareRecipesPacket.DeclaredSmeltingRecipe create(@NotNull SmeltingRecipe smeltingRecipe) {
+        return  new DeclareRecipesPacket.DeclaredSmeltingRecipe(
+                smeltingRecipe.getRecipeId(),
+                smeltingRecipe.getGroup(),
+                smeltingRecipe.getCategory(),
+                smeltingRecipe.getIngredient(),
+                smeltingRecipe.getResult(),
+                smeltingRecipe.getExperience(),
+                smeltingRecipe.getCookingTime());
+    }
+
+    @NotNull
+    static DeclareRecipesPacket.DeclaredBlastingRecipe create(@NotNull BlastingRecipe blastingRecipe) {
+        return new DeclareRecipesPacket.DeclaredBlastingRecipe(
+                blastingRecipe.getRecipeId(),
+                blastingRecipe.getGroup(),
+                blastingRecipe.getCategory(),
+                blastingRecipe.getIngredient(),
+                blastingRecipe.getResult(),
+                blastingRecipe.getExperience(),
+                blastingRecipe.getCookingTime());
+    }
+
+    @NotNull
+    static DeclareRecipesPacket.DeclaredSmokingRecipe create(@NotNull SmokingRecipe smokingRecipe) {
+        return new DeclareRecipesPacket.DeclaredSmokingRecipe(
+                smokingRecipe.getRecipeId(),
+                smokingRecipe.getGroup(),
+                smokingRecipe.getCategory(),
+                smokingRecipe.getIngredient(),
+                smokingRecipe.getResult(),
+                smokingRecipe.getExperience(),
+                smokingRecipe.getCookingTime());
+    }
+
+    @NotNull
+    static DeclareRecipesPacket.DeclaredCampfireCookingRecipe create(@NotNull CampfireCookingRecipe campfireCookingRecipe) {
+        return new DeclareRecipesPacket.DeclaredCampfireCookingRecipe(
+                campfireCookingRecipe.getRecipeId(),
+                campfireCookingRecipe.getGroup(),
+                campfireCookingRecipe.getCategory(),
+                campfireCookingRecipe.getIngredient(),
+                campfireCookingRecipe.getResult(),
+                campfireCookingRecipe.getExperience(),
+                campfireCookingRecipe.getCookingTime());
+    }
+
+    @NotNull
+    static DeclareRecipesPacket.DeclaredStonecutterRecipe create(@NotNull StonecutterRecipe stonecuttingRecipe) {
+        return new DeclareRecipesPacket.DeclaredStonecutterRecipe(
+                stonecuttingRecipe.getRecipeId(),
+                stonecuttingRecipe.getGroup(),
+                stonecuttingRecipe.getIngredient(),
+                stonecuttingRecipe.getResult());
+    }
+
+    @NotNull
+    static DeclareRecipesPacket.DeclaredSmithingTransformRecipe create(@NotNull SmithingTransformRecipe smithingTransformRecipe) {
+        return  new DeclareRecipesPacket.DeclaredSmithingTransformRecipe(
+                smithingTransformRecipe.getRecipeId(),
+                smithingTransformRecipe.getTemplate(),
+                smithingTransformRecipe.getBaseIngredient(),
+                smithingTransformRecipe.getAdditionIngredient(),
+                smithingTransformRecipe.getResult());
+    }
+
+    @NotNull
+    static DeclareRecipesPacket.DeclaredSmithingTrimRecipe create(@NotNull SmithingTrimRecipe smithingTrimRecipe) {
+        return  new DeclareRecipesPacket.DeclaredSmithingTrimRecipe(
+                smithingTrimRecipe.getRecipeId(),
+                smithingTrimRecipe.getTemplate(),
+                smithingTrimRecipe.getBaseIngredient(),
+                smithingTrimRecipe.getAdditionIngredient());
+    }
+}

--- a/src/main/java/net/minestom/server/recipe/RecipeManager.java
+++ b/src/main/java/net/minestom/server/recipe/RecipeManager.java
@@ -41,113 +41,22 @@ public class RecipeManager {
     }
 
     private void refreshRecipesPacket() {
-        List<DeclareRecipesPacket.DeclaredRecipe> recipesCache = new ArrayList<>();
-        for (Recipe recipe : recipes) {
-            switch (recipe.recipeType) {
-                case SHAPELESS -> {
-                    ShapelessRecipe shapelessRecipe = (ShapelessRecipe) recipe;
-                    recipesCache.add(
-                            new DeclareRecipesPacket.DeclaredShapelessCraftingRecipe(
-                                    shapelessRecipe.getRecipeId(),
-                                    shapelessRecipe.getGroup(),
-                                    shapelessRecipe.getCategory(),
-                                    shapelessRecipe.getIngredients(),
-                                    shapelessRecipe.getResult()));
-                }
-                case SHAPED -> {
-                    ShapedRecipe shapedRecipe = (ShapedRecipe) recipe;
-                    recipesCache.add(
-                            new DeclareRecipesPacket.DeclaredShapedCraftingRecipe(
-                                    shapedRecipe.getRecipeId(),
-                                    shapedRecipe.getGroup(),
-                                    shapedRecipe.getCategory(),
-                                    shapedRecipe.getWidth(),
-                                    shapedRecipe.getHeight(),
-                                    shapedRecipe.getIngredients(),
-                                    shapedRecipe.getResult(),
-                                    shapedRecipe.getShowNotification()));
-                }
-                case SMELTING -> {
-                    SmeltingRecipe smeltingRecipe = (SmeltingRecipe) recipe;
-                    recipesCache.add(
-                            new DeclareRecipesPacket.DeclaredSmeltingRecipe(
-                                    smeltingRecipe.getRecipeId(),
-                                    smeltingRecipe.getGroup(),
-                                    smeltingRecipe.getCategory(),
-                                    smeltingRecipe.getIngredient(),
-                                    smeltingRecipe.getResult(),
-                                    smeltingRecipe.getExperience(),
-                                    smeltingRecipe.getCookingTime()));
-                }
-                case BLASTING -> {
-                    BlastingRecipe blastingRecipe = (BlastingRecipe) recipe;
-                    recipesCache.add(
-                            new DeclareRecipesPacket.DeclaredBlastingRecipe(
-                                    blastingRecipe.getRecipeId(),
-                                    blastingRecipe.getGroup(),
-                                    blastingRecipe.getCategory(),
-                                    blastingRecipe.getIngredient(),
-                                    blastingRecipe.getResult(),
-                                    blastingRecipe.getExperience(),
-                                    blastingRecipe.getCookingTime()));
-                }
-                case SMOKING -> {
-                    SmokingRecipe smokingRecipe = (SmokingRecipe) recipe;
-                    recipesCache.add(
-                            new DeclareRecipesPacket.DeclaredSmokingRecipe(
-                                    smokingRecipe.getRecipeId(),
-                                    smokingRecipe.getGroup(),
-                                    smokingRecipe.getCategory(),
-                                    smokingRecipe.getIngredient(),
-                                    smokingRecipe.getResult(),
-                                    smokingRecipe.getExperience(),
-                                    smokingRecipe.getCookingTime()));
-                }
-                case CAMPFIRE_COOKING -> {
-                    CampfireCookingRecipe campfireCookingRecipe = (CampfireCookingRecipe) recipe;
-                    recipesCache.add(
-                            new DeclareRecipesPacket.DeclaredCampfireCookingRecipe(
-                                    campfireCookingRecipe.getRecipeId(),
-                                    campfireCookingRecipe.getGroup(),
-                                    campfireCookingRecipe.getCategory(),
-                                    campfireCookingRecipe.getIngredient(),
-                                    campfireCookingRecipe.getResult(),
-                                    campfireCookingRecipe.getExperience(),
-                                    campfireCookingRecipe.getCookingTime()));
-                }
-                case STONECUTTING -> {
-                    StonecutterRecipe stonecuttingRecipe = (StonecutterRecipe) recipe;
-                    recipesCache.add(
-                            new DeclareRecipesPacket.DeclaredStonecutterRecipe(
-                                    stonecuttingRecipe.getRecipeId(),
-                                    stonecuttingRecipe.getGroup(),
-                                    stonecuttingRecipe.getIngredient(),
-                                    stonecuttingRecipe.getResult()));
-                }
-                case SMITHING_TRANSFORM -> {
-                    SmithingTransformRecipe smithingTransformRecipe = (SmithingTransformRecipe) recipe;
-                    recipesCache.add(
-                            new DeclareRecipesPacket.DeclaredSmithingTransformRecipe(
-                                    smithingTransformRecipe.getRecipeId(),
-                                    smithingTransformRecipe.getTemplate(),
-                                    smithingTransformRecipe.getBaseIngredient(),
-                                    smithingTransformRecipe.getAdditionIngredient(),
-                                    smithingTransformRecipe.getResult()));
-                }
-                case SMITHING_TRIM -> {
-                    SmithingTrimRecipe smithingTrimRecipe = (SmithingTrimRecipe) recipe;
-                    recipesCache.add(
-                            new DeclareRecipesPacket.DeclaredSmithingTrimRecipe(
-                                    smithingTrimRecipe.getRecipeId(),
-                                    smithingTrimRecipe.getTemplate(),
-                                    smithingTrimRecipe.getBaseIngredient(),
-                                    smithingTrimRecipe.getAdditionIngredient()));
-                }
-            }
-        }
+        declareRecipesPacket = new DeclareRecipesPacket(recipes.stream().map(this::mapPacket).toList());
+    }
 
-        declareRecipesPacket = new DeclareRecipesPacket(recipesCache);
-        // TODO; refresh and update players recipes
+    @NotNull
+    private DeclareRecipesPacket.DeclaredRecipe mapPacket(@NotNull Recipe recipe) {
+        return switch (recipe.recipeType) {
+            case SHAPELESS -> PacketDeclaration.create((ShapelessRecipe) recipe);
+            case SHAPED -> PacketDeclaration.create((ShapedRecipe) recipe);
+            case SMELTING -> PacketDeclaration.create((SmeltingRecipe) recipe);
+            case BLASTING -> PacketDeclaration.create((BlastingRecipe) recipe);
+            case SMOKING -> PacketDeclaration.create((SmokingRecipe) recipe);
+            case CAMPFIRE_COOKING -> PacketDeclaration.create((CampfireCookingRecipe) recipe);
+            case STONECUTTING -> PacketDeclaration.create((StonecutterRecipe) recipe);
+            case SMITHING_TRANSFORM -> PacketDeclaration.create((SmithingTransformRecipe) recipe);
+            case SMITHING_TRIM -> PacketDeclaration.create((SmithingTrimRecipe) recipe);
+        };
     }
 
 }


### PR DESCRIPTION
This PR improves the code structure and readability for the recipe manager. The packages were extracted into an interface with a static method and only released on package. A To-Do has been removed and the switch statement has been tidied up.
