### PR TITLE
Properly handle HTTP requests

### DIFF
--- a/src/main/java/net/minestom/server/network/player/PlayerSocketConnection.java
+++ b/src/main/java/net/minestom/server/network/player/PlayerSocketConnection.java
@@ -131,8 +131,6 @@ public class PlayerSocketConnection extends PlayerConnection {
             try {
                 final ByteBuffer buffer = ByteBuffer.wrap(("""
                         HTTP/1.1 418 I'm a teapot
-                        Date: Wed, 21 Mar 2024 00:00:00 GMT
-                        Server: Apache/2.4.46 (Unix)
                         Content-Length: 275
                         Content-Type: text/html; charset=UTF-8
 

--- a/src/main/java/net/minestom/server/utils/PacketUtils.java
+++ b/src/main/java/net/minestom/server/utils/PacketUtils.java
@@ -189,12 +189,15 @@ public final class PacketUtils {
 
     @ApiStatus.Internal
     public static @Nullable BinaryBuffer readPackets(@NotNull BinaryBuffer readBuffer, boolean compressed,
-                                                     BiConsumer<Integer, ByteBuffer> payloadConsumer) throws DataFormatException {
+                                                     BiConsumer<Integer, ByteBuffer> payloadConsumer) throws DataFormatException, IllegalStateException {
         BinaryBuffer remaining = null;
         ByteBuffer pool = ObjectPool.PACKET_POOL.get();
         while (readBuffer.readableBytes() > 0) {
             final var beginMark = readBuffer.mark();
             try {
+                // Check for http request
+                final byte firstByte = readBuffer.readBytes(1)[0];
+                if (firstByte == 'G') throw new IllegalStateException("I'm a teapot!");
                 // Ensure that the buffer contains the full packet (or wait for next socket read)
                 final int packetLength = readBuffer.readVarInt();
                 final int readerStart = readBuffer.readerOffset();

--- a/src/main/java/net/minestom/server/utils/PacketUtils.java
+++ b/src/main/java/net/minestom/server/utils/PacketUtils.java
@@ -189,15 +189,12 @@ public final class PacketUtils {
 
     @ApiStatus.Internal
     public static @Nullable BinaryBuffer readPackets(@NotNull BinaryBuffer readBuffer, boolean compressed,
-                                                     BiConsumer<Integer, ByteBuffer> payloadConsumer) throws DataFormatException, IllegalStateException {
+                                                     BiConsumer<Integer, ByteBuffer> payloadConsumer) throws DataFormatException {
         BinaryBuffer remaining = null;
         ByteBuffer pool = ObjectPool.PACKET_POOL.get();
         while (readBuffer.readableBytes() > 0) {
             final var beginMark = readBuffer.mark();
             try {
-                // Check for http request
-                final byte firstByte = readBuffer.readBytes(1)[0];
-                if (firstByte == 'G') throw new IllegalStateException("I'm a teapot!");
                 // Ensure that the buffer contains the full packet (or wait for next socket read)
                 final int packetLength = readBuffer.readVarInt();
                 final int readerStart = readBuffer.readerOffset();


### PR DESCRIPTION
Right now, Minestom just throws errors if you try to connect to the server port with a web client. This is stupid. We have a HTTP status code for this: 418. I propose that we fix Minestom bug and make it handle this common case properly.

Also, funny.