### PR TITLE
Help gc to collect unused LazyEventNode handler

### DIFF
--- a/src/main/java/net/minestom/server/event/EventNodeImpl.java
+++ b/src/main/java/net/minestom/server/event/EventNodeImpl.java
@@ -337,6 +337,7 @@ non-sealed class EventNodeImpl<T extends Event> implements EventNode<T> {
 
         void invalidate() {
             this.updated = false;
+            this.listener = null;
         }
 
         @Nullable Consumer<E> updatedListener() {


### PR DESCRIPTION
Removing the reference to the listener field in EventNodeImpl#Handle when invalidate is executed. Before the listener is recreated there is always a check for updated, and if it is false, the listener is recreated. Until then, it hangs in memory and prevents GC from collecting references contained in this listener, which will never be needed again