### PR TITLE
Only consider online players for unregisterInstance

### DIFF
--- a/src/main/java/net/minestom/server/instance/InstanceManager.java
+++ b/src/main/java/net/minestom/server/instance/InstanceManager.java
@@ -1,6 +1,7 @@
 package net.minestom.server.instance;
 
 import net.minestom.server.MinecraftServer;
+import net.minestom.server.entity.Player;
 import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.instance.InstanceRegisterEvent;
 import net.minestom.server.event.instance.InstanceUnregisterEvent;
@@ -117,7 +118,8 @@ public final class InstanceManager {
      * @param instance the {@link Instance} to unregister
      */
     public void unregisterInstance(@NotNull Instance instance) {
-        Check.stateCondition(!instance.getPlayers().isEmpty(), "You cannot unregister an instance with players inside.");
+        long onlinePlayers = instance.getPlayers().stream().filter(Player::isOnline).count();
+        Check.stateCondition(onlinePlayers > 0, "You cannot unregister an instance with players inside.");
         synchronized (instance) {
             InstanceUnregisterEvent event = new InstanceUnregisterEvent(instance);
             EventDispatcher.call(event);


### PR DESCRIPTION
unregisterInstance checks players inside based on the entity tracker.
But when a player is kicked, they are removed from the entity tracker on the next tick.

Besides, if a tree falls in a forest...