### PR TITLE
Refactor EquipmentHandler

### DIFF
--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -10,6 +10,7 @@ import net.minestom.server.entity.attribute.AttributeModifier;
 import net.minestom.server.entity.attribute.AttributeOperation;
 import net.minestom.server.entity.damage.Damage;
 import net.minestom.server.entity.damage.DamageType;
+import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.entity.metadata.LivingEntityMeta;
 import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.entity.EntityDamageEvent;
@@ -83,34 +84,23 @@ public class LivingEntity extends Entity implements EquipmentHandler {
     private float health = 1F;
 
     // Equipments
-    private ItemStack mainHandItem;
-    private ItemStack offHandItem;
+    private ItemStack mainHandItem = ItemStack.AIR;
+    private ItemStack offHandItem = ItemStack.AIR;
 
-    private ItemStack helmet;
-    private ItemStack chestplate;
-    private ItemStack leggings;
-    private ItemStack boots;
+    private ItemStack helmet = ItemStack.AIR;
+    private ItemStack chestplate = ItemStack.AIR;
+    private ItemStack leggings = ItemStack.AIR;
+    private ItemStack boots = ItemStack.AIR;
 
     /**
      * Constructor which allows to specify an UUID. Only use if you know what you are doing!
      */
     public LivingEntity(@NotNull EntityType entityType, @NotNull UUID uuid) {
         super(entityType, uuid);
-        initEquipments();
     }
 
     public LivingEntity(@NotNull EntityType entityType) {
         this(entityType, UUID.randomUUID());
-    }
-
-    private void initEquipments() {
-        this.mainHandItem = ItemStack.AIR;
-        this.offHandItem = ItemStack.AIR;
-
-        this.helmet = ItemStack.AIR;
-        this.chestplate = ItemStack.AIR;
-        this.leggings = ItemStack.AIR;
-        this.boots = ItemStack.AIR;
     }
 
     @Override
@@ -125,91 +115,37 @@ public class LivingEntity extends Entity implements EquipmentHandler {
         else speed.removeModifier(SPRINTING_SPEED_MODIFIER);
     }
 
-    @NotNull
     @Override
-    public ItemStack getItemInMainHand() {
-        return mainHandItem;
+    public @NotNull ItemStack getEquipment(@NotNull EquipmentSlot slot) {
+        return switch (slot) {
+            case MAIN_HAND -> mainHandItem;
+            case OFF_HAND -> offHandItem;
+            case BOOTS -> boots;
+            case LEGGINGS -> leggings;
+            case CHESTPLATE -> chestplate;
+            case HELMET -> helmet;
+        };
     }
 
     @Override
-    public void setItemInMainHand(@NotNull ItemStack itemStack) {
-        ItemStack oldItem = this.mainHandItem;
-        this.mainHandItem = getEquipmentItem(itemStack, EquipmentSlot.MAIN_HAND);
-        syncEquipment(EquipmentSlot.MAIN_HAND);
-        updateEquipmentAttributes(oldItem, this.mainHandItem, EquipmentSlot.MAIN_HAND);
+    public void setEquipment(@NotNull EquipmentSlot slot, @NotNull ItemStack itemStack) {
+        ItemStack oldItem = getEquipment(slot);
+        ItemStack newItem = slotChangeEvent(itemStack, slot);
+
+        switch (slot) {
+            case MAIN_HAND -> mainHandItem = newItem;
+            case OFF_HAND -> offHandItem = newItem;
+            case BOOTS -> boots = newItem;
+            case LEGGINGS -> leggings = newItem;
+            case CHESTPLATE -> chestplate = newItem;
+            case HELMET -> helmet = newItem;
+        }
+
+        syncEquipment(slot);
+        updateEquipmentAttributes(oldItem, newItem, slot);
     }
 
-    @NotNull
-    @Override
-    public ItemStack getItemInOffHand() {
-        return offHandItem;
-    }
-
-    @Override
-    public void setItemInOffHand(@NotNull ItemStack itemStack) {
-        ItemStack oldItem = this.offHandItem;
-        this.offHandItem = getEquipmentItem(itemStack, EquipmentSlot.OFF_HAND);
-        syncEquipment(EquipmentSlot.OFF_HAND);
-        updateEquipmentAttributes(oldItem, this.offHandItem, EquipmentSlot.OFF_HAND);
-    }
-
-    @NotNull
-    @Override
-    public ItemStack getHelmet() {
-        return helmet;
-    }
-
-    @Override
-    public void setHelmet(@NotNull ItemStack itemStack) {
-        ItemStack oldItem = this.helmet;
-        this.helmet = getEquipmentItem(itemStack, EquipmentSlot.HELMET);
-        syncEquipment(EquipmentSlot.HELMET);
-        updateEquipmentAttributes(oldItem, this.helmet, EquipmentSlot.HELMET);
-    }
-
-    @NotNull
-    @Override
-    public ItemStack getChestplate() {
-        return chestplate;
-    }
-
-    @Override
-    public void setChestplate(@NotNull ItemStack itemStack) {
-        ItemStack oldItem = this.chestplate;
-        this.chestplate = getEquipmentItem(itemStack, EquipmentSlot.CHESTPLATE);
-        syncEquipment(EquipmentSlot.CHESTPLATE);
-        updateEquipmentAttributes(oldItem, this.chestplate, EquipmentSlot.CHESTPLATE);
-    }
-
-    @NotNull
-    @Override
-    public ItemStack getLeggings() {
-        return leggings;
-    }
-
-    @Override
-    public void setLeggings(@NotNull ItemStack itemStack) {
-        ItemStack oldItem = this.leggings;
-        this.leggings = getEquipmentItem(itemStack, EquipmentSlot.LEGGINGS);
-        syncEquipment(EquipmentSlot.LEGGINGS);
-        updateEquipmentAttributes(oldItem, this.leggings, EquipmentSlot.LEGGINGS);
-    }
-
-    @NotNull
-    @Override
-    public ItemStack getBoots() {
-        return boots;
-    }
-
-    @Override
-    public void setBoots(@NotNull ItemStack itemStack) {
-        ItemStack oldItem = this.boots;
-        this.boots = getEquipmentItem(itemStack, EquipmentSlot.BOOTS);
-        syncEquipment(EquipmentSlot.BOOTS);
-        updateEquipmentAttributes(oldItem, this.boots, EquipmentSlot.BOOTS);
-    }
-
-    private ItemStack getEquipmentItem(@NotNull ItemStack itemStack, @NotNull EquipmentSlot slot) {
+    private ItemStack slotChangeEvent(@NotNull ItemStack itemStack, @NotNull EquipmentSlot slot) {
         EntityEquipEvent entityEquipEvent = new EntityEquipEvent(this, itemStack, slot);
         EventDispatcher.call(entityEquipEvent);
         return entityEquipEvent.getEquippedItem();
@@ -720,7 +656,7 @@ public class LivingEntity extends Entity implements EquipmentHandler {
     }
 
     /**
-     * Gets {@link net.minestom.server.entity.metadata.EntityMeta} of this entity casted to {@link LivingEntityMeta}.
+     * Gets {@link EntityMeta} of this entity casted to {@link LivingEntityMeta}.
      *
      * @return null if meta of this entity does not inherit {@link LivingEntityMeta}, casted value otherwise.
      */

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -2291,63 +2291,13 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
     }
 
     @Override
-    public @NotNull ItemStack getItemInMainHand() {
-        return inventory.getItemInMainHand();
+    public @NotNull ItemStack getEquipment(@NotNull EquipmentSlot slot) {
+        return inventory.getEquipment(slot);
     }
 
     @Override
-    public void setItemInMainHand(@NotNull ItemStack itemStack) {
-        inventory.setItemInMainHand(itemStack);
-    }
-
-    @Override
-    public @NotNull ItemStack getItemInOffHand() {
-        return inventory.getItemInOffHand();
-    }
-
-    @Override
-    public void setItemInOffHand(@NotNull ItemStack itemStack) {
-        inventory.setItemInOffHand(itemStack);
-    }
-
-    @Override
-    public @NotNull ItemStack getHelmet() {
-        return inventory.getHelmet();
-    }
-
-    @Override
-    public void setHelmet(@NotNull ItemStack itemStack) {
-        inventory.setHelmet(itemStack);
-    }
-
-    @Override
-    public @NotNull ItemStack getChestplate() {
-        return inventory.getChestplate();
-    }
-
-    @Override
-    public void setChestplate(@NotNull ItemStack itemStack) {
-        inventory.setChestplate(itemStack);
-    }
-
-    @Override
-    public @NotNull ItemStack getLeggings() {
-        return inventory.getLeggings();
-    }
-
-    @Override
-    public void setLeggings(@NotNull ItemStack itemStack) {
-        inventory.setLeggings(itemStack);
-    }
-
-    @Override
-    public @NotNull ItemStack getBoots() {
-        return inventory.getBoots();
-    }
-
-    @Override
-    public void setBoots(@NotNull ItemStack itemStack) {
-        inventory.setBoots(itemStack);
+    public void setEquipment(@NotNull EquipmentSlot slot, @NotNull ItemStack itemStack) {
+        inventory.setEquipment(slot, itemStack);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/inventory/EquipmentHandler.java
+++ b/src/main/java/net/minestom/server/inventory/EquipmentHandler.java
@@ -16,32 +16,50 @@ import java.util.Map;
 public interface EquipmentHandler {
 
     /**
+     * Gets the equipment in a specific slot.
+     *
+     * @param slot the equipment to get the item from
+     * @return the equipment {@link ItemStack}
+     */
+    @NotNull ItemStack getEquipment(@NotNull EquipmentSlot slot);
+
+    void setEquipment(@NotNull EquipmentSlot slot, @NotNull ItemStack itemStack);
+
+    /**
      * Gets the {@link ItemStack} in main hand.
      *
      * @return the {@link ItemStack} in main hand
      */
-    @NotNull ItemStack getItemInMainHand();
+    default @NotNull ItemStack getItemInMainHand() {
+        return getEquipment(EquipmentSlot.MAIN_HAND);
+    }
 
     /**
      * Changes the main hand {@link ItemStack}.
      *
      * @param itemStack the main hand {@link ItemStack}
      */
-    void setItemInMainHand(@NotNull ItemStack itemStack);
+    default void setItemInMainHand(@NotNull ItemStack itemStack) {
+        setEquipment(EquipmentSlot.MAIN_HAND, itemStack);
+    }
 
     /**
      * Gets the {@link ItemStack} in off hand.
      *
      * @return the item in off hand
      */
-    @NotNull ItemStack getItemInOffHand();
+    default @NotNull ItemStack getItemInOffHand() {
+        return getEquipment(EquipmentSlot.OFF_HAND);
+    }
 
     /**
      * Changes the off hand {@link ItemStack}.
      *
      * @param itemStack the off hand {@link ItemStack}
      */
-    void setItemInOffHand(@NotNull ItemStack itemStack);
+    default void setItemInOffHand(@NotNull ItemStack itemStack) {
+        setEquipment(EquipmentSlot.OFF_HAND, itemStack);
+    }
 
     /**
      * Gets the {@link ItemStack} in the specific hand.
@@ -74,83 +92,71 @@ public interface EquipmentHandler {
      *
      * @return the helmet
      */
-    @NotNull ItemStack getHelmet();
+    default @NotNull ItemStack getHelmet() {
+        return getEquipment(EquipmentSlot.HELMET);
+    }
 
     /**
      * Changes the helmet.
      *
      * @param itemStack the helmet
      */
-    void setHelmet(@NotNull ItemStack itemStack);
+    default void setHelmet(@NotNull ItemStack itemStack) {
+        setEquipment(EquipmentSlot.HELMET, itemStack);
+    }
 
     /**
      * Gets the chestplate.
      *
      * @return the chestplate
      */
-    @NotNull ItemStack getChestplate();
+    default @NotNull ItemStack getChestplate() {
+        return getEquipment(EquipmentSlot.CHESTPLATE);
+    }
 
     /**
      * Changes the chestplate.
      *
      * @param itemStack the chestplate
      */
-    void setChestplate(@NotNull ItemStack itemStack);
+    default void setChestplate(@NotNull ItemStack itemStack) {
+        setEquipment(EquipmentSlot.CHESTPLATE, itemStack);
+    }
 
     /**
      * Gets the leggings.
      *
      * @return the leggings
      */
-    @NotNull ItemStack getLeggings();
+    default @NotNull ItemStack getLeggings() {
+        return getEquipment(EquipmentSlot.LEGGINGS);
+    }
 
     /**
      * Changes the leggings.
      *
      * @param itemStack the leggings
      */
-    void setLeggings(@NotNull ItemStack itemStack);
+    default void setLeggings(@NotNull ItemStack itemStack) {
+        setEquipment(EquipmentSlot.LEGGINGS, itemStack);
+    }
 
     /**
      * Gets the boots.
      *
      * @return the boots
      */
-    @NotNull ItemStack getBoots();
+    default @NotNull ItemStack getBoots() {
+        return getEquipment(EquipmentSlot.BOOTS);
+    }
 
     /**
      * Changes the boots.
      *
      * @param itemStack the boots
      */
-    void setBoots(@NotNull ItemStack itemStack);
-
-    /**
-     * Gets the equipment in a specific slot.
-     *
-     * @param slot the equipment to get the item from
-     * @return the equipment {@link ItemStack}
-     */
-    default @NotNull ItemStack getEquipment(@NotNull EquipmentSlot slot) {
-        return switch (slot) {
-            case MAIN_HAND -> getItemInMainHand();
-            case OFF_HAND -> getItemInOffHand();
-            case HELMET -> getHelmet();
-            case CHESTPLATE -> getChestplate();
-            case LEGGINGS -> getLeggings();
-            case BOOTS -> getBoots();
-        };
-    }
-
-    default void setEquipment(@NotNull EquipmentSlot slot, @NotNull ItemStack itemStack) {
-        switch (slot) {
-            case MAIN_HAND -> setItemInMainHand(itemStack);
-            case OFF_HAND -> setItemInOffHand(itemStack);
-            case HELMET -> setHelmet(itemStack);
-            case CHESTPLATE -> setChestplate(itemStack);
-            case LEGGINGS -> setLeggings(itemStack);
-            case BOOTS -> setBoots(itemStack);
-        }
+    default void setBoots(@NotNull ItemStack itemStack) {
+        setEquipment(EquipmentSlot.BOOTS, itemStack);
     }
 
     default boolean hasEquipment(@NotNull EquipmentSlot slot) {

--- a/src/main/java/net/minestom/server/inventory/PlayerInventory.java
+++ b/src/main/java/net/minestom/server/inventory/PlayerInventory.java
@@ -44,64 +44,22 @@ public non-sealed class PlayerInventory extends AbstractInventory implements Equ
         return INNER_INVENTORY_SIZE;
     }
 
-    @Override
-    public @NotNull ItemStack getItemInMainHand() {
-        return getItemStack(player.getHeldSlot());
+    private int getSlotId(@NotNull EquipmentSlot slot) {
+        return switch (slot) {
+            case MAIN_HAND -> player.getHeldSlot();
+            case OFF_HAND -> OFFHAND_SLOT;
+            default -> slot.armorSlot();
+        };
     }
 
     @Override
-    public void setItemInMainHand(@NotNull ItemStack itemStack) {
-        safeItemInsert(player.getHeldSlot(), itemStack);
+    public @NotNull ItemStack getEquipment(@NotNull EquipmentSlot slot) {
+        return getItemStack(getSlotId(slot));
     }
 
     @Override
-    public @NotNull ItemStack getItemInOffHand() {
-        return getItemStack(OFFHAND_SLOT);
-    }
-
-    @Override
-    public void setItemInOffHand(@NotNull ItemStack itemStack) {
-        safeItemInsert(OFFHAND_SLOT, itemStack);
-    }
-
-    @Override
-    public @NotNull ItemStack getHelmet() {
-        return getItemStack(HELMET_SLOT);
-    }
-
-    @Override
-    public void setHelmet(@NotNull ItemStack itemStack) {
-        safeItemInsert(HELMET_SLOT, itemStack);
-    }
-
-    @Override
-    public @NotNull ItemStack getChestplate() {
-        return getItemStack(CHESTPLATE_SLOT);
-    }
-
-    @Override
-    public void setChestplate(@NotNull ItemStack itemStack) {
-        safeItemInsert(CHESTPLATE_SLOT, itemStack);
-    }
-
-    @Override
-    public @NotNull ItemStack getLeggings() {
-        return getItemStack(LEGGINGS_SLOT);
-    }
-
-    @Override
-    public void setLeggings(@NotNull ItemStack itemStack) {
-        safeItemInsert(LEGGINGS_SLOT, itemStack);
-    }
-
-    @Override
-    public @NotNull ItemStack getBoots() {
-        return getItemStack(BOOTS_SLOT);
-    }
-
-    @Override
-    public void setBoots(@NotNull ItemStack itemStack) {
-        safeItemInsert(BOOTS_SLOT, itemStack);
+    public void setEquipment(@NotNull EquipmentSlot slot, @NotNull ItemStack itemStack) {
+        safeItemInsert(getSlotId(slot), itemStack);
     }
 
     /**


### PR DESCRIPTION
EquipmentHandler logic was, for some reason, centered around hardcoded functions for each slot, with `#getEquipment(EquipmentSlot)` referring back to those methods. This PR fixes that by instead having `#getEquipment(EquipmentSlot)` as the source of truth, and having those methods rely on it.

This doesn't change any API or behaviour, but it removes a bunch of boilerplate.