### PR TITLE
Offer more control over LightingChunk invalidations

### DIFF
--- a/src/main/java/net/minestom/server/instance/LightingChunk.java
+++ b/src/main/java/net/minestom/server/instance/LightingChunk.java
@@ -112,7 +112,7 @@ public class LightingChunk extends DynamicChunk {
         this.freezeInvalidation = freezeInvalidation;
     }
 
-    public void invalidateSection(int coordinate) {
+    public void invalidateNeighborsSection(int coordinate) {
         if (freezeInvalidation) {
             return;
         }
@@ -143,8 +143,6 @@ public class LightingChunk extends DynamicChunk {
         for (int i = -1; i <= 1; i++) {
             for (int j = -1; j <= 1; j++) {
                 Chunk neighborChunk = instance.getChunk(chunkX + i, chunkZ + j);
-                if (neighborChunk == null) continue;
-
                 if (neighborChunk instanceof LightingChunk light) {
                     light.resendTimer.set(resendDelay);
                 }
@@ -162,7 +160,7 @@ public class LightingChunk extends DynamicChunk {
         // Invalidate neighbor chunks, since they can be updated by this block change
         int coordinate = ChunkUtils.getChunkCoordinate(y);
         if (chunkLoaded && !freezeInvalidation) {
-            invalidateSection(coordinate);
+            invalidateNeighborsSection(coordinate);
             invalidateResendDelay();
             this.lightCache.invalidate();
         }

--- a/src/main/java/net/minestom/server/instance/LightingChunk.java
+++ b/src/main/java/net/minestom/server/instance/LightingChunk.java
@@ -43,6 +43,7 @@ public class LightingChunk extends DynamicChunk {
 
     boolean chunkLoaded = false;
     private int highestBlock;
+    private boolean freezeInvalidation = false;
 
     private final ReentrantLock packetGenerationLock = new ReentrantLock();
     private final AtomicInteger resendTimer = new AtomicInteger(-1);
@@ -107,7 +108,15 @@ public class LightingChunk extends DynamicChunk {
         return occludesBottom || occludesTop;
     }
 
-    private void invalidateSection(int coordinate) {
+    public void setFreezeInvalidation(boolean freezeInvalidation) {
+        this.freezeInvalidation = freezeInvalidation;
+    }
+
+    public void invalidateSection(int coordinate) {
+        if (freezeInvalidation) {
+            return;
+        }
+
         for (int i = -1; i <= 1; i++) {
             for (int j = -1; j <= 1; j++) {
                 Chunk neighborChunk = instance.getChunk(chunkX + i, chunkZ + j);
@@ -126,6 +135,23 @@ public class LightingChunk extends DynamicChunk {
         }
     }
 
+    public void invalidateResendDelay() {
+        if (!doneInit) {
+            return;
+        }
+
+        for (int i = -1; i <= 1; i++) {
+            for (int j = -1; j <= 1; j++) {
+                Chunk neighborChunk = instance.getChunk(chunkX + i, chunkZ + j);
+                if (neighborChunk == null) continue;
+
+                if (neighborChunk instanceof LightingChunk light) {
+                    light.resendTimer.set(resendDelay);
+                }
+            }
+        }
+    }
+
     @Override
     public void setBlock(int x, int y, int z, @NotNull Block block,
                          @Nullable BlockHandler.Placement placement,
@@ -135,22 +161,10 @@ public class LightingChunk extends DynamicChunk {
 
         // Invalidate neighbor chunks, since they can be updated by this block change
         int coordinate = ChunkUtils.getChunkCoordinate(y);
-        if (chunkLoaded) {
+        if (chunkLoaded && !freezeInvalidation) {
             invalidateSection(coordinate);
+            invalidateResendDelay();
             this.lightCache.invalidate();
-
-            if (doneInit) {
-                for (int i = -1; i <= 1; i++) {
-                    for (int j = -1; j <= 1; j++) {
-                        Chunk neighborChunk = instance.getChunk(chunkX + i, chunkZ + j);
-                        if (neighborChunk == null) continue;
-
-                        if (neighborChunk instanceof LightingChunk light) {
-                            light.resendTimer.set(resendDelay);
-                        }
-                    }
-                }
-            }
         }
     }
 

--- a/src/main/java/net/minestom/server/instance/LightingChunk.java
+++ b/src/main/java/net/minestom/server/instance/LightingChunk.java
@@ -136,7 +136,7 @@ public class LightingChunk extends DynamicChunk {
     }
 
     public void invalidateResendDelay() {
-        if (!doneInit) {
+        if (!doneInit || freezeInvalidation) {
             return;
         }
 


### PR DESCRIPTION
I'm doing a lot of block updates at once and calling the invalidation every setBlock shows up on the profiler.
This allows doing the invalidation later all at once.