### PR TITLE
Fix issue #757 affecting LargeFramebuffer#preparePacket(int,int,int)

### DIFF
--- a/src/main/java/net/minestom/server/map/LargeFramebuffer.java
+++ b/src/main/java/net/minestom/server/map/LargeFramebuffer.java
@@ -33,8 +33,8 @@ public interface LargeFramebuffer {
         byte[] colors = new byte[Framebuffer.WIDTH * Framebuffer.WIDTH];
         final int width = Math.min(width(), left + Framebuffer.WIDTH) - left;
         final int height = Math.min(height(), top + Framebuffer.HEIGHT) - top;
-        for (int y = top; y < height; y++) {
-            for (int x = left; x < width; x++) {
+        for (int y = top; y < top+height; y++) {
+            for (int x = left; x < left+width; x++) {
                 final byte color = getMapColor(x, y);
                 colors[Framebuffer.index(x - left, y - top)] = color;
             }


### PR DESCRIPTION
Fixes issue #757, which causes LargeFramebuffer#preparePacket(...) to output incorrect values with a left or top value greater than zero. This was most notable with a left or top value greater than 128, which would cause it to return a packet corresponding to a blank map.

With the fix applied, map packets created by LargeFramebuffer#preparePacket(...) are created from coordinates (left,top) to (left+width,top+height) of the original framebuffer, instead of (left,top) to (width,height) (which produces incorrect results).

Before the fix (using a purple/black checker pattern to test):
![image](https://github.com/Minestom/Minestom/assets/49409835/cea8936e-4cfb-4bdf-81bc-9a7b53155795)

After the fix:
![image](https://github.com/Minestom/Minestom/assets/49409835/f42fde5c-47b0-466f-8138-1ab2cb842b31)
