### PR TITLE
feat: use ticks for potion duration instead of system time

### DIFF
--- a/src/main/java/net/minestom/server/potion/TimedPotion.java
+++ b/src/main/java/net/minestom/server/potion/TimedPotion.java
@@ -2,22 +2,9 @@ package net.minestom.server.potion;
 
 import org.jetbrains.annotations.NotNull;
 
-public class TimedPotion {
-
-    private final Potion potion;
-    private final long startingTime;
-
-    public TimedPotion(@NotNull Potion potion, long startingTime) {
-        this.potion = potion;
-        this.startingTime = startingTime;
-    }
-
-    @NotNull
-    public Potion getPotion() {
+public record TimedPotion(Potion potion, long startingTicks) {
+    @Override
+    public @NotNull Potion potion() {
         return potion;
-    }
-
-    public long getStartingTime() {
-        return startingTime;
     }
 }

--- a/src/main/java/net/minestom/server/potion/TimedPotion.java
+++ b/src/main/java/net/minestom/server/potion/TimedPotion.java
@@ -1,10 +1,3 @@
 package net.minestom.server.potion;
 
-import org.jetbrains.annotations.NotNull;
-
-public record TimedPotion(Potion potion, long startingTicks) {
-    @Override
-    public @NotNull Potion potion() {
-        return potion;
-    }
-}
+public record TimedPotion(Potion potion, long startingTicks) {}


### PR DESCRIPTION
Potions should be timed via entity ticks to improve consistency.
I.e. If we give a zombie speed 3 and let it run forward for 40 ticks, we need to be certain that it will travel with speed 3 for exactly 40 ticks. System time would make this amount vary, likely between 39-41 ticks causing unexpected bugs in scenarios like this.
- Also converted TimedPotions to records