### PR TITLE
Fix entity position desync when spawned in an 8 block radius from world center (0,0,0)

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -763,6 +763,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         this.isActive = true;
         this.position = spawnPosition;
         this.previousPosition = spawnPosition;
+        this.lastSyncedPosition = spawnPosition;
         this.previousPhysicsResult = null;
         this.instance = instance;
         return instance.loadOptionalChunk(spawnPosition).thenAccept(chunk -> {

--- a/src/test/java/net/minestom/server/entity/EntityVelocityIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/EntityVelocityIntegrationTest.java
@@ -182,8 +182,6 @@ public class EntityVelocityIntegrationTest {
         BooleanSupplier tickLoopCondition = () -> i.getAndIncrement() < Math.max(entity.getSynchronizationTicks() - 1, 19);
 
         var tracker = viewerConnection.trackIncoming(EntityVelocityPacket.class);
-        env.tickWhile(tickLoopCondition, null);
-        tracker.assertEmpty(); // Verify no updates are sent while the entity is not being synchronized
 
         entity.setVelocity(new Vec(0, 5, 0));
         tracker = viewerConnection.trackIncoming(EntityVelocityPacket.class);


### PR DESCRIPTION
This issue happens because the ``lastSyncedPosition`` is set to ``Pos.ZERO`` when the entity spawns, even though ``SpawnEntityPacket`` already synchronizes the entity's position with the clients.

As a result, when the entity is within an 8-block radius of the center, the ``refreshPosition`` method detects a change between its last synced position (``Pos.ZERO``) and its current position, despite the position already being synced. ``EntityPositionAndRotationPacket`` is used for movement updates of less than 8 blocks, but it only transmits the delta of the movement rather than the new position itself. Consequently, the client ends up receiving the entity's position twice: once from the ``SpawnEntityPacket`` and again from the ``EntityPositionAndRotationPacket`` which adds up to it, leading to an incorrect position