### PR TITLE
Fix incorrect slot updating

### DIFF
--- a/src/main/java/net/minestom/server/inventory/PlayerInventory.java
+++ b/src/main/java/net/minestom/server/inventory/PlayerInventory.java
@@ -167,10 +167,10 @@ public non-sealed class PlayerInventory extends AbstractInventory implements Equ
      */
     protected void sendSlotRefresh(short slot, ItemStack itemStack) {
         var openInventory = player.getOpenInventory();
-        if (openInventory == null || !(slot >= OFFSET && slot < OFFSET + INNER_INVENTORY_SIZE)) {
-            this.player.sendPacket(new SetSlotPacket((byte) 0, 0, slot, itemStack));
-        } else {
+        if (openInventory != null && slot >= OFFSET && slot < OFFSET + INNER_INVENTORY_SIZE) {
             this.player.sendPacket(new SetSlotPacket(openInventory.getWindowId(), 0, (short) (slot + openInventory.getSize() - OFFSET), itemStack));
+        } else if (openInventory == null || slot == OFFHAND_SLOT) {
+            this.player.sendPacket(new SetSlotPacket((byte) 0, 0, slot, itemStack));
         }
     }
 

--- a/src/main/java/net/minestom/server/inventory/PlayerInventory.java
+++ b/src/main/java/net/minestom/server/inventory/PlayerInventory.java
@@ -166,7 +166,12 @@ public non-sealed class PlayerInventory extends AbstractInventory implements Equ
      * @param itemStack the item stack in the slot
      */
     protected void sendSlotRefresh(short slot, ItemStack itemStack) {
-        this.player.sendPacket(new SetSlotPacket((byte) 0, 0, slot, itemStack));
+        var openInventory = player.getOpenInventory();
+        if (openInventory == null || !(slot >= OFFSET && slot < OFFSET + INNER_INVENTORY_SIZE)) {
+            this.player.sendPacket(new SetSlotPacket((byte) 0, 0, slot, itemStack));
+        } else {
+            this.player.sendPacket(new SetSlotPacket(openInventory.getWindowId(), 0, (short) (slot + openInventory.getSize() - OFFSET), itemStack));
+        }
     }
 
     /**


### PR DESCRIPTION
Minestom currently updates the player inventory by sending a SetSlotPacket with inventory ID 0. This is correct except when dealing with inner inventory slots (storage and hotbar) while the player has another inventory open, in which case you need to send these 36 slots as though they exist directly after the opened inventory (which is the way the client sends click packets).

This was likely not caught because it only occurs to inner inventory slot changes without an inventory update.

This PR fixes Minestom and updates slots in the correct manner.