### PR TITLE
chore: move packet flush to after ServerTickMonitorEvent

### DIFF
--- a/src/main/java/net/minestom/server/ServerProcessImpl.java
+++ b/src/main/java/net/minestom/server/ServerProcessImpl.java
@@ -276,9 +276,6 @@ final class ServerProcessImpl implements ServerProcess {
             // Flush all waiting packets
             PacketUtils.flush();
 
-            // Server connection tick
-            server().tick();
-
             // Monitoring
             {
                 final double acquisitionTimeMs = Acquirable.resetAcquiringTime() / 1e6D;
@@ -286,6 +283,9 @@ final class ServerProcessImpl implements ServerProcess {
                 final TickMonitor tickMonitor = new TickMonitor(tickTimeMs, acquisitionTimeMs);
                 EventDispatcher.call(new ServerTickMonitorEvent(tickMonitor));
             }
+
+            // Server connection tick
+            server().tick();
         }
 
         private void serverTick(long tickStart) {


### PR DESCRIPTION
ServerTickMonitorEvent is a very useful event for running logic on final state the server is in on a given tick
packets should flushed after this event to reflect any logic here immediately
