### PR TITLE
feat: proper passenger position handling for most entities, fix passengers not always being applied to the client, don't sync passengers

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -1318,7 +1318,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     private void updatePassengerPosition(Point newPosition, Entity passenger) {
         final Pos oldPassengerPos = passenger.position;
         final Pos newPassengerPos = oldPassengerPos.withCoord(newPosition.x(),
-                newPosition.y() + EntityUtils.getPassengerHeightOffset(vehicle, passenger),
+                newPosition.y() + EntityUtils.getPassengerHeightOffset(this, passenger),
                 newPosition.z());
         passenger.position = newPassengerPos;
         passenger.previousPosition = oldPassengerPos;

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -467,9 +467,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         final Set<Entity> passengers = this.passengers;
         if (!passengers.isEmpty()) {
             for (Entity passenger : passengers) {
-                if (passenger != player && !passenger.isViewer(player)) {
-                    passenger.addViewer(player);
-                }
+                if (passenger != player) passenger.updateNewViewer(player);
             }
             player.sendPacket(getPassengersPacket());
         }

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -1312,15 +1312,15 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     }
 
     /**
-     * Sets the coordinates of the passenger to the coordinates of this vehicle + {@link EntityUtils#getPassengerOffset(Entity, Entity)}
+     * Sets the coordinates of the passenger to the coordinates of this vehicle + {@link EntityUtils#getPassengerHeightOffset(Entity, Entity)}
      *
-     * @param newPosition The X,Y,Z position of this vehicle
-     * @param passenger   The passenger to be moved
+     * @param newPosition the new position of this vehicle
+     * @param passenger   the passenger to be moved
      */
     private void updatePassengerPosition(Point newPosition, Entity passenger) {
         final Pos oldPassengerPos = passenger.position;
         final Pos newPassengerPos = oldPassengerPos.withCoord(newPosition.x(), newPosition.y(), newPosition.z())
-                .add(EntityUtils.getPassengerOffset(this, passenger));
+                .add(0, EntityUtils.getPassengerHeightOffset(this, passenger), 0);
         passenger.position = newPassengerPos;
         passenger.previousPosition = oldPassengerPos;
         passenger.refreshCoordinate(newPassengerPos);

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -1317,8 +1317,9 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
      */
     private void updatePassengerPosition(Point newPosition, Entity passenger) {
         final Pos oldPassengerPos = passenger.position;
-        final Pos newPassengerPos = oldPassengerPos.withCoord(newPosition.x(), newPosition.y(), newPosition.z())
-                .add(0, EntityUtils.getPassengerHeightOffset(this, passenger), 0);
+        final Pos newPassengerPos = oldPassengerPos.withCoord(newPosition.x(),
+                newPosition.y() + EntityUtils.getPassengerHeightOffset(vehicle, passenger),
+                newPosition.z());
         passenger.position = newPassengerPos;
         passenger.previousPosition = oldPassengerPos;
         passenger.refreshCoordinate(newPassengerPos);

--- a/src/main/java/net/minestom/server/entity/EntityView.java
+++ b/src/main/java/net/minestom/server/entity/EntityView.java
@@ -40,7 +40,7 @@ final class EntityView {
                     var lock2 = lock1 == entity ? player : entity;
                     synchronized (lock1.viewEngine.mutex) {
                         synchronized (lock2.viewEngine.mutex) {
-                            if (!entity.viewEngine.viewableOption.predicate(player) ||
+                            if (entity.isViewer(player) || !entity.viewEngine.viewableOption.predicate(player) ||
                                     !player.viewEngine.viewerOption.predicate(entity)) return;
                             entity.viewEngine.viewableOption.register(player);
                             player.viewEngine.viewerOption.register(entity);

--- a/src/main/java/net/minestom/server/entity/EntityView.java
+++ b/src/main/java/net/minestom/server/entity/EntityView.java
@@ -40,12 +40,14 @@ final class EntityView {
                     var lock2 = lock1 == entity ? player : entity;
                     synchronized (lock1.viewEngine.mutex) {
                         synchronized (lock2.viewEngine.mutex) {
-                            if (entity.isViewer(player) || !entity.viewEngine.viewableOption.predicate(player) ||
+                            if (!entity.viewEngine.viewableOption.predicate(player) ||
                                     !player.viewEngine.viewerOption.predicate(entity)) return;
                             entity.viewEngine.viewableOption.register(player);
                             player.viewEngine.viewerOption.register(entity);
                         }
                     }
+                    // Entity#updateNewViewer handles calling itself for passengers
+                    if (entity.getVehicle() != null) return;
                     entity.updateNewViewer(player);
                 },
                 player -> {

--- a/src/main/java/net/minestom/server/utils/entity/EntityUtils.java
+++ b/src/main/java/net/minestom/server/utils/entity/EntityUtils.java
@@ -1,154 +1,31 @@
 package net.minestom.server.utils.entity;
 
 import net.minestom.server.coordinate.Pos;
-import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.EntityType;
-import net.minestom.server.entity.metadata.AgeableMobMeta;
-import net.minestom.server.entity.metadata.EntityMeta;
-import net.minestom.server.entity.metadata.monster.PiglinMeta;
-import net.minestom.server.entity.metadata.monster.ZoglinMeta;
-import net.minestom.server.entity.metadata.monster.zombie.ZombieMeta;
-import net.minestom.server.entity.metadata.other.SlimeMeta;
 import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.block.Block;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Map;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.UnaryOperator;
+import java.util.Set;
 
 public final class EntityUtils {
-    private static final MountInfo DEFAULT_MOUNT_INFO = MountInfo.heightOnly(height -> height, 0, true);
-    private static final MountInfo MINECART_MOUNT_INFO = MountInfo.heightOnly(height -> 0.1875);
-    private static final MountInfo SLIME_MOUNT_INFO = new MountInfo(slime ->
-            new Vec(0, slime.getBoundingBox().height() - 0.015625 * ((SlimeMeta)slime.getEntityMeta()).getSize(), 0));
-    private static final MountInfo LLAMA_MOUNT_INFO = new MountInfo(llama -> llama.getPosition()
-            .direction().withY(0).normalize().mul(-0.3 * (isBaby(llama) ? 0.5 : 1))
-            .add(0, llama.getEntityType().height() - (isBaby(llama) ? 0.8125 : 0.5), 0));
-    private static final Map<EntityType, MountInfo> MOUNT_INFO = Map.<EntityType, MountInfo>ofEntries(
-            Map.entry(EntityType.SKELETON,         MountInfo.heightOnly(height -> height, -0.7)),
-            Map.entry(EntityType.STRAY,            MountInfo.heightOnly(height -> height, -0.7)),
-            Map.entry(EntityType.WITHER_SKELETON,  MountInfo.heightOnly(height -> height, -0.875)),
-            Map.entry(EntityType.ALLAY,            MountInfo.heightOnly(height -> height,  0.04)),
-            Map.entry(EntityType.PLAYER,           MountInfo.heightOnly(height -> height, -0.6)),
-            Map.entry(EntityType.GIANT,            MountInfo.heightOnly(height -> height, -3.75)),
-
-            Map.entry(EntityType.CAT,              MountInfo.heightOnly(height -> height - 0.1875)),
-            Map.entry(EntityType.GOAT,             MountInfo.heightOnly(height -> height - 0.1875)),
-
-            Map.entry(EntityType.PIG,              MountInfo.heightOnly(height -> height - 0.03125)),
-            Map.entry(EntityType.COW,              MountInfo.heightOnly(height -> height - 0.03125)),
-            Map.entry(EntityType.WOLF,             MountInfo.heightOnly(height -> height - 0.03125)),
-            Map.entry(EntityType.WITCH,            MountInfo.heightOnly(height -> height - 0.03125)),
-
-            Map.entry(EntityType.FOX,              MountInfo.heightOnly(height -> height - 0.0625)),
-            Map.entry(EntityType.OCELOT,           MountInfo.heightOnly(height -> height - 0.0625)),
-            Map.entry(EntityType.SHEEP,            MountInfo.heightOnly(height -> height - 0.0625)),
-            Map.entry(EntityType.ENDERMITE,        MountInfo.heightOnly(height -> height - 0.0625)),
-            Map.entry(EntityType.SILVERFISH,       MountInfo.heightOnly(height -> height - 0.0625)),
-            Map.entry(EntityType.VEX,              MountInfo.heightOnly(height -> height - 0.0625, 0.04)),
-
-            Map.entry(EntityType.RAVAGER,          MountInfo.heightOnly(height -> height + 0.0625, -0.7)),
-            Map.entry(EntityType.PIGLIN,           MountInfo.heightOnly(height -> height + 0.0625, -0.7)),
-            Map.entry(EntityType.PIGLIN_BRUTE,     MountInfo.heightOnly(height -> height + 0.0625, -0.7)),
-            Map.entry(EntityType.ZOMBIE,           MountInfo.heightOnly(height -> height + 0.0625, -0.7)),
-            Map.entry(EntityType.DROWNED,          MountInfo.heightOnly(height -> height + 0.0625, -0.7)),
-
-            Map.entry(EntityType.GHAST,            MountInfo.heightOnly(height -> height + 0.0625, 0.5)),
-
-            Map.entry(EntityType.ZOMBIFIED_PIGLIN, MountInfo.heightOnly(height -> height + 0.05,  -0.7)),
-
-            Map.entry(EntityType.PILLAGER,         MountInfo.heightOnly(height -> height + 0.05, -0.6)),
-            Map.entry(EntityType.EVOKER,           MountInfo.heightOnly(height -> height + 0.05, -0.6)),
-            Map.entry(EntityType.VINDICATOR,       MountInfo.heightOnly(height -> height + 0.05, -0.6)),
-            Map.entry(EntityType.ILLUSIONER,       MountInfo.heightOnly(height -> height + 0.05, -0.6)),
-
-            Map.entry(EntityType.ENDERMAN,         MountInfo.heightOnly(height -> height - 0.09375)),
-            Map.entry(EntityType.PARROT,           MountInfo.heightOnly(height -> height - 0.4375f)),
-            Map.entry(EntityType.SNIFFER,          MountInfo.heightOnly(height -> height + 0.34375)),
-            Map.entry(EntityType.ELDER_GUARDIAN,   MountInfo.heightOnly(height -> height + 0.353215)),
-            Map.entry(EntityType.GUARDIAN,         MountInfo.heightOnly(height -> height + 0.125)),
-            Map.entry(EntityType.HUSK,             MountInfo.heightOnly(height -> height + 0.125)),
-            Map.entry(EntityType.FROG,             MountInfo.heightOnly(height -> height - 0.125f)),
-            Map.entry(EntityType.WARDEN,           MountInfo.heightOnly(height -> height + 0.25)),
-            Map.entry(EntityType.ZOMBIE_VILLAGER,  MountInfo.heightOnly(height -> height + 0.175)),
-
-            Map.entry(EntityType.SPIDER,           MountInfo.heightOnly(height -> height * 0.85,  -0.3125, true)),
-            Map.entry(EntityType.CAVE_SPIDER,      MountInfo.heightOnly(height -> height * 0.85,  -0.21875, true)),
-            Map.entry(EntityType.PHANTOM,          MountInfo.heightOnly(height -> height * 0.675, -0.125, true)),
-
-            Map.entry(EntityType.HOGLIN,           MountInfo.heightOnly(height -> height - 0.09375)),
-            Map.entry(EntityType.ZOGLIN,           MountInfo.heightOnly(height -> height - 0.09375)),
-
-            Map.entry(EntityType.PANDA,            MountInfo.explicitBabyHeight((height, isBaby) -> height - (isBaby ? 0.4375 : 0))),
-            Map.entry(EntityType.SKELETON_HORSE,   MountInfo.explicitBabyHeight((height, isBaby) -> height - (isBaby ? 0.03125 : 0.28125))),
-
-
-            Map.entry(EntityType.TURTLE,           new MountInfo(turtle -> turtle.getPosition()
-                    .direction().withY(0).normalize().mul(-0.25 * (isBaby(turtle) ? 0.3 : 1))
-                    .add(0, turtle.getBoundingBox().height() + (isBaby(turtle) ? 0 : 0.15625), 0), 0, 0.3, false)),
-            Map.entry(EntityType.CHICKEN,          new MountInfo(chicken -> chicken.getPosition()
-                    .direction().withY(0).normalize().mul(-0.1 * (isBaby(chicken) ? 0.5 : 1))
-                    .add(0, chicken.getBoundingBox().height(), 0))),
-
-            Map.entry(EntityType.SLIME,            SLIME_MOUNT_INFO),
-            Map.entry(EntityType.MAGMA_CUBE,       SLIME_MOUNT_INFO),
-
-            Map.entry(EntityType.MINECART,         MINECART_MOUNT_INFO),
-            Map.entry(EntityType.CHEST_MINECART,   MINECART_MOUNT_INFO),
-            Map.entry(EntityType.FURNACE_MINECART, MINECART_MOUNT_INFO),
-            Map.entry(EntityType.HOPPER_MINECART,  MINECART_MOUNT_INFO),
-            Map.entry(EntityType.TNT_MINECART,     MINECART_MOUNT_INFO),
-
-            Map.entry(EntityType.LLAMA,            LLAMA_MOUNT_INFO),
-            Map.entry(EntityType.TRADER_LLAMA,     LLAMA_MOUNT_INFO),
-
-            Map.entry(EntityType.BOAT,             MountInfo.heightOnly(height -> height / 3, 0, true)),
-            Map.entry(EntityType.CHEST_BOAT,       MountInfo.heightOnly(height -> height / 3, 0, true))
-    );
+    private static final Set<EntityType> SITTING_ENTITIES = Set.of(EntityType.ZOMBIE, EntityType.HUSK, EntityType.DROWNED,
+            EntityType.SKELETON, EntityType.STRAY, EntityType.WITHER_SKELETON, EntityType.PIGLIN, EntityType.PIGLIN_BRUTE,
+            EntityType.ZOMBIFIED_PIGLIN);
 
     /**
-     * Get the offset of a passenger based on this specific entity vehicle-passenger combination
-     *
-     * @param vehicle the vehicle to use
-     * @param passenger the passenger to be offset
-     * @return a vec to offset the passenger by
+     * @param vehicle the target vehicle
+     * @param passenger the target passenger
+     * @return the height offset for the passenger of this vehicle
      */
-    public static @NotNull Vec getPassengerOffset(@NotNull Entity vehicle, @NotNull Entity passenger) {
-        MountInfo vehicleMountInfo = MOUNT_INFO.getOrDefault(passenger.getEntityType(), DEFAULT_MOUNT_INFO);
-        MountInfo passengerMountInfo = MOUNT_INFO.getOrDefault(passenger.getEntityType(), DEFAULT_MOUNT_INFO);
-
-        Vec vehicleOffset = vehicleMountInfo.vehicleOffset().apply(vehicle);
-        if (!vehicleMountInfo.ignoreVehicleBabyScaling() && isBaby(vehicle)) {
-            // The extra mount height should be affected by the babyScaling multiplier
-            double height = vehicle.getBoundingBox().height();
-            double difference = height - vehicleOffset.y();
-            vehicleOffset = new Vec(0, height + difference * vehicleMountInfo.babyScaling(), 0);
-        }
-
-        double passengerOffset = passengerMountInfo.passengerHeightOffset();
-        if (isBaby(passenger)) {
-            passengerOffset *= passengerMountInfo.babyScaling();
-        }
-
-        return vehicleOffset.add(0, passengerOffset, 0);
-    }
-
-    /**
-     * Check the entity's metadata to determine if it is a baby.
-     *
-     * @param entity the entity to check
-     * @return true if the entity is baby, otherwise false
-     */
-    public static boolean isBaby(@NotNull Entity entity) {
-        EntityMeta entityMeta = entity.getEntityMeta();
-        if (entityMeta instanceof AgeableMobMeta meta) return meta.isBaby();
-        if (entityMeta instanceof ZombieMeta meta) return meta.isBaby();
-        if (entityMeta instanceof PiglinMeta meta) return meta.isBaby();
-        if (entityMeta instanceof ZoglinMeta meta) return meta.isBaby();
-        return false;
+    public static double getPassengerHeightOffset(@NotNull Entity vehicle, @NotNull Entity passenger) {
+        // TODO: Refactor this in 1.20.5
+        if (vehicle.getEntityType() == EntityType.BOAT) return -0.1;
+        if (vehicle.getEntityType() == EntityType.MINECART) return 0.0;
+        if (SITTING_ENTITIES.contains(passenger.getEntityType()))
+            return vehicle.getBoundingBox().height() * 0.75;
+        return vehicle.getBoundingBox().height();
     }
 
     private EntityUtils() {
@@ -169,48 +46,6 @@ public final class EntityUtils {
         } catch (NullPointerException e) {
             // Probably an entity at the border of an unloaded chunk
             return false;
-        }
-    }
-
-    /**
-     *  A representation of the unique mount properties each entity has
-     *
-     * @param vehicleOffset the offset this entity displaces its passengers by
-     * @param passengerHeightOffset the offset this entity has when it is a passenger
-     * @param babyScaling how much to automatically multiply height values by when an entity is a baby
-     * @param ignoreVehicleBabyScaling true if the vehicle height should not be multiplied by babyScaling
-     */
-    private record MountInfo(Function<Entity, Vec> vehicleOffset, double passengerHeightOffset, double babyScaling,
-                             boolean ignoreVehicleBabyScaling) {
-        private MountInfo(Function<Entity, Vec> mountOffset, double passengerHeightOffset) {
-            this(mountOffset, passengerHeightOffset, 0.5, false);
-        }
-
-        private MountInfo(Function<Entity, Vec> mountOffset) {
-            this(mountOffset, 0);
-        }
-
-        /**
-         * Shorthand for when we only need the height of an entity
-         */
-        private static MountInfo heightOnly(UnaryOperator<Double> height, double passengerOffset, boolean ignoreVehicleBabyScaling) {
-            return new MountInfo(entity -> new Vec(0, height.apply(entity.getBoundingBox().height()), 0),
-                    passengerOffset, 0.5, ignoreVehicleBabyScaling);
-        }
-
-        private static MountInfo heightOnly(UnaryOperator<Double> height, double passengerOffset) {
-            return new MountInfo(entity -> new Vec(0, height.apply(entity.getBoundingBox().height()), 0), passengerOffset);
-        }
-
-        private static MountInfo heightOnly(UnaryOperator<Double> height) {
-            return heightOnly(height, 0);
-        }
-
-        /**
-         * Shorthand for when unique height + baby size logic is required
-         */
-        private static MountInfo explicitBabyHeight(BiFunction<Double, Boolean, Double> babyHeight) {
-            return new MountInfo(entity -> new Vec(0, babyHeight.apply(entity.getBoundingBox().height(), isBaby(entity)), 0), 0);
         }
     }
 }

--- a/src/main/java/net/minestom/server/utils/entity/EntityUtils.java
+++ b/src/main/java/net/minestom/server/utils/entity/EntityUtils.java
@@ -1,12 +1,155 @@
 package net.minestom.server.utils.entity;
 
 import net.minestom.server.coordinate.Pos;
+import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.EntityType;
+import net.minestom.server.entity.metadata.AgeableMobMeta;
+import net.minestom.server.entity.metadata.EntityMeta;
+import net.minestom.server.entity.metadata.monster.PiglinMeta;
+import net.minestom.server.entity.metadata.monster.ZoglinMeta;
+import net.minestom.server.entity.metadata.monster.zombie.ZombieMeta;
+import net.minestom.server.entity.metadata.other.SlimeMeta;
 import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.block.Block;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
 public final class EntityUtils {
+    private static final MountInfo DEFAULT_MOUNT_INFO = MountInfo.heightOnly(height -> height, 0, true);
+    private static final MountInfo MINECART_MOUNT_INFO = MountInfo.heightOnly(height -> 0.1875);
+    private static final MountInfo SLIME_MOUNT_INFO = new MountInfo(slime ->
+            new Vec(0, slime.getBoundingBox().height() - 0.015625 * ((SlimeMeta)slime.getEntityMeta()).getSize(), 0));
+    private static final MountInfo LLAMA_MOUNT_INFO = new MountInfo(llama -> llama.getPosition()
+            .direction().withY(0).normalize().mul(-0.3 * (isBaby(llama) ? 0.5 : 1))
+            .add(0, llama.getEntityType().height() - (isBaby(llama) ? 0.8125 : 0.5), 0));
+    private static final Map<EntityType, MountInfo> MOUNT_INFO = Map.<EntityType, MountInfo>ofEntries(
+            Map.entry(EntityType.SKELETON,         MountInfo.heightOnly(height -> height, -0.7)),
+            Map.entry(EntityType.STRAY,            MountInfo.heightOnly(height -> height, -0.7)),
+            Map.entry(EntityType.WITHER_SKELETON,  MountInfo.heightOnly(height -> height, -0.875)),
+            Map.entry(EntityType.ALLAY,            MountInfo.heightOnly(height -> height,  0.04)),
+            Map.entry(EntityType.PLAYER,           MountInfo.heightOnly(height -> height, -0.6)),
+            Map.entry(EntityType.GIANT,            MountInfo.heightOnly(height -> height, -3.75)),
+
+            Map.entry(EntityType.CAT,              MountInfo.heightOnly(height -> height - 0.1875)),
+            Map.entry(EntityType.GOAT,             MountInfo.heightOnly(height -> height - 0.1875)),
+
+            Map.entry(EntityType.PIG,              MountInfo.heightOnly(height -> height - 0.03125)),
+            Map.entry(EntityType.COW,              MountInfo.heightOnly(height -> height - 0.03125)),
+            Map.entry(EntityType.WOLF,             MountInfo.heightOnly(height -> height - 0.03125)),
+            Map.entry(EntityType.WITCH,            MountInfo.heightOnly(height -> height - 0.03125)),
+
+            Map.entry(EntityType.FOX,              MountInfo.heightOnly(height -> height - 0.0625)),
+            Map.entry(EntityType.OCELOT,           MountInfo.heightOnly(height -> height - 0.0625)),
+            Map.entry(EntityType.SHEEP,            MountInfo.heightOnly(height -> height - 0.0625)),
+            Map.entry(EntityType.ENDERMITE,        MountInfo.heightOnly(height -> height - 0.0625)),
+            Map.entry(EntityType.SILVERFISH,       MountInfo.heightOnly(height -> height - 0.0625)),
+            Map.entry(EntityType.VEX,              MountInfo.heightOnly(height -> height - 0.0625, 0.04)),
+
+            Map.entry(EntityType.RAVAGER,          MountInfo.heightOnly(height -> height + 0.0625, -0.7)),
+            Map.entry(EntityType.PIGLIN,           MountInfo.heightOnly(height -> height + 0.0625, -0.7)),
+            Map.entry(EntityType.PIGLIN_BRUTE,     MountInfo.heightOnly(height -> height + 0.0625, -0.7)),
+            Map.entry(EntityType.ZOMBIE,           MountInfo.heightOnly(height -> height + 0.0625, -0.7)),
+            Map.entry(EntityType.DROWNED,          MountInfo.heightOnly(height -> height + 0.0625, -0.7)),
+
+            Map.entry(EntityType.GHAST,            MountInfo.heightOnly(height -> height + 0.0625, 0.5)),
+
+            Map.entry(EntityType.ZOMBIFIED_PIGLIN, MountInfo.heightOnly(height -> height + 0.05,  -0.7)),
+
+            Map.entry(EntityType.PILLAGER,         MountInfo.heightOnly(height -> height + 0.05, -0.6)),
+            Map.entry(EntityType.EVOKER,           MountInfo.heightOnly(height -> height + 0.05, -0.6)),
+            Map.entry(EntityType.VINDICATOR,       MountInfo.heightOnly(height -> height + 0.05, -0.6)),
+            Map.entry(EntityType.ILLUSIONER,       MountInfo.heightOnly(height -> height + 0.05, -0.6)),
+
+            Map.entry(EntityType.ENDERMAN,         MountInfo.heightOnly(height -> height - 0.09375)),
+            Map.entry(EntityType.PARROT,           MountInfo.heightOnly(height -> height - 0.4375f)),
+            Map.entry(EntityType.SNIFFER,          MountInfo.heightOnly(height -> height + 0.34375)),
+            Map.entry(EntityType.ELDER_GUARDIAN,   MountInfo.heightOnly(height -> height + 0.353215)),
+            Map.entry(EntityType.GUARDIAN,         MountInfo.heightOnly(height -> height + 0.125)),
+            Map.entry(EntityType.HUSK,             MountInfo.heightOnly(height -> height + 0.125)),
+            Map.entry(EntityType.FROG,             MountInfo.heightOnly(height -> height - 0.125f)),
+            Map.entry(EntityType.WARDEN,           MountInfo.heightOnly(height -> height + 0.25)),
+            Map.entry(EntityType.ZOMBIE_VILLAGER,  MountInfo.heightOnly(height -> height + 0.175)),
+
+            Map.entry(EntityType.SPIDER,           MountInfo.heightOnly(height -> height * 0.85,  -0.3125, true)),
+            Map.entry(EntityType.CAVE_SPIDER,      MountInfo.heightOnly(height -> height * 0.85,  -0.21875, true)),
+            Map.entry(EntityType.PHANTOM,          MountInfo.heightOnly(height -> height * 0.675, -0.125, true)),
+
+            Map.entry(EntityType.HOGLIN,           MountInfo.heightOnly(height -> height - 0.09375)),
+            Map.entry(EntityType.ZOGLIN,           MountInfo.heightOnly(height -> height - 0.09375)),
+
+            Map.entry(EntityType.PANDA,            MountInfo.explicitBabyHeight((height, isBaby) -> height - (isBaby ? 0.4375 : 0))),
+            Map.entry(EntityType.SKELETON_HORSE,   MountInfo.explicitBabyHeight((height, isBaby) -> height - (isBaby ? 0.03125 : 0.28125))),
+
+
+            Map.entry(EntityType.TURTLE,           new MountInfo(turtle -> turtle.getPosition()
+                    .direction().withY(0).normalize().mul(-0.25 * (isBaby(turtle) ? 0.3 : 1))
+                    .add(0, turtle.getBoundingBox().height() + (isBaby(turtle) ? 0 : 0.15625), 0), 0, 0.3, false)),
+            Map.entry(EntityType.CHICKEN,          new MountInfo(chicken -> chicken.getPosition()
+                    .direction().withY(0).normalize().mul(-0.1 * (isBaby(chicken) ? 0.5 : 1))
+                    .add(0, chicken.getBoundingBox().height(), 0))),
+
+            Map.entry(EntityType.SLIME,            SLIME_MOUNT_INFO),
+            Map.entry(EntityType.MAGMA_CUBE,       SLIME_MOUNT_INFO),
+
+            Map.entry(EntityType.MINECART,         MINECART_MOUNT_INFO),
+            Map.entry(EntityType.CHEST_MINECART,   MINECART_MOUNT_INFO),
+            Map.entry(EntityType.FURNACE_MINECART, MINECART_MOUNT_INFO),
+            Map.entry(EntityType.HOPPER_MINECART,  MINECART_MOUNT_INFO),
+            Map.entry(EntityType.TNT_MINECART,     MINECART_MOUNT_INFO),
+
+            Map.entry(EntityType.LLAMA,            LLAMA_MOUNT_INFO),
+            Map.entry(EntityType.TRADER_LLAMA,     LLAMA_MOUNT_INFO),
+
+            Map.entry(EntityType.BOAT,             MountInfo.heightOnly(height -> height / 3, 0, true)),
+            Map.entry(EntityType.CHEST_BOAT,       MountInfo.heightOnly(height -> height / 3, 0, true))
+    );
+
+    /**
+     * Get the offset of a passenger based on this specific entity vehicle-passenger combination
+     *
+     * @param vehicle the vehicle to use
+     * @param passenger the passenger to be offset
+     * @return a vec to offset the passenger by
+     */
+    public static @NotNull Vec getPassengerOffset(@NotNull Entity vehicle, @NotNull Entity passenger) {
+        MountInfo vehicleMountInfo = MOUNT_INFO.getOrDefault(passenger.getEntityType(), DEFAULT_MOUNT_INFO);
+        MountInfo passengerMountInfo = MOUNT_INFO.getOrDefault(passenger.getEntityType(), DEFAULT_MOUNT_INFO);
+
+        Vec vehicleOffset = vehicleMountInfo.vehicleOffset().apply(vehicle);
+        if (!vehicleMountInfo.ignoreVehicleBabyScaling() && isBaby(vehicle)) {
+            // The extra mount height should be affected by the babyScaling multiplier
+            double height = vehicle.getBoundingBox().height();
+            double difference = height - vehicleOffset.y();
+            vehicleOffset = new Vec(0, height + difference * vehicleMountInfo.babyScaling(), 0);
+        }
+
+        double passengerOffset = passengerMountInfo.passengerHeightOffset();
+        if (isBaby(passenger)) {
+            passengerOffset *= passengerMountInfo.babyScaling();
+        }
+
+        return vehicleOffset.add(0, passengerOffset, 0);
+    }
+
+    /**
+     * Check the entity's metadata to determine if it is a baby.
+     *
+     * @param entity the entity to check
+     * @return true if the entity is baby, otherwise false
+     */
+    public static boolean isBaby(@NotNull Entity entity) {
+        EntityMeta entityMeta = entity.getEntityMeta();
+        if (entityMeta instanceof AgeableMobMeta meta) return meta.isBaby();
+        if (entityMeta instanceof ZombieMeta meta) return meta.isBaby();
+        if (entityMeta instanceof PiglinMeta meta) return meta.isBaby();
+        if (entityMeta instanceof ZoglinMeta meta) return meta.isBaby();
+        return false;
+    }
 
     private EntityUtils() {
     }
@@ -26,6 +169,48 @@ public final class EntityUtils {
         } catch (NullPointerException e) {
             // Probably an entity at the border of an unloaded chunk
             return false;
+        }
+    }
+
+    /**
+     *  A representation of the unique mount properties each entity has
+     *
+     * @param vehicleOffset the offset this entity displaces its passengers by
+     * @param passengerHeightOffset the offset this entity has when it is a passenger
+     * @param babyScaling how much to automatically multiply height values by when an entity is a baby
+     * @param ignoreVehicleBabyScaling true if the vehicle height should not be multiplied by babyScaling
+     */
+    private record MountInfo(Function<Entity, Vec> vehicleOffset, double passengerHeightOffset, double babyScaling,
+                             boolean ignoreVehicleBabyScaling) {
+        private MountInfo(Function<Entity, Vec> mountOffset, double passengerHeightOffset) {
+            this(mountOffset, passengerHeightOffset, 0.5, false);
+        }
+
+        private MountInfo(Function<Entity, Vec> mountOffset) {
+            this(mountOffset, 0);
+        }
+
+        /**
+         * Shorthand for when we only need the height of an entity
+         */
+        private static MountInfo heightOnly(UnaryOperator<Double> height, double passengerOffset, boolean ignoreVehicleBabyScaling) {
+            return new MountInfo(entity -> new Vec(0, height.apply(entity.getBoundingBox().height()), 0),
+                    passengerOffset, 0.5, ignoreVehicleBabyScaling);
+        }
+
+        private static MountInfo heightOnly(UnaryOperator<Double> height, double passengerOffset) {
+            return new MountInfo(entity -> new Vec(0, height.apply(entity.getBoundingBox().height()), 0), passengerOffset);
+        }
+
+        private static MountInfo heightOnly(UnaryOperator<Double> height) {
+            return heightOnly(height, 0);
+        }
+
+        /**
+         * Shorthand for when unique height + baby size logic is required
+         */
+        private static MountInfo explicitBabyHeight(BiFunction<Double, Boolean, Double> babyHeight) {
+            return new MountInfo(entity -> new Vec(0, babyHeight.apply(entity.getBoundingBox().height(), isBaby(entity)), 0), 0);
         }
     }
 }

--- a/src/test/java/net/minestom/server/entity/PassengerIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/PassengerIntegrationTest.java
@@ -67,20 +67,22 @@ public class PassengerIntegrationTest {
 
         connection.connect(instance, new Pos(0, 40, 0)).join();
 
+        int startingId = passenger3.getEntityId();
         passengerTracker.assertCount(3);
         var passengerPackets = passengerTracker.collect();
         for (int i = 0; i < passengerPackets.size(); i++) {
             // Passenger packet order will be sent backwards down the chain of passenger vehicles
-            assertEquals(passengerPackets.size() + 1 - i, passengerPackets.get(i).passengersId().get(0));
+            assertEquals(startingId - i, passengerPackets.get(i).passengersId().get(0));
         }
 
         // Ensure spawn packets are never sent more than once per entity
+        startingId = vehicle.getEntityId();
         spawnTracker.assertCount(4);
         var spawnPackets = spawnTracker.collect();
         for (int i = 0; i < spawnPackets.size(); i++) {
             // If the passenger spawn packets are sent in order we know that
             // Entity#updateNewViewer ran as it should
-            assertEquals(i + 1, spawnPackets.get(i).entityId());
+            assertEquals(startingId + i, spawnPackets.get(i).entityId());
         }
     }
 }

--- a/src/test/java/net/minestom/server/entity/PassengerIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/PassengerIntegrationTest.java
@@ -1,5 +1,7 @@
 package net.minestom.server.entity;
 
+import net.minestom.server.network.packet.server.play.SetPassengersPacket;
+import net.minestom.server.network.packet.server.play.SpawnEntityPacket;
 import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
 import net.minestom.server.coordinate.Pos;
@@ -46,4 +48,39 @@ public class PassengerIntegrationTest {
         assertTrue(passenger.getDistance(vehicle) < 2);
     }
 
+    @Test
+    public void passengerPacketOrder(Env env) {
+        var instance = env.createFlatInstance();
+        var vehicle = new Entity(EntityType.ZOMBIE);
+        vehicle.setInstance(instance, new Pos(0, 40, 0)).join();
+        // Add 3 passengers to vehicle to test Entity#updateNewViewer recursion
+        var passenger1 = new Entity(EntityType.ZOMBIE);
+        var passenger2 = new Entity(EntityType.ZOMBIE);
+        var passenger3 = new Entity(EntityType.ZOMBIE);
+        vehicle.addPassenger(passenger1);
+        passenger1.addPassenger(passenger2);
+        passenger2.addPassenger(passenger3);
+
+        var connection = env.createConnection();
+        var spawnTracker = connection.trackIncoming(SpawnEntityPacket.class);
+        var passengerTracker = connection.trackIncoming(SetPassengersPacket.class);
+
+        connection.connect(instance, new Pos(0, 40, 0)).join();
+
+        passengerTracker.assertCount(3);
+        var passengerPackets = passengerTracker.collect();
+        for (int i = 0; i < passengerPackets.size(); i++) {
+            // Passenger packet order will be sent backwards down the chain of passenger vehicles
+            assertEquals(passengerPackets.size() + 1 - i, passengerPackets.get(i).passengersId().get(0));
+        }
+
+        // Ensure spawn packets are never sent more than once per entity
+        spawnTracker.assertCount(4);
+        var spawnPackets = spawnTracker.collect();
+        for (int i = 0; i < spawnPackets.size(); i++) {
+            // If the passenger spawn packets are sent in order we know that
+            // Entity#updateNewViewer ran as it should
+            assertEquals(i + 1, spawnPackets.get(i).entityId());
+        }
+    }
 }


### PR DESCRIPTION
Fix description: Passengers would get their updateNewViewer() forcibly called by the passenger loop in Entity#updateNewViewer, this applies the required packets correctly in theory. However, after this loop runs, the viewer engine still adds all the entities automatically which calls updateNewViewer again: sends a new spawn packet, overriding the passenger packets. To fix this I opted to use addViewer rather than updateNewViewer. Then, in the view engine I ensured that if the player can already see an entity, it returns early (senseless to call this method twice).

Comments on proper passenger position handling: Unfortunately, almost every vanilla entity has specific hardcoded values/actions for where to offset passenger entities. I've implemented a baseline for getting the offset values based on the passed in entity.
- Only a few entities are missing proper implementation, in general the server now has a better grip on where passengers are (for applying particles and collision handling to them, this change doesn't affect entity position visually on the client)

