### PR TITLE
chore: Cleanup some deprecations in the project

### DIFF
--- a/src/main/java/net/minestom/server/adventure/audience/PacketGroupingAudience.java
+++ b/src/main/java/net/minestom/server/adventure/audience/PacketGroupingAudience.java
@@ -57,6 +57,7 @@ public interface PacketGroupingAudience extends ForwardingAudience {
         PacketUtils.sendGroupedPacket(getPlayers(), packet);
     }
 
+    @Deprecated
     @Override
     default void sendMessage(@NotNull Identity source, @NotNull Component message, @NotNull MessageType type) {
         Messenger.sendMessage(this.getPlayers(), message, ChatPosition.fromMessageType(type), source.uuid());

--- a/src/main/java/net/minestom/server/adventure/provider/NBTLegacyHoverEventSerializer.java
+++ b/src/main/java/net/minestom/server/adventure/provider/NBTLegacyHoverEventSerializer.java
@@ -4,7 +4,7 @@ import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.api.BinaryTagHolder;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
-import net.kyori.adventure.text.serializer.gson.LegacyHoverEventSerializer;
+import net.kyori.adventure.text.serializer.json.LegacyHoverEventSerializer;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.kyori.adventure.util.Codec;
 import net.minestom.server.adventure.MinestomAdventure;
@@ -37,7 +37,7 @@ final class NBTLegacyHoverEventSerializer implements LegacyHoverEventSerializer 
             final NBTCompound tag = contents.getCompound(ITEM_TAG);
 
             // create the event
-            return HoverEvent.ShowItem.of(
+            return HoverEvent.ShowItem.showItem(
                     Key.key(Objects.requireNonNullElse(contents.getString(ITEM_TYPE), "")),
                     Objects.requireNonNullElse(contents.getByte(ITEM_COUNT), (byte) 1),
                     tag == null ? null : BinaryTagHolder.encode(tag, MinestomAdventure.NBT_CODEC)
@@ -54,7 +54,7 @@ final class NBTLegacyHoverEventSerializer implements LegacyHoverEventSerializer 
             final NBT nbt = MinestomAdventure.NBT_CODEC.decode(raw);
             if (!(nbt instanceof NBTCompound contents)) throw new IOException("contents were not a compound");
 
-            return HoverEvent.ShowEntity.of(
+            return HoverEvent.ShowEntity.showEntity(
                     Key.key(Objects.requireNonNullElse(contents.getString(ENTITY_TYPE), "")),
                     UUID.fromString(Objects.requireNonNullElse(contents.getString(ENTITY_ID), "")),
                     componentDecoder.decode(Objects.requireNonNullElse(contents.getString(ENTITY_NAME), ""))

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -1556,7 +1556,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     }
 
     protected @NotNull Vec getVelocityForPacket() {
-        return this.velocity.mul(8000f / MinecraftServer.TICK_PER_SECOND);
+        return this.velocity.mul(8000f / ServerFlag.SERVER_TICKS_PER_SECOND);
     }
 
     protected @NotNull EntityVelocityPacket getVelocityPacket() {
@@ -1666,9 +1666,9 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     public void takeKnockback(float strength, final double x, final double z) {
         if (strength > 0) {
             //TODO check possible side effects of unnatural TPS (other than 20TPS)
-            strength *= MinecraftServer.TICK_PER_SECOND;
+            strength *= ServerFlag.SERVER_TICKS_PER_SECOND;
             final Vec velocityModifier = new Vec(x, z).normalize().mul(strength);
-            final double verticalLimit = .4d * MinecraftServer.TICK_PER_SECOND;
+            final double verticalLimit = .4d * ServerFlag.SERVER_TICKS_PER_SECOND;
 
             setVelocity(new Vec(velocity.x() / 2d - velocityModifier.x(),
                     onGround ? Math.min(verticalLimit, velocity.y() / 2d + strength) : velocity.y(),

--- a/src/main/java/net/minestom/server/entity/EntityView.java
+++ b/src/main/java/net/minestom/server/entity/EntityView.java
@@ -5,6 +5,7 @@ import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import net.minestom.server.MinecraftServer;
+import net.minestom.server.ServerFlag;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.instance.EntityTracker;
 import net.minestom.server.instance.Instance;
@@ -17,7 +18,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 final class EntityView {
-    private static final int RANGE = MinecraftServer.getEntityViewDistance();
+    private static final int RANGE = ServerFlag.ENTITY_VIEW_DISTANCE;
     private final Entity entity;
     private final Set<Player> manualViewers = new HashSet<>();
 

--- a/src/main/java/net/minestom/server/instance/EntityTrackerImpl.java
+++ b/src/main/java/net/minestom/server/instance/EntityTrackerImpl.java
@@ -2,6 +2,7 @@ package net.minestom.server.instance;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.minestom.server.MinecraftServer;
+import net.minestom.server.ServerFlag;
 import net.minestom.server.Viewable;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
@@ -48,7 +49,7 @@ final class EntityTrackerImpl implements EntityTracker {
         }
         if (update != null) {
             update.referenceUpdate(point, this);
-            nearbyEntitiesByChunkRange(point, MinecraftServer.getEntityViewDistance(), target, newEntity -> {
+            nearbyEntitiesByChunkRange(point, ServerFlag.ENTITY_VIEW_DISTANCE, target, newEntity -> {
                 if (newEntity == entity) return;
                 update.add(newEntity);
             });
@@ -69,7 +70,7 @@ final class EntityTrackerImpl implements EntityTracker {
         }
         if (update != null) {
             update.referenceUpdate(point, null);
-            nearbyEntitiesByChunkRange(point, MinecraftServer.getEntityViewDistance(), target, newEntity -> {
+            nearbyEntitiesByChunkRange(point, ServerFlag.ENTITY_VIEW_DISTANCE, target, newEntity -> {
                 if (newEntity == entity) return;
                 update.remove(newEntity);
             });
@@ -181,7 +182,7 @@ final class EntityTrackerImpl implements EntityTracker {
                                                @NotNull Target<T> target, @NotNull Update<T> update) {
         final TargetEntry<Entity> entry = entries[target.ordinal()];
         forDifferingChunksInRange(newPoint.chunkX(), newPoint.chunkZ(), oldPoint.chunkX(), oldPoint.chunkZ(),
-                MinecraftServer.getEntityViewDistance(), (chunkX, chunkZ) -> {
+                ServerFlag.ENTITY_VIEW_DISTANCE, (chunkX, chunkZ) -> {
                     // Add
                     final List<Entity> entities = entry.chunkEntities.get(getChunkIndex(chunkX, chunkZ));
                     if (entities == null || entities.isEmpty()) return;
@@ -275,7 +276,7 @@ final class EntityTrackerImpl implements EntityTracker {
         }
 
         private void collectPlayers(EntityTracker tracker, Int2ObjectOpenHashMap<Player> map) {
-            tracker.nearbyEntitiesByChunkRange(point, MinecraftServer.getChunkViewDistance(),
+            tracker.nearbyEntitiesByChunkRange(point, ServerFlag.CHUNK_VIEW_DISTANCE,
                     EntityTracker.Target.PLAYERS, (player) -> map.putIfAbsent(player.getEntityId(), player));
         }
 

--- a/src/main/java/net/minestom/server/item/ItemStack.java
+++ b/src/main/java/net/minestom/server/item/ItemStack.java
@@ -169,7 +169,7 @@ public sealed interface ItemStack extends TagReadable, HoverEventSource<HoverEve
     @Override
     default @NotNull HoverEvent<HoverEvent.ShowItem> asHoverEvent(@NotNull UnaryOperator<HoverEvent.ShowItem> op) {
         final BinaryTagHolder tagHolder = BinaryTagHolder.encode(meta().toNBT(), MinestomAdventure.NBT_CODEC);
-        return HoverEvent.showItem(op.apply(HoverEvent.ShowItem.of(material(), amount(), tagHolder)));
+        return HoverEvent.showItem(op.apply(HoverEvent.ShowItem.showItem(material(), amount(), tagHolder)));
     }
 
     /**

--- a/src/main/java/net/minestom/server/listener/manager/PacketPlayListenerConsumer.java
+++ b/src/main/java/net/minestom/server/listener/manager/PacketPlayListenerConsumer.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Player;
 import net.minestom.server.network.packet.client.ClientPacket;
 
 /**
- * Small convenient interface to use method references with {@link PacketListenerManager#setListener(Class, PacketPlayListenerConsumer)}.
+ * Small convenient interface to use method references with {@link PacketListenerManager#setPlayListener(Class, PacketPlayListenerConsumer)}.
  *
  * @param <T> the packet type
  */

--- a/src/test/java/net/minestom/server/collision/EntityProjectileCollisionIntegrationTest.java
+++ b/src/test/java/net/minestom/server/collision/EntityProjectileCollisionIntegrationTest.java
@@ -1,6 +1,7 @@
 package net.minestom.server.collision;
 
 import net.minestom.server.MinecraftServer;
+import net.minestom.server.ServerFlag;
 import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
 import net.minestom.server.coordinate.Point;
@@ -46,7 +47,7 @@ public class EntityProjectileCollisionIntegrationTest {
         MinecraftServer.getGlobalEventHandler().addListener(ProjectileCollideWithBlockEvent.class, eventRef::set);
 
         final long tick = TimeUnit.SERVER_TICK.getDuration().toMillis();
-        for (int i = 0; i < MinecraftServer.TICK_PER_SECOND; ++i) {
+        for (int i = 0; i < ServerFlag.SERVER_TICKS_PER_SECOND; ++i) {
             projectile.tick(i * tick);
         }
 
@@ -60,8 +61,8 @@ public class EntityProjectileCollisionIntegrationTest {
         eventRef.set(null);
         instance.setBlock(blockPosition, Block.AIR);
 
-        for (int i = 0; i < MinecraftServer.TICK_PER_SECOND; ++i) {
-            projectile.tick((MinecraftServer.TICK_PER_SECOND + i) * tick);
+        for (int i = 0; i < ServerFlag.SERVER_TICKS_PER_SECOND; ++i) {
+            projectile.tick((ServerFlag.SERVER_TICKS_PER_SECOND + i) * tick);
         }
         event = eventRef.get();
         final var event2 = eventRef2.get();
@@ -105,7 +106,7 @@ public class EntityProjectileCollisionIntegrationTest {
         MinecraftServer.getGlobalEventHandler().addChild(eventNode);
 
         final long tick = TimeUnit.SERVER_TICK.getDuration().toMillis();
-        for (int i = 0; i < MinecraftServer.TICK_PER_SECOND; ++i) {
+        for (int i = 0; i < ServerFlag.SERVER_TICKS_PER_SECOND; ++i) {
             if (!projectile.isRemoved()) {
                 projectile.tick(i * tick);
             }
@@ -138,7 +139,7 @@ public class EntityProjectileCollisionIntegrationTest {
         });
 
         final long tick = TimeUnit.SERVER_TICK.getDuration().toMillis();
-        for (int i = 0; i < MinecraftServer.TICK_PER_SECOND * 5; ++i) {
+        for (int i = 0; i < ServerFlag.SERVER_TICKS_PER_SECOND * 5; ++i) {
             if (!projectile.isRemoved()) {
                 projectile.tick(i * tick);
             }

--- a/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerRespawnChunkIntegrationTest.java
@@ -1,6 +1,7 @@
 package net.minestom.server.entity.player;
 
 import net.minestom.server.MinecraftServer;
+import net.minestom.server.ServerFlag;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.Player;
 import net.minestom.server.network.packet.client.play.ClientStatusPacket;
@@ -46,7 +47,7 @@ public class PlayerRespawnChunkIntegrationTest {
         player.setHealth(0);
         player.respawn();
         // Player should have all their chunks reloaded
-        int chunkLoads = ChunkUtils.getChunkCount(Math.min(MinecraftServer.getChunkViewDistance(), player.getSettings().getViewDistance()));
+        int chunkLoads = ChunkUtils.getChunkCount(Math.min(ServerFlag.CHUNK_VIEW_DISTANCE, player.getSettings().getViewDistance()));
         loadChunkTracker.assertCount(chunkLoads);
     }
 
@@ -62,7 +63,7 @@ public class PlayerRespawnChunkIntegrationTest {
         player.interpretPacketQueue();
         List<ChunkDataPacket> dataPacketList = loadChunkTracker.collect();
         Set<ChunkDataPacket> duplicateCheck = new HashSet<>();
-        int actualViewDistance = Math.min(MinecraftServer.getChunkViewDistance(), player.getSettings().getViewDistance());
+        int actualViewDistance = Math.min(ServerFlag.CHUNK_VIEW_DISTANCE, player.getSettings().getViewDistance());
         int chunkLoads = ChunkUtils.getChunkCount(actualViewDistance);
         loadChunkTracker.assertCount(chunkLoads);
         for (ChunkDataPacket packet : dataPacketList) {

--- a/src/test/java/net/minestom/server/instance/EntityTrackerIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/EntityTrackerIntegrationTest.java
@@ -1,6 +1,7 @@
 package net.minestom.server.instance;
 
 import net.minestom.server.MinecraftServer;
+import net.minestom.server.ServerFlag;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.EntityType;
@@ -25,11 +26,10 @@ public class EntityTrackerIntegrationTest {
     @Test
     public void maxDistance(Env env) {
         final Instance instance = env.createFlatInstance();
-        final Instance anotherInstance = env.createFlatInstance();
         final Pos spawnPos = new Pos(0, 41, 0);
-        final int viewDistanceInChunks = MinecraftServer.getEntityViewDistance();
+        final int viewDistanceInChunks = ServerFlag.ENTITY_VIEW_DISTANCE;
 
-        final Player viewer = createTestPlayer();
+        final Player viewer = env.createPlayer(instance, spawnPos);
         final AtomicInteger viewersCount = new AtomicInteger();
         final Entity entity = new Entity(EntityType.ZOMBIE) {
             @Override
@@ -43,8 +43,6 @@ public class EntityTrackerIntegrationTest {
             }
         };
         entity.setInstance(instance, spawnPos).join();
-        assertEquals(0, viewersCount.get());
-        viewer.setInstance(instance, spawnPos).join(); // viewer at spawn
         assertEquals(1, viewersCount.get());
         viewer.teleport(new Pos(viewDistanceInChunks * 16 + 15, 41, 0)).join(); // viewer at max chunk range
         assertEquals(1, viewersCount.get());
@@ -59,9 +57,9 @@ public class EntityTrackerIntegrationTest {
         final Instance instance = env.createFlatInstance();
         final Instance anotherInstance = env.createFlatInstance();
         final Pos spawnPos = new Pos(0, 41, 0);
-        final int viewDistanceInChunks = MinecraftServer.getEntityViewDistance();
+        final int viewDistanceInChunks = ServerFlag.ENTITY_VIEW_DISTANCE;
 
-        final Player viewer = createTestPlayer();
+        final Player viewer = env.createPlayer(instance, spawnPos);
         final AtomicInteger viewersCount = new AtomicInteger();
         final Entity entity = new Entity(EntityType.ZOMBIE) {
             @Override
@@ -75,8 +73,6 @@ public class EntityTrackerIntegrationTest {
             }
         };
         entity.setInstance(instance, spawnPos).join();
-        assertEquals(0, viewersCount.get());
-        viewer.setInstance(instance, spawnPos).join(); // viewer at spawn
         assertEquals(1, viewersCount.get());
         viewer.teleport(new Pos(viewDistanceInChunks * 16 + 15, 41, 0)).join(); // viewer at max chunk range
         assertEquals(1, viewersCount.get());
@@ -128,19 +124,4 @@ public class EntityTrackerIntegrationTest {
         player.setInstance(shared2, spawnPos).join();
         assertEquals(1, viewable.getViewers().size());
     }
-
-    private Player createTestPlayer() {
-        return new Player(UUID.randomUUID(), "TestPlayer", new PlayerConnection() {
-            @Override
-            public void sendPacket(@NotNull SendablePacket packet) {
-                // nothing
-            }
-
-            @Override
-            public @NotNull SocketAddress getRemoteAddress() {
-                return null;
-            }
-        });
-    }
-
 }


### PR DESCRIPTION
Cleans up some deprecations in the project, mainly regarding chunk/entity view distance that was replaced by ServerFlags, and a couple from the Adventure library.

Also removes some unneeded code from a test class.