### PR TITLE
Remove cursor items from individual inventories

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -1785,14 +1785,9 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         Inventory openInventory = getOpenInventory();
 
         // Drop cursor item when closing inventory
-        ItemStack cursorItem;
-        if (openInventory == null) {
-            cursorItem = getInventory().getCursorItem();
-            getInventory().setCursorItem(ItemStack.AIR);
-        } else {
-            cursorItem = openInventory.getCursorItem(this);
-            openInventory.setCursorItem(this, ItemStack.AIR);
-        }
+        ItemStack cursorItem = getInventory().getCursorItem();
+        getInventory().setCursorItem(ItemStack.AIR);
+
         if (!cursorItem.isAir()) {
             // Add item to inventory if he hasn't been able to drop it
             if (!dropItem(cursorItem)) {

--- a/src/main/java/net/minestom/server/inventory/Inventory.java
+++ b/src/main/java/net/minestom/server/inventory/Inventory.java
@@ -16,7 +16,6 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -156,7 +155,7 @@ public non-sealed class Inventory extends AbstractInventory implements Viewable 
      * Gets the cursor item of a player.
      *
      * @deprecated normal inventories no longer store cursor items
-     * @see <a href="https://github.com/Minestom/Minestom/pull/2294/files">...</a>
+     * @see <a href="https://github.com/Minestom/Minestom/pull/2294">the relevant PR</a>
      */
     @Deprecated
     public @NotNull ItemStack getCursorItem(@NotNull Player player) {
@@ -167,7 +166,7 @@ public non-sealed class Inventory extends AbstractInventory implements Viewable 
      * Changes the cursor item of a player.
      *
      * @deprecated normal inventories no longer store cursor items
-     * @see <a href="https://github.com/Minestom/Minestom/pull/2294/files">...</a>
+     * @see <a href="https://github.com/Minestom/Minestom/pull/2294">the relevant PR</a>
      */
     @Deprecated
     public void setCursorItem(@NotNull Player player, @NotNull ItemStack cursorItem) {

--- a/src/main/java/net/minestom/server/inventory/Inventory.java
+++ b/src/main/java/net/minestom/server/inventory/Inventory.java
@@ -101,11 +101,6 @@ public non-sealed class Inventory extends AbstractInventory implements Viewable 
         return id;
     }
 
-    @Override
-    public synchronized void clear() {
-        super.clear();
-    }
-
     /**
      * Refreshes the inventory for all viewers.
      */
@@ -155,6 +150,28 @@ public non-sealed class Inventory extends AbstractInventory implements Viewable 
         final boolean result = this.viewers.remove(player);
         this.clickProcessor.clearCache(player);
         return result;
+    }
+
+    /**
+     * Gets the cursor item of a player.
+     *
+     * @deprecated normal inventories no longer store cursor items
+     * @see <a href="https://github.com/Minestom/Minestom/pull/2294/files">...</a>
+     */
+    @Deprecated
+    public @NotNull ItemStack getCursorItem(@NotNull Player player) {
+        return player.getInventory().getCursorItem();
+    }
+
+    /**
+     * Changes the cursor item of a player.
+     *
+     * @deprecated normal inventories no longer store cursor items
+     * @see <a href="https://github.com/Minestom/Minestom/pull/2294/files">...</a>
+     */
+    @Deprecated
+    public void setCursorItem(@NotNull Player player, @NotNull ItemStack cursorItem) {
+        player.getInventory().setCursorItem(cursorItem);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/listener/WindowListener.java
+++ b/src/main/java/net/minestom/server/listener/WindowListener.java
@@ -55,7 +55,7 @@ public class WindowListener {
         } else if (clickType == ClientClickWindowPacket.ClickType.CLONE) {
             successful = player.getGameMode() == GameMode.CREATIVE;
             if (successful) {
-                setCursor(player, inventory, packet.clickedItem());
+                player.getInventory().setCursorItem(packet.clickedItem());
             }
         } else if (clickType == ClientClickWindowPacket.ClickType.THROW) {
             successful = inventory.drop(player, false, slot, button);
@@ -74,7 +74,8 @@ public class WindowListener {
         }
 
         // Prevent the player from picking a ghost item in cursor
-        refreshCursorItem(player, inventory);
+        ItemStack cursorItem = player.getInventory().getCursorItem();
+        player.sendPacket(SetSlotPacket.createCursorPacket(cursorItem));
 
         // (Why is the ping packet necessary?)
         player.sendPacket(new PingPacket((1 << 30) | (windowId << 16)));
@@ -96,30 +97,4 @@ public class WindowListener {
             player.openInventory(newInventory);
     }
 
-    /**
-     * @param player    the player to refresh the cursor item
-     * @param inventory the player open inventory, null if not any (could be player inventory)
-     */
-    private static void refreshCursorItem(Player player, AbstractInventory inventory) {
-        ItemStack cursorItem;
-        if (inventory instanceof PlayerInventory playerInventory) {
-            cursorItem = playerInventory.getCursorItem();
-        } else if (inventory instanceof Inventory standardInventory) {
-            cursorItem = standardInventory.getCursorItem(player);
-        } else {
-            throw new RuntimeException("Invalid inventory: " + inventory.getClass());
-        }
-        final SetSlotPacket setSlotPacket = SetSlotPacket.createCursorPacket(cursorItem);
-        player.sendPacket(setSlotPacket);
-    }
-
-    private static void setCursor(Player player, AbstractInventory inventory, ItemStack itemStack) {
-        if (inventory instanceof PlayerInventory playerInventory) {
-            playerInventory.setCursorItem(itemStack);
-        } else if (inventory instanceof Inventory standardInventory) {
-            standardInventory.setCursorItem(player, itemStack);
-        } else {
-            throw new RuntimeException("Invalid inventory: " + inventory.getClass());
-        }
-    }
 }

--- a/src/test/java/net/minestom/server/inventory/click/integration/HeldClickIntegrationTest.java
+++ b/src/test/java/net/minestom/server/inventory/click/integration/HeldClickIntegrationTest.java
@@ -113,10 +113,10 @@ public class HeldClickIntegrationTest {
                 if (event.getInventory() != null) assertEquals(inventory, event.getInventory());
                 assertEquals(0, event.getSlot());
                 assertEquals(ClickType.CHANGE_HELD, event.getClickType());
-                assertEquals(ItemStack.AIR, inventory.getCursorItem(player));
+                assertEquals(ItemStack.AIR, player.getInventory().getCursorItem());
             });
             heldClickOpenInventory(player, 0, 0);
-            assertEquals(ItemStack.AIR, inventory.getCursorItem(player));
+            assertEquals(ItemStack.AIR, player.getInventory().getCursorItem());
             assertEquals(ItemStack.AIR, inventory.getItemStack(0));
         }
         // Swap empty
@@ -124,10 +124,10 @@ public class HeldClickIntegrationTest {
             listener.followup(event -> {
                 if (event.getInventory() != null) assertEquals(inventory, event.getInventory());
                 assertTrue(event.getSlot() == 1 || event.getSlot() == 0);
-                assertEquals(ItemStack.AIR, inventory.getCursorItem(player));
+                assertEquals(ItemStack.AIR, player.getInventory().getCursorItem());
             });
             heldClickOpenInventory(player, 1, 0);
-            assertEquals(ItemStack.AIR, inventory.getCursorItem(player));
+            assertEquals(ItemStack.AIR, player.getInventory().getCursorItem());
             assertEquals(ItemStack.AIR, inventory.getItemStack(1));
             assertEquals(ItemStack.of(Material.DIAMOND), playerInv.getItemStack(0));
         }
@@ -136,10 +136,10 @@ public class HeldClickIntegrationTest {
             listener.followup(event -> {
                 if (event.getInventory() != null) assertEquals(inventory, event.getInventory());
                 assertTrue(event.getSlot() == 2 || event.getSlot() == 0);
-                assertEquals(ItemStack.AIR, inventory.getCursorItem(player));
+                assertEquals(ItemStack.AIR, player.getInventory().getCursorItem());
             });
             heldClickOpenInventory(player, 2, 0);
-            assertEquals(ItemStack.AIR, inventory.getCursorItem(player));
+            assertEquals(ItemStack.AIR, player.getInventory().getCursorItem());
             assertEquals(ItemStack.of(Material.DIAMOND), inventory.getItemStack(2));
             assertEquals(ItemStack.of(Material.GOLD_INGOT), playerInv.getItemStack(0));
         }
@@ -157,7 +157,7 @@ public class HeldClickIntegrationTest {
         {
             listener.followup(event -> event.setCancelled(true));
             heldClickOpenInventory(player, 2, 0);
-            assertEquals(ItemStack.AIR, inventory.getCursorItem(player));
+            assertEquals(ItemStack.AIR, player.getInventory().getCursorItem());
             assertEquals(ItemStack.of(Material.DIAMOND), inventory.getItemStack(2));
             assertEquals(ItemStack.of(Material.GOLD_INGOT), playerInv.getItemStack(0));
         }

--- a/src/test/java/net/minestom/server/inventory/click/integration/LeftClickIntegrationTest.java
+++ b/src/test/java/net/minestom/server/inventory/click/integration/LeftClickIntegrationTest.java
@@ -95,7 +95,7 @@ public class LeftClickIntegrationTest {
                 assertNull(event.getInventory()); // Player inventory
                 assertEquals(0, event.getSlot());
                 assertEquals(ClickType.LEFT_CLICK, event.getClickType());
-                assertEquals(ItemStack.AIR, inventory.getCursorItem(player));
+                assertEquals(ItemStack.AIR, player.getInventory().getCursorItem());
             });
             leftClick(player, 0);
         }
