### PR TITLE
feat: factor data support for darkness effects

### DIFF
--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityEffectPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityEffectPacket.java
@@ -5,23 +5,18 @@ import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.ServerPacketIdentifier;
 import net.minestom.server.potion.Potion;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.jglrxavpok.hephaistos.nbt.NBTCompound;
 
 import static net.minestom.server.network.NetworkBuffer.*;
 
-public record EntityEffectPacket(int entityId, @NotNull Potion potion,
-                                 @Nullable NBTCompound factorCodec) implements ServerPacket.Play {
+public record EntityEffectPacket(int entityId, @NotNull Potion potion) implements ServerPacket.Play {
     public EntityEffectPacket(@NotNull NetworkBuffer reader) {
-        this(reader.read(VAR_INT), new Potion(reader),
-                reader.read(BOOLEAN) ? (NBTCompound) reader.read(NBT) : null);
+        this(reader.read(VAR_INT), new Potion(reader));
     }
 
     @Override
     public void write(@NotNull NetworkBuffer writer) {
         writer.write(VAR_INT, entityId);
         writer.write(potion);
-        writer.writeOptional(NBT, factorCodec);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/potion/FactorData.java
+++ b/src/main/java/net/minestom/server/potion/FactorData.java
@@ -1,0 +1,47 @@
+package net.minestom.server.potion;
+
+import net.minestom.server.entity.Entity;
+import net.minestom.server.network.NetworkBuffer;
+import org.jetbrains.annotations.NotNull;
+import org.jglrxavpok.hephaistos.nbt.NBT;
+import org.jglrxavpok.hephaistos.nbt.NBTCompound;
+
+import java.util.Map;
+
+/**
+ * Used to customize the {@link PotionEffect#DARKNESS} effect.
+ */
+public record FactorData(int paddingDuration, float factorStart, float factorTarget, float factorCurrent,
+                         int effectChangedTimestamp, float factorPreviousFrame, boolean hadEffectLastTick) implements NetworkBuffer.Writer {
+    @Override
+    public void write(@NotNull NetworkBuffer writer) {
+        writer.write(NetworkBuffer.NBT, this.toNBT());
+    }
+
+    public @NotNull NBTCompound toNBT() {
+        return NBT.Compound(Map.of(
+                "padding_duration", NBT.Int(paddingDuration),
+                "factor_start", NBT.Float(factorStart),
+                "factor_target", NBT.Float(factorTarget),
+                "factor_current", NBT.Float(factorCurrent),
+                "effect_changed_timestamp", NBT.Int(effectChangedTimestamp),
+                "factor_previous_frame", NBT.Float(factorPreviousFrame),
+                "had_effect_last_tick", NBT.Boolean(hadEffectLastTick)
+        ));
+    }
+
+    /**
+     * The default factor data that vanilla uses.
+     *
+     * @param entity the entity with the effect being applied to
+     * @return the default factor data
+     */
+    public static @NotNull FactorData defaultFactorData(@NotNull Entity entity) {
+        return new FactorData(22, 0, 1, 0, 0, 0, entity.hasEffect(PotionEffect.DARKNESS));
+    }
+
+    public static @NotNull FactorData fromNBT(@NotNull NBTCompound nbt) {
+        return new FactorData(nbt.getInt("padding_duration"), nbt.getFloat("factor_start"), nbt.getFloat("factor_target"), nbt.getFloat("factor_current"),
+                nbt.getInt("effect_changed_timestamp"), nbt.getFloat("factor_previous_frame"), nbt.getBoolean("had_effect_last_tick"));
+    }
+}

--- a/src/main/java/net/minestom/server/potion/Potion.java
+++ b/src/main/java/net/minestom/server/potion/Potion.java
@@ -76,7 +76,7 @@ public record Potion(@NotNull PotionEffect effect, byte amplifier,
 
     public Potion(@NotNull NetworkBuffer reader) {
         this(Objects.requireNonNull(PotionEffect.fromId(reader.read(VAR_INT))), reader.read(BYTE),
-                reader.read(VAR_INT), reader.read(BYTE), reader.read(BOOLEAN) ? FactorData.fromNBT((NBTCompound) reader.read(NBT)) : null);
+                reader.read(VAR_INT), reader.read(BYTE), reader.readOptional(r -> FactorData.fromNBT((NBTCompound) r.read(NBT))));
     }
 
     /**


### PR DESCRIPTION
The current behaviour of darkness is to blind the player entirely, this is because factor data is essential for darkness to work correctly.
I've created a FactorData record for ease of use, additionally I've created a Potion#darkness helper method to give developers factor values akin to what vanilla does 