### PR TITLE
feat: Acquirable, ThreadDispatcher usage improvements

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -41,6 +41,7 @@ import net.minestom.server.snapshot.Snapshotable;
 import net.minestom.server.tag.TagHandler;
 import net.minestom.server.tag.Taggable;
 import net.minestom.server.thread.Acquirable;
+import net.minestom.server.thread.AcquirableSource;
 import net.minestom.server.timer.Schedulable;
 import net.minestom.server.timer.Scheduler;
 import net.minestom.server.timer.TaskSchedule;
@@ -78,7 +79,7 @@ import java.util.function.UnaryOperator;
  * To create your own entity you probably want to extend {@link LivingEntity} or {@link EntityCreature} instead.
  */
 public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, EventHandler<EntityEvent>, Taggable,
-        PermissionHandler, HoverEventSource<ShowEntity>, Sound.Emitter, Shape {
+        PermissionHandler, HoverEventSource<ShowEntity>, Sound.Emitter, Shape, AcquirableSource<Entity> {
     private static final AtomicInteger LAST_ENTITY_ID = new AtomicInteger();
 
     // Certain entities should only have their position packets sent during synchronization
@@ -1569,11 +1570,6 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         return HoverEvent.showEntity(ShowEntity.showEntity(this.entityType, this.uuid));
     }
 
-    @ApiStatus.Experimental
-    public <T extends Entity> @NotNull Acquirable<T> getAcquirable() {
-        return (Acquirable<T>) acquirable;
-    }
-
     @Override
     public @NotNull TagHandler tagHandler() {
         return tagHandler;
@@ -1731,6 +1727,12 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
 
     public boolean hasCollision() {
         return hasCollision;
+    }
+
+    @ApiStatus.Experimental
+    @Override
+    public @NotNull Acquirable<? extends Entity> getAcquirable() {
+        return acquirable;
     }
 
     public enum Pose {

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -1729,9 +1729,23 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         return hasCollision;
     }
 
+    /**
+     * Acquires this entity.
+     *
+     * @deprecated It's preferred to use {@link AcquirableSource#acquirable()} instead, as it is overridden by
+     * subclasses
+     * @return the acquirable for this entity
+     * @param <T> the type of object to be acquired
+     */
+    @Deprecated
+    @ApiStatus.Experimental
+    public <T extends Entity> @NotNull Acquirable<T> getAcquirable() {
+        return (Acquirable<T>) acquirable;
+    }
+
     @ApiStatus.Experimental
     @Override
-    public @NotNull Acquirable<? extends Entity> getAcquirable() {
+    public @NotNull Acquirable<? extends Entity> acquirable() {
         return acquirable;
     }
 

--- a/src/main/java/net/minestom/server/entity/EntityCreature.java
+++ b/src/main/java/net/minestom/server/entity/EntityCreature.java
@@ -151,7 +151,7 @@ public class EntityCreature extends LivingEntity implements NavigableEntity, Ent
     @SuppressWarnings("unchecked")
     @ApiStatus.Experimental
     @Override
-    public @NotNull Acquirable<? extends EntityCreature> getAcquirable() {
-        return (Acquirable<? extends EntityCreature>) super.getAcquirable();
+    public @NotNull Acquirable<? extends EntityCreature> acquirable() {
+        return (Acquirable<? extends EntityCreature>) super.acquirable();
     }
 }

--- a/src/main/java/net/minestom/server/entity/EntityCreature.java
+++ b/src/main/java/net/minestom/server/entity/EntityCreature.java
@@ -8,7 +8,9 @@ import net.minestom.server.entity.pathfinding.Navigator;
 import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.entity.EntityAttackEvent;
 import net.minestom.server.instance.Instance;
+import net.minestom.server.thread.Acquirable;
 import net.minestom.server.utils.time.TimeUnit;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -146,4 +148,10 @@ public class EntityCreature extends LivingEntity implements NavigableEntity, Ent
         attack(target, false);
     }
 
+    @SuppressWarnings("unchecked")
+    @ApiStatus.Experimental
+    @Override
+    public @NotNull Acquirable<? extends EntityCreature> getAcquirable() {
+        return (Acquirable<? extends EntityCreature>) super.getAcquirable();
+    }
 }

--- a/src/main/java/net/minestom/server/entity/EntityProjectile.java
+++ b/src/main/java/net/minestom/server/entity/EntityProjectile.java
@@ -192,7 +192,7 @@ public class EntityProjectile extends Entity {
     @ApiStatus.Experimental
     @SuppressWarnings("unchecked")
     @Override
-    public @NotNull Acquirable<? extends EntityProjectile> getAcquirable() {
-        return (Acquirable<? extends EntityProjectile>) super.getAcquirable();
+    public @NotNull Acquirable<? extends EntityProjectile> acquirable() {
+        return (Acquirable<? extends EntityProjectile>) super.acquirable();
     }
 }

--- a/src/main/java/net/minestom/server/entity/EntityProjectile.java
+++ b/src/main/java/net/minestom/server/entity/EntityProjectile.java
@@ -13,6 +13,8 @@ import net.minestom.server.event.entity.projectile.ProjectileUncollideEvent;
 import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
+import net.minestom.server.thread.Acquirable;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -185,5 +187,12 @@ public class EntityProjectile extends Entity {
             }
         }
         return false;
+    }
+
+    @ApiStatus.Experimental
+    @SuppressWarnings("unchecked")
+    @Override
+    public @NotNull Acquirable<? extends EntityProjectile> getAcquirable() {
+        return (Acquirable<? extends EntityProjectile>) super.getAcquirable();
     }
 }