@@ -105,12 +105,12 @@ public class LeftClickIntegrationTest {
                 assertEquals(inventory, event.getInventory());
                 assertEquals(1, event.getSlot());
                 // Ensure that the inventory didn't change yet
-                assertEquals(ItemStack.AIR, inventory.getCursorItem(player));
+                assertEquals(ItemStack.AIR, player.getInventory().getCursorItem());
                 assertEquals(ItemStack.of(Material.DIAMOND), inventory.getItemStack(1));
             });
             leftClickOpenInventory(player, 1);
             // Verify inventory changes
-            assertEquals(ItemStack.of(Material.DIAMOND), inventory.getCursorItem(player));
+            assertEquals(ItemStack.of(Material.DIAMOND), player.getInventory().getCursorItem());
             assertEquals(ItemStack.AIR, inventory.getItemStack(1));
         }
         // Place it back
@@ -118,18 +118,18 @@ public class LeftClickIntegrationTest {
             listener.followup(event -> {
                 assertEquals(inventory, event.getInventory());
                 assertEquals(1, event.getSlot());
-                assertEquals(ItemStack.of(Material.DIAMOND), inventory.getCursorItem(player));
+                assertEquals(ItemStack.of(Material.DIAMOND), player.getInventory().getCursorItem());
                 assertEquals(ItemStack.AIR, inventory.getItemStack(1));
             });
             leftClickOpenInventory(player, 1);
-            assertEquals(ItemStack.AIR, inventory.getCursorItem(player));
+            assertEquals(ItemStack.AIR, player.getInventory().getCursorItem());
             assertEquals(ItemStack.of(Material.DIAMOND), inventory.getItemStack(1));
         }
         // Cancel event
         {
             listener.followup(event -> event.setCancelled(true));
             leftClickOpenInventory(player, 1);
-            assertEquals(ItemStack.AIR, inventory.getCursorItem(player), "Left click cancellation did not work");
+            assertEquals(ItemStack.AIR, player.getInventory().getCursorItem(), "Left click cancellation did not work");
             assertEquals(ItemStack.of(Material.DIAMOND), inventory.getItemStack(1));
         }
         // Change items
