### PR TITLE
feat: allow changing the threadcount used by the server process ThreadDispatcher

### DIFF
--- a/src/main/java/net/minestom/server/ServerFlag.java
+++ b/src/main/java/net/minestom/server/ServerFlag.java
@@ -19,6 +19,7 @@ public final class ServerFlag {
     public static final int ENTITY_VIEW_DISTANCE = intProperty("minestom.entity-view-distance", 5);
     public static final int ENTITY_SYNCHRONIZATION_TICKS = intProperty("minestom.entity-synchronization-ticks", 20);
     public static final int WORKER_COUNT = intProperty("minestom.workers", Runtime.getRuntime().availableProcessors());
+    public static final int DISPATCHER_THREADS = intProperty("minestom.dispatcher-threads", 1);
     public static final int MAX_PACKET_SIZE = intProperty("minestom.max-packet-size", 2_097_151); // 3 bytes var-int
     public static final int SOCKET_SEND_BUFFER_SIZE = intProperty("minestom.send-buffer-size", 262_143);
     public static final int SOCKET_RECEIVE_BUFFER_SIZE = intProperty("minestom.receive-buffer-size", 32_767);

--- a/src/main/java/net/minestom/server/ServerProcessImpl.java
+++ b/src/main/java/net/minestom/server/ServerProcessImpl.java
@@ -35,6 +35,7 @@ import net.minestom.server.scoreboard.TeamManager;
 import net.minestom.server.snapshot.*;
 import net.minestom.server.thread.Acquirable;
 import net.minestom.server.thread.ThreadDispatcher;
+import net.minestom.server.thread.ThreadProvider;
 import net.minestom.server.timer.SchedulerManager;
 import net.minestom.server.utils.PacketUtils;
 import net.minestom.server.utils.collection.MappedCollection;
@@ -136,7 +137,7 @@ final class ServerProcessImpl implements ServerProcess {
 
         this.server = new Server(packetProcessor);
 
-        this.dispatcher = ThreadDispatcher.singleThread();
+        this.dispatcher = ThreadDispatcher.of(ThreadProvider.counter(), ServerFlag.DISPATCHER_THREADS);
         this.ticker = new TickerImpl();
     }
 


### PR DESCRIPTION
Previously, there was no way to change the number of threads used by the `ServerProcessImpl`s thread dispatcher (it was hardcoded to be single-threaded). This pull request makes it read the `minestom.dispatcher-threads` system property instead (defaults to 1, so no change in behavior unless adjusted). 