### PR TITLE
Move static Entity lookup maps to EntityTracker

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -1437,7 +1437,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         remove(true);
     }
 
-    public void remove(boolean permanent) {
+    protected void remove(boolean permanent) {
         if (isRemoved()) return;
         EventDispatcher.call(new EntityDespawnEvent(this));
         try {

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -673,14 +673,10 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
      */
     public void setUuid(@NotNull UUID uuid) {
         if (instance != null) {
-            instance.getEntityTracker().unregister(this, trackingTarget, trackingUpdate);
+            instance.getEntityTracker().changeUuid(this, this.uuid);
         }
 
         this.uuid = uuid;
-
-        if (instance != null) {
-            instance.getEntityTracker().register(this, position, trackingTarget, trackingUpdate);
-        }
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/EntityView.java
+++ b/src/main/java/net/minestom/server/entity/EntityView.java
@@ -4,7 +4,6 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
-import net.minestom.server.MinecraftServer;
 import net.minestom.server.ServerFlag;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.instance.EntityTracker;
@@ -167,7 +166,7 @@ final class EntityView {
         }
 
         public void register(T entity) {
-            assert Entity.getEntity(entity.getEntityId()) == entity : "Unregistered entity shouldn't be registered as viewer";
+            assert entity.getInstance() != null : "Unregistered entity shouldn't be registered as viewer";
             this.bitSet.add(entity.getEntityId());
         }
 
@@ -247,10 +246,12 @@ final class EntityView {
             synchronized (mutex) {
                 var bitSet = viewableOption.bitSet;
                 if (bitSet.isEmpty()) return Collections.emptyIterator();
+                Instance instance = entity.getInstance();
+                if (instance == null) return Collections.emptyIterator();
                 players = new ArrayList<>(bitSet.size());
                 for (IntIterator it = bitSet.intIterator(); it.hasNext(); ) {
                     final int id = it.nextInt();
-                    final Player player = (Player) Entity.getEntity(id);
+                    final Player player = (Player) instance.getEntityById(id);
                     if (player != null) players.add(player);
                 }
             }

--- a/src/main/java/net/minestom/server/entity/EntityView.java
+++ b/src/main/java/net/minestom/server/entity/EntityView.java
@@ -166,7 +166,7 @@ final class EntityView {
         }
 
         public void register(T entity) {
-            assert entity.getInstance() != null : "Unregistered entity shouldn't be registered as viewer";
+            assert entity.getInstance() != null : "Instance-less entity shouldn't be registered as viewer";
             this.bitSet.add(entity.getEntityId());
         }
 

--- a/src/main/java/net/minestom/server/instance/EntityTracker.java
+++ b/src/main/java/net/minestom/server/instance/EntityTracker.java
@@ -62,6 +62,11 @@ public sealed interface EntityTracker permits EntityTrackerImpl {
     <T extends Entity> void move(@NotNull Entity entity, @NotNull Point newPoint,
                                  @NotNull Target<T> target, @Nullable Update<T> update);
 
+    /**
+     * Called whenever the entity's uuid changes, can be called async
+     */
+    void changeUuid(@NotNull Entity entity, UUID oldUuid);
+
     @UnmodifiableView <T extends Entity> Collection<T> chunkEntities(int chunkX, int chunkZ, @NotNull Target<T> target);
 
     @UnmodifiableView

--- a/src/main/java/net/minestom/server/instance/EntityTracker.java
+++ b/src/main/java/net/minestom/server/instance/EntityTracker.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.UnmodifiableView;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Consumer;
 
 /**
@@ -37,6 +38,22 @@ public sealed interface EntityTracker permits EntityTrackerImpl {
      * Unregister an entity tracking.
      */
     <T extends Entity> void unregister(@NotNull Entity entity, @NotNull Target<T> target, @Nullable Update<T> update);
+
+    /**
+     * Gets an entity based on its id (from {@link Entity#getEntityId()}).
+     *
+     * @param id the entity id
+     * @return the entity having the specified id, null if not found
+     */
+    @Nullable Entity getEntityById(int id);
+
+    /**
+     * Gets an entity based on its UUID (from {@link Entity#getUuid()}).
+     *
+     * @param uuid the entity UUID
+     * @return the entity having the specified uuid, null if not found
+     */
+    @Nullable Entity getEntityByUuid(UUID uuid);
 
     /**
      * Called every time an entity move, you may want to verify if the new

--- a/src/main/java/net/minestom/server/instance/EntityTrackerImpl.java
+++ b/src/main/java/net/minestom/server/instance/EntityTrackerImpl.java
@@ -13,6 +13,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jetbrains.annotations.UnmodifiableView;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import space.vectrix.flare.fastutil.Int2ObjectSyncMap;
 import space.vectrix.flare.fastutil.Long2ObjectSyncMap;
 
@@ -28,6 +30,8 @@ import static net.minestom.server.instance.Chunk.CHUNK_SIZE_Z;
 import static net.minestom.server.utils.chunk.ChunkUtils.*;
 
 final class EntityTrackerImpl implements EntityTracker {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EntityTrackerImpl.class);
+
     static final AtomicInteger TARGET_COUNTER = new AtomicInteger();
 
     // Store all data associated to a Target
@@ -103,7 +107,10 @@ final class EntityTrackerImpl implements EntityTracker {
     public <T extends Entity> void move(@NotNull Entity entity, @NotNull Point newPoint,
                                         @NotNull Target<T> target, @Nullable Update<T> update) {
         EntityTrackerEntry entry = entriesByEntityId.get(entity.getEntityId());
-        if (entry == null) return;
+        if (entry == null) {
+            LOGGER.warn("Attempted to move unregistered entity {} in the entity tracker", entity.getEntityId());
+            return;
+        }
         Point oldPoint = entry.getLastPosition();
         entry.setLastPosition(newPoint);
         if (oldPoint == null || oldPoint.sameChunk(newPoint)) return;

--- a/src/main/java/net/minestom/server/instance/EntityTrackerImpl.java
+++ b/src/main/java/net/minestom/server/instance/EntityTrackerImpl.java
@@ -39,7 +39,7 @@ final class EntityTrackerImpl implements EntityTracker {
     @Override
     public <T extends Entity> void register(@NotNull Entity entity, @NotNull Point point,
                                             @NotNull Target<T> target, @Nullable Update<T> update) {
-        EntityTrackerEntry newEntry = new EntityTrackerEntry(entity);
+        EntityTrackerEntry newEntry = new EntityTrackerEntry(entity, point);
         EntityTrackerEntry prevEntry = entriesByEntityId.putIfAbsent(entity.getEntityId(), newEntry);
         if (prevEntry != null) return;
         entriesByEntityUuid.put(entity.getUuid(), newEntry);
@@ -99,7 +99,7 @@ final class EntityTrackerImpl implements EntityTracker {
     @Override
     public <T extends Entity> void move(@NotNull Entity entity, @NotNull Point newPoint,
                                         @NotNull Target<T> target, @Nullable Update<T> update) {
-        EntityTrackerEntry entry = entriesByEntityId.computeIfAbsent(entity.getEntityId(), id -> new EntityTrackerEntry(entity));
+        EntityTrackerEntry entry = entriesByEntityId.computeIfAbsent(entity.getEntityId(), id -> new EntityTrackerEntry(entity, entity.getPosition()));
         Point oldPoint = entry.getLastPosition();
         entry.setLastPosition(newPoint);
         if (oldPoint == null || oldPoint.sameChunk(newPoint)) return;
@@ -209,8 +209,9 @@ final class EntityTrackerImpl implements EntityTracker {
         private final Entity entity;
         private Point lastPosition;
 
-        private EntityTrackerEntry(Entity entity) {
+        private EntityTrackerEntry(Entity entity, Point lastPosition) {
             this.entity = entity;
+            this.lastPosition = lastPosition;
         }
 
         public Entity getEntity() {

--- a/src/main/java/net/minestom/server/instance/EntityTrackerImpl.java
+++ b/src/main/java/net/minestom/server/instance/EntityTrackerImpl.java
@@ -43,9 +43,9 @@ final class EntityTrackerImpl implements EntityTracker {
         EntityTrackerEntry newEntry = new EntityTrackerEntry(entity, point);
 
         EntityTrackerEntry prevEntryWithId = entriesByEntityId.putIfAbsent(entity.getEntityId(), newEntry);
-        Check.stateCondition(prevEntryWithId == null, "There is already an entity registered with id {0}", entity.getEntityId());
+        Check.isTrue(prevEntryWithId == null, "There is already an entity registered with id {0}", entity.getEntityId());
         EntityTrackerEntry prevEntryWithUuid = entriesByEntityUuid.putIfAbsent(entity.getUuid(), newEntry);
-        Check.stateCondition(prevEntryWithUuid == null, "There is already an entity registered with uuid {0}", entity.getUuid());
+        Check.isTrue(prevEntryWithUuid == null, "There is already an entity registered with uuid {0}", entity.getUuid());
 
         final long index = getChunkIndex(point);
         for (TargetEntry<Entity> targetEntry : targetEntries) {

--- a/src/main/java/net/minestom/server/instance/EntityTrackerImpl.java
+++ b/src/main/java/net/minestom/server/instance/EntityTrackerImpl.java
@@ -1,7 +1,6 @@
 package net.minestom.server.instance;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import net.minestom.server.MinecraftServer;
 import net.minestom.server.ServerFlag;
 import net.minestom.server.Viewable;
 import net.minestom.server.coordinate.Point;
@@ -32,19 +31,24 @@ final class EntityTrackerImpl implements EntityTracker {
 
     // Store all data associated to a Target
     // The array index is the Target enum ordinal
-    final TargetEntry<Entity>[] entries = EntityTracker.Target.TARGETS.stream().map((Function<Target<?>, TargetEntry>) TargetEntry::new).toArray(TargetEntry[]::new);
-    private final Int2ObjectSyncMap<Point> entityPositions = Int2ObjectSyncMap.hashmap();
+    final TargetEntry<Entity>[] targetEntries = EntityTracker.Target.TARGETS.stream().map((Function<Target<?>, TargetEntry>) TargetEntry::new).toArray(TargetEntry[]::new);
+
+    private final Int2ObjectSyncMap<EntityTrackerEntry> entriesByEntityId = Int2ObjectSyncMap.hashmap();
+    private final Map<UUID, EntityTrackerEntry> entriesByEntityUuid = new ConcurrentHashMap<>();
 
     @Override
     public <T extends Entity> void register(@NotNull Entity entity, @NotNull Point point,
                                             @NotNull Target<T> target, @Nullable Update<T> update) {
-        var prevPoint = entityPositions.putIfAbsent(entity.getEntityId(), point);
-        if (prevPoint != null) return;
+        EntityTrackerEntry newEntry = new EntityTrackerEntry(entity);
+        EntityTrackerEntry prevEntry = entriesByEntityId.putIfAbsent(entity.getEntityId(), newEntry);
+        if (prevEntry != null) return;
+        entriesByEntityUuid.put(entity.getUuid(), newEntry);
+
         final long index = getChunkIndex(point);
-        for (TargetEntry<Entity> entry : entries) {
-            if (entry.target.type().isInstance(entity)) {
-                entry.entities.add(entity);
-                entry.addToChunk(index, entity);
+        for (TargetEntry<Entity> targetEntry : targetEntries) {
+            if (targetEntry.target.type().isInstance(entity)) {
+                targetEntry.entities.add(entity);
+                targetEntry.addToChunk(index, entity);
             }
         }
         if (update != null) {
@@ -59,13 +63,16 @@ final class EntityTrackerImpl implements EntityTracker {
     @Override
     public <T extends Entity> void unregister(@NotNull Entity entity,
                                               @NotNull Target<T> target, @Nullable Update<T> update) {
-        final Point point = entityPositions.remove(entity.getEntityId());
+        EntityTrackerEntry entry = entriesByEntityId.remove(entity.getEntityId());
+        entriesByEntityUuid.remove(entity.getUuid());
+        final Point point = entry == null ? null : entry.getLastPosition();
         if (point == null) return;
+
         final long index = getChunkIndex(point);
-        for (TargetEntry<Entity> entry : entries) {
-            if (entry.target.type().isInstance(entity)) {
-                entry.entities.remove(entity);
-                entry.removeFromChunk(index, entity);
+        for (TargetEntry<Entity> targetEntry : targetEntries) {
+            if (targetEntry.target.type().isInstance(entity)) {
+                targetEntry.entities.remove(entity);
+                targetEntry.removeFromChunk(index, entity);
             }
         }
         if (update != null) {
@@ -78,16 +85,30 @@ final class EntityTrackerImpl implements EntityTracker {
     }
 
     @Override
+    public @Nullable Entity getEntityById(int id) {
+        EntityTrackerEntry entry = entriesByEntityId.get(id);
+        return entry == null ? null : entry.getEntity();
+    }
+
+    @Override
+    public @Nullable Entity getEntityByUuid(UUID uuid) {
+        EntityTrackerEntry entry = entriesByEntityUuid.get(uuid);
+        return entry == null ? null : entry.getEntity();
+    }
+
+    @Override
     public <T extends Entity> void move(@NotNull Entity entity, @NotNull Point newPoint,
                                         @NotNull Target<T> target, @Nullable Update<T> update) {
-        Point oldPoint = entityPositions.put(entity.getEntityId(), newPoint);
+        EntityTrackerEntry entry = entriesByEntityId.computeIfAbsent(entity.getEntityId(), id -> new EntityTrackerEntry(entity));
+        Point oldPoint = entry.getLastPosition();
+        entry.setLastPosition(newPoint);
         if (oldPoint == null || oldPoint.sameChunk(newPoint)) return;
         final long oldIndex = getChunkIndex(oldPoint);
         final long newIndex = getChunkIndex(newPoint);
-        for (TargetEntry<Entity> entry : entries) {
-            if (entry.target.type().isInstance(entity)) {
-                entry.addToChunk(newIndex, entity);
-                entry.removeFromChunk(oldIndex, entity);
+        for (TargetEntry<Entity> targetEntry : targetEntries) {
+            if (targetEntry.target.type().isInstance(entity)) {
+                targetEntry.addToChunk(newIndex, entity);
+                targetEntry.removeFromChunk(oldIndex, entity);
             }
         }
         if (update != null) {
@@ -108,7 +129,7 @@ final class EntityTrackerImpl implements EntityTracker {
 
     @Override
     public @Unmodifiable <T extends Entity> Collection<T> chunkEntities(int chunkX, int chunkZ, @NotNull Target<T> target) {
-        final TargetEntry<Entity> entry = entries[target.ordinal()];
+        final TargetEntry<Entity> entry = targetEntries[target.ordinal()];
         //noinspection unchecked
         var chunkEntities = (List<T>) entry.chunkEntities(getChunkIndex(chunkX, chunkZ));
         return Collections.unmodifiableList(chunkEntities);
@@ -116,7 +137,7 @@ final class EntityTrackerImpl implements EntityTracker {
 
     @Override
     public <T extends Entity> void nearbyEntitiesByChunkRange(@NotNull Point point, int chunkRange, @NotNull Target<T> target, @NotNull Consumer<T> query) {
-        final Long2ObjectSyncMap<List<Entity>> entities = entries[target.ordinal()].chunkEntities;
+        final Long2ObjectSyncMap<List<Entity>> entities = targetEntries[target.ordinal()].chunkEntities;
         if (chunkRange == 0) {
             // Single chunk
             final var chunkEntities = (List<T>) entities.get(getChunkIndex(point));
@@ -135,7 +156,7 @@ final class EntityTrackerImpl implements EntityTracker {
 
     @Override
     public <T extends Entity> void nearbyEntities(@NotNull Point point, double range, @NotNull Target<T> target, @NotNull Consumer<T> query) {
-        final Long2ObjectSyncMap<List<Entity>> entities = entries[target.ordinal()].chunkEntities;
+        final Long2ObjectSyncMap<List<Entity>> entities = targetEntries[target.ordinal()].chunkEntities;
         final int minChunkX = ChunkUtils.getChunkCoordinate(point.x() - range);
         final int minChunkZ = ChunkUtils.getChunkCoordinate(point.z() - range);
         final int maxChunkX = ChunkUtils.getChunkCoordinate(point.x() + range);
@@ -146,7 +167,7 @@ final class EntityTrackerImpl implements EntityTracker {
             final var chunkEntities = (List<T>) entities.get(getChunkIndex(point));
             if (chunkEntities != null && !chunkEntities.isEmpty()) {
                 chunkEntities.forEach(entity -> {
-                    final Point position = entityPositions.get(entity.getEntityId());
+                    final Point position = entriesByEntityId.get(entity.getEntityId()).getLastPosition();
                     if (point.distanceSquared(position) <= squaredRange) query.accept(entity);
                 });
             }
@@ -157,7 +178,7 @@ final class EntityTrackerImpl implements EntityTracker {
                 final var chunkEntities = (List<T>) entities.get(getChunkIndex(chunkX, chunkZ));
                 if (chunkEntities == null || chunkEntities.isEmpty()) return;
                 chunkEntities.forEach(entity -> {
-                    final Point position = entityPositions.get(entity.getEntityId());
+                    final Point position = entriesByEntityId.get(entity.getEntityId()).getLastPosition();
                     if (point.distanceSquared(position) <= squaredRange) {
                         query.accept(entity);
                     }
@@ -169,18 +190,39 @@ final class EntityTrackerImpl implements EntityTracker {
     @Override
     public @UnmodifiableView @NotNull <T extends Entity> Set<@NotNull T> entities(@NotNull Target<T> target) {
         //noinspection unchecked
-        return (Set<T>) entries[target.ordinal()].entitiesView;
+        return (Set<T>) targetEntries[target.ordinal()].entitiesView;
     }
 
     @Override
     public @NotNull Viewable viewable(@NotNull List<@NotNull SharedInstance> sharedInstances, int chunkX, int chunkZ) {
-        var entry = entries[Target.PLAYERS.ordinal()];
+        var entry = targetEntries[Target.PLAYERS.ordinal()];
         return entry.viewers.computeIfAbsent(new ChunkViewKey(sharedInstances, chunkX, chunkZ), ChunkView::new);
+    }
+
+    private static class EntityTrackerEntry {
+        private final Entity entity;
+        private Point lastPosition;
+
+        private EntityTrackerEntry(Entity entity) {
+            this.entity = entity;
+        }
+
+        public Entity getEntity() {
+            return entity;
+        }
+
+        public Point getLastPosition() {
+            return lastPosition;
+        }
+
+        public void setLastPosition(Point lastPosition) {
+            this.lastPosition = lastPosition;
+        }
     }
 
     private <T extends Entity> void difference(Point oldPoint, Point newPoint,
                                                @NotNull Target<T> target, @NotNull Update<T> update) {
-        final TargetEntry<Entity> entry = entries[target.ordinal()];
+        final TargetEntry<Entity> entry = targetEntries[target.ordinal()];
         forDifferingChunksInRange(newPoint.chunkX(), newPoint.chunkZ(), oldPoint.chunkX(), oldPoint.chunkZ(),
                 ServerFlag.ENTITY_VIEW_DISTANCE, (chunkX, chunkZ) -> {
                     // Add

--- a/src/main/java/net/minestom/server/instance/EntityTrackerImpl.java
+++ b/src/main/java/net/minestom/server/instance/EntityTrackerImpl.java
@@ -128,6 +128,12 @@ final class EntityTrackerImpl implements EntityTracker {
     }
 
     @Override
+    public void changeUuid(@NotNull Entity entity, UUID oldUuid) {
+        entriesByEntityUuid.remove(oldUuid);
+        entriesByEntityUuid.put(entity.getUuid(), new EntityTrackerEntry(entity));
+    }
+
+    @Override
     public @Unmodifiable <T extends Entity> Collection<T> chunkEntities(int chunkX, int chunkZ, @NotNull Target<T> target) {
         final TargetEntry<Entity> entry = targetEntries[target.ordinal()];
         //noinspection unchecked

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -593,6 +593,26 @@ public abstract class Instance implements Block.Getter, Block.Setter,
     }
 
     /**
+     * Gets an entity based on its id (from {@link Entity#getEntityId()}).
+     *
+     * @param id the entity id
+     * @return the entity having the specified id, null if not found
+     */
+    public @Nullable Entity getEntityById(int id) {
+        return entityTracker.getEntityById(id);
+    }
+
+    /**
+     * Gets an entity based on its UUID (from {@link Entity#getUuid()}).
+     *
+     * @param uuid the entity UUID
+     * @return the entity having the specified uuid, null if not found
+     */
+    public @Nullable Entity getEntityByUuid(UUID uuid) {
+        return entityTracker.getEntityByUuid(uuid);
+    }
+
+    /**
      * Gets the players in the instance;
      *
      * @return an unmodifiable {@link Set} containing all the players in the instance

--- a/src/main/java/net/minestom/server/listener/SpectateListener.java
+++ b/src/main/java/net/minestom/server/listener/SpectateListener.java
@@ -19,7 +19,7 @@ public class SpectateListener {
         }
 
         final UUID targetUuid = packet.target();
-        final Entity target = Entity.getEntity(targetUuid);
+        final Entity target = player.getInstance().getEntityByUuid(targetUuid);
 
         // Check if the target is valid
         if (target == null || target == player) {

--- a/src/main/java/net/minestom/server/listener/UseEntityListener.java
+++ b/src/main/java/net/minestom/server/listener/UseEntityListener.java
@@ -13,7 +13,7 @@ import net.minestom.server.network.packet.client.play.ClientInteractEntityPacket
 public class UseEntityListener {
 
     public static void useEntityListener(ClientInteractEntityPacket packet, Player player) {
-        final Entity entity = Entity.getEntity(packet.targetId());
+        final Entity entity = player.getInstance().getEntityById(packet.targetId());
         if (entity == null || !entity.isViewer(player) || player.getDistanceSquared(entity) > 6 * 6)
             return;
 

--- a/src/main/java/net/minestom/server/utils/entity/EntityFinder.java
+++ b/src/main/java/net/minestom/server/utils/entity/EntityFinder.java
@@ -12,7 +12,6 @@ import net.minestom.server.entity.GameMode;
 import net.minestom.server.entity.Player;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.network.ConnectionManager;
-import net.minestom.server.network.ConnectionState;
 import net.minestom.server.utils.MathUtils;
 import net.minestom.server.utils.math.IntRange;
 import net.minestom.server.utils.validate.Check;
@@ -135,7 +134,8 @@ public class EntityFinder {
             return player != null ? List.of(player) : List.of();
         } else if (targetSelector == TargetSelector.MINESTOM_UUID) {
             Check.notNull(constantUuid, "The UUID should not be null when searching for it");
-            final Entity entity = Entity.getEntity(constantUuid);
+            Check.notNull(instance, "The instance should not be null when searching by UUID");
+            final Entity entity = instance.getEntityByUuid(constantUuid);
             return entity != null ? List.of(entity) : List.of();
         }
 

--- a/src/main/java/net/minestom/server/utils/validate/Check.java
+++ b/src/main/java/net/minestom/server/utils/validate/Check.java
@@ -63,4 +63,17 @@ public final class Check {
         }
     }
 
+    @Contract("false, _ -> fail")
+    public static void isTrue(boolean condition, @NotNull String reason) {
+        if (!condition) {
+            throw new IllegalStateException(reason);
+        }
+    }
+
+    @Contract("false, _, _ -> fail")
+    public static void isTrue(boolean condition, @NotNull String reason, Object... arguments) {
+        if (!condition) {
+            throw new IllegalStateException(MessageFormat.format(reason, arguments));
+        }
+    }
 }


### PR DESCRIPTION
EntityTrackerEntry exists to ensure the same behavior as before in regards to the recorded position in the tracker.