### PR TITLE
fix team visibility

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -613,15 +613,6 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
     }
 
     @Override
-    public void updateOldViewer(@NotNull Player player) {
-        super.updateOldViewer(player);
-        // Team
-        if (this.getTeam() != null && this.getTeam().getMembers().size() == 1) {// If team only contains "this" player
-            player.sendPacket(this.getTeam().createTeamDestructionPacket());
-        }
-    }
-
-    @Override
     public void sendPacketToViewersAndSelf(@NotNull SendablePacket packet) {
         sendPacket(packet);
         super.sendPacketToViewersAndSelf(packet);


### PR DESCRIPTION
Fixed an issue that caused teams to become invisible when using TeamManager.
With this fix applied, player team will remain visible to other teams even after being untracked.