@@ -141,7 +141,7 @@ public class LeftClickIntegrationTest {
                 event.setCursorItem(ItemStack.of(Material.DIAMOND));
             });
             leftClick(player, 9);
-            assertEquals(ItemStack.AIR, inventory.getCursorItem(player));
+            assertEquals(ItemStack.AIR, player.getInventory().getCursorItem());
             assertEquals(ItemStack.of(Material.DIAMOND, 6), player.getInventory().getItemStack(9));
         }
     }

--- a/src/test/java/net/minestom/server/inventory/click/integration/RightClickIntegrationTest.java
+++ b/src/test/java/net/minestom/server/inventory/click/integration/RightClickIntegrationTest.java
@@ -117,7 +117,7 @@ public class RightClickIntegrationTest {
                 assertNull(event.getInventory()); // Player inventory
                 assertEquals(0, event.getSlot());
                 assertEquals(ClickType.RIGHT_CLICK, event.getClickType());
-                assertEquals(ItemStack.AIR, inventory.getCursorItem(player));
+                assertEquals(ItemStack.AIR, player.getInventory().getCursorItem());
             });
             rightClick(player, 0);
         }
@@ -126,11 +126,11 @@ public class RightClickIntegrationTest {
             listener.followup(event -> {
                 assertEquals(inventory, event.getInventory());
                 assertEquals(1, event.getSlot());
-                assertEquals(ItemStack.AIR, inventory.getCursorItem(player));
+                assertEquals(ItemStack.AIR, player.getInventory().getCursorItem());
                 assertEquals(ItemStack.of(Material.DIAMOND), inventory.getItemStack(1));
             });
             rightClickOpenInventory(player, 1);
-            assertEquals(ItemStack.of(Material.DIAMOND), inventory.getCursorItem(player));
+            assertEquals(ItemStack.of(Material.DIAMOND), player.getInventory().getCursorItem());
             assertEquals(ItemStack.AIR, inventory.getItemStack(1));
         }
         // Place back to player inv
