### PR TITLE
Include ourself as a viewer when sending SWING_MAIN_ARM animation

### DIFF
--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -523,7 +523,7 @@ public class LivingEntity extends Entity implements EquipmentHandler {
      * (can be used for attack animation).
      */
     public void swingMainHand() {
-        sendPacketToViewers(new EntityAnimationPacket(getEntityId(), EntityAnimationPacket.Animation.SWING_MAIN_ARM));
+        swingMainHand(false);
     }
 
     /**
@@ -531,7 +531,36 @@ public class LivingEntity extends Entity implements EquipmentHandler {
      * (can be used for attack animation).
      */
     public void swingOffHand() {
-        sendPacketToViewers(new EntityAnimationPacket(getEntityId(), EntityAnimationPacket.Animation.SWING_OFF_HAND));
+        swingOffHand(false);
+    }
+
+    /**
+     * Sends a {@link EntityAnimationPacket} to swing the main hand
+     * (can be used for attack animation).
+     *
+     * @param fromClient if true, broadcast only to viewers
+     */
+    public void swingMainHand(boolean fromClient) {
+        swingHand(fromClient, EntityAnimationPacket.Animation.SWING_MAIN_ARM);
+    }
+
+    /**
+     * Sends a {@link EntityAnimationPacket} to swing the off hand
+     * (can be used for attack animation).
+     *
+     * @param fromClient if true, broadcast only to viewers
+     */
+    public void swingOffHand(boolean fromClient) {
+        swingHand(fromClient, EntityAnimationPacket.Animation.SWING_OFF_HAND);
+    }
+
+    private void swingHand(boolean fromClient, EntityAnimationPacket.Animation animation) {
+        EntityAnimationPacket packet = new EntityAnimationPacket(getEntityId(), animation);
+        if (fromClient) {
+            sendPacketToViewers(packet);
+        } else {
+            sendPacketToViewersAndSelf(packet);
+        }
     }
 
     public void refreshActiveHand(boolean isHandActive, boolean offHand, boolean riptideSpinAttack) {

--- a/src/main/java/net/minestom/server/listener/AnimationListener.java
+++ b/src/main/java/net/minestom/server/listener/AnimationListener.java
@@ -15,8 +15,8 @@ public class AnimationListener {
         PlayerHandAnimationEvent handAnimationEvent = new PlayerHandAnimationEvent(player, hand);
         EventDispatcher.callCancellable(handAnimationEvent, () -> {
             switch (hand) {
-                case MAIN -> player.swingMainHand();
-                case OFF -> player.swingOffHand();
+                case MAIN -> player.swingMainHand(true);
+                case OFF -> player.swingOffHand(true);
             }
         });
     }


### PR DESCRIPTION
I found it stupid that in the swingMainHand() method, the packet isn't sent to us as well.