### PR TITLE
Fix client kick on setting trident loyalty level

### DIFF
--- a/src/main/java/net/minestom/server/entity/metadata/projectile/ThrownTridentMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/ThrownTridentMeta.java
@@ -13,12 +13,12 @@ public class ThrownTridentMeta extends AbstractArrowMeta {
         super(entity, metadata);
     }
 
-    public int getLoyaltyLevel() {
-        return super.metadata.getIndex(OFFSET, 0);
+    public byte getLoyaltyLevel() {
+        return super.metadata.getIndex(OFFSET, (byte) 0);
     }
 
-    public void setLoyaltyLevel(int value) {
-        super.metadata.setIndex(OFFSET, Metadata.VarInt(value));
+    public void setLoyaltyLevel(byte value) {
+        super.metadata.setIndex(OFFSET, Metadata.Byte(value));
     }
 
     public boolean isHasEnchantmentGlint() {


### PR DESCRIPTION
The trident loyalty level has been changed to a byte instead of an int, which would cause the client to disconnect itself when setting it on the server