@@ -138,12 +138,12 @@ public class RightClickIntegrationTest {
             listener.followup(event -> {
                 assertNull(event.getInventory());
                 assertEquals(1, event.getSlot());
-                assertEquals(ItemStack.of(Material.DIAMOND), inventory.getCursorItem(player));
+                assertEquals(ItemStack.of(Material.DIAMOND), player.getInventory().getCursorItem());
                 assertEquals(ItemStack.AIR, inventory.getItemStack(1));
                 assertEquals(ItemStack.AIR, player.getInventory().getItemStack(1));
             });
             rightClick(player, 1);
-            assertEquals(ItemStack.AIR, inventory.getCursorItem(player));
+            assertEquals(ItemStack.AIR, player.getInventory().getCursorItem());
             assertEquals(ItemStack.of(Material.DIAMOND), player.getInventory().getItemStack(1));
         }
         // Cancel event
@@ -151,7 +151,7 @@ public class RightClickIntegrationTest {
             listener.followup(event -> event.setCancelled(true));
             rightClick(player, 1);
             assertEquals(ItemStack.of(Material.DIAMOND), player.getInventory().getItemStack(1), "Left click cancellation did not work");
-            assertEquals(ItemStack.AIR, inventory.getCursorItem(player));
+            assertEquals(ItemStack.AIR, player.getInventory().getCursorItem());
         }
         // Change items
         {
@@ -162,7 +162,7 @@ public class RightClickIntegrationTest {
                 event.setCursorItem(ItemStack.of(Material.DIAMOND));
             });
             rightClick(player, 9);
-            assertEquals(ItemStack.AIR, inventory.getCursorItem(player));
+            assertEquals(ItemStack.AIR, player.getInventory().getCursorItem());
             assertEquals(ItemStack.of(Material.DIAMOND, 6), player.getInventory().getItemStack(9));
         }
     }


### PR DESCRIPTION
Each inventory, as well as the player inventory, having its own inventory was rather complicated. Now, only player inventories have a cursor item.

Breaking changes:
- Removed a few functions from `Inventory`
- Clearing an `Inventory` no longer clears the cursor item (you must clear the player inventory for that)

All tests pass, clicking in the demo server works fine, and tests were added/modified to verify this behaviour.