### PR TITLE
Fix: disable time updates when not needed

### DIFF
--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -470,6 +470,7 @@ public abstract class Instance implements Block.Getter, Block.Setter,
      */
     public void setTimeRate(int timeRate) {
         Check.stateCondition(timeRate < 0, "The time rate cannot be lower than 0");
+        if (timeRate == 0) setTimeUpdate(null);
         this.timeRate = timeRate;
     }
 

--- a/src/test/java/net/minestom/server/instance/InstanceTimeTest.java
+++ b/src/test/java/net/minestom/server/instance/InstanceTimeTest.java
@@ -1,0 +1,17 @@
+package net.minestom.server.instance;
+
+import net.minestom.testing.Env;
+import net.minestom.testing.EnvTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@EnvTest
+public class InstanceTimeTest {
+    @Test
+    public void testNoUpdatesWhenZeroTimeRate(Env env) {
+        var instance = env.createFlatInstance();
+        instance.setTimeRate(0);
+
+        Assertions.assertNull(instance.getTimeUpdate());
+    }
+}


### PR DESCRIPTION
When time rate is zero we do not need to send TimeUpdatePackets to users.