### PR TITLE
fix: damaged entities not playing their animation, animation type for source-less damage

### DIFF
--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -20,10 +20,7 @@ import net.minestom.server.inventory.EquipmentHandler;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.network.ConnectionState;
 import net.minestom.server.network.packet.server.LazyPacket;
-import net.minestom.server.network.packet.server.play.CollectItemPacket;
-import net.minestom.server.network.packet.server.play.EntityAnimationPacket;
-import net.minestom.server.network.packet.server.play.EntityPropertiesPacket;
-import net.minestom.server.network.packet.server.play.SoundEffectPacket;
+import net.minestom.server.network.packet.server.play.*;
 import net.minestom.server.network.player.PlayerConnection;
 import net.minestom.server.scoreboard.Team;
 import net.minestom.server.sound.SoundEvent;
@@ -335,8 +332,13 @@ public class LivingEntity extends Entity implements EquipmentHandler {
 
             float remainingDamage = entityDamageEvent.getDamage().getAmount();
 
-            if (entityDamageEvent.shouldAnimate()) {
-                sendPacketToViewersAndSelf(new EntityAnimationPacket(getEntityId(), EntityAnimationPacket.Animation.TAKE_DAMAGE));
+            EntityDamageEvent.AnimationType animation = entityDamageEvent.getAnimationType();
+            if (animation != EntityDamageEvent.AnimationType.NONE) {
+                int entitySourceId = damage.getSource() == null ? 0 : damage.getSource().getEntityId();
+                boolean withSource = animation == EntityDamageEvent.AnimationType.WITH_SOURCE;
+                DamageEventPacket damageEventPacket = withSource ? new DamageEventPacket(getEntityId(), damage.getType().id(), entitySourceId, entitySourceId, damage.getSourcePosition()) :
+                        new DamageEventPacket(getEntityId(), damage.getType().id(), 0, 0, null);
+                sendPacketToViewersAndSelf(damageEventPacket);
             }
 
             // Additional hearts support

--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -334,11 +334,10 @@ public class LivingEntity extends Entity implements EquipmentHandler {
 
             EntityDamageEvent.AnimationType animation = entityDamageEvent.getAnimationType();
             if (animation != EntityDamageEvent.AnimationType.NONE) {
-                int entitySourceId = damage.getSource() == null ? 0 : damage.getSource().getEntityId();
                 boolean withSource = animation == EntityDamageEvent.AnimationType.WITH_SOURCE;
-                DamageEventPacket damageEventPacket = withSource ? new DamageEventPacket(getEntityId(), damage.getType().id(), entitySourceId, entitySourceId, damage.getSourcePosition()) :
-                        new DamageEventPacket(getEntityId(), damage.getType().id(), 0, 0, null);
-                sendPacketToViewersAndSelf(damageEventPacket);
+                int entitySourceId = withSource && damage.getSource() != null ? damage.getSource().getEntityId() : 0;
+                Point sourcePoint = withSource ? damage.getSourcePosition() : null;
+                sendPacketToViewersAndSelf(new DamageEventPacket(getEntityId(), damage.getType().id(), entitySourceId, entitySourceId, sourcePoint));
             }
 
             // Additional hearts support

--- a/src/main/java/net/minestom/server/event/entity/EntityDamageEvent.java
+++ b/src/main/java/net/minestom/server/event/entity/EntityDamageEvent.java
@@ -18,7 +18,7 @@ public class EntityDamageEvent implements EntityInstanceEvent, CancellableEvent 
     private final Entity entity;
     private final Damage damage;
     private SoundEvent sound;
-    private boolean animation = true;
+    private AnimationType animationType = AnimationType.WITH_SOURCE;
 
     private boolean cancelled;
 
@@ -64,21 +64,21 @@ public class EntityDamageEvent implements EntityInstanceEvent, CancellableEvent 
     }
 
     /**
-     * Gets whether the damage animation should be played.
+     * Gets the damage animation.
      *
-     * @return true if the animation should be played
+     * @return the damage animation
      */
-    public boolean shouldAnimate() {
-        return animation;
+    public @NotNull AnimationType getAnimationType() {
+        return animationType;
     }
 
     /**
-     * Sets whether the damage animation should be played.
+     * Sets the animation type to be used.
      *
-     * @param animation whether the animation should be played or not
+     * @param animation the new animation type
      */
-    public void setAnimation(boolean animation) {
-        this.animation = animation;
+    public void setAnimationType(@NotNull AnimationType animation) {
+        this.animationType = animation;
     }
 
     @Override
@@ -89,5 +89,25 @@ public class EntityDamageEvent implements EntityInstanceEvent, CancellableEvent 
     @Override
     public void setCancelled(boolean cancel) {
         this.cancelled = cancel;
+    }
+
+    /**
+     * The different damage animation types
+     */
+    public enum AnimationType {
+        /**
+         * No damage animation will be played
+         */
+        NONE,
+        /**
+         * The damage animation will be played with the screen shake animation
+         * tilting towards the damage source
+         */
+        WITH_SOURCE,
+        /**
+         * The damage animation will be played with the screen shake animation
+         * ignoring source (pre 1.20 behaviour)
+         */
+        WITHOUT_SOURCE
     }
 }


### PR DESCRIPTION
We need to send a DamageEventPacket rather than an EntityAnimationPacket.
Additionally, an AnimationType needed to be added to let the damage animation be played in a similar style to pre-1.20 (damage tilt remains constant regardless of source)

fix for #2061