### PR TITLE
Fix add transaction

### DIFF
--- a/src/main/java/net/minestom/server/inventory/TransactionType.java
+++ b/src/main/java/net/minestom/server/inventory/TransactionType.java
@@ -58,10 +58,20 @@ public interface TransactionType {
                 // Cancelled transaction
                 continue;
             }
-            // Fill the slot
-            itemChangesMap.put(i, itemStack);
-            itemStack = ItemStack.AIR;
-            break;
+
+            final int maxSize = itemStack.maxStackSize();
+            final int currentSize = itemStack.amount();
+
+            if (!MathUtils.isBetween(currentSize, 0, maxSize)) {
+                // Slot cannot accept the whole item, reduce amount to 'itemStack'
+                itemChangesMap.put(i, itemStack.withAmount(maxSize));
+                itemStack = itemStack.withAmount(currentSize - maxSize);
+            } else {
+                // Slot can accept the whole item
+                itemChangesMap.put(i, itemStack.withAmount(currentSize));
+                itemStack = ItemStack.AIR;
+                break;
+            }
         }
         return Pair.of(itemStack, itemChangesMap);
     };


### PR DESCRIPTION
Currently `Inventory::addItemStack` will fill air slots with the entire item stack size, ignoring stacking rules.
This fix makes item stack rules not get ignored when using `addItemStack`

It's worth noting that `addItemStack` doesn't ignore stacking rules if it finds the item and is adding to it.