### PR TITLE
Addition: PlayerOnGroundChangeEvent

### DIFF
--- a/src/main/java/net/minestom/server/event/player/PlayerOnGroundChangeEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerOnGroundChangeEvent.java
@@ -1,0 +1,48 @@
+package net.minestom.server.event.player;
+
+import net.minestom.server.entity.Player;
+import net.minestom.server.event.trait.CancellableEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class PlayerOnGroundChangeEvent implements PlayerInstanceEvent, CancellableEvent {
+
+    private final Player player;
+    private final boolean onGround;
+    private final boolean clientSent;
+
+    private boolean cancelled;
+
+    public PlayerOnGroundChangeEvent(Player player, boolean onGround, boolean clientSent) {
+        this.player = player;
+        this.onGround = onGround;
+        this.clientSent = clientSent;
+    }
+
+    @Override
+    public @NotNull Player getPlayer() {
+        return player;
+    }
+
+    public boolean isOnGround() {
+        return onGround;
+    }
+
+    /**
+     * @return whether the client sent this change to the server or not
+     */
+    public boolean isClientSent() {
+        return clientSent;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+}

--- a/src/main/java/net/minestom/server/event/player/PlayerOnGroundChangeEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerOnGroundChangeEvent.java
@@ -1,22 +1,20 @@
 package net.minestom.server.event.player;
 
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.CancellableEvent;
 import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
 
-public class PlayerOnGroundChangeEvent implements PlayerInstanceEvent, CancellableEvent {
+/**
+ * Called just before the on ground state of the player is changed.
+ */
+public class PlayerOnGroundChangeEvent implements PlayerInstanceEvent {
 
     private final Player player;
     private final boolean onGround;
-    private final boolean clientSent;
 
-    private boolean cancelled;
-
-    public PlayerOnGroundChangeEvent(Player player, boolean onGround, boolean clientSent) {
+    public PlayerOnGroundChangeEvent(Player player, boolean onGround) {
         this.player = player;
         this.onGround = onGround;
-        this.clientSent = clientSent;
     }
 
     @Override
@@ -26,23 +24,6 @@ public class PlayerOnGroundChangeEvent implements PlayerInstanceEvent, Cancellab
 
     public boolean isOnGround() {
         return onGround;
-    }
-
-    /**
-     * @return whether the client sent this change to the server or not
-     */
-    public boolean isClientSent() {
-        return clientSent;
-    }
-
-    @Override
-    public boolean isCancelled() {
-        return cancelled;
-    }
-
-    @Override
-    public void setCancelled(boolean cancel) {
-        this.cancelled = cancel;
     }
 
 }

--- a/src/main/java/net/minestom/server/listener/PlayerPositionListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerPositionListener.java
@@ -15,7 +15,7 @@ public class PlayerPositionListener {
 
     public static void playerPacketListener(ClientPlayerPacket packet, Player player) {
         final boolean onGround = packet.onGround();
-        refreshOnGround(player, onGround, true);
+        refreshOnGround(player, onGround);
     }
 
     public static void playerLookListener(ClientPlayerRotationPacket packet, Player player) {
@@ -70,12 +70,12 @@ public class PlayerPositionListener {
         if (packetPosition.equals(eventPosition)) {
             // Event didn't change the position
             player.refreshPosition(eventPosition);
-            refreshOnGround(player, onGround, false);
+            refreshOnGround(player, onGround);
         } else {
             // Position modified by the event
             if (packetPosition.samePoint(eventPosition)) {
                 player.refreshPosition(eventPosition, true);
-                refreshOnGround(player, onGround, false);
+                refreshOnGround(player, onGround);
                 player.setView(eventPosition.yaw(), eventPosition.pitch());
             } else {
                 player.teleport(eventPosition);
@@ -83,11 +83,9 @@ public class PlayerPositionListener {
         }
     }
 
-    private static void refreshOnGround(Player player, boolean onGround, boolean clientSent) {
-        PlayerOnGroundChangeEvent groundChangeEvent = new PlayerOnGroundChangeEvent(player, onGround, clientSent);
+    private static void refreshOnGround(Player player, boolean onGround) {
+        PlayerOnGroundChangeEvent groundChangeEvent = new PlayerOnGroundChangeEvent(player, onGround);
         EventDispatcher.call(groundChangeEvent);
-        if (!groundChangeEvent.isCancelled()) {
-            player.refreshOnGround(onGround);
-        }
+        player.refreshOnGround(onGround);
     }
 }


### PR DESCRIPTION
This pull request allows people to more easily track the on-ground value of a player, which can be helpful for fall damage implementations. Additionally, it provides context for whether the client claims they are on the ground or if the server does.