### PR TITLE
fix: Round up total sectors in region file

### DIFF
--- a/src/main/java/net/minestom/server/instance/anvil/RegionFile.java
+++ b/src/main/java/net/minestom/server/instance/anvil/RegionFile.java
@@ -149,7 +149,7 @@ final class RegionFile implements AutoCloseable {
 
         //todo: addPadding()
 
-        final long totalSectors = file.length() / SECTOR_SIZE;
+        final long totalSectors = ((file.length() - 1) / SECTOR_SIZE) + 1; // Round up, last sector does not need to be full size
         for (int i = 0; i < totalSectors; i++) freeSectors.add(true);
         freeSectors.set(0, false); // First sector is locations
         freeSectors.set(1, false); // Second sector is timestamps


### PR DESCRIPTION
Stumbled across this while trying to update to 1.21, was getting errors if the input region files had a file size not divisible by 4096.

In vanilla when validating the header it determines the start offset of the target sector and checks if that exceeds the file size, so it does not require a target sector to exist entirely, just that its start is within the file. So since Minestom currently rounds down it will deny the last sector in the file if its size is not 4096 bytes. The fix is to round up so that the last sector is allowed even if it's not full size.