### PR TITLE
Fix Attribute Read/Write due to initialization shenanagins

### DIFF
--- a/src/main/java/net/minestom/server/entity/attribute/Attribute.java
+++ b/src/main/java/net/minestom/server/entity/attribute/Attribute.java
@@ -12,8 +12,8 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Collection;
 
 public sealed interface Attribute extends StaticProtocolObject, Attributes permits AttributeImpl {
-    @NotNull NetworkBuffer.Type<Attribute> NETWORK_TYPE = AttributeImpl.NETWORK_TYPE;
-    @NotNull BinaryTagSerializer<Attribute> NBT_TYPE = AttributeImpl.NBT_TYPE;
+    @NotNull NetworkBuffer.Type<Attribute> NETWORK_TYPE = NetworkBuffer.VAR_INT.map(AttributeImpl::getId, Attribute::id);
+    @NotNull BinaryTagSerializer<Attribute> NBT_TYPE =  BinaryTagSerializer.STRING.map(AttributeImpl::get, Attribute::name);
 
     @Contract(pure = true)
     @NotNull Registry.AttributeEntry registry();

--- a/src/main/java/net/minestom/server/entity/attribute/AttributeImpl.java
+++ b/src/main/java/net/minestom/server/entity/attribute/AttributeImpl.java
@@ -11,9 +11,6 @@ record AttributeImpl(@NotNull Registry.AttributeEntry registry) implements Attri
     private static final Registry.Container<Attribute> CONTAINER = Registry.createStaticContainer(Registry.Resource.ATTRIBUTES,
             (namespace, properties) -> new AttributeImpl(Registry.attribute(namespace, properties)));
 
-    public static final NetworkBuffer.Type<Attribute> NETWORK_TYPE = NetworkBuffer.VAR_INT.map(AttributeImpl::getId, Attribute::id);
-    public static final BinaryTagSerializer<Attribute> NBT_TYPE = BinaryTagSerializer.STRING.map(AttributeImpl::get, Attribute::name);
-
     static Attribute get(@NotNull String namespace) {
         return CONTAINER.get(namespace);
     }

--- a/src/test/java/net/minestom/server/item/component/ItemAttributeTest.java
+++ b/src/test/java/net/minestom/server/item/component/ItemAttributeTest.java
@@ -1,0 +1,34 @@
+package net.minestom.server.item.component;
+
+import net.minestom.server.component.DataComponent;
+import net.minestom.server.entity.attribute.Attribute;
+import net.minestom.server.entity.attribute.AttributeModifier;
+import net.minestom.server.entity.attribute.AttributeOperation;
+import net.minestom.server.item.ItemComponent;
+import net.minestom.server.item.attribute.AttributeSlot;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class ItemAttributeTest extends AbstractItemComponentTest<AttributeList> {
+    @Override
+    protected @NotNull DataComponent<AttributeList> component() {
+        return ItemComponent.ATTRIBUTE_MODIFIERS;
+    }
+
+    @Override
+    protected @NotNull List<Map.Entry<String, AttributeList>> directReadWriteEntries() {
+        return List.of(
+                Map.entry("empty", AttributeList.EMPTY),
+                Map.entry("single", new AttributeList(new AttributeList.Modifier(Attribute.GENERIC_MOVEMENT_SPEED, new AttributeModifier(UUID.randomUUID(), "MovementTest", 0.1, AttributeOperation.ADD_VALUE), AttributeSlot.MAINHAND))),
+                Map.entry("multiple", new AttributeList(List.of(
+                        new AttributeList.Modifier(Attribute.GENERIC_MAX_HEALTH, new AttributeModifier(UUID.randomUUID(), "HealthTest", 5, AttributeOperation.ADD_VALUE), AttributeSlot.MAINHAND),
+                        new AttributeList.Modifier(Attribute.GENERIC_ATTACK_DAMAGE, new AttributeModifier(UUID.randomUUID(), "AttackTest", 3, AttributeOperation.ADD_VALUE), AttributeSlot.ANY),
+                        new AttributeList.Modifier(Attribute.GENERIC_ATTACK_DAMAGE, new AttributeModifier(UUID.randomUUID(), "AttackTest1", 1.4, AttributeOperation.MULTIPLY_BASE), AttributeSlot.CHEST)
+
+                )))
+        );
+    }
+}


### PR DESCRIPTION
Currently, attempting to create an item with attributes fails due to the following error:
```
java.lang.NullPointerException: Cannot invoke "net.minestom.server.network.NetworkBuffer$Type.write(net.minestom.server.network.NetworkBuffer, Object)" because "type" is null
	at net.minestom.server.network.NetworkBuffer.write(NetworkBuffer.java:118)
	at net.minestom.server.item.component.AttributeList$Modifier.write(AttributeList.java:96)
	at net.minestom.server.network.NetworkBuffer.write(NetworkBuffer.java:122)
	at net.minestom.server.network.NetworkBuffer.writeCollection(NetworkBuffer.java:167)
	at net.minestom.server.item.component.AttributeList$1.write(AttributeList.java:23)
	at net.minestom.server.item.component.AttributeList$1.write(AttributeList.java:20)
	at net.minestom.server.component.DataComponentImpl.write(DataComponentImpl.java:58)
	at net.minestom.server.component.DataComponentMapImpl$1.write(DataComponentMapImpl.java:42)
	at net.minestom.server.component.DataComponentMapImpl$1.write(DataComponentMapImpl.java:25)
	at net.minestom.server.network.NetworkBuffer.write(NetworkBuffer.java:118)
```

While the code seems fine at first glance, the Attribute.NETWORK_TYPE is always null, resulting in this error. I do not completely understand why this is the case, but I assume it has to do with how static variables are initialized. Moving the mapping functions to attribute fixes this issue, and I have added a new test to catch this in the future. 