### PR TITLE
Solves a problem regarding biomes and the registry method

### DIFF
--- a/src/main/java/net/minestom/server/world/biomes/BiomeImpl.java
+++ b/src/main/java/net/minestom/server/world/biomes/BiomeImpl.java
@@ -27,6 +27,7 @@ final class BiomeImpl implements ProtocolObject, Biome {
         return CONTAINER.getSafe(namespace);
     }
 
+    private Registry.BiomeEntry entry;
     @NotNull
     private final NamespaceID name;
     private final float depth;
@@ -52,6 +53,7 @@ final class BiomeImpl implements ProtocolObject, Biome {
     }
 
     BiomeImpl(Registry.BiomeEntry entry) {
+        this.entry = entry;
         this.name = entry.namespace();
         this.depth = 0.2f;
         this.scale = 0.2f;
@@ -85,7 +87,7 @@ final class BiomeImpl implements ProtocolObject, Biome {
     @Nullable
     @Override
     public Registry.BiomeEntry registry() {
-        return null;
+        return this.entry;
     }
 
     @Override


### PR DESCRIPTION
Due to the implementation of the vanilla biome generation, a method call was forgotten to be implemented correctly. This PR fixes the problem and solves the null referencing in some cases 
