### PR TITLE
Address some todos, create IntProvider for DimensionType

### DIFF
--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -411,7 +411,7 @@ public class LivingEntity extends Entity implements EquipmentHandler {
     }
 
     /**
-     * Sets the heal of the entity as its max health.
+     * Sets the health of the entity to its max health.
      * <p>
      * Retrieved from {@link #getAttributeValue(Attribute)} with the attribute {@link Attribute#GENERIC_MAX_HEALTH}.
      */

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -135,7 +135,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
     // Magic values: https://wiki.vg/Entity_statuses#Player
     private static final int STATUS_ENABLE_REDUCED_DEBUG_INFO = 22;
     private static final int STATUS_DISABLE_REDUCED_DEBUG_INFO = 23;
-    private static final int STATUS_PERMISSION_LEVEL_OFFSET = 24;
+    public static final int STATUS_PERMISSION_LEVEL_OFFSET = 24;
 
     private long lastKeepAlive;
     private boolean answerKeepAlive;

--- a/src/main/java/net/minestom/server/entity/metadata/animal/tameable/WolfMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/tameable/WolfMeta.java
@@ -27,8 +27,6 @@ public class WolfMeta extends TameableAnimalMeta {
         super(entity, metadata);
     }
 
-    //todo variant
-
     public boolean isBegging() {
         return super.metadata.getIndex(OFFSET, false);
     }

--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -25,7 +25,6 @@ import net.minestom.server.network.packet.server.play.BlockEntityDataPacket;
 import net.minestom.server.network.packet.server.play.EffectPacket;
 import net.minestom.server.network.packet.server.play.UnloadChunkPacket;
 import net.minestom.server.registry.DynamicRegistry;
-import net.minestom.server.tag.Tag;
 import net.minestom.server.utils.NamespaceID;
 import net.minestom.server.utils.PacketUtils;
 import net.minestom.server.utils.async.AsyncUtils;
