### PR TITLE
chore: expose previous position with a getter

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -1479,6 +1479,15 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     }
 
     /**
+     * Gets the previous entity position.
+     *
+     * @return the previous position of the entity
+     */
+    public @NotNull Pos getPreviousPosition() {
+        return previousPosition;
+    }
+
+    /**
      * Gets the entity eye height.
      * <p>
      * Default to {@link BoundingBox#height()}x0.85


### PR DESCRIPTION
Exposing this field would let us do operations with the previousPosition without needing to track it ourselves, i.e. by setting up a scheduler to record it manually each tick.

An example of its usefulness would be particle effects where the direction the player travelled in needs to be known, along with the fact that the player's position on other player's clients is closer to their previousPosition due to entity interpolation.