### PR TITLE
fix: don't send EntityHeadLook/Rotation packets to self

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -1688,8 +1688,8 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     }
 
     private void synchronizeView() {
-        sendPacketToViewersAndSelf(new EntityHeadLookPacket(getEntityId(), position.yaw()));
-        sendPacketToViewersAndSelf(new EntityRotationPacket(getEntityId(), position.yaw(), position.pitch(), onGround));
+        sendPacketToViewers(new EntityHeadLookPacket(getEntityId(), position.yaw()));
+        sendPacketToViewers(new EntityRotationPacket(getEntityId(), position.yaw(), position.pitch(), onGround));
     }
 
     /**


### PR DESCRIPTION
EntityHeadLookPacket and EntityRotationPacket should never be sent to the player's client.
They're meant to be disregarded by the client but I've run into some issues with these packets causing my game to momentarily stop responding to incoming packets after receiving these