### PR TITLE
Item usage duration

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -433,7 +433,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         if (isUsingItem()) {
             if (time - startItemUseTime >= itemUseTime) {
                 triggerStatus((byte) 9); // Mark item use as finished
-                ItemUpdateStateEvent itemUpdateStateEvent = callItemUpdateStateEvent(itemUseHand);
+                ItemUpdateStateEvent itemUpdateStateEvent = callItemUpdateStateEvent(itemUseHand, true);
 
                 // Refresh hand
                 final boolean isOffHand = itemUpdateStateEvent.getHand() == Player.Hand.OFF;
@@ -2214,8 +2214,8 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
      *
      * @return the called {@link ItemUpdateStateEvent},
      */
-    public @NotNull ItemUpdateStateEvent callItemUpdateStateEvent(@NotNull Hand hand) {
-        ItemUpdateStateEvent itemUpdateStateEvent = new ItemUpdateStateEvent(this, hand, getItemInHand(hand));
+    public @NotNull ItemUpdateStateEvent callItemUpdateStateEvent(@NotNull Hand hand, boolean completed) {
+        ItemUpdateStateEvent itemUpdateStateEvent = new ItemUpdateStateEvent(this, hand, getItemInHand(hand), completed);
         EventDispatcher.call(itemUpdateStateEvent);
 
         return itemUpdateStateEvent;

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -1107,14 +1107,23 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
      *
      * @return true if the player is eating, false otherwise
      */
+    public boolean isEating() {
+        return isUsingItem() && getItemInHand(itemUseHand).material().isFood();
+    }
+
+    /**
+     * Gets if the player is using an item.
+     *
+     * @return true if the player is using an item, false otherwise
+     */
     public boolean isUsingItem() {
         return itemUseHand != null;
     }
 
     /**
-     * Gets the hand which the player is eating from.
+     * Gets the hand which the player is using an item from.
      *
-     * @return the eating hand, null if none
+     * @return the item use hand, null if none
      */
     public @Nullable Hand getItemUseHand() {
         return itemUseHand;

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -2181,7 +2181,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
 
     /**
      * Changes the held item for the player viewers
-     * Also cancel eating if {@link #isUsingItem()} was true.
+     * Also cancel item usage if {@link #isUsingItem()} was true.
      * <p>
      * Warning: the player will not be noticed by this chance, only his viewers,
      * see instead: {@link #setHeldItemSlot(byte)}.

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -40,6 +40,7 @@ import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.inventory.InventoryOpenEvent;
 import net.minestom.server.event.item.ItemDropEvent;
 import net.minestom.server.event.item.ItemUpdateStateEvent;
+import net.minestom.server.event.item.ItemUsageCompleteEvent;
 import net.minestom.server.event.item.PickupExperienceEvent;
 import net.minestom.server.event.player.*;
 import net.minestom.server.instance.Chunk;
@@ -433,7 +434,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         if (isUsingItem()) {
             if (time - startItemUseTime >= itemUseTime) {
                 triggerStatus((byte) 9); // Mark item use as finished
-                ItemUpdateStateEvent itemUpdateStateEvent = callItemUpdateStateEvent(itemUseHand, true);
+                ItemUpdateStateEvent itemUpdateStateEvent = callItemUpdateStateEvent(itemUseHand);
 
                 // Refresh hand
                 final boolean isOffHand = itemUpdateStateEvent.getHand() == Player.Hand.OFF;
@@ -446,6 +447,9 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
                     PlayerEatEvent playerEatEvent = new PlayerEatEvent(this, item, itemUseHand);
                     EventDispatcher.call(playerEatEvent);
                 }
+
+                var itemUsageCompleteEvent = new ItemUsageCompleteEvent(this, itemUseHand, item);
+                EventDispatcher.call(itemUsageCompleteEvent);
 
                 refreshItemUse(null);
             }
@@ -2214,8 +2218,8 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
      *
      * @return the called {@link ItemUpdateStateEvent},
      */
-    public @NotNull ItemUpdateStateEvent callItemUpdateStateEvent(@NotNull Hand hand, boolean completed) {
-        ItemUpdateStateEvent itemUpdateStateEvent = new ItemUpdateStateEvent(this, hand, getItemInHand(hand), completed);
+    public @NotNull ItemUpdateStateEvent callItemUpdateStateEvent(@NotNull Hand hand) {
+        ItemUpdateStateEvent itemUpdateStateEvent = new ItemUpdateStateEvent(this, hand, getItemInHand(hand));
         EventDispatcher.call(itemUpdateStateEvent);
 
         return itemUpdateStateEvent;

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -2203,29 +2203,6 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
      * Used to call {@link ItemUpdateStateEvent} with the proper item
      * It does check which hand to get the item to update.
      *
-     * @param allowFood true if food should be updated, false otherwise
-     * @return the called {@link ItemUpdateStateEvent},
-     * null if there is no item to update the state
-     * @deprecated Use {@link #callItemUpdateStateEvent(Hand)} instead
-     */
-    @Deprecated
-    public @Nullable ItemUpdateStateEvent callItemUpdateStateEvent(boolean allowFood, @NotNull Hand hand) {
-        final ItemStack updatedItem = getItemInHand(hand);
-        final boolean isFood = updatedItem.material().isFood();
-
-        if (isFood && !allowFood)
-            return null;
-
-        ItemUpdateStateEvent itemUpdateStateEvent = new ItemUpdateStateEvent(this, hand, updatedItem);
-        EventDispatcher.call(itemUpdateStateEvent);
-
-        return itemUpdateStateEvent;
-    }
-
-    /**
-     * Used to call {@link ItemUpdateStateEvent} with the proper item
-     * It does check which hand to get the item to update. Allows food.
-     *
      * @return the called {@link ItemUpdateStateEvent},
      */
     public @NotNull ItemUpdateStateEvent callItemUpdateStateEvent(@NotNull Hand hand) {

--- a/src/main/java/net/minestom/server/event/item/ItemUpdateStateEvent.java
+++ b/src/main/java/net/minestom/server/event/item/ItemUpdateStateEvent.java
@@ -8,38 +8,25 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Event when a player updates an item state, meaning when they stop using the item.
- * This event is also called when the item usage duration has passed, in which case {@link #isCompleted()} returns true.
  */
 public class ItemUpdateStateEvent implements PlayerInstanceEvent, ItemEvent {
 
     private final Player player;
     private final Player.Hand hand;
     private final ItemStack itemStack;
-    private final boolean completed;
 
     private boolean handAnimation;
     private boolean riptideSpinAttack;
 
-    public ItemUpdateStateEvent(@NotNull Player player, @NotNull Player.Hand hand,
-                                @NotNull ItemStack itemStack, boolean completed) {
+    public ItemUpdateStateEvent(@NotNull Player player, @NotNull Player.Hand hand, @NotNull ItemStack itemStack) {
         this.player = player;
         this.hand = hand;
         this.itemStack = itemStack;
-        this.completed = completed;
     }
 
     @NotNull
     public Player.Hand getHand() {
         return hand;
-    }
-
-    /**
-     * Gets whether the item usage is completed. This is the case if the item usage duration has passed.
-     *
-     * @return whether the item usage is completed
-     */
-    public boolean isCompleted() {
-        return completed;
     }
 
     /**

--- a/src/main/java/net/minestom/server/event/item/ItemUpdateStateEvent.java
+++ b/src/main/java/net/minestom/server/event/item/ItemUpdateStateEvent.java
@@ -6,6 +6,9 @@ import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Event when a player updates an item state, meaning when they stop using the item.
+ */
 public class ItemUpdateStateEvent implements PlayerInstanceEvent, ItemEvent {
 
     private final Player player;

--- a/src/main/java/net/minestom/server/event/item/ItemUpdateStateEvent.java
+++ b/src/main/java/net/minestom/server/event/item/ItemUpdateStateEvent.java
@@ -8,24 +8,38 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Event when a player updates an item state, meaning when they stop using the item.
+ * This event is also called when the item usage duration has passed, in which case {@link #isCompleted()} returns true.
  */
 public class ItemUpdateStateEvent implements PlayerInstanceEvent, ItemEvent {
 
     private final Player player;
     private final Player.Hand hand;
     private final ItemStack itemStack;
+    private final boolean completed;
+
     private boolean handAnimation;
     private boolean riptideSpinAttack;
 
-    public ItemUpdateStateEvent(@NotNull Player player, @NotNull Player.Hand hand, @NotNull ItemStack itemStack) {
+    public ItemUpdateStateEvent(@NotNull Player player, @NotNull Player.Hand hand,
+                                @NotNull ItemStack itemStack, boolean completed) {
         this.player = player;
         this.hand = hand;
         this.itemStack = itemStack;
+        this.completed = completed;
     }
 
     @NotNull
     public Player.Hand getHand() {
         return hand;
+    }
+
+    /**
+     * Gets whether the item usage is completed. This is the case if the item usage duration has passed.
+     *
+     * @return whether the item usage is completed
+     */
+    public boolean isCompleted() {
+        return completed;
     }
 
     /**

--- a/src/main/java/net/minestom/server/event/item/ItemUsageCompleteEvent.java
+++ b/src/main/java/net/minestom/server/event/item/ItemUsageCompleteEvent.java
@@ -1,0 +1,39 @@
+package net.minestom.server.event.item;
+
+import net.minestom.server.entity.Player;
+import net.minestom.server.event.trait.ItemEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
+import net.minestom.server.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Event when the item usage duration has passed for a player, meaning when the item has completed its usage.
+ */
+public class ItemUsageCompleteEvent implements PlayerInstanceEvent, ItemEvent {
+
+    private final Player player;
+    private final Player.Hand hand;
+    private final ItemStack itemStack;
+
+    public ItemUsageCompleteEvent(@NotNull Player player, @NotNull Player.Hand hand,
+                                  @NotNull ItemStack itemStack) {
+        this.player = player;
+        this.hand = hand;
+        this.itemStack = itemStack;
+    }
+
+    @NotNull
+    public Player.Hand getHand() {
+        return hand;
+    }
+
+    @Override
+    public @NotNull ItemStack getItemStack() {
+        return itemStack;
+    }
+
+    @Override
+    public @NotNull Player getPlayer() {
+        return player;
+    }
+}

--- a/src/main/java/net/minestom/server/event/player/PlayerItemAnimationEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerItemAnimationEvent.java
@@ -6,7 +6,7 @@ import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Used when a {@link Player} finish the animation of an item.
+ * Used when a {@link Player} starts the animation of an item.
  *
  * @see ItemAnimationType
  */
@@ -51,7 +51,11 @@ public class PlayerItemAnimationEvent implements PlayerInstanceEvent, Cancellabl
         CROSSBOW,
         TRIDENT,
         SHIELD,
-        EAT
+        SPYGLASS,
+        HORN,
+        BRUSH,
+        EAT,
+        OTHER
     }
 
     @Override

--- a/src/main/java/net/minestom/server/event/player/PlayerUseItemEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerUseItemEvent.java
@@ -1,6 +1,7 @@
 package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
+import net.minestom.server.event.item.ItemUpdateStateEvent;
 import net.minestom.server.event.trait.CancellableEvent;
 import net.minestom.server.event.trait.ItemEvent;
 import net.minestom.server.event.trait.PlayerInstanceEvent;
@@ -16,12 +17,14 @@ public class PlayerUseItemEvent implements PlayerInstanceEvent, ItemEvent, Cance
     private final Player.Hand hand;
     private final ItemStack itemStack;
 
+    private long itemUseTime;
     private boolean cancelled;
 
-    public PlayerUseItemEvent(@NotNull Player player, @NotNull Player.Hand hand, @NotNull ItemStack itemStack) {
+    public PlayerUseItemEvent(@NotNull Player player, @NotNull Player.Hand hand, @NotNull ItemStack itemStack, long itemUseTime) {
         this.player = player;
         this.hand = hand;
         this.itemStack = itemStack;
+        this.itemUseTime = itemUseTime;
     }
 
     /**
@@ -29,19 +32,37 @@ public class PlayerUseItemEvent implements PlayerInstanceEvent, ItemEvent, Cance
      *
      * @return the hand used
      */
-    @NotNull
-    public Player.Hand getHand() {
+    public @NotNull Player.Hand getHand() {
         return hand;
     }
 
     /**
-     * Gets the item which have been used.
+     * Gets the item which has been used.
      *
      * @return the item
      */
-    @NotNull
-    public ItemStack getItemStack() {
+    @Override
+    public @NotNull ItemStack getItemStack() {
         return itemStack;
+    }
+
+    /**
+     * Gets the item usage duration. After this amount of milliseconds,
+     * the animation will stop automatically and {@link ItemUpdateStateEvent} is called.
+     *
+     * @return the item use time
+     */
+    public long getItemUseTime() {
+        return itemUseTime;
+    }
+
+    /**
+     * Changes the item usage duration.
+     *
+     * @param itemUseTime the new item use time
+     */
+    public void setItemUseTime(long itemUseTime) {
+        this.itemUseTime = itemUseTime;
     }
 
     @Override

--- a/src/main/java/net/minestom/server/listener/PlayerDiggingListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerDiggingListener.java
@@ -152,7 +152,7 @@ public final class PlayerDiggingListener {
         player.refreshItemUse(null);
         player.triggerStatus((byte) 9);
 
-        ItemUpdateStateEvent itemUpdateStateEvent = player.callItemUpdateStateEvent(hand);
+        ItemUpdateStateEvent itemUpdateStateEvent = player.callItemUpdateStateEvent(hand, false);
 
         final boolean isOffHand = itemUpdateStateEvent.getHand() == Player.Hand.OFF;
         player.refreshActiveHand(itemUpdateStateEvent.hasHandAnimation(),

--- a/src/main/java/net/minestom/server/listener/PlayerDiggingListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerDiggingListener.java
@@ -152,7 +152,7 @@ public final class PlayerDiggingListener {
         player.refreshItemUse(null);
         player.triggerStatus((byte) 9);
 
-        ItemUpdateStateEvent itemUpdateStateEvent = player.callItemUpdateStateEvent(hand, false);
+        ItemUpdateStateEvent itemUpdateStateEvent = player.callItemUpdateStateEvent(hand);
 
         final boolean isOffHand = itemUpdateStateEvent.getHand() == Player.Hand.OFF;
         player.refreshActiveHand(itemUpdateStateEvent.hasHandAnimation(),

--- a/src/main/java/net/minestom/server/listener/PlayerDiggingListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerDiggingListener.java
@@ -149,17 +149,14 @@ public final class PlayerDiggingListener {
         if (meta == null || !meta.isHandActive()) return;
         Player.Hand hand = meta.getActiveHand();
 
-        player.refreshEating(null);
+        player.refreshItemUse(null);
         player.triggerStatus((byte) 9);
 
         ItemUpdateStateEvent itemUpdateStateEvent = player.callItemUpdateStateEvent(hand);
-        if (itemUpdateStateEvent == null) {
-            player.refreshActiveHand(true, false, false);
-        } else {
-            final boolean isOffHand = itemUpdateStateEvent.getHand() == Player.Hand.OFF;
-            player.refreshActiveHand(itemUpdateStateEvent.hasHandAnimation(),
-                    isOffHand, itemUpdateStateEvent.isRiptideSpinAttack());
-        }
+
+        final boolean isOffHand = itemUpdateStateEvent.getHand() == Player.Hand.OFF;
+        player.refreshActiveHand(itemUpdateStateEvent.hasHandAnimation(),
+                isOffHand, itemUpdateStateEvent.isRiptideSpinAttack());
     }
 
     private static void swapItemHand(Player player) {

--- a/src/main/java/net/minestom/server/listener/UseItemListener.java
+++ b/src/main/java/net/minestom/server/listener/UseItemListener.java
@@ -69,13 +69,14 @@ public class UseItemListener {
             itemAnimationType = PlayerItemAnimationEvent.ItemAnimationType.OTHER;
         }
 
-        if (itemUseTime > 0)
+        if (itemUseTime > 0) {
             player.refreshItemUse(hand, itemUseTime);
 
-        PlayerItemAnimationEvent playerItemAnimationEvent = new PlayerItemAnimationEvent(player, itemAnimationType, hand);
-        EventDispatcher.callCancellable(playerItemAnimationEvent, () -> {
-            player.refreshActiveHand(true, hand == Player.Hand.OFF, false);
-            player.sendPacketToViewers(player.getMetadataPacket());
-        });
+            PlayerItemAnimationEvent playerItemAnimationEvent = new PlayerItemAnimationEvent(player, itemAnimationType, hand);
+            EventDispatcher.callCancellable(playerItemAnimationEvent, () -> {
+                player.refreshActiveHand(true, hand == Player.Hand.OFF, false);
+                player.sendPacketToViewers(player.getMetadataPacket());
+            });
+        }
     }
 }


### PR DESCRIPTION
This pr generalizes the food code in `Player` and `UseItemListener` to also allow for non-food items to have a usage duration specified beforehand.

While this does make `PlayerPreEatEvent` and `PlayerEatEvent` redundant (the same can be done with `PlayerUseItemEvent` and `ItemUpdateStateEvent`), I left those in for clarity and backwards compatibility. For the same reason I left `Player#isEating`, which now just checks if the currently used item is a food. Please let me know if these should be removed instead.

Along with those changes I added spyglass, horn and brush item animation types, since Minestom already had support for bow, crossbow, trident, etc. I also removed the deprecated `Player#callItemUpdateStateEvent(boolean, Hand)` since it has been deprecated for a long time and I think it was time for it to be removed.