--- a/src/main/java/net/minestom/server/entity/ExperienceOrb.java
+++ b/src/main/java/net/minestom/server/entity/ExperienceOrb.java
@@ -1,6 +1,9 @@
 package net.minestom.server.entity;
 
 import net.minestom.server.coordinate.Vec;
+import net.minestom.server.thread.Acquirable;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Comparator;
 
@@ -104,5 +107,12 @@ public class ExperienceOrb extends Entity {
         if (closest == null) return null;
         if (closest.getDistanceSquared(entity) > maxDistance * maxDistance) return null;
         return closest;
+    }
+
+    @ApiStatus.Experimental
+    @SuppressWarnings("unchecked")
+    @Override
+    public @NotNull Acquirable<? extends ExperienceOrb> getAcquirable() {
+        return (Acquirable<? extends ExperienceOrb>) super.getAcquirable();
     }
 }

--- a/src/main/java/net/minestom/server/entity/ExperienceOrb.java
+++ b/src/main/java/net/minestom/server/entity/ExperienceOrb.java
@@ -112,7 +112,7 @@ public class ExperienceOrb extends Entity {
     @ApiStatus.Experimental
     @SuppressWarnings("unchecked")
     @Override
-    public @NotNull Acquirable<? extends ExperienceOrb> getAcquirable() {
-        return (Acquirable<? extends ExperienceOrb>) super.getAcquirable();
+    public @NotNull Acquirable<? extends ExperienceOrb> acquirable() {
+        return (Acquirable<? extends ExperienceOrb>) super.acquirable();
     }
 }

--- a/src/main/java/net/minestom/server/entity/ItemEntity.java
+++ b/src/main/java/net/minestom/server/entity/ItemEntity.java
@@ -5,9 +5,11 @@ import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.entity.EntityItemMergeEvent;
 import net.minestom.server.instance.EntityTracker;
 import net.minestom.server.item.ItemStack;
+import net.minestom.server.thread.Acquirable;
 import net.minestom.server.utils.MathUtils;
 import net.minestom.server.utils.time.Cooldown;
 import net.minestom.server.utils.time.TimeUnit;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -215,5 +217,12 @@ public class ItemEntity extends Entity {
      */
     public long getSpawnTime() {
         return spawnTime;
+    }
+
+    @ApiStatus.Experimental
+    @SuppressWarnings("unchecked")
+    @Override
+    public @NotNull Acquirable<? extends ItemEntity> getAcquirable() {
+        return (Acquirable<? extends ItemEntity>) super.getAcquirable();
     }
 }

--- a/src/main/java/net/minestom/server/entity/ItemEntity.java
+++ b/src/main/java/net/minestom/server/entity/ItemEntity.java
@@ -222,7 +222,7 @@ public class ItemEntity extends Entity {
     @ApiStatus.Experimental
     @SuppressWarnings("unchecked")
     @Override
-    public @NotNull Acquirable<? extends ItemEntity> getAcquirable() {
-        return (Acquirable<? extends ItemEntity>) super.getAcquirable();
+    public @NotNull Acquirable<? extends ItemEntity> acquirable() {
+        return (Acquirable<? extends ItemEntity>) super.acquirable();
     }
 }

--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -677,7 +677,7 @@ public class LivingEntity extends Entity implements EquipmentHandler {
     @SuppressWarnings("unchecked")
     @ApiStatus.Experimental
     @Override
-    public @NotNull Acquirable<? extends LivingEntity> getAcquirable() {
-        return (Acquirable<? extends LivingEntity>) super.getAcquirable();
+    public @NotNull Acquirable<? extends LivingEntity> acquirable() {
+        return (Acquirable<? extends LivingEntity>) super.acquirable();
     }
 }

--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -28,6 +28,7 @@ import net.minestom.server.network.player.PlayerConnection;
 import net.minestom.server.registry.DynamicRegistry;
 import net.minestom.server.scoreboard.Team;
 import net.minestom.server.sound.SoundEvent;
+import net.minestom.server.thread.Acquirable;
 import net.minestom.server.utils.NamespaceID;
 import net.minestom.server.utils.block.BlockIterator;
 import net.minestom.server.utils.time.Cooldown;
@@ -671,5 +672,12 @@ public class LivingEntity extends Entity implements EquipmentHandler {
     public void takeKnockback(float strength, final double x, final double z) {
         strength *= (float) (1 - getAttributeValue(Attribute.GENERIC_KNOCKBACK_RESISTANCE));
         super.takeKnockback(strength, x, z);
+    }
+
+    @SuppressWarnings("unchecked")
+    @ApiStatus.Experimental
+    @Override
+    public @NotNull Acquirable<? extends LivingEntity> getAcquirable() {
+        return (Acquirable<? extends LivingEntity>) super.getAcquirable();
     }
 }

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -82,6 +82,7 @@ import net.minestom.server.snapshot.PlayerSnapshot;
 import net.minestom.server.snapshot.SnapshotImpl;
 import net.minestom.server.snapshot.SnapshotUpdater;
 import net.minestom.server.statistic.PlayerStatistic;
+import net.minestom.server.thread.Acquirable;
 import net.minestom.server.timer.Scheduler;
 import net.minestom.server.utils.MathUtils;
 import net.minestom.server.utils.PacketUtils;
@@ -2566,4 +2567,10 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         return Integer.compare(chunkDistanceA, chunkDistanceB);
     }
 
+    @SuppressWarnings("unchecked")
+    @ApiStatus.Experimental
+    @Override
+    public @NotNull Acquirable<? extends Player> getAcquirable() {
+        return (Acquirable<? extends Player>) super.getAcquirable();
+    }
 }

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -2570,7 +2570,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
     @SuppressWarnings("unchecked")
     @ApiStatus.Experimental
     @Override
-    public @NotNull Acquirable<? extends Player> getAcquirable() {
-        return (Acquirable<? extends Player>) super.getAcquirable();
+    public @NotNull Acquirable<? extends Player> acquirable() {
+        return (Acquirable<? extends Player>) super.acquirable();
     }
 }

--- a/src/main/java/net/minestom/server/entity/PlayerProjectile.java
+++ b/src/main/java/net/minestom/server/entity/PlayerProjectile.java
@@ -184,7 +184,7 @@ public class PlayerProjectile extends Entity {
     @ApiStatus.Experimental
     @SuppressWarnings("unchecked")
     @Override
-    public @NotNull Acquirable<? extends PlayerProjectile> getAcquirable() {
-        return (Acquirable<? extends PlayerProjectile>) super.getAcquirable();
+    public @NotNull Acquirable<? extends PlayerProjectile> acquirable() {
+        return (Acquirable<? extends PlayerProjectile>) super.acquirable();
     }
 }

--- a/src/main/java/net/minestom/server/entity/PlayerProjectile.java
+++ b/src/main/java/net/minestom/server/entity/PlayerProjectile.java
@@ -14,6 +14,8 @@ import net.minestom.server.event.entity.projectile.ProjectileCollideWithBlockEve
 import net.minestom.server.event.entity.projectile.ProjectileCollideWithEntityEvent;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
+import net.minestom.server.thread.Acquirable;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Random;
@@ -177,5 +179,12 @@ public class PlayerProjectile extends Entity {
             var e = new ProjectileCollideWithBlockEvent(this, Pos.fromPoint(hitPoint), hitBlock);
             MinecraftServer.getGlobalEventHandler().call(e);
         }
+    }
+
+    @ApiStatus.Experimental
+    @SuppressWarnings("unchecked")
+    @Override
+    public @NotNull Acquirable<? extends PlayerProjectile> getAcquirable() {
+        return (Acquirable<? extends PlayerProjectile>) super.getAcquirable();
     }
 }

