### PR TITLE
ClientKeepAlivePacket processing moved to worker thread

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -131,13 +131,13 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
     private static final int STATUS_PERMISSION_LEVEL_OFFSET = 24;
 
     private long lastKeepAlive;
-    private boolean answerKeepAlive;
+    private volatile boolean answerKeepAlive;
 
     private String username;
     private Component usernameComponent;
     protected final PlayerConnection playerConnection;
 
-    private int latency;
+    private volatile int latency;
     private Component displayName;
     private PlayerSkin skin;
 

--- a/src/main/java/net/minestom/server/network/PacketProcessor.java
+++ b/src/main/java/net/minestom/server/network/PacketProcessor.java
@@ -4,6 +4,7 @@ import net.minestom.server.entity.Player;
 import net.minestom.server.listener.manager.PacketListenerManager;
 import net.minestom.server.network.packet.client.ClientPacket;
 import net.minestom.server.network.packet.client.ClientPacketsHandler;
+import net.minestom.server.network.packet.client.common.ClientKeepAlivePacket;
 import net.minestom.server.network.packet.client.handshake.ClientHandshakePacket;
 import net.minestom.server.network.player.PlayerConnection;
 import org.jetbrains.annotations.NotNull;
@@ -57,9 +58,14 @@ public class PacketProcessor {
             case HANDSHAKE, STATUS, LOGIN -> packetListenerManager.processClientPacket(packet, connection);
             // Process config and play packets on the next tick
             case CONFIGURATION, PLAY -> {
-                final Player player = connection.getPlayer();
-                assert player != null;
-                player.addPacketToQueue(packet);
+                if (packet instanceof ClientKeepAlivePacket) {
+                    packetListenerManager.processClientPacket(packet, connection);
+                }
+                else {
+                    final Player player = connection.getPlayer();
+                    assert player != null;
+                    player.addPacketToQueue(packet);
+                }
             }
         }
         return packet;


### PR DESCRIPTION
This pull request resolves #2100

# Problem
The Minestom server isn't processing `ClientKeepAlivePacket` correctly.

This happens because all packets with `CONFIGURATION` and `PLAY` states are added to the player's packet queue and processed in the minestom tick thread.

As a result, the player's latency is overestimated. For example, if you run a local minestom server, the latency will be about 50ms instead of the expected 0ms.

# Solution
The packet `ClientKeepAlivePacket` is now processed bypassing the player's packet queue (similar to packets with `HANDSHAKE`, `STATUS` and `LOGIN` states).

The thread-safety is also taken into account.