### PR TITLE
Fix the NBT representation of Unit

### DIFF
--- a/src/main/java/net/minestom/server/utils/nbt/BinaryTagSerializer.java
+++ b/src/main/java/net/minestom/server/utils/nbt/BinaryTagSerializer.java
@@ -127,7 +127,7 @@ public interface BinaryTagSerializer<T> {
     BinaryTagSerializer<Unit> UNIT = new BinaryTagSerializer<>() {
         @Override
         public @NotNull BinaryTag write(@NotNull Unit value) {
-            return EndBinaryTag.endBinaryTag();
+            return CompoundBinaryTag.empty();
         }
 
         @Override


### PR DESCRIPTION
This code:
![image](https://github.com/Minestom/Minestom/assets/979743/c6efb2e2-c9ef-44f2-aad5-f3b0741081cd)

Prints this exception:
![image](https://github.com/Minestom/Minestom/assets/979743/99a4abb9-1b45-4a5b-bf6b-179ba0f1ed6d)

This change fixed the exception and now it prints ok.