### PR TITLE
Fix Entity::getEffectLevel having two meanings when returning 0

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -1453,11 +1453,11 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
      * Gets the level of the specified effect.
      *
      * @param effect the effect type
-     * @return the effect level, 0 if not found
+     * @return the effect level, -1 if not found
      */
     public int getEffectLevel(@NotNull PotionEffect effect) {
         TimedPotion timedPotion = getEffect(effect);
-        return timedPotion == null ? 0 : timedPotion.potion().amplifier();
+        return timedPotion == null ? -1 : timedPotion.potion().amplifier();
     }
 
     /**


### PR DESCRIPTION
Returning 0 is wrong, because amplifiers start at 0, meaning whether you have speed 1 or no speed, this method returns 0.