### PR TITLE
Send an acknowledgement packet for item usage

### DIFF
--- a/src/main/java/net/minestom/server/listener/UseItemListener.java
+++ b/src/main/java/net/minestom/server/listener/UseItemListener.java
@@ -10,6 +10,7 @@ import net.minestom.server.inventory.PlayerInventory;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
 import net.minestom.server.network.packet.client.play.ClientUseItemPacket;
+import net.minestom.server.network.packet.server.play.AcknowledgeBlockChangePacket;
 
 public class UseItemListener {
 
@@ -21,6 +22,7 @@ public class UseItemListener {
         PlayerUseItemEvent useItemEvent = new PlayerUseItemEvent(player, hand, itemStack);
         EventDispatcher.call(useItemEvent);
 
+        player.sendPacket(new AcknowledgeBlockChangePacket(packet.sequence()));
         final PlayerInventory playerInventory = player.getInventory();
         if (useItemEvent.isCancelled()) {
             playerInventory.update();


### PR DESCRIPTION
Without an acknowledgement packet, certain actions are not recognized by the client.
For example, the player sends two packets and expects two acknowledgements (for different reasons) when placing a water bucket. Previously, with only one being sent, it was impossible to send a block change over this water (including setting it to air) until another acknowledgement was sent.

Thank you to SoSeDiK for doing a lot of the debugging.