### PR TITLE
Improve chat API

### DIFF
--- a/src/main/java/net/minestom/server/event/player/PlayerChatEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerChatEvent.java
@@ -87,7 +87,6 @@ public class PlayerChatEvent implements PlayerInstanceEvent, CancellableEvent {
                 .arguments(
                         Component.text(player.getUsername())
                                 .insertion(player.getUsername())
-                                .clickEvent(ClickEvent.suggestCommand("/msg " + player.getUsername() + " "))
                                 .hoverEvent(player),
                         Component.text(content));
     }

--- a/src/main/java/net/minestom/server/event/player/PlayerChatEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerChatEvent.java
@@ -17,16 +17,16 @@ import java.util.Collection;
 public class PlayerChatEvent implements PlayerInstanceEvent, CancellableEvent {
     private final Player player;
     private final Collection<Player> recipients;
-    private final String content;
-    private Component finalMessage;
+    private final String rawMessage;
+    private Component formattedMessage;
     private boolean cancelled;
 
     public PlayerChatEvent(@NotNull Player player, @NotNull Collection<Player> recipients,
-                           @NotNull String content) {
+                           @NotNull String rawMessage) {
         this.player = player;
         this.recipients = new ArrayList<>(recipients);
-        this.content = content;
-        this.finalMessage = buildDefaultChatMessage();
+        this.rawMessage = rawMessage;
+        formattedMessage = buildDefaultChatMessage();
     }
 
     /**
@@ -45,8 +45,8 @@ public class PlayerChatEvent implements PlayerInstanceEvent, CancellableEvent {
      *
      * @return the sender's message
      */
-    public @NotNull String getContent() {
-        return content;
+    public @NotNull String getRawMessage() {
+        return rawMessage;
     }
 
     /**
@@ -54,8 +54,8 @@ public class PlayerChatEvent implements PlayerInstanceEvent, CancellableEvent {
      *
      * @return the chat message component
      */
-    public Component getFinalMessage() {
-        return finalMessage;
+    public Component getFormattedMessage() {
+        return formattedMessage;
     }
 
     /**
@@ -63,8 +63,8 @@ public class PlayerChatEvent implements PlayerInstanceEvent, CancellableEvent {
      *
      * @param message the new message component
      */
-    public void setFinalMessage(@NotNull Component message) {
-        this.finalMessage = message;
+    public void setFormattedMessage(@NotNull Component message) {
+        formattedMessage = message;
     }
 
     @Override
@@ -88,6 +88,6 @@ public class PlayerChatEvent implements PlayerInstanceEvent, CancellableEvent {
                         Component.text(player.getUsername())
                                 .insertion(player.getUsername())
                                 .hoverEvent(player),
-                        Component.text(content));
+                        Component.text(rawMessage));
     }
 }

--- a/src/main/java/net/minestom/server/event/player/PlayerChatEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerChatEvent.java
@@ -12,14 +12,13 @@ import java.util.Collection;
 
 /**
  * Called every time a {@link Player} writes and sends something in the chat.
- * The event can be cancelled to do not send anything, and the message can be changed.
+ * The event can be cancelled to not send anything, and the final message can be changed.
  */
 public class PlayerChatEvent implements PlayerInstanceEvent, CancellableEvent {
     private final Player player;
     private final Collection<Player> recipients;
     private final String content;
     private Component finalMessage;
-
     private boolean cancelled;
 
     public PlayerChatEvent(@NotNull Player player, @NotNull Collection<Player> recipients,
@@ -31,11 +30,11 @@ public class PlayerChatEvent implements PlayerInstanceEvent, CancellableEvent {
     }
 
     /**
-     * Those are the players who will receive the message.
+     * Returns the players who will receive the message.
      * <p>
-     * It can be modified to add or remove recipient.
+     * It can be modified to add and remove recipients.
      *
-     * @return a modifiable list of message targets
+     * @return a modifiable list of the message's targets
      */
     public @NotNull Collection<Player> getRecipients() {
         return recipients;
@@ -51,18 +50,18 @@ public class PlayerChatEvent implements PlayerInstanceEvent, CancellableEvent {
     }
 
     /**
-     * Gets the message format that will be sent.
+     * Gets the final message component that will be sent.
      *
-     * @return The chat message format.
+     * @return the chat message component
      */
     public Component getFinalMessage() {
         return finalMessage;
     }
 
     /**
-     * Used to change the message format.
+     * Used to change the final message component.
      *
-     * @param message the new message
+     * @param message the new message component
      */
     public void setFinalMessage(@NotNull Component message) {
         this.finalMessage = message;

--- a/src/main/java/net/minestom/server/event/player/PlayerChatEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerChatEvent.java
@@ -1,46 +1,33 @@
 package net.minestom.server.event.player;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.CancellableEvent;
 import net.minestom.server.event.trait.PlayerInstanceEvent;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * Called every time a {@link Player} writes and sends something in the chat.
- * The event can be cancelled to do not send anything, and the format can be changed.
+ * The event can be cancelled to do not send anything, and the message can be changed.
  */
 public class PlayerChatEvent implements PlayerInstanceEvent, CancellableEvent {
-
     private final Player player;
     private final Collection<Player> recipients;
-    private String message;
-    private Function<PlayerChatEvent, Component> chatFormat;
+    private final String content;
+    private Component finalMessage;
 
     private boolean cancelled;
 
     public PlayerChatEvent(@NotNull Player player, @NotNull Collection<Player> recipients,
-                           @NotNull Function<PlayerChatEvent, Component> defaultChatFormat,
-                           @NotNull String message) {
+                           @NotNull String content) {
         this.player = player;
         this.recipients = new ArrayList<>(recipients);
-        this.chatFormat = defaultChatFormat;
-        this.message = message;
-    }
-
-    /**
-     * Changes the chat format.
-     *
-     * @param chatFormat the custom chat format
-     */
-    public void setChatFormat(@NotNull Function<PlayerChatEvent, Component> chatFormat) {
-        this.chatFormat = chatFormat;
+        this.content = content;
+        this.finalMessage = buildDefaultChatMessage();
     }
 
     /**
@@ -55,31 +42,30 @@ public class PlayerChatEvent implements PlayerInstanceEvent, CancellableEvent {
     }
 
     /**
-     * Gets the message sent.
+     * Gets the original message content sent by the player.
      *
      * @return the sender's message
      */
-    public @NotNull String getMessage() {
-        return message;
+    public @NotNull String getContent() {
+        return content;
     }
 
     /**
-     * Used to change the message.
+     * Gets the message format that will be sent.
+     *
+     * @return The chat message format.
+     */
+    public Component getFinalMessage() {
+        return finalMessage;
+    }
+
+    /**
+     * Used to change the message format.
      *
      * @param message the new message
      */
-    public void setMessage(@NotNull String message) {
-        this.message = message;
-    }
-
-    /**
-     * Used to retrieve the chat format for this message.
-     * <p>
-     *
-     * @return the chat format which will be used
-     */
-    public @NotNull Function<@NotNull PlayerChatEvent, @NotNull Component> getChatFormatFunction() {
-        return chatFormat;
+    public void setFinalMessage(@NotNull Component message) {
+        this.finalMessage = message;
     }
 
     @Override
@@ -95,5 +81,15 @@ public class PlayerChatEvent implements PlayerInstanceEvent, CancellableEvent {
     @Override
     public @NotNull Player getPlayer() {
         return player;
+    }
+
+    private Component buildDefaultChatMessage() {
+        return Component.translatable("chat.type.text")
+                .arguments(
+                        Component.text(player.getUsername())
+                                .insertion(player.getUsername())
+                                .clickEvent(ClickEvent.suggestCommand("/msg " + player.getUsername() + " "))
+                                .hoverEvent(player),
+                        Component.text(content));
     }
 }

--- a/src/main/java/net/minestom/server/listener/ChatMessageListener.java
+++ b/src/main/java/net/minestom/server/listener/ChatMessageListener.java
@@ -44,7 +44,7 @@ public class ChatMessageListener {
                 // delegate to the messenger to avoid sending messages we shouldn't be
                 Messenger.sendMessage(
                         recipients,
-                        playerChatEvent.getFinalMessage(),
+                        playerChatEvent.getFormattedMessage(),
                         ChatPosition.CHAT,
                         player.getUuid());
             }

--- a/src/main/java/net/minestom/server/listener/ChatMessageListener.java
+++ b/src/main/java/net/minestom/server/listener/ChatMessageListener.java
@@ -1,6 +1,5 @@
 package net.minestom.server.listener;
 
-import net.kyori.adventure.text.Component;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.command.CommandManager;
 import net.minestom.server.entity.Player;
@@ -13,7 +12,6 @@ import net.minestom.server.network.packet.client.play.ClientChatMessagePacket;
 import net.minestom.server.network.packet.client.play.ClientCommandChatPacket;
 
 import java.util.Collection;
-import java.util.function.Function;
 
 public class ChatMessageListener {
     private static final CommandManager COMMAND_MANAGER = MinecraftServer.getCommandManager();
@@ -41,9 +39,14 @@ public class ChatMessageListener {
         // Call the event
         EventDispatcher.callCancellable(playerChatEvent, () -> {
             final Collection<Player> recipients = playerChatEvent.getRecipients();
+
             if (!recipients.isEmpty()) {
                 // delegate to the messenger to avoid sending messages we shouldn't be
-                Messenger.sendMessage(recipients, playerChatEvent.getFinalMessage(), ChatPosition.CHAT, player.getUuid());
+                Messenger.sendMessage(
+                        recipients,
+                        playerChatEvent.getFinalMessage(),
+                        ChatPosition.CHAT,
+                        player.getUuid());
             }
         });
     }

--- a/src/main/java/net/minestom/server/listener/ChatMessageListener.java
+++ b/src/main/java/net/minestom/server/listener/ChatMessageListener.java
@@ -1,7 +1,6 @@
 package net.minestom.server.listener;
 
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.event.ClickEvent;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.command.CommandManager;
 import net.minestom.server.entity.Player;
@@ -10,16 +9,13 @@ import net.minestom.server.event.player.PlayerChatEvent;
 import net.minestom.server.message.ChatPosition;
 import net.minestom.server.message.Messenger;
 import net.minestom.server.network.ConnectionManager;
-import net.minestom.server.network.ConnectionState;
 import net.minestom.server.network.packet.client.play.ClientChatMessagePacket;
 import net.minestom.server.network.packet.client.play.ClientCommandChatPacket;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 import java.util.function.Function;
 
 public class ChatMessageListener {
-
     private static final CommandManager COMMAND_MANAGER = MinecraftServer.getCommandManager();
     private static final ConnectionManager CONNECTION_MANAGER = MinecraftServer.getConnectionManager();
 
@@ -40,30 +36,15 @@ public class ChatMessageListener {
         }
 
         final Collection<Player> players = CONNECTION_MANAGER.getOnlinePlayers();
-        PlayerChatEvent playerChatEvent = new PlayerChatEvent(player, players, (e) -> buildDefaultChatMessage(e.getPlayer(), e.getMessage()), message);
+        PlayerChatEvent playerChatEvent = new PlayerChatEvent(player, players, message);
 
         // Call the event
         EventDispatcher.callCancellable(playerChatEvent, () -> {
-            final Function<PlayerChatEvent, Component> formatFunction = playerChatEvent.getChatFormatFunction();
-            Component textObject = formatFunction.apply(playerChatEvent);
-
             final Collection<Player> recipients = playerChatEvent.getRecipients();
             if (!recipients.isEmpty()) {
                 // delegate to the messenger to avoid sending messages we shouldn't be
-                Messenger.sendMessage(recipients, textObject, ChatPosition.CHAT, player.getUuid());
+                Messenger.sendMessage(recipients, playerChatEvent.getFinalMessage(), ChatPosition.CHAT, player.getUuid());
             }
         });
     }
-
-    private static @NotNull Component buildDefaultChatMessage(@NotNull Player player, @NotNull String message) {
-        final String username = player.getUsername();
-        return Component.translatable("chat.type.text")
-                .args(Component.text(username)
-                                .insertion(username)
-                                .clickEvent(ClickEvent.suggestCommand("/msg " + username + " "))
-                                .hoverEvent(player),
-                        Component.text(message)
-                );
-    }
-
 }


### PR DESCRIPTION
Having the second layer of setting the message format function which takes in a chat event is confusing and unnecessary. This pull request removes that. I also renamed `message` to `content` which should make the usage clearer. (breaking)