### PR TITLE
fix: send EntityHeadLookPacket on teleport

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -323,7 +323,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
             this.position = position;
             refreshCoordinate(position);
             synchronizePosition(true);
-            setView(position.yaw(), position.pitch());
+            sendPacketToViewers(new EntityHeadLookPacket(getEntityId(), position.yaw()));
         };
 
         if (chunks != null && chunks.length > 0) {

--- a/src/test/java/net/minestom/server/entity/EntityTeleportIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/EntityTeleportIntegrationTest.java
@@ -1,5 +1,6 @@
 package net.minestom.server.entity;
 
+import net.minestom.server.network.packet.server.play.EntityHeadLookPacket;
 import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
 import net.minestom.server.coordinate.Pos;
@@ -7,6 +8,8 @@ import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.play.EntityTeleportPacket;
 import net.minestom.server.network.packet.server.play.PlayerPositionAndLookPacket;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -58,10 +61,16 @@ public class EntityTeleportIntegrationTest {
         tracker.assertSingle(PlayerPositionAndLookPacket.class,
                 packet -> assertEquals(teleportPosition, packet.position()));
         // Verify broadcast packet(s)
-        viewerTracker.assertSingle(EntityTeleportPacket.class, packet -> {
-            assertEquals(player.getEntityId(), packet.entityId());
-            assertEquals(teleportPosition, packet.position());
-        });
+
+        viewerTracker.assertCount(2);
+        List<ServerPacket> packets = viewerTracker.collect();
+        var teleportPacket = (EntityTeleportPacket) packets.get(0);
+        assertEquals(player.getEntityId(), teleportPacket.entityId());
+        assertEquals(teleportPosition, teleportPacket.position());
+
+        var headLookPacket = (EntityHeadLookPacket) packets.get(1);
+        assertEquals(player.getEntityId(), headLookPacket.entityId());
+        assertEquals(teleportPosition.yaw(), headLookPacket.yaw());
     }
 
     @Test


### PR DESCRIPTION
setView will always return immediately before sending the EntityHeadLookPacket
there's no reason to call it, rather, we should send the necessary packet explicitly