### PR TITLE
Add feature flags to AsyncPlayerConfigurationEvent

### DIFF
--- a/src/main/java/net/minestom/server/network/ConnectionManager.java
+++ b/src/main/java/net/minestom/server/network/ConnectionManager.java
@@ -18,6 +18,7 @@ import net.minestom.server.network.packet.server.common.TagsPacket;
 import net.minestom.server.network.packet.server.configuration.FinishConfigurationPacket;
 import net.minestom.server.network.packet.server.configuration.ResetChatPacket;
 import net.minestom.server.network.packet.server.configuration.SelectKnownPacksPacket;
+import net.minestom.server.network.packet.server.configuration.UpdateEnabledFeaturesPacket;
 import net.minestom.server.network.packet.server.login.LoginSuccessPacket;
 import net.minestom.server.network.packet.server.play.StartConfigurationPacket;
 import net.minestom.server.network.player.PlayerConnection;
@@ -276,6 +277,8 @@ public final class ConnectionManager {
             var event = new AsyncPlayerConfigurationEvent(player, isFirstConfig);
             EventDispatcher.call(event);
             if (!player.isOnline()) return; // Player was kicked during config.
+
+            player.sendPacket(new UpdateEnabledFeaturesPacket(event.getFeatureFlags())); // send player features that were enabled or disabled during async config event
 
             final Instance spawningInstance = event.getSpawningInstance();
             Check.notNull(spawningInstance, "You need to specify a spawning instance in the AsyncPlayerConfigurationEvent");


### PR DESCRIPTION
hi themode, mattw, and co, can we get this added to minestom please thank u.

(Adds the ability to add and remove feature flags during the AsyncPlayerConfigurationEvent on a per basis without requiring the user to send packets. By default includes the "minecraft:vanilla" feature flag, to keep vanilla-esque behavior. No feature flag namespaces are hardcoded anywhere besides vanilla, mainly because I did not want to deal with data generator or keeping that maintained.)