### PR TITLE
fix: server has no tick catch up limit

### DIFF
--- a/src/main/java/net/minestom/server/ServerFlag.java
+++ b/src/main/java/net/minestom/server/ServerFlag.java
@@ -13,6 +13,7 @@ public final class ServerFlag {
 
     // Server Behavior
     public static final int SERVER_TICKS_PER_SECOND = Integer.getInteger("minestom.tps", 20);
+    public static final int SERVER_MAX_TICK_CATCH_UP = Integer.getInteger("minestom.max-tick-catch-up", 5);
     public static final int CHUNK_VIEW_DISTANCE = Integer.getInteger("minestom.chunk-view-distance", 8);
     public static final int ENTITY_VIEW_DISTANCE = Integer.getInteger("minestom.entity-view-distance", 5);
     public static final int ENTITY_SYNCHRONIZATION_TICKS = Integer.getInteger("minestom.entity-synchronization-ticks", 20);


### PR DESCRIPTION
- Add a SERVER_MAX_TICK_CATCH_UP flag to control the limit for how many ticks the server will immediately tick to compensate for a slow tick.
- Base the next server tick off of the server's start time + tick counter to remove the possibility of any timer drift. If the server stalls for too long reset the "baseTime" and tick counter to the current time to abort catch ups that are too large