@@ -85,7 +84,7 @@ public class InstanceContainer extends Instance {
 
     // used to supply a new chunk object at a position when requested
     private ChunkSupplier chunkSupplier;
-    
+
     // Fields for instance copy
     protected InstanceContainer srcInstance; // only present if this instance has been created using a copy
     private long lastBlockChangeTime; // Time at which the last block change happened (#setBlock)

--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -25,6 +25,7 @@ import net.minestom.server.network.packet.server.play.BlockEntityDataPacket;
 import net.minestom.server.network.packet.server.play.EffectPacket;
 import net.minestom.server.network.packet.server.play.UnloadChunkPacket;
 import net.minestom.server.registry.DynamicRegistry;
+import net.minestom.server.tag.Tag;
 import net.minestom.server.utils.NamespaceID;
 import net.minestom.server.utils.PacketUtils;
 import net.minestom.server.utils.async.AsyncUtils;
@@ -84,10 +85,7 @@ public class InstanceContainer extends Instance {
 
     // used to supply a new chunk object at a position when requested
     private ChunkSupplier chunkSupplier;
-
-    // The number of blocks below the minimum Y before any entities are considered 'in the void'
-    private int voidThreshold = 64;
-
+    
     // Fields for instance copy
     protected InstanceContainer srcInstance; // only present if this instance has been created using a copy
     private long lastBlockChangeTime; // Time at which the last block change happened (#setBlock)
@@ -453,29 +451,7 @@ public class InstanceContainer extends Instance {
 
     @Override
     public boolean isInVoid(@NotNull Point point) {
-        return point.y() < getCachedDimensionType().minY() - voidThreshold;
-    }
-
-    /**
-     * Sets the new void threshold
-     * <p>
-     * The void threshold is the number of blocks added to the minimum y value to determine when entities are considered 'in the void'.
-     * <p>
-     * Positive numbers indicate that the void threshold is that many blocks below the instance's minimum y (defined by dimension type), negative values indicate that the void is inside the buildable area of the instance.
-     * @param newVoidThreshold The new number of blocks to be considered
-     */
-    public void setVoidThreshold(int newVoidThreshold) {
-        this.voidThreshold = newVoidThreshold;
-    }
-
-    /**
-     * Gets the current void threshold
-     * <p>
-     * The void threshold is the number of blocks added to the minimum y value to determine when entities are considered 'in the void'.
-     * @return The current void threshold
-     */
-    public int getVoidThreshold() {
-        return voidThreshold;
+        return point.y() < getCachedDimensionType().minY() - 64;
     }
 
     /**

--- a/src/main/java/net/minestom/server/registry/Registry.java
+++ b/src/main/java/net/minestom/server/registry/Registry.java
@@ -28,6 +28,7 @@ import net.minestom.server.utils.NamespaceID;
 import net.minestom.server.utils.collection.ObjectArray;
 import net.minestom.server.utils.nbt.BinaryTagSerializer;
 import net.minestom.server.utils.validate.Check;
+import net.minestom.server.world.IntProvider;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -417,6 +418,8 @@ public final class Registry {
             int logicalHeight,
             int minY,
             int height,
+            @NotNull IntProvider monsterSpawnLightLevel,
+            int monsterSpawnBlockLightLimit,
             String infiniburn,
             String effects,
             Properties custom
@@ -438,6 +441,9 @@ public final class Registry {
                     main.getInt("logical_height"),
                     main.getInt("min_y"),
                     main.getInt("height"),
+                    // Have to convert to map since it can be a long or a hashmap
+                    IntProvider.createIntProvider(main.asMap().get("monster_spawn_light_level")),
+                    main.getInt("monster_spawn_block_light_limit"),
                     main.getString("infiniburn"),
                     main.getString("effects"),
                     custom);

--- a/src/main/java/net/minestom/server/world/DimensionType.java
+++ b/src/main/java/net/minestom/server/world/DimensionType.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * https://minecraft.wiki/w/Custom_dimension
+ * <a href="https://minecraft.wiki/w/Custom_dimension">...</a>
  */
 public sealed interface DimensionType extends ProtocolObject, DimensionTypes permits DimensionTypeImpl {
 
@@ -65,6 +65,10 @@ public sealed interface DimensionType extends ProtocolObject, DimensionTypes per
 
     int height();
 
+    int monsterSpawnBlockLightLimit();
+
+    @NotNull IntProvider monsterSpawnLightLevel();
+
     @NotNull String infiniburn();
 
     @NotNull String effects();
@@ -89,6 +93,8 @@ public sealed interface DimensionType extends ProtocolObject, DimensionTypes per
         private int logicalHeight = VANILLA_MAX_Y - VANILLA_MIN_Y + 1;
         private int minY = VANILLA_MIN_Y;
         private int height = VANILLA_MAX_Y - VANILLA_MIN_Y + 1;
+        private IntProvider monsterSpawnLightLevel = IntProvider.createIntProvider(0);
+        private int monsterSpawnBlockLightLimit = 0;
         private String infiniburn = "#minecraft:infiniburn_overworld";
         private String effects = "minecraft:overworld";
 
@@ -180,6 +186,24 @@ public sealed interface DimensionType extends ProtocolObject, DimensionTypes per
         }
 
         @Contract(value = "_ -> this", pure = true)
+        public @NotNull Builder monsterSpawnBlockLightLimit(int blockLightLimit) {
+            this.monsterSpawnBlockLightLimit = blockLightLimit;
+            return this;
+        }
+
+        @Contract(value = "_ -> this", pure = true)
+        public @NotNull Builder monsterSpawnLightLevel(int spawnLightLevel) {
+            this.monsterSpawnLightLevel = IntProvider.createIntProvider(spawnLightLevel);
+            return this;
+        }
+
+        @Contract(value = "_ -> this", pure = true)
+        public @NotNull Builder monsterSpawnLightLevel(@NotNull IntProvider spawnLightLevel) {
+            this.monsterSpawnLightLevel = spawnLightLevel;
+            return this;
+        }
+
+        @Contract(value = "_ -> this", pure = true)
         public @NotNull Builder infiniburn(@NotNull String infiniburn) {
             this.infiniburn = infiniburn;
             return this;
@@ -196,7 +220,7 @@ public sealed interface DimensionType extends ProtocolObject, DimensionTypes per
             return new DimensionTypeImpl(
                     ultrawarm, natural, coordinateScale, hasSkylight, hasCeiling, ambientLight,
                     fixedTime, piglinSafe, bedWorks, respawnAnchorWorks, hasRaids, logicalHeight, minY, height,
-                    infiniburn, effects, null
+                    monsterSpawnBlockLightLimit, monsterSpawnLightLevel, infiniburn, effects, null
             );
         }
     }

--- a/src/main/java/net/minestom/server/world/DimensionTypeImpl.java
+++ b/src/main/java/net/minestom/server/world/DimensionTypeImpl.java
@@ -21,6 +21,8 @@ record DimensionTypeImpl(
         int logicalHeight,
         int minY,
         int height,
+        int monsterSpawnBlockLightLimit,
+        @NotNull IntProvider monsterSpawnLightLevel,
         @NotNull String infiniburn,
         @NotNull String effects,
         @Nullable Registry.DimensionTypeEntry registry
@@ -47,10 +49,8 @@ record DimensionTypeImpl(
                         .putInt("height", dimensionType.height())
                         .putString("infiniburn", dimensionType.infiniburn())
                         .putString("effects", dimensionType.effects())
-
-                        //todo load these from registry
-                        .putInt("monster_spawn_block_light_limit", 0)
-                        .putInt("monster_spawn_light_level", 0);
+                        .putInt("monster_spawn_block_light_limit", dimensionType.monsterSpawnBlockLightLimit())
+                        .put("monster_spawn_light_level", dimensionType.monsterSpawnLightLevel().toBinaryTag());
                 Long fixedTime = dimensionType.fixedTime();
                 if (fixedTime != null) builder.putLong("fixed_time", fixedTime);
                 return builder.build();
@@ -61,7 +61,7 @@ record DimensionTypeImpl(
         this(registry.ultrawarm(), registry.natural(), registry.coordinateScale(),
                 registry.hasSkylight(), registry.hasCeiling(), registry.ambientLight(), registry.fixedTime(),
                 registry.piglinSafe(), registry.bedWorks(), registry.respawnAnchorWorks(), registry.hasRaids(),
-                registry.logicalHeight(), registry.minY(), registry.height(), registry.infiniburn(),
+                registry.logicalHeight(), registry.minY(), registry.height(), registry.monsterSpawnBlockLightLimit(), registry.monsterSpawnLightLevel(), registry.infiniburn(),
                 registry.effects(), registry);
     }
 }

--- a/src/main/java/net/minestom/server/world/IntProvider.java
+++ b/src/main/java/net/minestom/server/world/IntProvider.java
@@ -1,0 +1,96 @@
+package net.minestom.server.world;
+
+import net.kyori.adventure.nbt.BinaryTag;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Random;
+
+/**
+ * Represents the Int Provider for monster_spawn_light_level for <a href="https://minecraft.wiki/w/Dimension_type">Dimension Type</a>
+ */
+public interface IntProvider {
+
+    int get(@NotNull Random random);
+
+    int getMin();
+
+    int getMax();
+
+    @NotNull
+    BinaryTag toBinaryTag();
+
+    record ConstantIntProvider(int constant) implements IntProvider {
+
+        @Override
+        public int get(@NotNull Random random) {
+            return constant;
+        }
+
+        @Override
+        public int getMin() {
+            return constant;
+        }
+
+        @Override
+        public int getMax() {
+            return constant;
+        }
+
+        @Override
+        public @NotNull BinaryTag toBinaryTag() {
+            return CompoundBinaryTag.builder().putString("type", "minecraft:constant").putInt("value", constant).build();
+        }
+    }
+
+    record UniformIntProvider(int min, int max) implements IntProvider {
+
+        @Override
+        public int get(@NotNull Random random) {
+            return Math.round(random.nextFloat() * (max - min)) + min;
+        }
+
+        @Override
+        public int getMin() {
+            return min;
+        }
+
+        @Override
+        public int getMax() {
+            return max;
+        }
+
+        @Override
+        public @NotNull BinaryTag toBinaryTag() {
+            return CompoundBinaryTag.builder().putString("type", "minecraft:uniform").putInt("min_inclusive", min).putInt("max_inclusive", max).build();
+        }
+    }
+
+    static @NotNull IntProvider createIntProvider(int constant) {
+        return new ConstantIntProvider(constant);
+    }
+
+    static @NotNull IntProvider createIntProvider(@NotNull Object properties) {
+        if (properties instanceof Long longNum) {
+            return new ConstantIntProvider(longNum.intValue());
+        }
+        if (properties instanceof HashMap<?,?> hashMap) {
+            String type = (String) hashMap.get("type");
+            switch (type) {
+                case "minecraft:uniform" -> {
+                    // Have to cast them to longs since they are stored as longs
+                    Long min = (Long) hashMap.get("min_inclusive");
+                    Long max = (Long) hashMap.get("max_inclusive");
+                    return new UniformIntProvider(min.intValue(), max.intValue());
+                }
+                case "minecraft:constant" -> {
+                    return new ConstantIntProvider(((Long) hashMap.get("value")).intValue());
+                }
+                default -> throw new IllegalArgumentException("Unknown IntProvider type " + type);
+            }
+            // TODO Biased to bottom, clamped, clamped normal, weighed list
+        }
+        return new ConstantIntProvider(0);
+    }
+}

--- a/src/test/java/net/minestom/server/entity/player/PlayerIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerIntegrationTest.java
@@ -173,7 +173,7 @@ public class PlayerIntegrationTest {
         // Ensure that the player was sent the permission levels
         for (var statusPacket : trackerStatus.collect()) {
             assertEquals(player.getEntityId(), statusPacket.entityId());
-            assertEquals(24 + TEST_PERMISSION_LEVEL, statusPacket.status()); // TODO: Remove magic value of 24
+            assertEquals(Player.STATUS_PERMISSION_LEVEL_OFFSET + TEST_PERMISSION_LEVEL, statusPacket.status());
         }
     }
 


### PR DESCRIPTION
* Changed Javadoc of LivingEntity#heal()
* Made STATUS_PERMISSION_LEVEL_OFFSET public to remove a magic number from a test
* Removed todo variant from WolfMeta since it has it
* Add IntProvider class for Dimension Type, adapted from https://minecraft.wiki/w/Dimension_type and Fabric's https://maven.fabricmc.net/docs/yarn-1.17+build.13/net/minecraft/util/math/intprovider/IntProvider.html