### PR TITLE
Make PlayerProjectile extend Entity instead of LivingEntity

### DIFF
--- a/src/main/java/net/minestom/server/entity/PlayerProjectile.java
+++ b/src/main/java/net/minestom/server/entity/PlayerProjectile.java
@@ -20,7 +20,7 @@ import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
 
-public class PlayerProjectile extends LivingEntity {
+public class PlayerProjectile extends Entity {
     private final Entity shooter;
     private long cooldown = 0;
 


### PR DESCRIPTION
When spawning a `PlayerProjectile` on 1.20.4 and later, there is a short lag spike on the client. I suspect it is caused by repeatedly logging this error:
```
[22:11:39] [Render thread/ERROR]: Error executing task on Client
net.minecraft.class_148: Main thread packet handler
	at net.minecraft.class_2600.method_11072(class_2600.java:33) ~[client-intermediary.jar:?]
	at net.minecraft.class_1255.method_18859(class_1255.java:156) ~[client-intermediary.jar:?]
	at net.minecraft.class_4093.method_18859(class_4093.java:23) ~[client-intermediary.jar:?]
	at net.minecraft.class_1255.method_16075(class_1255.java:130) ~[client-intermediary.jar:?]
	at net.minecraft.class_1255.method_5383(class_1255.java:115) ~[client-intermediary.jar:?]
	at net.minecraft.class_310.method_1523(class_310.java:1283) ~[client-intermediary.jar:?]
	at net.minecraft.class_310.method_1514(class_310.java:888) ~[client-intermediary.jar:?]
	at net.minecraft.client.main.Main.main(Main.java:265) ~[minecraft-1.20.4-client.jar:?]
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:470) ~[fabric-loader-0.15.11.jar:?]
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74) ~[fabric-loader-0.15.11.jar:?]
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23) ~[fabric-loader-0.15.11.jar:?]
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:100) ~[NewLaunch.jar:?]
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129) ~[NewLaunch.jar:?]
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70) ~[NewLaunch.jar:?]
Caused by: java.lang.IllegalStateException: Server tried to update attributes of a non-living entity (actually: class_1680['Snowball'/1272, l='ClientLevel', x=10.80, y=66.87, z=2.62])
	at net.minecraft.class_634.method_11149(class_634.java:2076) ~[client-intermediary.jar:?]
	at net.minecraft.class_2781.method_11936(class_2781.java:59) ~[client-intermediary.jar:?]
	at net.minecraft.class_2781.method_11054(class_2781.java:15) ~[client-intermediary.jar:?]
	at net.minecraft.class_2600.method_11072(class_2600.java:24) ~[client-intermediary.jar:?]
	... 13 more
```
Because `PlayerProjectile` is currently a living entity, its attribute modifiers are [sent to new viewers automatically](https://github.com/Minestom/Minestom/blob/982233141eaad32c76b6300527c9f4440401af6d/src/main/java/net/minestom/server/entity/LivingEntity.java#L512). The client doesn't expect this, so it logs an error.

Switching the superclass from LivingEntity to Entity fixes this issue. iam also [found this same issue](https://discord.com/channels/706185253441634317/706186227493109860/1222792680891875430) in March, but I don't think any action was made to fix it at the time.

Here's another relevant discussion I found on Discord: https://discord.com/channels/706185253441634317/706186227493109860/1114544857336262717