### PR TITLE
feat: add ability to clear modifiers from an AttributeInstance

### DIFF
--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -38,6 +38,7 @@ import net.minestom.server.utils.time.TimeUnit;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 import java.time.Duration;
 import java.util.*;
@@ -46,6 +47,12 @@ import java.util.concurrent.ConcurrentHashMap;
 public class LivingEntity extends Entity implements EquipmentHandler {
 
     private static final AttributeModifier SPRINTING_SPEED_MODIFIER = new AttributeModifier(NamespaceID.from("minecraft:sprinting"), 0.3, AttributeOperation.MULTIPLY_TOTAL);
+
+    /**
+     * IDs of modifiers that are protected from removal by methods like {@link AttributeInstance#clearModifiers()}.
+     */
+    @ApiStatus.Internal
+    public static final Set<NamespaceID> PROTECTED_MODIFIERS = Set.of(SPRINTING_SPEED_MODIFIER.id());
 
     // ItemStack pickup
     protected boolean canPickupItem;
@@ -59,6 +66,8 @@ public class LivingEntity extends Entity implements EquipmentHandler {
     protected BoundingBox expandedBoundingBox;
 
     private final Map<String, AttributeInstance> attributeModifiers = new ConcurrentHashMap<>();
+    private final Collection<AttributeInstance> unmodifiableModifiers =
+            Collections.unmodifiableCollection(attributeModifiers.values());
 
     // Abilities
     protected boolean invulnerable;
@@ -497,8 +506,8 @@ public class LivingEntity extends Entity implements EquipmentHandler {
      *
      * @return a collection of all attribute instances on this entity
      */
-    public @NotNull Collection<AttributeInstance> getAttributeInstances() {
-        return attributeModifiers.values();
+    public @NotNull @UnmodifiableView Collection<AttributeInstance> getAttributes() {
+        return unmodifiableModifiers;
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -40,10 +40,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.Duration;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class LivingEntity extends Entity implements EquipmentHandler {
@@ -493,6 +490,15 @@ public class LivingEntity extends Entity implements EquipmentHandler {
     public @NotNull AttributeInstance getAttribute(@NotNull Attribute attribute) {
         return attributeModifiers.computeIfAbsent(attribute.name(),
                 s -> new AttributeInstance(attribute, this::onAttributeChanged));
+    }
+
+    /**
+     * Retrieves all {@link AttributeInstance}s on this entity.
+     *
+     * @return a collection of all attribute instances on this entity
+     */
+    public @NotNull Collection<AttributeInstance> getAttributeInstances() {
+        return attributeModifiers.values();
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/attribute/AttributeInstance.java
+++ b/src/main/java/net/minestom/server/entity/attribute/AttributeInstance.java
@@ -4,6 +4,7 @@ import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.utils.NamespaceID;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -92,6 +93,7 @@ public final class AttributeInstance {
      * @return an immutable collection of the modifiers applied to this attribute.
      */
     @NotNull
+    @UnmodifiableView
     public Collection<AttributeModifier> modifiers() {
         return unmodifiableModifiers;
     }
@@ -116,6 +118,14 @@ public final class AttributeInstance {
      */
     public AttributeModifier removeModifier(@NotNull AttributeModifier modifier) {
         return removeModifier(modifier.id());
+    }
+
+    /**
+     * Clears all modifiers on this instance.
+     */
+    public void clearModifiers() {
+        this.modifiers.clear();
+        refreshCachedValue();
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/attribute/AttributeInstance.java
+++ b/src/main/java/net/minestom/server/entity/attribute/AttributeInstance.java
@@ -127,7 +127,7 @@ public final class AttributeInstance {
      */
     public void clearModifiers() {
         this.modifiers.values().removeIf(modifier -> !LivingEntity.PROTECTED_MODIFIERS.contains(modifier.id()));
-        refreshCachedValue();
+        refreshCachedValue(getBaseValue());
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/attribute/AttributeInstance.java
+++ b/src/main/java/net/minestom/server/entity/attribute/AttributeInstance.java
@@ -1,5 +1,6 @@
 package net.minestom.server.entity.attribute;
 
+import net.minestom.server.entity.LivingEntity;
 import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.utils.NamespaceID;
 import org.jetbrains.annotations.NotNull;
@@ -121,10 +122,11 @@ public final class AttributeInstance {
     }
 
     /**
-     * Clears all modifiers on this instance.
+     * Clears all modifiers on this instance, excepting those whose ID is defined in
+     * {@link LivingEntity#PROTECTED_MODIFIERS}.
      */
     public void clearModifiers() {
-        this.modifiers.clear();
+        this.modifiers.values().removeIf(modifier -> !LivingEntity.PROTECTED_MODIFIERS.contains(modifier.id()));
         refreshCachedValue();
     }
 


### PR DESCRIPTION
Also, add a method to get all `AttributeInstance`s on a `LivingEntity`. Useful if you want to inspect the player's current attribute modifiers, or remove all of them without needing to know every kind of `Attribute` they might have.