### PR TITLE
Scheduler try catch

### DIFF
--- a/src/main/java/net/minestom/server/timer/SchedulerImpl.java
+++ b/src/main/java/net/minestom/server/timer/SchedulerImpl.java
@@ -94,7 +94,7 @@ final class SchedulerImpl implements Scheduler {
         try {
             schedule = task.task().get();
         } catch (Throwable t) {
-            MinecraftServer.LOGGER.error("Error in scheduled task", t);
+            MinecraftServer.getExceptionManager().handleException(new RuntimeException("Exception in scheduled task", t));
             schedule = TaskSchedule.stop();
         }
 

--- a/src/main/java/net/minestom/server/timer/SchedulerImpl.java
+++ b/src/main/java/net/minestom/server/timer/SchedulerImpl.java
@@ -1,6 +1,7 @@
 package net.minestom.server.timer;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectAVLTreeMap;
+import net.minestom.server.MinecraftServer;
 import org.jctools.queues.MpscUnboundedArrayQueue;
 import org.jetbrains.annotations.NotNull;
 
@@ -89,7 +90,14 @@ final class SchedulerImpl implements Scheduler {
     }
 
     private void handleTask(TaskImpl task) {
-        final TaskSchedule schedule = task.task().get();
+        TaskSchedule schedule;
+        try {
+            schedule = task.task().get();
+        } catch (Throwable t) {
+            MinecraftServer.LOGGER.error("Error in scheduled task", t);
+            schedule = TaskSchedule.stop();
+        }
+
         if (schedule instanceof TaskScheduleImpl.DurationSchedule durationSchedule) {
             final Duration duration = durationSchedule.duration();
             SCHEDULER.schedule(() -> safeExecute(task), duration.toMillis(), TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Currently, if a task in a scheduler fails, it will skip everything else in the TickerImpl (server scheduler) or instance tick.
It seems preferable to individually fail tasks and keep other tasks/ticking intact.