### PR TITLE
Retain offset in BoundingBox::contract and expand

### DIFF
--- a/src/main/java/net/minestom/server/collision/BoundingBox.java
+++ b/src/main/java/net/minestom/server/collision/BoundingBox.java
@@ -99,7 +99,7 @@ public final class BoundingBox implements Shape {
      * @return a new {@link BoundingBox} expanded
      */
     public @NotNull BoundingBox expand(double x, double y, double z) {
-        return new BoundingBox(this.width + x, this.height + y, this.depth + z);
+        return new BoundingBox(this.width + x, this.height + y, this.depth + z, offset);
     }
 
     /**
@@ -111,7 +111,7 @@ public final class BoundingBox implements Shape {
      * @return a new bounding box contracted
      */
     public @NotNull BoundingBox contract(double x, double y, double z) {
-        return new BoundingBox(this.width - x, this.height - y, this.depth - z);
+        return new BoundingBox(this.width - x, this.height - y, this.depth - z, offset);
     }
 
     /**


### PR DESCRIPTION
This is a breaking change to those methods but I expected those to behave like this so much that I think it's a bug.