### PR TITLE
Fix infinite recursion in BlockVec#div(double,double,double)

### DIFF
--- a/src/main/java/net/minestom/server/coordinate/BlockVec.java
+++ b/src/main/java/net/minestom/server/coordinate/BlockVec.java
@@ -150,7 +150,7 @@ public record BlockVec(double x, double y, double z) implements Point {
 
     @Override
     public @NotNull Point div(double x, double y, double z) {
-        return div(this.x / x, this.y / y, this.z / z);
+        return new Vec(this.x / x, this.y / y, this.z / z);
     }
 
     @Override


### PR DESCRIPTION
Fix infinite recursion caused by a mistaken call to div(this.x/x,this.y/y,this.z/z) instead of new Vec(...).