--- a/src/main/java/net/minestom/server/thread/AcquirableSource.java
+++ b/src/main/java/net/minestom/server/thread/AcquirableSource.java
@@ -19,5 +19,5 @@ public interface AcquirableSource<T> {
      *
      * @return an Acquirable which can be used to synchronize access to this object
      */
-    @NotNull Acquirable<? extends T> getAcquirable();
+    @NotNull Acquirable<? extends T> acquirable();
 }

--- a/src/main/java/net/minestom/server/thread/AcquirableSource.java
+++ b/src/main/java/net/minestom/server/thread/AcquirableSource.java
@@ -1,0 +1,23 @@
+package net.minestom.server.thread;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Consumer;
+
+/**
+ * An object that is a source of {@link Acquirable} objects, and can be synchronized within a {@link ThreadDispatcher}.
+ *
+ * @param <T> the type of the acquired object
+ */
+@ApiStatus.Experimental
+public interface AcquirableSource<T> {
+    /**
+     * Obtains an {@link Acquirable}. To safely perform operations on this object, the user must call
+     * {@link Acquirable#sync(Consumer)}, {@link Acquirable#async(Consumer)}, or {@link Acquirable#lock()} (followed by
+     * a subsequent unlock) on the Acquirable instance.
+     *
+     * @return an Acquirable which can be used to synchronize access to this object
+     */
+    @NotNull Acquirable<? extends T> getAcquirable();
+}

