### PR TITLE
Improved socket handling for the server

### DIFF
--- a/src/main/java/net/minestom/server/network/socket/Server.java
+++ b/src/main/java/net/minestom/server/network/socket/Server.java
@@ -15,8 +15,12 @@ import java.nio.channels.SocketChannel;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class Server {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Server.class);
 
     public static final boolean NO_DELAY = true;
 
@@ -112,8 +116,21 @@ public final class Server {
         } catch (IOException e) {
             MinecraftServer.getExceptionManager().handleException(e);
         }
-        this.selector.wakeup();
-        this.workers.forEach(worker -> worker.selector.wakeup());
+        try {
+            this.selector.close();
+        } catch (IOException e) {
+            LOGGER.error("Server socket sector could not be closed", e);
+            System.exit(-1);
+        }
+        this.workers.forEach(worker -> {
+            try {
+                worker.selector.close();
+            } catch (IOException e) {
+                Worker.LOGGER.error("Worker Socket Sector could not be closed", e);
+                System.exit(-1);
+            }
+
+        });
     }
 
     @ApiStatus.Internal

--- a/src/main/java/net/minestom/server/network/socket/Server.java
+++ b/src/main/java/net/minestom/server/network/socket/Server.java
@@ -117,6 +117,7 @@ public final class Server {
             MinecraftServer.getExceptionManager().handleException(e);
         }
         try {
+            this.selector.wakeup();
             this.selector.close();
         } catch (IOException e) {
             LOGGER.error("Server socket sector could not be closed", e);

--- a/src/main/java/net/minestom/server/network/socket/Server.java
+++ b/src/main/java/net/minestom/server/network/socket/Server.java
@@ -122,15 +122,7 @@ public final class Server {
             LOGGER.error("Server socket sector could not be closed", e);
             System.exit(-1);
         }
-        this.workers.forEach(worker -> {
-            try {
-                worker.selector.close();
-            } catch (IOException e) {
-                Worker.LOGGER.error("Worker Socket Sector could not be closed", e);
-                System.exit(-1);
-            }
-
-        });
+        this.workers.forEach(Worker::close);
     }
 
     @ApiStatus.Internal

--- a/src/main/java/net/minestom/server/network/socket/Worker.java
+++ b/src/main/java/net/minestom/server/network/socket/Worker.java
@@ -26,9 +26,9 @@ import org.slf4j.LoggerFactory;
 public final class Worker extends MinestomThread {
     private static final AtomicInteger COUNTER = new AtomicInteger();
 
-    static final Logger LOGGER = LoggerFactory.getLogger(Server.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Server.class);
 
-    final Selector selector;
+    private final Selector selector;
     private final Map<SocketChannel, PlayerSocketConnection> connectionMap = new ConcurrentHashMap<>();
     private final Server server;
     private final MpscUnboundedXaddArrayQueue<Runnable> queue = new MpscUnboundedXaddArrayQueue<>(1024);
@@ -45,6 +45,16 @@ public final class Worker extends MinestomThread {
 
     public void tick() {
         this.selector.wakeup();
+    }
+
+    public void close() {
+        this.selector.wakeup();
+        try {
+            this.selector.close();
+        } catch (IOException e) {
+            LOGGER.error("Worker Socket Sector could not be closed", e);
+            System.exit(-1);
+        }
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/socket/Worker.java
+++ b/src/main/java/net/minestom/server/network/socket/Worker.java
@@ -19,10 +19,14 @@ import java.nio.channels.SocketChannel;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ApiStatus.Internal
 public final class Worker extends MinestomThread {
     private static final AtomicInteger COUNTER = new AtomicInteger();
+
+    static final Logger LOGGER = LoggerFactory.getLogger(Server.class);
 
     final Selector selector;
     private final Map<SocketChannel, PlayerSocketConnection> connectionMap = new ConcurrentHashMap<>();


### PR DESCRIPTION
The PR now closes the socket correctly as soon as the Stop method is called by the server class. In addition, thrown errors are handled in the sense that the program can still function stably afterwards. And the errors are passed to a logger.

The changes are due to the fact that on Unix systems with a low ulimit a `java.io.FileNotFoundException: XXX (Too many open files)` occurred. This happened especially with unit tests.
