### PR TITLE
Add bounds check to CreativeInventoryListener

### DIFF
--- a/src/main/java/net/minestom/server/listener/CreativeInventoryActionListener.java
+++ b/src/main/java/net/minestom/server/listener/CreativeInventoryActionListener.java
@@ -19,7 +19,8 @@ public final class CreativeInventoryActionListener {
             return;
         }
         // Bounds check
-        if (slot < 0 || slot > PlayerInventoryUtils.OFFHAND_SLOT) {
+        // 0 is crafting result inventory slot, ignore attempts to place into it
+        if (slot < 1 || slot > PlayerInventoryUtils.OFFHAND_SLOT) {
             return;
         }
         // Set item

--- a/src/main/java/net/minestom/server/listener/CreativeInventoryActionListener.java
+++ b/src/main/java/net/minestom/server/listener/CreativeInventoryActionListener.java
@@ -18,6 +18,10 @@ public final class CreativeInventoryActionListener {
             player.dropItem(item);
             return;
         }
+        // Bounds check
+        if (slot < 0 || slot > PlayerInventoryUtils.OFFHAND_SLOT) {
+            return;
+        }
         // Set item
         slot = (short) PlayerInventoryUtils.convertPlayerInventorySlot(slot, PlayerInventoryUtils.OFFSET);
         PlayerInventory inventory = player.getInventory();

--- a/src/test/java/net/minestom/server/inventory/PlayerCreativeSlotTest.java
+++ b/src/test/java/net/minestom/server/inventory/PlayerCreativeSlotTest.java
@@ -1,0 +1,42 @@
+package net.minestom.server.inventory;
+
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.GameMode;
+import net.minestom.server.item.ItemStack;
+import net.minestom.server.item.Material;
+import net.minestom.server.listener.CreativeInventoryActionListener;
+import net.minestom.server.network.packet.client.play.ClientCreativeInventoryActionPacket;
+import net.minestom.server.utils.inventory.PlayerInventoryUtils;
+import net.minestom.testing.Env;
+import net.minestom.testing.EnvTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@EnvTest
+public class PlayerCreativeSlotTest {
+
+    @Test
+    public void testCreativeSlots(Env env) {
+        var instance = env.createFlatInstance();
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+        assertEquals(instance, player.getInstance());
+
+        player.setGameMode(GameMode.CREATIVE);
+        player.addPacketToQueue(new ClientCreativeInventoryActionPacket((short) PlayerInventoryUtils.OFFHAND_SLOT, ItemStack.of(Material.STICK)));
+        player.interpretPacketQueue();
+        assertEquals(Material.STICK, player.getInventory().getItemInOffHand().material());
+    }
+
+    @Test
+    public void testBoundsCheck(Env env) {
+        var instance = env.createFlatInstance();
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+        player.setGameMode(GameMode.CREATIVE);
+
+        assertDoesNotThrow(() -> CreativeInventoryActionListener.listener(new ClientCreativeInventoryActionPacket((short) 76, ItemStack.of(Material.OAK_LOG)), player));
+    }
+}


### PR DESCRIPTION
Closes #1726.

Currently, there is no bounds checking on this listener. Normally, this would not be an issue (except for malicious clients seeking to attack the server), but the vanilla client appears to have a bug where if you are on any Creative Inventory Screen (except the survival inventory), hover over one of your hotbar slots, and press the Swap Offhand key, it sends a packet with slot id 76, outside of valid bounds.

This PR fixes this by adding a bounds check to the listener