### PR TITLE
Add Player#getCurrentItemUseTime

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -1160,7 +1160,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
      */
     public long getCurrentItemUseTime() {
         if (!isUsingItem()) return 0;
-        return instance.getWorldAge() - startItemUseTime;
+        return getAliveTicks() - startItemUseTime;
     }
 
     @Override
@@ -2209,7 +2209,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
     public void refreshItemUse(@Nullable Hand itemUseHand, long itemUseTimeTicks) {
         this.itemUseHand = itemUseHand;
         if (itemUseHand != null) {
-            this.startItemUseTime = instance.getWorldAge();
+            this.startItemUseTime = getAliveTicks();
             this.itemUseTime = itemUseTimeTicks;
         } else {
             this.startItemUseTime = 0;

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -441,7 +441,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
 
         // Eating animation
         if (isUsingItem()) {
-            if (instance.getWorldAge() - startItemUseTime >= itemUseTime && itemUseTime > 0) {
+            if (itemUseTime > 0 && getCurrentItemUseTime() >= itemUseTime) {
                 triggerStatus((byte) 9); // Mark item use as finished
                 ItemUpdateStateEvent itemUpdateStateEvent = callItemUpdateStateEvent(itemUseHand);
 
@@ -1151,6 +1151,16 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
      */
     public @Nullable Hand getItemUseHand() {
         return itemUseHand;
+    }
+
+    /**
+     * Gets the amount of ticks which have passed since the player started using an item.
+     *
+     * @return the amount of ticks which have passed, or zero if the player is not using an item
+     */
+    public long getCurrentItemUseTime() {
+        if (!isUsingItem()) return 0;
+        return instance.getWorldAge() - startItemUseTime;
     }
 
     @Override


### PR DESCRIPTION
This adds a method to get the current amount of ticks which have passed since the start of the item usage. Useful for determining the strength of a bowshot, etc.