### PR TITLE
Add fields for kicking players in AsyncPlayerConfigurationEvent

### DIFF
--- a/src/main/java/net/minestom/server/event/player/AsyncPlayerConfigurationEvent.java
+++ b/src/main/java/net/minestom/server/event/player/AsyncPlayerConfigurationEvent.java
@@ -2,6 +2,8 @@ package net.minestom.server.event.player;
 
 import it.unimi.dsi.fastutil.objects.ObjectArraySet;
 import it.unimi.dsi.fastutil.objects.ObjectSets;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.PlayerEvent;
 import net.minestom.server.instance.Instance;
@@ -31,6 +33,8 @@ public class AsyncPlayerConfigurationEvent implements PlayerEvent {
     private boolean clearChat;
     private boolean sendRegistryData;
     private Instance spawningInstance;
+    private ConfigurationResult configurationResult;
+    private Component kickMessage;
 
     public AsyncPlayerConfigurationEvent(@NotNull Player player, boolean isFirstConfig) {
         this.player = player;
@@ -42,6 +46,8 @@ public class AsyncPlayerConfigurationEvent implements PlayerEvent {
         this.clearChat = false;
         this.sendRegistryData = isFirstConfig;
         this.spawningInstance = null;
+        this.configurationResult = ConfigurationResult.ALLOW;
+        this.kickMessage = Component.empty();
     }
 
     @Override
@@ -137,5 +143,40 @@ public class AsyncPlayerConfigurationEvent implements PlayerEvent {
 
     public void setSpawningInstance(@Nullable Instance spawningInstance) {
         this.spawningInstance = spawningInstance;
+    }
+
+    public @NotNull ConfigurationResult getConfigurationResult() {
+        return configurationResult;
+    }
+
+    public void setConfigurationResult(@NotNull ConfigurationResult configurationResult) {
+        this.configurationResult = configurationResult;
+    }
+
+    public @NotNull Component getKickMessage() {
+        return kickMessage;
+    }
+
+    public void setKickMessage(@NotNull Component kickMessage) {
+        this.kickMessage = kickMessage;
+    }
+
+    public enum ConfigurationResult {
+        ALLOW(Component.empty()), // Player is allowed to join
+        DENY_SERVER_FULL(Component.text("Failed to join, the server is full", NamedTextColor.RED)), // Player is not allowed to join due to the server being full
+        DENY_BANNED(Component.text("You are banned from this server", NamedTextColor.RED)), // Player is not allowed to join due to them being banned
+        DENY_NOT_ALLOWLISTED(Component.text("You are not allowlisted on this server", NamedTextColor.RED)), // Player is not allowed to join due to not being allowlisted/whitelisted
+        DENY_GENERIC(Component.text("You cannot join this server.", NamedTextColor.RED)) // Player is not allowed to join for some other reason
+        ;
+
+        private final Component defaultMessage;
+
+        ConfigurationResult(@NotNull Component defaultMessage) {
+            this.defaultMessage = defaultMessage;
+        }
+
+        public @NotNull Component getDefaultMessage() {
+            return defaultMessage;
+        }
     }
 }

--- a/src/main/java/net/minestom/server/network/ConnectionManager.java
+++ b/src/main/java/net/minestom/server/network/ConnectionManager.java
@@ -277,6 +277,14 @@ public final class ConnectionManager {
             var event = new AsyncPlayerConfigurationEvent(player, isFirstConfig);
             EventDispatcher.call(event);
             if (!player.isOnline()) return; // Player was kicked during config.
+            if (event.getConfigurationResult() != AsyncPlayerConfigurationEvent.ConfigurationResult.ALLOW) {
+                if (Component.IS_NOT_EMPTY.test(event.getKickMessage())) {
+                    player.kick(event.getKickMessage());
+                } else {
+                    player.kick(event.getConfigurationResult().getDefaultMessage());
+                }
+                return;
+            }
 
             player.sendPacket(new UpdateEnabledFeaturesPacket(event.getFeatureFlags())); // send player features that were enabled or disabled during async config event
 


### PR DESCRIPTION
This updates the AsyncPlayerConfigEvent with 2 new fields, a 'ConfigurationResult' field and a 'KickMessage' field.

This brings the behavior closer to [Spigot's equivalent event](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/event/player/AsyncPlayerPreLoginEvent.html), and I believe the Spigot version is more useful because it provides a more obvious way of kicking people during the join process, where you can set the status in the event rather than the unintuitive method of calling 'player.kick()' during the event.

The previous behavior of kicking during the event will still work, or you could set the ConfigurationResult so Minestom will kick them for you, and an optional field to provide a custom kick message or use the default one.