### PR TITLE
Direct writer for Adventure components

### DIFF
--- a/src/main/java/net/minestom/server/network/ComponentNetworkBufferTypeImpl.java
+++ b/src/main/java/net/minestom/server/network/ComponentNetworkBufferTypeImpl.java
@@ -56,8 +56,8 @@ record ComponentNetworkBufferTypeImpl() implements NetworkBufferTypeImpl<Compone
             case TranslatableComponent translatable -> {
                 writeUtf(buffer, "translatable");
 
-                buffer.write(BYTE, TAG_STRING); // Start "key" tag
-                writeUtf(buffer, "key");
+                buffer.write(BYTE, TAG_STRING); // Start "translate" tag
+                writeUtf(buffer, "translate");
                 writeUtf(buffer, translatable.key());
 
                 final String fallback = translatable.fallback();
@@ -70,7 +70,7 @@ record ComponentNetworkBufferTypeImpl() implements NetworkBufferTypeImpl<Compone
                 final List<TranslationArgument> args = translatable.arguments();
                 if (!args.isEmpty()) {
                     buffer.write(BYTE, TAG_LIST);
-                    writeUtf(buffer, "args");
+                    writeUtf(buffer, "with");
                     buffer.write(BYTE, TAG_COMPOUND); // List type
                     buffer.write(INT, args.size());
                     for (final TranslationArgument arg : args)
@@ -81,7 +81,7 @@ record ComponentNetworkBufferTypeImpl() implements NetworkBufferTypeImpl<Compone
                 writeUtf(buffer, "score");
 
                 buffer.write(BYTE, TAG_COMPOUND); // Start "score" tag
-                writeUtf(buffer, "name");
+                writeUtf(buffer, "score");
                 {
                     buffer.write(BYTE, TAG_STRING);
                     writeUtf(buffer, "name");
@@ -90,13 +90,6 @@ record ComponentNetworkBufferTypeImpl() implements NetworkBufferTypeImpl<Compone
                     buffer.write(BYTE, TAG_STRING);
                     writeUtf(buffer, "objective");
                     writeUtf(buffer, score.objective());
-
-                    @SuppressWarnings("deprecation") final String value = score.value();
-                    if (value != null) {
-                        buffer.write(BYTE, TAG_STRING);
-                        writeUtf(buffer, "value");
-                        writeUtf(buffer, value);
-                    }
                 }
                 buffer.write(BYTE, TAG_END); // End "score" tag
 

--- a/src/main/java/net/minestom/server/network/ComponentNetworkBufferTypeImpl.java
+++ b/src/main/java/net/minestom/server/network/ComponentNetworkBufferTypeImpl.java
@@ -1,0 +1,329 @@
+package net.minestom.server.network;
+
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.nbt.BinaryTag;
+import net.kyori.adventure.text.*;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.minestom.server.adventure.serializer.nbt.NbtComponentSerializer;
+import net.minestom.server.utils.validate.Check;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+import static net.minestom.server.network.NetworkBuffer.*;
+
+record ComponentNetworkBufferTypeImpl() implements NetworkBufferTypeImpl<Component> {
+
+    @Override
+    public void write(@NotNull NetworkBuffer buffer, @NotNull Component value) {
+        Check.notNull(value, "Component cannot be null");
+
+        buffer.write(BYTE, TAG_COMPOUND);
+        writeInnerComponent(buffer, value);
+    }
+
+    @Override
+    public Component read(@NotNull NetworkBuffer buffer) {
+        final BinaryTag nbt = buffer.read(NBT);
+        return NbtComponentSerializer.nbt().deserialize(nbt);
+    }
+
+    // WRITING IMPL, pretty gross. Would not recommend reading.
+
+    private static final byte TAG_END = 0;
+    private static final byte TAG_BYTE = 1;
+    private static final byte TAG_INT = 3;
+    private static final byte TAG_STRING = 8;
+    private static final byte TAG_LIST = 9;
+    private static final byte TAG_COMPOUND = 10;
+
+    private void writeInnerComponent(@NotNull NetworkBuffer buffer, @NotNull Component component) {
+        buffer.write(BYTE, TAG_STRING); // Start first tag (always the type)
+        writeUtf(buffer, "type");
+        switch (component) {
+            case TextComponent text -> {
+                writeUtf(buffer, "text");
+
+                buffer.write(BYTE, TAG_STRING); // Start "text" tag
+                writeUtf(buffer, "text");
+                writeUtf(buffer, text.content());
+            }
+            case TranslatableComponent translatable -> {
+                writeUtf(buffer, "translatable");
+
+                buffer.write(BYTE, TAG_STRING); // Start "key" tag
+                writeUtf(buffer, "key");
+                writeUtf(buffer, translatable.key());
+
+                final String fallback = translatable.fallback();
+                if (fallback != null) {
+                    buffer.write(BYTE, TAG_STRING);
+                    writeUtf(buffer, "fallback");
+                    writeUtf(buffer, fallback);
+                }
+
+                final List<TranslationArgument> args = translatable.arguments();
+                if (!args.isEmpty()) {
+                    buffer.write(BYTE, TAG_LIST);
+                    writeUtf(buffer, "args");
+                    buffer.write(BYTE, TAG_COMPOUND); // List type
+                    buffer.write(INT, args.size());
+                    for (final TranslationArgument arg : args)
+                        writeInnerComponent(buffer, arg.asComponent());
+                }
+            }
+            case ScoreComponent score -> {
+                writeUtf(buffer, "score");
+
+                buffer.write(BYTE, TAG_COMPOUND); // Start "score" tag
+                writeUtf(buffer, "name");
+                {
+                    buffer.write(BYTE, TAG_STRING);
+                    writeUtf(buffer, "name");
+                    writeUtf(buffer, score.name());
+
+                    buffer.write(BYTE, TAG_STRING);
+                    writeUtf(buffer, "objective");
+                    writeUtf(buffer, score.objective());
+
+                    @SuppressWarnings("deprecation") final String value = score.value();
+                    if (value != null) {
+                        buffer.write(BYTE, TAG_STRING);
+                        writeUtf(buffer, "value");
+                        writeUtf(buffer, value);
+                    }
+                }
+                buffer.write(BYTE, TAG_END); // End "score" tag
+
+            }
+            case SelectorComponent selector -> {
+                writeUtf(buffer, "selector");
+
+                buffer.write(BYTE, TAG_STRING);
+                writeUtf(buffer, "selector");
+                writeUtf(buffer, selector.pattern());
+
+                final Component separator = selector.separator();
+                if (separator != null) {
+                    buffer.write(BYTE, TAG_COMPOUND);
+                    writeUtf(buffer, "separator");
+                    writeInnerComponent(buffer, separator);
+                }
+            }
+            case KeybindComponent keybind -> {
+                writeUtf(buffer, "keybind");
+
+                buffer.write(BYTE, TAG_STRING);
+                writeUtf(buffer, "keybind");
+                writeUtf(buffer, keybind.keybind());
+            }
+            case NBTComponent<?, ?> nbt -> {
+                //todo
+                throw new UnsupportedOperationException("NBTComponent is not implemented yet");
+            }
+            default -> throw new UnsupportedOperationException("Unsupported component type: " + component.getClass());
+        }
+
+        // Children
+        if (!component.children().isEmpty()) {
+            buffer.write(BYTE, TAG_LIST);
+            writeUtf(buffer, "extra");
+            buffer.write(BYTE, TAG_COMPOUND); // List type
+
+            buffer.write(INT, component.children().size());
+            for (final Component child : component.children())
+                writeInnerComponent(buffer, child);
+        }
+
+        // Formatting/Interactivity
+        writeComponentStyle(buffer, component.style());
+
+        buffer.write(BYTE, TAG_END);
+    }
+
+    private void writeComponentStyle(@NotNull NetworkBuffer buffer, @NotNull Style style) {
+        final TextColor color = style.color();
+        if (color != null) {
+            buffer.write(BYTE, TAG_STRING);
+            writeUtf(buffer, "color");
+            if (color instanceof NamedTextColor namedColor)
+                writeUtf(buffer, namedColor.toString());
+            else writeUtf(buffer, color.asHexString());
+        }
+
+        final Key font = style.font();
+        if (font != null) {
+            buffer.write(BYTE, TAG_STRING);
+            writeUtf(buffer, "font");
+            writeUtf(buffer, font.asString());
+        }
+
+        final TextDecoration.State bold = style.decoration(TextDecoration.BOLD);
+        if (bold != TextDecoration.State.NOT_SET) {
+            buffer.write(BYTE, TAG_BYTE);
+            writeUtf(buffer, "bold");
+            buffer.write(BYTE, bold == TextDecoration.State.TRUE ? (byte) 1 : (byte) 0);
+        }
+
+        final TextDecoration.State italic = style.decoration(TextDecoration.ITALIC);
+        if (italic != TextDecoration.State.NOT_SET) {
+            buffer.write(BYTE, TAG_BYTE);
+            writeUtf(buffer, "italic");
+            buffer.write(BYTE, italic == TextDecoration.State.TRUE ? (byte) 1 : (byte) 0);
+        }
+
+        final TextDecoration.State underlined = style.decoration(TextDecoration.UNDERLINED);
+        if (underlined != TextDecoration.State.NOT_SET) {
+            buffer.write(BYTE, TAG_BYTE);
+            writeUtf(buffer, "underlined");
+            buffer.write(BYTE, underlined == TextDecoration.State.TRUE ? (byte) 1 : (byte) 0);
+        }
+
+        final TextDecoration.State strikethrough = style.decoration(TextDecoration.STRIKETHROUGH);
+        if (strikethrough != TextDecoration.State.NOT_SET) {
+            buffer.write(BYTE, TAG_BYTE);
+            writeUtf(buffer, "strikethrough");
+            buffer.write(BYTE, strikethrough == TextDecoration.State.TRUE ? (byte) 1 : (byte) 0);
+        }
+
+        final TextDecoration.State obfuscated = style.decoration(TextDecoration.OBFUSCATED);
+        if (obfuscated != TextDecoration.State.NOT_SET) {
+            buffer.write(BYTE, TAG_BYTE);
+            writeUtf(buffer, "obfuscated");
+            buffer.write(BYTE, obfuscated == TextDecoration.State.TRUE ? (byte) 1 : (byte) 0);
+        }
+
+        final String insertion = style.insertion();
+        if (insertion != null) {
+            buffer.write(BYTE, TAG_STRING);
+            writeUtf(buffer, "insertion");
+            writeUtf(buffer, insertion);
+        }
+
+        final ClickEvent clickEvent = style.clickEvent();
+        if (clickEvent != null) writeClickEvent(buffer, clickEvent);
+
+        final HoverEvent<?> hoverEvent = style.hoverEvent();
+        if (hoverEvent != null) writeHoverEvent(buffer, hoverEvent);
+    }
+
+    private void writeClickEvent(@NotNull NetworkBuffer buffer, @NotNull ClickEvent clickEvent) {
+        buffer.write(BYTE, TAG_COMPOUND);
+        writeUtf(buffer, "clickEvent");
+
+        buffer.write(BYTE, TAG_STRING);
+        writeUtf(buffer, "action");
+        writeUtf(buffer, clickEvent.action().name());
+
+        buffer.write(BYTE, TAG_STRING);
+        writeUtf(buffer, "value");
+        writeUtf(buffer, clickEvent.value());
+
+        buffer.write(BYTE, TAG_END);
+    }
+
+    @SuppressWarnings("unchecked") private void writeHoverEvent(@NotNull NetworkBuffer buffer, @NotNull HoverEvent<?> hoverEvent) {
+        buffer.write(BYTE, TAG_COMPOUND);
+        writeUtf(buffer, "hoverEvent");
+
+        buffer.write(BYTE, TAG_STRING);
+        writeUtf(buffer, "action");
+        writeUtf(buffer, hoverEvent.action().toString());
+
+        buffer.write(BYTE, TAG_COMPOUND); // Start contents tag
+        writeUtf(buffer, "contents");
+        if (hoverEvent.action() == HoverEvent.Action.SHOW_TEXT) {
+            writeInnerComponent(buffer, (Component) hoverEvent.value());
+        } else if (hoverEvent.action() == HoverEvent.Action.SHOW_ITEM) {
+            var value = ((HoverEvent<HoverEvent.ShowItem>) hoverEvent).value();
+
+            buffer.write(BYTE, TAG_STRING);
+            writeUtf(buffer, "id");
+            writeUtf(buffer, value.item().asString());
+
+            buffer.write(BYTE, TAG_INT);
+            writeUtf(buffer, "count");
+            buffer.write(INT, value.count());
+
+            buffer.write(BYTE, TAG_COMPOUND);
+            writeUtf(buffer, "components");
+            //todo item components
+            buffer.write(BYTE, TAG_END);
+
+            buffer.write(BYTE, TAG_END); // End contents tag
+        } else if (hoverEvent.action() == HoverEvent.Action.SHOW_ENTITY) {
+            var value = ((HoverEvent<HoverEvent.ShowEntity>) hoverEvent).value();
+
+            final Component name = value.name();
+            if (name != null) {
+                buffer.write(BYTE, TAG_COMPOUND);
+                writeUtf(buffer, "name");
+                writeInnerComponent(buffer, name);
+            }
+
+            buffer.write(BYTE, TAG_STRING);
+            writeUtf(buffer, "type");
+            writeUtf(buffer, value.type().asString());
+
+            buffer.write(BYTE, TAG_STRING);
+            writeUtf(buffer, "id");
+            writeUtf(buffer, value.id().toString());
+
+            buffer.write(BYTE, TAG_END); // End contents tag
+        } else {
+            throw new UnsupportedOperationException("Unknown hover event action: " + hoverEvent.action());
+        }
+
+        buffer.write(BYTE, TAG_END);
+    }
+
+    /**
+     * This is a very gross version of {@link java.io.DataOutputStream#writeUTF(String)}. We need the data in the java
+     * modified utf-8 format, and I couldnt find a method without creating a new buffer for it.
+     * 
+     * @param buffer the buffer to write to
+     * @param str the string to write
+     */
+    private static void writeUtf(@NotNull NetworkBuffer buffer, @NotNull String str) {
+        final int strlen = str.length();
+        int utflen = strlen; // optimized for ASCII
+
+        for (int i = 0; i < strlen; i++) {
+            int c = str.charAt(i);
+            if (c >= 0x80 || c == 0)
+                utflen += (c >= 0x800) ? 2 : 1;
+        }
+
+        if (utflen > 65535 || /* overflow */ utflen < strlen)
+            throw new RuntimeException("UTF-8 string too long");
+
+        buffer.write(SHORT, (short) utflen);
+        buffer.ensureSize(utflen);
+        int i;
+        for (i = 0; i < strlen; i++) { // optimized for initial run of ASCII
+            int c = str.charAt(i);
+            if (c >= 0x80 || c == 0) break;
+            buffer.nioBuffer.put(buffer.writeIndex++, (byte) c);
+        }
+
+        for (; i < strlen; i++) {
+            int c = str.charAt(i);
+            if (c < 0x80 && c != 0) {
+                buffer.nioBuffer.put(buffer.writeIndex++, (byte) c);
+            } else if (c >= 0x800) {
+                buffer.nioBuffer.put(buffer.writeIndex++, (byte) (0xE0 | ((c >> 12) & 0x0F)));
+                buffer.nioBuffer.put(buffer.writeIndex++, (byte) (0x80 | ((c >>  6) & 0x3F)));
+                buffer.nioBuffer.put(buffer.writeIndex++, (byte) (0x80 | ((c >>  0) & 0x3F)));
+            } else {
+                buffer.nioBuffer.put(buffer.writeIndex++, (byte) (0xC0 | ((c >>  6) & 0x1F)));
+                buffer.nioBuffer.put(buffer.writeIndex++, (byte) (0x80 | ((c >>  0) & 0x3F)));
+            }
+        }
+    }
+
+}

--- a/src/main/java/net/minestom/server/network/NetworkBuffer.java
+++ b/src/main/java/net/minestom/server/network/NetworkBuffer.java
@@ -40,7 +40,7 @@ public final class NetworkBuffer {
     public static final Type<String> STRING = new NetworkBufferTypeImpl.StringType();
     public static final Type<BinaryTag> NBT = new NetworkBufferTypeImpl.NbtType();
     public static final Type<Point> BLOCK_POSITION = new NetworkBufferTypeImpl.BlockPositionType();
-    public static final Type<Component> COMPONENT = new NetworkBufferTypeImpl.ComponentType();
+    public static final Type<Component> COMPONENT = new ComponentNetworkBufferTypeImpl();
     public static final Type<Component> JSON_COMPONENT = new NetworkBufferTypeImpl.JsonComponentType();
     public static final Type<UUID> UUID = new NetworkBufferTypeImpl.UUIDType();
 

--- a/src/main/java/net/minestom/server/network/NetworkBufferTypeImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferTypeImpl.java
@@ -3,7 +3,6 @@ package net.minestom.server.network;
 import net.kyori.adventure.nbt.BinaryTag;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
-import net.minestom.server.adventure.serializer.nbt.NbtComponentSerializer;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.network.packet.server.play.data.WorldPos;
@@ -362,20 +361,6 @@ interface NetworkBufferTypeImpl<T> extends NetworkBuffer.Type<T> {
             final int y = (int) (value << 52 >> 52);
             final int z = (int) (value << 26 >> 38);
             return new Vec(x, y, z);
-        }
-    }
-
-    record ComponentType() implements NetworkBufferTypeImpl<Component> {
-        @Override
-        public void write(@NotNull NetworkBuffer buffer, Component value) {
-            final BinaryTag nbt = NbtComponentSerializer.nbt().serialize(value);
-            buffer.write(NBT, nbt);
-        }
-
-        @Override
-        public Component read(@NotNull NetworkBuffer buffer) {
-            final BinaryTag nbt = buffer.read(NBT);
-            return NbtComponentSerializer.nbt().deserialize(nbt);
         }
     }
 

--- a/src/test/java/net/minestom/server/network/ComponentNetworkBufferTypeTest.java
+++ b/src/test/java/net/minestom/server/network/ComponentNetworkBufferTypeTest.java
@@ -1,0 +1,74 @@
+package net.minestom.server.network;
+
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import static net.minestom.server.network.NetworkBuffer.COMPONENT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ComponentNetworkBufferTypeTest {
+    // All of these tests use NbtComponentSerializerImpl as the source of truth. If there is an inaccuracy in that
+    // implementation, these tests will not be accurate.
+
+    @Test
+    void empty() {
+        var comp = Component.empty();
+        assertWriteReadEquality(comp);
+    }
+
+    @Test
+    void text() {
+        var comp = Component.text("Hello, world!");
+        assertWriteReadEquality(comp);
+    }
+
+    @Test
+    void textChildren() {
+        var comp = Component.text("Hello, world!").children(List.of(
+                Component.text("child 1"),
+                Component.text("child 2")
+        ));
+        assertWriteReadEquality(comp);
+    }
+
+    @Test
+    void translatable() {
+        var comp = Component.translatable("a.b.c", "I am fallback", Component.text("arg1"), Component.text("arg2"));
+        assertWriteReadEquality(comp);
+    }
+
+    @Test
+    void score() {
+        var comp = Component.score("test123", "obj");
+        assertWriteReadEquality(comp);
+    }
+
+    @Test
+    void selector() {
+        var comp = Component.selector("@a", Component.text(", "));
+        assertWriteReadEquality(comp);
+    }
+
+    @Test
+    void keybind() {
+        var comp = Component.keybind("key.jump");
+        assertWriteReadEquality(comp);
+    }
+
+    @Test
+    void textModifiedUtf8() {
+        var comp = Component.text("abc\0\0def");
+        assertWriteReadEquality(comp);
+    }
+
+    private static void assertWriteReadEquality(@NotNull Component comp) {
+        var array = NetworkBuffer.makeArray(buffer -> buffer.write(COMPONENT, comp));
+        // Reading uses the normal nbt serializer, not the direct one.
+        var actual = new NetworkBuffer(ByteBuffer.wrap(array)).read(COMPONENT);
+        assertEquals(comp, actual);
+    }
+}

--- a/src/test/java/net/minestom/server/network/ComponentNetworkBufferTypeTest.java
+++ b/src/test/java/net/minestom/server/network/ComponentNetworkBufferTypeTest.java
@@ -1,6 +1,7 @@
 package net.minestom.server.network;
 
 import net.kyori.adventure.text.Component;
+import net.minestom.server.adventure.serializer.nbt.NbtComponentSerializer;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
@@ -8,11 +9,17 @@ import java.nio.ByteBuffer;
 import java.util.List;
 
 import static net.minestom.server.network.NetworkBuffer.COMPONENT;
+import static net.minestom.server.network.NetworkBuffer.NBT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ComponentNetworkBufferTypeTest {
     // All of these tests use NbtComponentSerializerImpl as the source of truth. If there is an inaccuracy in that
-    // implementation, these tests will not be accurate.
+    // implementation, these tests will not be accurate. This will be replaced with the adventure serializer once
+    // it is merged into adventure (see https://github.com/KyoriPowered/adventure/pull/1084). This can be considered
+    // a known-good implementation.
+
+    private static final ComponentNetworkBufferTypeImpl WRITER = new ComponentNetworkBufferTypeImpl();
+    private static final NbtComponentSerializer NBT_READER = NbtComponentSerializer.nbt();
 
     @Test
     void empty() {
@@ -67,8 +74,7 @@ public class ComponentNetworkBufferTypeTest {
 
     private static void assertWriteReadEquality(@NotNull Component comp) {
         var array = NetworkBuffer.makeArray(buffer -> buffer.write(COMPONENT, comp));
-        // Reading uses the normal nbt serializer, not the direct one.
-        var actual = new NetworkBuffer(ByteBuffer.wrap(array)).read(COMPONENT);
+        var actual = NBT_READER.deserialize(new NetworkBuffer(ByteBuffer.wrap(array)).read(NBT));
         assertEquals(comp, actual);
     }
 }


### PR DESCRIPTION
Adds a direct writer (without NBT struct intermediate) writer for Adventure components. Writing them was slow (see attached test with bots chatting).
![slowcomponentserializer](https://github.com/user-attachments/assets/a109a135-907e-41f7-a745-8bbc6542ab57)

Will add some tests before merging, and any more voodoo @TheMode wants to add.