### PR TITLE
Generator fix #setRelative

### DIFF
--- a/src/main/java/net/minestom/server/instance/generator/GeneratorImpl.java
+++ b/src/main/java/net/minestom/server/instance/generator/GeneratorImpl.java
@@ -3,7 +3,6 @@ package net.minestom.server.instance.generator;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.minestom.server.coordinate.Point;
-import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.palette.Palette;
@@ -432,7 +431,7 @@ public final class GeneratorImpl {
         }
 
         private GenerationUnit findRelativeSection(int x, int y, int z) {
-            return findAbsolute(sections, Pos.ZERO, width, height, depth, x, y, z);
+            return findAbsolute(sections, Vec.ZERO, width, height, depth, x, y, z);
         }
 
         private void checkBorder(int x, int y, int z) {

--- a/src/main/java/net/minestom/server/instance/generator/GeneratorImpl.java
+++ b/src/main/java/net/minestom/server/instance/generator/GeneratorImpl.java
@@ -3,6 +3,7 @@ package net.minestom.server.instance.generator;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.minestom.server.coordinate.Point;
+import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.palette.Palette;
@@ -431,11 +432,7 @@ public final class GeneratorImpl {
         }
 
         private GenerationUnit findRelativeSection(int x, int y, int z) {
-            final int sectionX = getChunkCoordinate(x);
-            final int sectionY = getChunkCoordinate(y);
-            final int sectionZ = getChunkCoordinate(z);
-            final int index = sectionZ + sectionY * depth + sectionX * depth * height;
-            return sections.get(index);
+            return findAbsolute(sections, Pos.ZERO, width, height, depth, x, y, z);
         }
 
         private void checkBorder(int x, int y, int z) {


### PR DESCRIPTION
19c4b5d598cdb0570456856945e0c64cfbfdac03 changed some of the generator code, causing x and z coordinates of AreaModifierImpl#setRelative to end up swapped. This PR makes sure #setRelative uses the same calculation as #setBlock (absolute).
Should also fix CI test issues in #2335