### PR TITLE
Make initial lighting not require send to fix race condition

### DIFF
--- a/src/main/java/net/minestom/server/instance/light/BlockLight.java
+++ b/src/main/java/net/minestom/server/instance/light/BlockLight.java
@@ -25,7 +25,7 @@ final class BlockLight implements Light {
     private byte[] contentPropagationSwap;
 
     private boolean isValidBorders = true;
-    private boolean needsSend = true;
+    private boolean needsSend = false;
 
     private Set<Point> toUpdateSet = new HashSet<>();
     private final Section[] neighborSections = new Section[BlockFace.values().length];

--- a/src/main/java/net/minestom/server/instance/light/SkyLight.java
+++ b/src/main/java/net/minestom/server/instance/light/SkyLight.java
@@ -25,7 +25,7 @@ final class SkyLight implements Light {
     private byte[] contentPropagationSwap;
 
     private boolean isValidBorders = true;
-    private boolean needsSend = true;
+    private boolean needsSend = false;
 
     private Set<Point> toUpdateSet = new HashSet<>();
     private final Section[] neighborSections = new Section[BlockFace.values().length];


### PR DESCRIPTION
Might fix an issue where lighting generation stage starts before the chunk is loaded