### PR TITLE
Invalidate previous physics result on instance change

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -805,6 +805,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         this.isActive = true;
         this.position = spawnPosition;
         this.previousPosition = spawnPosition;
+        this.previousPhysicsResult = null;
         this.instance = instance;
         return instance.loadOptionalChunk(spawnPosition).thenAccept(chunk -> {
             try {


### PR DESCRIPTION
Using previous physics results after an instance change results in an exception because additional calculations use the cached position, which throws an error if the position is unloaded.

Fixes #2083.

Minimal reproducer (thanks snavy): https://github.com/bbSnavy/minestom_test