### PR TITLE
Fix NullPointer when changing equipment before checking attributes

### DIFF
--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -224,7 +224,7 @@ public class LivingEntity extends Entity implements EquipmentHandler {
             for (AttributeList.Modifier modifier : oldAttributes.modifiers()) {
                 // If the modifier currently modifies the slot we are updating
                 if (modifier.slot().contains(slot)) {
-                    AttributeInstance attributeInstance = attributeModifiers.get(modifier.attribute().name());
+                    AttributeInstance attributeInstance = getAttribute(modifier.attribute());
                     attributeInstance.removeModifier(modifier.modifier().id());
                 }
             }
@@ -235,7 +235,7 @@ public class LivingEntity extends Entity implements EquipmentHandler {
             for (AttributeList.Modifier modifier : newAttributes.modifiers()) {
                 // If the modifier currently modifies the slot we are updating
                 if (modifier.slot().contains(slot)) {
-                    AttributeInstance attributeInstance = attributeModifiers.get(modifier.attribute().name());
+                    AttributeInstance attributeInstance = getAttribute(modifier.attribute());
                     attributeInstance.addModifier(modifier.modifier());
                 }
             }

--- a/src/test/java/net/minestom/server/entity/EntityAttributeTest.java
+++ b/src/test/java/net/minestom/server/entity/EntityAttributeTest.java
@@ -72,4 +72,22 @@ public class EntityAttributeTest {
         player.setItemInMainHand(ItemStack.AIR);
         assertEquals(0, Double.compare(player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue(), baseHealth));
     }
+
+    @Test
+    public void testDirectlyAddAttributes(Env env) {
+        var instance = env.createFlatInstance();
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0, 42, 1)).join();
+
+        double baseHealth = 20;
+        double addition = 10;
+        // Don't compare against base health first (that will initialize the attribute, and we want to make sure we don't error when we add an item with attribute modifiers)
+
+        ItemStack itemStack = ItemStack.builder(Material.DIAMOND).set(ItemComponent.ATTRIBUTE_MODIFIERS,
+                new AttributeList(new AttributeList.Modifier(Attribute.GENERIC_MAX_HEALTH,
+                        new AttributeModifier(NamespaceID.from("minestom:health"), addition, AttributeOperation.ADD_VALUE), EquipmentSlotGroup.MAIN_HAND))).build();
+
+        player.setItemInMainHand(itemStack);
+        assertEquals(0, Double.compare(player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue(), baseHealth + addition));
+    }
 }


### PR DESCRIPTION
Currently when equipment is updated for a LivingEntity, there's a good possibility that a NullPointerException will occur. This is due to attributeModifiers not containing a list of every attribute when an entity is initialized, and this a `.get()` call can return null.

This PR fixes this by using the `getAttribute()` method instead, this is guaranteed to not return null. I have also added a test case to catch this in the future if any regressions occur.