### PR TITLE
Fix: Server does not stop

### DIFF
--- a/src/main/java/net/minestom/server/MinecraftServer.java
+++ b/src/main/java/net/minestom/server/MinecraftServer.java
@@ -194,6 +194,10 @@ public final class MinecraftServer {
         return !isStarted();
     }
 
+    public static boolean isStopped() {
+        return serverProcess.isStopped();
+    }
+
     /**
      * Gets the chunk view distance of the server.
      * <p>

--- a/src/main/java/net/minestom/server/ServerProcess.java
+++ b/src/main/java/net/minestom/server/ServerProcess.java
@@ -137,9 +137,28 @@ public interface ServerProcess extends Snapshotable {
 
     void start(@NotNull SocketAddress socketAddress);
 
+    /**
+     * Request the server to stop
+     */
     void stop();
 
+    /**
+     * Shutdown all sub processes
+     * <p>
+     * Order:
+     * <ul>
+     * {@link SchedulerManager#shutdown()}
+     * {@link ConnectionManager#shutdown()}
+     * {@link Server#stop()}
+     * {@link BenchmarkManager#disable()}
+     * {@link ThreadDispatcher#shutdown()}
+     * </ul>
+     */
+    void shutdown();
+
     boolean isAlive();
+
+    boolean isStopped();
 
     @ApiStatus.NonExtendable
     interface Ticker {

--- a/src/main/java/net/minestom/server/ServerProcessImpl.java
+++ b/src/main/java/net/minestom/server/ServerProcessImpl.java
@@ -71,6 +71,7 @@ final class ServerProcessImpl implements ServerProcess {
     private final Ticker ticker;
 
     private final AtomicBoolean started = new AtomicBoolean();
+    private final AtomicBoolean stopping = new AtomicBoolean();
     private final AtomicBoolean stopped = new AtomicBoolean();
 
     public ServerProcessImpl() throws IOException {
@@ -230,6 +231,13 @@ final class ServerProcessImpl implements ServerProcess {
 
     @Override
     public void stop() {
+        if (!stopping.compareAndSet(false, true))
+            return;
+        LOGGER.info("Stopping " + MinecraftServer.getBrandName() + " server...");
+    }
+
+    @Override
+    public void shutdown() {
         if (!stopped.compareAndSet(false, true))
             return;
         LOGGER.info("Stopping " + MinecraftServer.getBrandName() + " server.");
@@ -243,8 +251,13 @@ final class ServerProcessImpl implements ServerProcess {
     }
 
     @Override
+    public boolean isStopped() {
+        return stopped.get();
+    }
+
+    @Override
     public boolean isAlive() {
-        return started.get() && !stopped.get();
+        return started.get() && !stopping.get() && !stopped.get();
     }
 
     @Override

--- a/src/test/java/net/minestom/server/ServerProcessTest.java
+++ b/src/test/java/net/minestom/server/ServerProcessTest.java
@@ -5,8 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class ServerProcessTest {
@@ -21,6 +20,8 @@ public class ServerProcessTest {
         assertDoesNotThrow(() -> process.get().start(new InetSocketAddress("localhost", 25565)));
         assertThrows(Exception.class, () -> process.get().start(new InetSocketAddress("localhost", 25566)));
         assertDoesNotThrow(() -> process.get().stop());
+        assertFalse(() -> process.get().isAlive(), "Server is still alive");
+        assertDoesNotThrow(() -> process.get().shutdown());
     }
 
     @Test
@@ -33,5 +34,7 @@ public class ServerProcessTest {
         var ticker = process.ticker();
         assertDoesNotThrow(() -> ticker.tick(System.currentTimeMillis()));
         assertDoesNotThrow(process::stop);
+        assertFalse(process::isAlive, "Server is still alive");
+        assertDoesNotThrow(process::shutdown);
     }
 }


### PR DESCRIPTION
Problem: Server doesn't stop when using `MinecraftServer#stopCleanly` inside a command

Resolves #2096 

Why this bug happens ?
During the server lifecycle commands are executed in `connection().tick(msTime)` (`ServerProcessImpl.TickerImpl` class)
![image](https://github.com/Minestom/Minestom/assets/42631255/af5c9aef-f158-4924-a1a6-5b1becb990a6)

When you use the _/shutdown_ command, `MinecraftServer#stopCleanly` method is called which stops all `TickThread`
After all commands are executed, `serverTick(msTime)` is called which start (stopped TickThread) and wait until threads are finished

Solution: set a flag to true when stop method is called and check this flag at end of tick