### PR TITLE
feat: Allow disabling "block does not have any corresponding handler" warning

### DIFF
--- a/src/main/java/net/minestom/server/ServerFlag.java
+++ b/src/main/java/net/minestom/server/ServerFlag.java
@@ -30,6 +30,7 @@ public final class ServerFlag {
     public static final long KEEP_ALIVE_DELAY = longProperty("minestom.keep-alive-delay", 10_000);
     public static final long KEEP_ALIVE_KICK = longProperty("minestom.keep-alive-kick", 30_000);
     public static final long LOGIN_PLUGIN_MESSAGE_TIMEOUT = longProperty("minestom.login-plugin-message-timeout", 5_000);
+    public static final boolean MISSING_BLOCK_HANDLER_WARNING = booleanProperty("minestom.missing-block-handler-warning", true);
 
     // Chunk update
     public static final float MIN_CHUNKS_PER_TICK = floatProperty("minestom.chunk-queue.min-per-tick", 0.01f);

--- a/src/main/java/net/minestom/server/instance/block/BlockManager.java
+++ b/src/main/java/net/minestom/server/instance/block/BlockManager.java
@@ -2,6 +2,7 @@ package net.minestom.server.instance.block;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import net.minestom.server.ServerFlag;
 import net.minestom.server.instance.block.rule.BlockPlacementRule;
 import net.minestom.server.utils.NamespaceID;
 import net.minestom.server.utils.validate.Check;
@@ -42,7 +43,7 @@ public final class BlockManager {
     public @NotNull BlockHandler getHandlerOrDummy(@NotNull String namespace) {
         BlockHandler handler = getHandler(namespace);
         if (handler == null) {
-            if (dummyWarning.add(namespace)) {
+            if (ServerFlag.MISSING_BLOCK_HANDLER_WARNING && dummyWarning.add(namespace)) {
                 LOGGER.warn("""
                         Block {} does not have any corresponding handler, default to dummy.
                         You may want to register a handler for this namespace to prevent any data loss.""", namespace);


### PR DESCRIPTION
When using `AnvilLoader`, some blocks need a handler, which if missing will generate a warning in the console. However, this warning is not always useful, as in some cases it is not necessary (or desirable) to implement one. This PR allows users to disable this warning by setting the server flag `minestom.missing-block-handler-warning` to `false` (defaults to `true`). 