--- a/src/main/java/net/minestom/server/thread/ThreadDispatcher.java
+++ b/src/main/java/net/minestom/server/thread/ThreadDispatcher.java
@@ -273,7 +273,7 @@ public final class ThreadDispatcher<P> {
             this.elements.put(tickable, partitionEntry);
             partitionEntry.elements.add(tickable);
             if (tickable instanceof AcquirableSource<?> acquirableSource) {
-                ((AcquirableImpl<?>) acquirableSource.getAcquirable()).updateThread(partitionEntry.thread());
+                ((AcquirableImpl<?>) acquirableSource.acquirable()).updateThread(partitionEntry.thread());
             }
         }
     }

--- a/src/main/java/net/minestom/server/thread/ThreadDispatcher.java
+++ b/src/main/java/net/minestom/server/thread/ThreadDispatcher.java
@@ -1,7 +1,6 @@
 package net.minestom.server.thread;
 
 import net.minestom.server.Tickable;
-import net.minestom.server.entity.Entity;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.MpscUnboundedArrayQueue;
 import org.jetbrains.annotations.ApiStatus;
@@ -10,10 +9,20 @@ import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
+import java.util.function.IntFunction;
 
 /**
- * Used to link chunks into multiple groups.
- * Then executed into a thread pool.
+ * ThreadDispatcher can be used to dispatch updates (ticks) across a number of "partitions" (such as chunks) that
+ * house {@link Tickable} instances (such as entities). The parallelism of such updates is defined when the dispatcher
+ * is constructed.
+ * <p>
+ * It is recommended that {@link Tickable}s being added to a dispatcher also implement {@link AcquirableSource}, as
+ * doing so will allow the user to synchronize external access to them using the {@link Acquirable} API.
+ * <p>
+ * Instances of this class can be obtained by calling {@link ThreadDispatcher#of(ThreadProvider, int)}, or a similar
+ * overload.
+ * @see Acquirable
+ * @see AcquirableSource
  */
 public final class ThreadDispatcher<P> {
     private final ThreadProvider<P> provider;
@@ -24,29 +33,67 @@ public final class ThreadDispatcher<P> {
     private final Map<P, Partition> partitions = new WeakHashMap<>();
     // Cache to retrieve the threading context from a tickable element
     private final Map<Tickable, Partition> elements = new WeakHashMap<>();
-    // Queue to update chunks linked thread
+    // Queue to update partition linked thread
     private final ArrayDeque<P> partitionUpdateQueue = new ArrayDeque<>();
 
     // Requests consumed at the end of each tick
     private final MessagePassingQueue<DispatchUpdate<P>> updates = new MpscUnboundedArrayQueue<>(1024);
 
-    private ThreadDispatcher(ThreadProvider<P> provider, int threadCount) {
+    private ThreadDispatcher(ThreadProvider<P> provider, int threadCount,
+                             @NotNull IntFunction<? extends TickThread> threadGenerator) {
         this.provider = provider;
         TickThread[] threads = new TickThread[threadCount];
-        Arrays.setAll(threads, TickThread::new);
+        Arrays.setAll(threads, threadGenerator);
         this.threads = List.of(threads);
         this.threads.forEach(Thread::start);
     }
 
+    /**
+     * Creates a new ThreadDispatcher using default thread names (ex. Ms-Tick-n).
+     *
+     * @param provider the {@link ThreadProvider} instance to be used for defining thread IDs
+     * @param threadCount the number of threads to create for this dispatcher
+     * @return a new ThreadDispatcher instance
+     * @param <P> the dispatcher partition type
+     */
     public static <P> @NotNull ThreadDispatcher<P> of(@NotNull ThreadProvider<P> provider, int threadCount) {
-        return new ThreadDispatcher<>(provider, threadCount);
+        return new ThreadDispatcher<>(provider, threadCount, TickThread::new);
     }
 
+    /**
+     * Creates a new ThreadDispatcher using the caller-provided thread name generator {@code nameGenerator}. This is
+     * useful to disambiguate custom ThreadDispatcher instances from ones used in core Minestom code.
+     *
+     * @param provider the {@link ThreadProvider} instance to be used for defining thread IDs
+     * @param nameGenerator a function that should return unique names, given a thread index
+     * @param threadCount the number of threads to create for this dispatcher
+     * @return a new ThreadDispatcher instance
+     * @param <P> the dispatcher partition type
+     */
+    public static <P> @NotNull ThreadDispatcher<P> of(@NotNull ThreadProvider<P> provider,
+                                                      @NotNull IntFunction<String> nameGenerator, int threadCount) {
+        return new ThreadDispatcher<>(provider, threadCount, index -> new TickThread(nameGenerator.apply(index)));
+    }
+
+    /**
+     * Creates a single-threaded dispatcher that uses default thread names.
+     *
+     * @return a new ThreadDispatcher instance
+     * @param <P> the dispatcher partition type
+     */
     public static <P> @NotNull ThreadDispatcher<P> singleThread() {
         return of(ThreadProvider.counter(), 1);
     }
 
+    /**
+     * Gets the unmodifiable list of TickThreads used to dispatch updates.
+     * <p>
+     * This method is marked internal to reflect {@link TickThread}s own internal status.
+     *
+     * @return the TickThreads used to dispatch updates
+     */
     @Unmodifiable
+    @ApiStatus.Internal
     public @NotNull List<@NotNull TickThread> threads() {
         return threads;
     }
@@ -59,16 +106,16 @@ public final class ThreadDispatcher<P> {
     public synchronized void updateAndAwait(long time) {
         // Update dispatcher
         this.updates.drain(update -> {
-            if (update instanceof DispatchUpdate.PartitionLoad<P> chunkUpdate) {
-                processLoadedPartition(chunkUpdate.partition());
-            } else if (update instanceof DispatchUpdate.PartitionUnload<P> partitionUnload) {
-                processUnloadedPartition(partitionUnload.partition());
-            } else if (update instanceof DispatchUpdate.ElementUpdate<P> elementUpdate) {
-                processUpdatedElement(elementUpdate.tickable(), elementUpdate.partition());
-            } else if (update instanceof DispatchUpdate.ElementRemove elementRemove) {
-                processRemovedElement(elementRemove.tickable());
-            } else {
-                throw new IllegalStateException("Unknown update type: " + update.getClass().getSimpleName());
+            switch (update) {
+                case DispatchUpdate.PartitionLoad<P> chunkUpdate -> processLoadedPartition(chunkUpdate.partition());
+                case DispatchUpdate.PartitionUnload<P> partitionUnload ->
+                        processUnloadedPartition(partitionUnload.partition());
+                case DispatchUpdate.ElementUpdate<P> elementUpdate ->
+                        processUpdatedElement(elementUpdate.tickable(), elementUpdate.partition());
+                case DispatchUpdate.ElementRemove<P> elementRemove -> processRemovedElement(elementRemove.tickable());
+                case null, default ->
+                        throw new IllegalStateException("Unknown update type: " +
+                                (update == null ? "null" : update.getClass().getSimpleName()));
             }
         });
         // Tick all partitions
@@ -82,8 +129,8 @@ public final class ThreadDispatcher<P> {
     }
 
     /**
-     * Called at the end of each tick to clear removed entities,
-     * refresh the chunk linked to an entity, and chunk threads based on {@link ThreadProvider#findThread(Object)}.
+     * Called at the end of each tick to clear removed tickables, refresh the partition linked to a tickable, and
+     * partition threads based on {@link ThreadProvider#findThread(Object)}.
      *
      * @param nanoTimeout max time in nanoseconds to update partitions
      */
@@ -117,23 +164,48 @@ public final class ThreadDispatcher<P> {
         }
     }
 
+    /**
+     * Refreshes all thread as per {@link ThreadDispatcher#refreshThreads(long)}, with a timeout of
+     * {@link Long#MAX_VALUE}.
+     */
     public void refreshThreads() {
         refreshThreads(Long.MAX_VALUE);
     }
 
-    public void createPartition(P partition) {
+    /**
+     * Registers a new partition.
+     *
+     * @param partition the partition to register
+     */
+    public void createPartition(@NotNull P partition) {
         signalUpdate(new DispatchUpdate.PartitionLoad<>(partition));
     }
 
-    public void deletePartition(P partition) {
+    /**
+     * Deletes an existing partition.
+     *
+     * @param partition the partition to delete
+     */
+    public void deletePartition(@NotNull P partition) {
         signalUpdate(new DispatchUpdate.PartitionUnload<>(partition));
     }
 
-    public void updateElement(Tickable tickable, P partition) {
+    /**
+     * Updates a {@link Tickable}, signalling that it is a part of {@code partition}.
+     *
+     * @param tickable the Tickable to update
+     * @param partition the partition the Tickable is part of
+     */
+    public void updateElement(@NotNull Tickable tickable, @NotNull P partition) {
         signalUpdate(new DispatchUpdate.ElementUpdate<>(tickable, partition));
     }
 
-    public void removeElement(Tickable tickable) {
+    /**
+     * Removes a {@link Tickable}.
+     *
+     * @param tickable the Tickable to remove
+     */
+    public void removeElement(@NotNull Tickable tickable) {
         signalUpdate(new DispatchUpdate.ElementRemove<>(tickable));
     }
 
@@ -200,12 +272,15 @@ public final class ThreadDispatcher<P> {
         if (partitionEntry != null) {
             this.elements.put(tickable, partitionEntry);
             partitionEntry.elements.add(tickable);
-            if (tickable instanceof Entity entity) { // TODO support other types
-                ((AcquirableImpl<?>) entity.getAcquirable()).updateThread(partitionEntry.thread());
+            if (tickable instanceof AcquirableSource<?> acquirableSource) {
+                ((AcquirableImpl<?>) acquirableSource.getAcquirable()).updateThread(partitionEntry.thread());
             }
         }
     }
 
+    /**
+     * A data structure which may contain {@link Tickable}s, and is assigned a single {@link TickThread}.
+     */
     public static final class Partition {
         private TickThread thread;
         private final List<Tickable> elements = new ArrayList<>();
@@ -214,10 +289,23 @@ public final class ThreadDispatcher<P> {
             this.thread = thread;
         }
 
+        /**
+         * The {@link TickThread} used by this partition.
+         * <p>
+         * This method is marked internal to reflect {@link TickThread}s own internal status.
+         *
+         * @return the TickThread used by this partition
+         */
+        @ApiStatus.Internal
         public @NotNull TickThread thread() {
             return thread;
         }
 
+        /**
+         * The {@link Tickable}s assigned to this partition.
+         *
+         * @return the tickables assigned to this partition
+         */
         public @NotNull List<Tickable> elements() {
             return elements;
         }

--- a/src/main/java/net/minestom/server/thread/TickThread.java
+++ b/src/main/java/net/minestom/server/thread/TickThread.java
@@ -34,6 +34,10 @@ public final class TickThread extends MinestomThread {
         super(MinecraftServer.THREAD_NAME_TICK + "-" + number);
     }
 
+    public TickThread(@NotNull String name) {
+        super(name);
+    }
+
     public static @Nullable TickThread current() {
         if (Thread.currentThread() instanceof TickThread current)
             return current;

--- a/src/test/java/net/minestom/server/thread/AcquirableTest.java
+++ b/src/test/java/net/minestom/server/thread/AcquirableTest.java
@@ -18,7 +18,7 @@ public class AcquirableTest {
             @Override
             public void tick(long time) {
                 super.tick(time);
-                tickThread.set(getAcquirable().assignedThread());
+                tickThread.set(acquirable().assignedThread());
             }
         };
         Object first = new Object();


### PR DESCRIPTION
Closes #2014. 

Adds more convenient `getAcquirable` methods to Entity (and subclasses), more documentation, modifies ThreadDispatcher to be usable with any partition type, makes it no longer specific to just ticking entities, and includes a new static factory method for creating dispatchers with custom thread names. 

These shouldn't be breaking changes. 