### PR TITLE
Use int in Block#fromStateId

### DIFF
--- a/src/main/java/net/minestom/server/collision/ShapeImpl.java
+++ b/src/main/java/net/minestom/server/collision/ShapeImpl.java
@@ -191,7 +191,7 @@ public final class ShapeImpl implements Shape {
 
     public Block block() {
         Block block = this.block;
-        if (block == null) this.block = block = Block.fromStateId((short) blockEntry.stateId());
+        if (block == null) this.block = block = Block.fromStateId(blockEntry.stateId());
         return block;
     }
 

--- a/src/main/java/net/minestom/server/instance/DynamicChunk.java
+++ b/src/main/java/net/minestom/server/instance/DynamicChunk.java
@@ -177,7 +177,7 @@ public class DynamicChunk extends Chunk {
         final Section section = getSectionAt(y);
         final int blockStateId = section.blockPalette()
                 .get(toSectionRelativeCoordinate(x), toSectionRelativeCoordinate(y), toSectionRelativeCoordinate(z));
-        return Objects.requireNonNullElse(Block.fromStateId((short) blockStateId), Block.AIR);
+        return Objects.requireNonNullElse(Block.fromStateId(blockStateId), Block.AIR);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/instance/block/Block.java
+++ b/src/main/java/net/minestom/server/instance/block/Block.java
@@ -181,7 +181,7 @@ public sealed interface Block extends StaticProtocolObject, TagReadable, Blocks 
         return fromNamespaceId(namespaceID.asString());
     }
 
-    static @Nullable Block fromStateId(short stateId) {
+    static @Nullable Block fromStateId(int stateId) {
         return BlockImpl.getState(stateId);
     }
 

--- a/src/main/java/net/minestom/server/instance/light/BlockLight.java
+++ b/src/main/java/net/minestom/server/instance/light/BlockLight.java
@@ -49,7 +49,7 @@ final class BlockLight implements Light {
         ShortArrayFIFOQueue lightSources = new ShortArrayFIFOQueue();
         // Apply section light
         blockPalette.getAllPresent((x, y, z, stateId) -> {
-            final Block block = Block.fromStateId((short) stateId);
+            final Block block = Block.fromStateId(stateId);
             assert block != null;
             final byte lightEmission = (byte) block.registry().lightEmission();
 
@@ -62,7 +62,7 @@ final class BlockLight implements Light {
     }
 
     private static Block getBlock(Palette palette, int x, int y, int z) {
-        return Block.fromStateId((short)palette.get(x, y, z));
+        return Block.fromStateId(palette.get(x, y, z));
     }
 
     private ShortArrayFIFOQueue buildExternalQueue(Instance instance, Palette blockPalette, Point[] neighbors, byte[] content) {

--- a/src/main/java/net/minestom/server/instance/light/LightCompute.java
+++ b/src/main/java/net/minestom/server/instance/light/LightCompute.java
@@ -71,8 +71,8 @@ public final class LightCompute {
                 // Section
                 final int newIndex = xO | (zO << 4) | (yO << 8);
                 if (getLight(lightArray, newIndex) + 2 <= lightLevel) {
-                    final Block currentBlock = Objects.requireNonNullElse(Block.fromStateId((short)blockPalette.get(x, y, z)), Block.AIR);
-                    final Block propagatedBlock = Objects.requireNonNullElse(Block.fromStateId((short)blockPalette.get(xO, yO, zO)), Block.AIR);
+                    final Block currentBlock = Objects.requireNonNullElse(Block.fromStateId(blockPalette.get(x, y, z)), Block.AIR);
+                    final Block propagatedBlock = Objects.requireNonNullElse(Block.fromStateId(blockPalette.get(xO, yO, zO)), Block.AIR);
 
                     boolean airAir = currentBlock.isAir() && propagatedBlock.isAir();
                     if (!airAir && currentBlock.registry().collisionShape().isOccluded(propagatedBlock.registry().collisionShape(), face)) continue;

--- a/src/main/java/net/minestom/server/instance/light/SkyLight.java
+++ b/src/main/java/net/minestom/server/instance/light/SkyLight.java
@@ -78,7 +78,7 @@ final class SkyLight implements Light {
     }
 
     private static Block getBlock(Palette palette, int x, int y, int z) {
-        return Block.fromStateId((short)palette.get(x, y, z));
+        return Block.fromStateId(palette.get(x, y, z));
     }
 
     private ShortArrayFIFOQueue buildExternalQueue(Instance instance, Palette blockPalette, Point[] neighbors, byte[] content) {

--- a/src/main/java/net/minestom/server/particle/data/BlockMarkerParticleData.java
+++ b/src/main/java/net/minestom/server/particle/data/BlockMarkerParticleData.java
@@ -16,7 +16,7 @@ public record BlockMarkerParticleData(@NotNull Block block) implements ParticleD
     }
 
     private static Block read(NetworkBuffer reader) {
-        short blockState = reader.read(NetworkBuffer.VAR_INT).shortValue();
+        int blockState = reader.read(NetworkBuffer.VAR_INT);
         Block block = Block.fromStateId(blockState);
         Check.stateCondition(block == null, "Block state " + blockState + " is invalid");
         return block;

--- a/src/main/java/net/minestom/server/particle/data/BlockParticleData.java
+++ b/src/main/java/net/minestom/server/particle/data/BlockParticleData.java
@@ -16,7 +16,7 @@ public record BlockParticleData(Block block) implements ParticleData {
     }
 
     private static Block read(NetworkBuffer reader) {
-        short blockState = reader.read(NetworkBuffer.VAR_INT).shortValue();
+        int blockState = reader.read(NetworkBuffer.VAR_INT);
         Block block = Block.fromStateId(blockState);
         Check.stateCondition(block == null, "Block state " + blockState + " is invalid");
         return block;

--- a/src/main/java/net/minestom/server/particle/data/FallingDustParticleData.java
+++ b/src/main/java/net/minestom/server/particle/data/FallingDustParticleData.java
@@ -16,7 +16,7 @@ public record FallingDustParticleData(Block block) implements ParticleData {
     }
 
     private static Block read(NetworkBuffer reader) {
-        short blockState = reader.read(NetworkBuffer.VAR_INT).shortValue();
+        int blockState = reader.read(NetworkBuffer.VAR_INT);
         Block block = Block.fromStateId(blockState);
         Check.stateCondition(block == null, "Block state {0} is invalid", blockState);
         return block;

--- a/src/main/java/net/minestom/server/snapshot/SnapshotImpl.java
+++ b/src/main/java/net/minestom/server/snapshot/SnapshotImpl.java
@@ -95,7 +95,7 @@ public final class SnapshotImpl {
             final Section section = sections[getChunkCoordinate(y) - minSection];
             final int blockStateId = section.blockPalette()
                     .get(toSectionRelativeCoordinate(x), toSectionRelativeCoordinate(y), toSectionRelativeCoordinate(z));
-            return Objects.requireNonNullElse(Block.fromStateId((short) blockStateId), Block.AIR);
+            return Objects.requireNonNullElse(Block.fromStateId(blockStateId), Block.AIR);
         }
 
         @Override


### PR DESCRIPTION
Changes `Block#fromStateId` to accept `int` instead of `short` (protocol uses VarInt) and removes now unnecessary casts.