### PR TITLE
chore: fix EntityLiving#damage animation not cancellable, function/event refactor

### DIFF
--- a/src/main/java/net/minestom/server/entity/damage/Damage.java
+++ b/src/main/java/net/minestom/server/entity/damage/Damage.java
@@ -7,7 +7,6 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.LivingEntity;
 import net.minestom.server.entity.Player;
 import net.minestom.server.registry.DynamicRegistry;
-import net.minestom.server.sound.SoundEvent;
 import net.minestom.server.tag.TagHandler;
 import net.minestom.server.tag.Taggable;
 import net.minestom.server.utils.validate.Check;
@@ -156,28 +155,6 @@ public class Damage implements Taggable {
      */
     public @Nullable Component buildDeathScreenText(@NotNull Player killed) {
         return Component.translatable("death.attack." + type.messageId());
-    }
-
-    /**
-     * Sound event to play when the given entity is hit by this damage. Possible to return null if no sound should be played
-     *
-     * @param entity the entity hit by this damage
-     * @return the sound to play when the given entity is hurt by this damage type. Can be null if no sound should play
-     */
-    public @Nullable SoundEvent getSound(@NotNull LivingEntity entity) {
-        if (entity instanceof Player) {
-            return getPlayerSound((Player) entity);
-        }
-        return getGenericSound(entity);
-    }
-
-    protected SoundEvent getGenericSound(@NotNull LivingEntity entity) {
-        return SoundEvent.ENTITY_GENERIC_HURT;
-    }
-
-    protected SoundEvent getPlayerSound(@NotNull Player player) {
-        if (DamageType.ON_FIRE.equals(typeKey)) return SoundEvent.ENTITY_PLAYER_HURT_ON_FIRE;
-        return SoundEvent.ENTITY_PLAYER_HURT;
     }
 
     @Override

--- a/src/main/java/net/minestom/server/event/entity/EntityDamageEvent.java
+++ b/src/main/java/net/minestom/server/event/entity/EntityDamageEvent.java
@@ -1,5 +1,6 @@
 package net.minestom.server.event.entity;
 
+import net.kyori.adventure.sound.Sound;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.LivingEntity;
 import net.minestom.server.entity.damage.Damage;
@@ -16,12 +17,12 @@ public class EntityDamageEvent implements EntityInstanceEvent, CancellableEvent 
 
     private final Entity entity;
     private final Damage damage;
-    private SoundEvent sound;
+    private Sound sound;
     private boolean animation = true;
 
     private boolean cancelled;
 
-    public EntityDamageEvent(@NotNull LivingEntity entity, @NotNull Damage damage, @Nullable SoundEvent sound) {
+    public EntityDamageEvent(@NotNull LivingEntity entity, @NotNull Damage damage, @Nullable Sound sound) {
         this.entity = entity;
         this.damage = damage;
         this.sound = sound;
@@ -49,7 +50,7 @@ public class EntityDamageEvent implements EntityInstanceEvent, CancellableEvent 
      * @return the damage sound
      */
     @Nullable
-    public SoundEvent getSound() {
+    public Sound getSound() {
         return sound;
     }
 
@@ -58,7 +59,7 @@ public class EntityDamageEvent implements EntityInstanceEvent, CancellableEvent 
      *
      * @param sound the new damage sound
      */
-    public void setSound(@Nullable SoundEvent sound) {
+    public void setSound(@Nullable Sound sound) {
         this.sound = sound;
     }
 


### PR DESCRIPTION
A fix for cancelling the EntityDamageEvent's animation properly (DamageEventPacket needs to not be sent.)
Cleaned up some of the code nesting in this function as well.
Changed EntityDamageEvent#setSound to supply an actual sound instead of just the SoundEvent with fixed fields.
Removed the concept of Sound from the Damage class, I don't think sound belongs there and it wasn't providing correct sound behaviour anyway.