### PR TITLE
Fix potential threading bug in Acquirable

### DIFF
--- a/src/main/java/net/minestom/server/thread/Acquirable.java
+++ b/src/main/java/net/minestom/server/thread/Acquirable.java
@@ -104,8 +104,7 @@ public sealed interface Acquirable<T> permits AcquirableImpl {
         Acquired<T> acquired = lock();
         try {
             consumer.accept(acquired.get());
-        }
-        finally {
+        } finally {
             acquired.unlock();
         }
     }

--- a/src/main/java/net/minestom/server/thread/Acquirable.java
+++ b/src/main/java/net/minestom/server/thread/Acquirable.java
@@ -102,8 +102,12 @@ public sealed interface Acquirable<T> permits AcquirableImpl {
      */
     default void sync(@NotNull Consumer<T> consumer) {
         Acquired<T> acquired = lock();
-        consumer.accept(acquired.get());
-        acquired.unlock();
+        try {
+            consumer.accept(acquired.get());
+        }
+        finally {
+            acquired.unlock();
+        }
     }
 
     /**


### PR DESCRIPTION
Previously, Acquirable#sync(Consumer) would never release the acquired lock if the given consumer threw an exception. The simple solution is to add a try...finally clause.