### PR TITLE
Add the ability to cancel ItemUpdateStateEvent

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -441,21 +441,23 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
                 triggerStatus((byte) 9); // Mark item use as finished
                 ItemUpdateStateEvent itemUpdateStateEvent = callItemUpdateStateEvent(itemUseHand);
 
-                // Refresh hand
-                final boolean isOffHand = itemUpdateStateEvent.getHand() == Player.Hand.OFF;
-                refreshActiveHand(false, isOffHand, false);
+                if (!itemUpdateStateEvent.isCancelled()) {
+                    // Refresh hand
+                    final boolean isOffHand = itemUpdateStateEvent.getHand() == Player.Hand.OFF;
+                    refreshActiveHand(false, isOffHand, false);
 
-                final ItemStack item = itemUpdateStateEvent.getItemStack();
-                final boolean isFood = item.has(ItemComponent.FOOD);
-                if (isFood || item.material() == Material.POTION) {
-                    PlayerEatEvent playerEatEvent = new PlayerEatEvent(this, item, itemUseHand);
-                    EventDispatcher.call(playerEatEvent);
+                    final ItemStack item = itemUpdateStateEvent.getItemStack();
+                    final boolean isFood = item.has(ItemComponent.FOOD);
+                    if (isFood || item.material() == Material.POTION) {
+                        PlayerEatEvent playerEatEvent = new PlayerEatEvent(this, item, itemUseHand);
+                        EventDispatcher.call(playerEatEvent);
+                    }
+
+                    var itemUsageCompleteEvent = new ItemUsageCompleteEvent(this, itemUseHand, item);
+                    EventDispatcher.call(itemUsageCompleteEvent);
+
+                    clearItemUse();
                 }
-
-                var itemUsageCompleteEvent = new ItemUsageCompleteEvent(this, itemUseHand, item);
-                EventDispatcher.call(itemUsageCompleteEvent);
-
-                clearItemUse();
             }
         }
 

--- a/src/main/java/net/minestom/server/event/item/ItemUpdateStateEvent.java
+++ b/src/main/java/net/minestom/server/event/item/ItemUpdateStateEvent.java
@@ -1,6 +1,7 @@
 package net.minestom.server.event.item;
 
 import net.minestom.server.entity.Player;
+import net.minestom.server.event.trait.CancellableEvent;
 import net.minestom.server.event.trait.ItemEvent;
 import net.minestom.server.event.trait.PlayerInstanceEvent;
 import net.minestom.server.item.ItemStack;
@@ -9,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Event when a player updates an item state, meaning when they stop using the item.
  */
-public class ItemUpdateStateEvent implements PlayerInstanceEvent, ItemEvent {
+public class ItemUpdateStateEvent implements PlayerInstanceEvent, ItemEvent, CancellableEvent {
 
     private final Player player;
     private final Player.Hand hand;
@@ -17,6 +18,7 @@ public class ItemUpdateStateEvent implements PlayerInstanceEvent, ItemEvent {
 
     private boolean handAnimation;
     private boolean riptideSpinAttack;
+    private boolean cancelled = false;
 
     public ItemUpdateStateEvent(@NotNull Player player, @NotNull Player.Hand hand, @NotNull ItemStack itemStack) {
         this.player = player;
@@ -63,5 +65,15 @@ public class ItemUpdateStateEvent implements PlayerInstanceEvent, ItemEvent {
     @Override
     public @NotNull Player getPlayer() {
         return player;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
     }
 }

--- a/src/main/java/net/minestom/server/listener/PlayerDiggingListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerDiggingListener.java
@@ -151,12 +151,14 @@ public final class PlayerDiggingListener {
 
         ItemUpdateStateEvent itemUpdateStateEvent = player.callItemUpdateStateEvent(hand);
 
-        player.clearItemUse();
-        player.triggerStatus((byte) 9);
+        if (!itemUpdateStateEvent.isCancelled()) {
+            player.clearItemUse();
+            player.triggerStatus((byte) 9);
 
-        final boolean isOffHand = itemUpdateStateEvent.getHand() == Player.Hand.OFF;
-        player.refreshActiveHand(itemUpdateStateEvent.hasHandAnimation(),
-                isOffHand, itemUpdateStateEvent.isRiptideSpinAttack());
+            final boolean isOffHand = itemUpdateStateEvent.getHand() == Player.Hand.OFF;
+            player.refreshActiveHand(itemUpdateStateEvent.hasHandAnimation(),
+                    isOffHand, itemUpdateStateEvent.isRiptideSpinAttack());
+        }
     }
 
     private static void swapItemHand(Player player) {


### PR DESCRIPTION
Currently, it is impossible to prevent the Minestom server from sending the relevant updates once the client informs the server the eat/drink animation has finished. This can be undesirable in certain situations, for example, if you want to cancel the Eat/Drink animation to prevent the client from consuming the food or potion, desyncing from the server.