### PR TITLE
Fix chunk lighting optimization

### DIFF
--- a/src/main/java/net/minestom/server/instance/light/BlockLight.java
+++ b/src/main/java/net/minestom/server/instance/light/BlockLight.java
@@ -216,7 +216,7 @@ final class BlockLight implements Light {
         if (content == null) return new byte[0];
         if (contentPropagation == null) return content;
         var res = bake(contentPropagation, content);
-        if (Arrays.equals(res, emptyContent)) return new byte[0];
+        if (res == emptyContent) return new byte[0];
         return res;
     }
 
@@ -255,10 +255,12 @@ final class BlockLight implements Light {
 
     private byte[] bake(byte[] content1, byte[] content2) {
         if (content1 == null && content2 == null) return emptyContent;
-        if (Arrays.equals(content1, emptyContent) && Arrays.equals(content2, emptyContent)) return emptyContent;
+        if (content1 == emptyContent && content2 == emptyContent) return emptyContent;
 
         if (content1 == null) return content2;
         if (content2 == null) return content1;
+
+        if (Arrays.equals(content1, emptyContent) && Arrays.equals(content2, emptyContent)) return emptyContent;
 
         byte[] lightMax = new byte[LIGHT_LENGTH];
         for (int i = 0; i < content1.length; i++) {

--- a/src/main/java/net/minestom/server/instance/light/BlockLight.java
+++ b/src/main/java/net/minestom/server/instance/light/BlockLight.java
@@ -11,6 +11,7 @@ import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.instance.palette.Palette;
 import org.jetbrains.annotations.ApiStatus;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -215,7 +216,7 @@ final class BlockLight implements Light {
         if (content == null) return new byte[0];
         if (contentPropagation == null) return content;
         var res = bake(contentPropagation, content);
-        if (res == emptyContent) return new byte[0];
+        if (Arrays.equals(res, emptyContent)) return new byte[0];
         return res;
     }
 
@@ -254,7 +255,7 @@ final class BlockLight implements Light {
 
     private byte[] bake(byte[] content1, byte[] content2) {
         if (content1 == null && content2 == null) return emptyContent;
-        if (content1 == emptyContent && content2 == emptyContent) return emptyContent;
+        if (Arrays.equals(content1, emptyContent) && Arrays.equals(content2, emptyContent)) return emptyContent;
 
         if (content1 == null) return content2;
         if (content2 == null) return content1;

--- a/src/main/java/net/minestom/server/instance/light/SkyLight.java
+++ b/src/main/java/net/minestom/server/instance/light/SkyLight.java
@@ -12,6 +12,7 @@ import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.instance.palette.Palette;
 import org.jetbrains.annotations.ApiStatus;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -237,7 +238,7 @@ final class SkyLight implements Light {
         if (content == null) return new byte[0];
         if (contentPropagation == null) return content;
         var res = bake(contentPropagation, content);
-        if (res == emptyContent) return new byte[0];
+        if (Arrays.equals(res, emptyContent)) return new byte[0];
         return res;
     }
 
@@ -283,7 +284,7 @@ final class SkyLight implements Light {
 
     private byte[] bake(byte[] content1, byte[] content2) {
         if (content1 == null && content2 == null) return emptyContent;
-        if (content1 == emptyContent && content2 == emptyContent) return emptyContent;
+        if (Arrays.equals(content1, emptyContent) && Arrays.equals(content2, emptyContent)) return emptyContent;
 
         if (content1 == null) return content2;
         if (content2 == null) return content1;

--- a/src/main/java/net/minestom/server/instance/light/SkyLight.java
+++ b/src/main/java/net/minestom/server/instance/light/SkyLight.java
@@ -238,7 +238,7 @@ final class SkyLight implements Light {
         if (content == null) return new byte[0];
         if (contentPropagation == null) return content;
         var res = bake(contentPropagation, content);
-        if (Arrays.equals(res, emptyContent)) return new byte[0];
+        if (res == emptyContent) return new byte[0];
         return res;
     }
 
@@ -284,10 +284,12 @@ final class SkyLight implements Light {
 
     private byte[] bake(byte[] content1, byte[] content2) {
         if (content1 == null && content2 == null) return emptyContent;
-        if (Arrays.equals(content1, emptyContent) && Arrays.equals(content2, emptyContent)) return emptyContent;
+        if (content1 == emptyContent && content2 == emptyContent) return emptyContent;
 
         if (content1 == null) return content2;
         if (content2 == null) return content1;
+
+        if (Arrays.equals(content1, emptyContent) && Arrays.equals(content2, emptyContent)) return emptyContent;
 
         byte[] lightMax = new byte[LIGHT_LENGTH];
         for (int i = 0; i < content1.length; i++) {


### PR DESCRIPTION
When running my server outside of my own computer, I realized that chunk loading would take a long time to load (my client was receiving ~2 chunks every 5 seconds)
This is due to the chunk packets being massive due to the lighting data not being optimized when being set manually:

In Minestom, setting light to null or an array full of zeros will create a copy of its own static empty light array
However, Minestom's array() method which returns the backing array checks the array's reference, not its contents, but since the array is always copied, the reference will never be the same.

This is problematic because the code in charge of making the light data checks if the array's size is 0, but due to the bug it is never and Minestom ends up sending the whole light array.
This can also be a problem for world loaders as they'll have to store full light arrays instead of only storing an empty array