### PR TITLE
Eagerly enter PLAY phase after CONFIGURATION

### DIFF
--- a/src/main/java/net/minestom/server/network/ConnectionManager.java
+++ b/src/main/java/net/minestom/server/network/ConnectionManager.java
@@ -328,6 +328,7 @@ public final class ConnectionManager {
 
     @ApiStatus.Internal
     public void transitionConfigToPlay(@NotNull Player player) {
+        player.getPlayerConnection().setConnectionState(ConnectionState.PLAY);
         this.waitingPlayers.relaxedOffer(player);
     }
 
@@ -376,7 +377,6 @@ public final class ConnectionManager {
     public void updateWaitingPlayers() {
         this.waitingPlayers.drain(player -> {
             if (!player.isOnline()) return; // Player disconnected while in queued to join
-            player.getPlayerConnection().setConnectionState(ConnectionState.PLAY);
             playPlayers.add(player);
             keepAlivePlayers.add(player);
 

--- a/src/main/java/net/minestom/server/network/packet/client/configuration/ClientFinishConfigurationPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/configuration/ClientFinishConfigurationPacket.java
@@ -14,4 +14,8 @@ public record ClientFinishConfigurationPacket() implements ClientPacket {
     public void write(@NotNull NetworkBuffer writer) {
     }
 
+    @Override
+    public boolean processImmediately() {
+        return true;
+    }
 }


### PR DESCRIPTION
This PR eagerly enters the PLAY phase after CONFIGURATION. 
What I changed kinda looks like an oversight, but might also have some multithreading issues, since the change is not on the player's thread anymore.

Fixes #2316 