### PR TITLE
Fix wrong trim cache invalidation

### DIFF
--- a/src/main/java/net/minestom/server/item/armor/TrimManager.java
+++ b/src/main/java/net/minestom/server/item/armor/TrimManager.java
@@ -81,7 +81,7 @@ public class TrimManager {
     }
 
     public void addDefaultTrimPatterns() {
-        this.trimMaterialCache = null;
+        this.trimPatternCache = null;
         this.trimPatterns.addAll(TrimPattern.values());
     }
 
@@ -96,12 +96,12 @@ public class TrimManager {
     }
 
     public boolean addTrimPattern(TrimPattern trimPattern) {
-        this.trimMaterialCache = null;
+        this.trimPatternCache = null;
         return this.trimPatterns.add(trimPattern);
     }
 
     public boolean removeTrimPattern(TrimPattern trimPattern) {
-        this.trimMaterialCache = null;
+        this.trimPatternCache = null;
         return this.trimPatterns.remove(trimPattern);
     }
 }


### PR DESCRIPTION
In TrimManager only the material cache gets reset even in places where the patterns get changed.