### PR TITLE
Ability to get collision shape position from PhysicsResult

### DIFF
--- a/src/main/java/net/minestom/server/collision/BlockCollision.java
+++ b/src/main/java/net/minestom/server/collision/BlockCollision.java
@@ -29,7 +29,7 @@ final class BlockCollision {
         if (velocity.isZero()) {
             // TODO should return a constant
             return new PhysicsResult(entityPosition, Vec.ZERO, false, false, false, false,
-                    velocity, new Point[3], new Shape[3], false, SweepResult.NO_COLLISION);
+                    velocity, new Point[3], new Shape[3], new Point[3], false, SweepResult.NO_COLLISION);
         }
         // Fast-exit using cache
         final PhysicsResult cachedResult = cachedPhysics(velocity, entityPosition, getter, lastPhysicsResult);
@@ -90,12 +90,13 @@ final class BlockCollision {
                                              @NotNull Vec velocity, @NotNull Pos entityPosition,
                                              @NotNull Block.Getter getter, boolean singleCollision) {
         // Allocate once and update values
-        SweepResult finalResult = new SweepResult(1 - Vec.EPSILON, 0, 0, 0, null, 0, 0, 0);
+        SweepResult finalResult = new SweepResult(1 - Vec.EPSILON, 0, 0, 0, null, 0, 0, 0, 0, 0, 0);
 
         boolean foundCollisionX = false, foundCollisionY = false, foundCollisionZ = false;
 
         Point[] collidedPoints = new Point[3];
         Shape[] collisionShapes = new Shape[3];
+        Point[] collisionShapePositions = new Point[3];
 
         boolean hasCollided = false;
 
@@ -114,18 +115,21 @@ final class BlockCollision {
             if (result.collisionX()) {
                 foundCollisionX = true;
                 collisionShapes[0] = finalResult.collidedShape;
+                collisionShapePositions[0] = new Vec(finalResult.collidedShapeX, finalResult.collidedShapeY, finalResult.collidedShapeZ);
                 collidedPoints[0] = new Vec(finalResult.collidedPositionX, finalResult.collidedPositionY, finalResult.collidedPositionZ);
                 hasCollided = true;
                 if (singleCollision) break;
             } else if (result.collisionZ()) {
                 foundCollisionZ = true;
                 collisionShapes[2] = finalResult.collidedShape;
+                collisionShapePositions[2] = new Vec(finalResult.collidedShapeX, finalResult.collidedShapeY, finalResult.collidedShapeZ);
                 collidedPoints[2] = new Vec(finalResult.collidedPositionX, finalResult.collidedPositionY, finalResult.collidedPositionZ);
                 hasCollided = true;
                 if (singleCollision) break;
             } else if (result.collisionY()) {
                 foundCollisionY = true;
                 collisionShapes[1] = finalResult.collidedShape;
+                collisionShapePositions[1] = new Vec(finalResult.collidedShapeX, finalResult.collidedShapeY, finalResult.collidedShapeZ);
                 collidedPoints[1] = new Vec(finalResult.collidedPositionX, finalResult.collidedPositionY, finalResult.collidedPositionZ);
                 hasCollided = true;
                 if (singleCollision) break;
@@ -148,7 +152,7 @@ final class BlockCollision {
 
         return new PhysicsResult(result.newPosition(), new Vec(newDeltaX, newDeltaY, newDeltaZ),
                 newDeltaY == 0 && velocity.y() < 0,
-                foundCollisionX, foundCollisionY, foundCollisionZ, velocity, collidedPoints, collisionShapes, hasCollided, finalResult);
+                foundCollisionX, foundCollisionY, foundCollisionZ, velocity, collidedPoints, collisionShapes, collisionShapePositions, hasCollided, finalResult);
     }
 
     private static PhysicsResult computePhysics(@NotNull BoundingBox boundingBox,
@@ -185,7 +189,7 @@ final class BlockCollision {
 
         return new PhysicsResult(finalPos, new Vec(remainingX, remainingY, remainingZ),
                 collisionY, collisionX, collisionY, collisionZ,
-                Vec.ZERO, null, null, false, finalResult);
+                Vec.ZERO, null, null, null, false, finalResult);
     }
 
     private static boolean isDiagonal(Vec velocity) {

--- a/src/main/java/net/minestom/server/collision/BoundingBox.java
+++ b/src/main/java/net/minestom/server/collision/BoundingBox.java
@@ -53,6 +53,9 @@ public final class BoundingBox implements Shape {
             finalResult.collidedPositionX = rayStart.x() + rayDirection.x() * finalResult.res;
             finalResult.collidedPositionY = rayStart.y() + rayDirection.y() * finalResult.res;
             finalResult.collidedPositionZ = rayStart.z() + rayDirection.z() * finalResult.res;
+            finalResult.collidedShapeX = shapePos.x();
+            finalResult.collidedShapeY = shapePos.y();
+            finalResult.collidedShapeZ = shapePos.z();
             finalResult.collidedShape = this;
             return true;
         }

--- a/src/main/java/net/minestom/server/collision/CollisionUtils.java
+++ b/src/main/java/net/minestom/server/collision/CollisionUtils.java
@@ -191,6 +191,6 @@ public final class CollisionUtils {
     public static PhysicsResult blocklessCollision(@NotNull Pos entityPosition, @NotNull Vec entityVelocity) {
         return new PhysicsResult(entityPosition.add(entityVelocity), entityVelocity, false,
                 false, false, false, entityVelocity, new Point[3],
-                new Shape[3], false, SweepResult.NO_COLLISION);
+                new Shape[3], new Point[3], false, SweepResult.NO_COLLISION);
     }
 }

--- a/src/main/java/net/minestom/server/collision/EntityCollision.java
+++ b/src/main/java/net/minestom/server/collision/EntityCollision.java
@@ -23,7 +23,7 @@ final class EntityCollision {
         double projectileDistance = entityVelocity.length();
 
         for (Entity e : instance.getNearbyEntities(point, extendRadius + maxDistance + projectileDistance)) {
-            SweepResult sweepResult = new SweepResult(minimumRes, 0, 0, 0, null, 0, 0, 0);
+            SweepResult sweepResult = new SweepResult(minimumRes, 0, 0, 0, null, 0, 0, 0, 0, 0, 0);
 
             if (!entityFilter.apply(e)) continue;
             if (!e.hasCollision()) continue;

--- a/src/main/java/net/minestom/server/collision/PhysicsResult.java
+++ b/src/main/java/net/minestom/server/collision/PhysicsResult.java
@@ -4,9 +4,8 @@ import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.UnknownNullability;
 
-@ApiStatus.Experimental
 /**
  * The result of a physics simulation.
  * @param newPosition the new position of the entity
@@ -18,7 +17,9 @@ import org.jetbrains.annotations.NotNull;
  * @param originalDelta the velocity delta of the entity
  * @param collisionPoints the points where the entity collided
  * @param collisionShapes the shapes the entity collided with
+ * @param collisionShapePositions the positions of the shapes the entity collided with
  */
+@ApiStatus.Experimental
 public record PhysicsResult(
         Pos newPosition,
         Vec newVelocity,
@@ -27,8 +28,9 @@ public record PhysicsResult(
         boolean collisionY,
         boolean collisionZ,
         Vec originalDelta,
-        @NotNull Point[] collisionPoints,
-        @NotNull Shape[] collisionShapes,
+        @UnknownNullability Point @UnknownNullability [] collisionPoints,
+        @UnknownNullability Shape @UnknownNullability [] collisionShapes,
+        @UnknownNullability Point @UnknownNullability [] collisionShapePositions,
         boolean hasCollision,
         SweepResult res
 ) {

--- a/src/main/java/net/minestom/server/collision/PhysicsUtils.java
+++ b/src/main/java/net/minestom/server/collision/PhysicsUtils.java
@@ -15,16 +15,16 @@ public final class PhysicsUtils {
      * current velocity passed in. Then adjusting the velocity by applying
      * air resistance and friction.
      *
-     * @param entityPosition the current entity position
+     * @param entityPosition        the current entity position
      * @param entityVelocityPerTick the current entity velocity in blocks/tick
-     * @param entityBoundingBox the current entity bounding box
-     * @param worldBorder the world border to test bounds against
-     * @param blockGetter the block getter to test block collisions against
-     * @param aerodynamics the current entity aerodynamics
-     * @param entityNoGravity whether the entity has gravity
-     * @param entityHasPhysics whether the entity has physics
-     * @param entityOnGround whether the entity is on the ground
-     * @param entityFlying whether the entity is flying
+     * @param entityBoundingBox     the current entity bounding box
+     * @param worldBorder           the world border to test bounds against
+     * @param blockGetter           the block getter to test block collisions against
+     * @param aerodynamics          the current entity aerodynamics
+     * @param entityNoGravity       whether the entity has gravity
+     * @param entityHasPhysics      whether the entity has physics
+     * @param entityOnGround        whether the entity is on the ground
+     * @param entityFlying          whether the entity is flying
      * @param previousPhysicsResult the physics result from the previous simulation or null
      * @return a {@link PhysicsResult} containing the resulting physics state of this simulation
      */
@@ -41,7 +41,7 @@ public final class PhysicsUtils {
         Pos positionWithinBorder = CollisionUtils.applyWorldBorder(worldBorder, entityPosition, newPosition);
         newVelocity = updateVelocity(entityPosition, newVelocity, blockGetter, aerodynamics, !positionWithinBorder.samePoint(entityPosition), entityFlying, entityOnGround, entityNoGravity);
         return new PhysicsResult(positionWithinBorder, newVelocity, physicsResult.isOnGround(), physicsResult.collisionX(), physicsResult.collisionY(), physicsResult.collisionZ(),
-                physicsResult.originalDelta(), physicsResult.collisionPoints(), physicsResult.collisionShapes(), physicsResult.hasCollision(), physicsResult.res());
+                physicsResult.originalDelta(), physicsResult.collisionPoints(), physicsResult.collisionShapes(), physicsResult.collisionShapePositions(), physicsResult.hasCollision(), physicsResult.res());
     }
 
     private static @NotNull Vec updateVelocity(@NotNull Pos entityPosition, @NotNull Vec currentVelocity, @NotNull Block.Getter blockGetter, @NotNull Aerodynamics aerodynamics,
@@ -62,5 +62,6 @@ public final class PhysicsUtils {
         return new Vec(Math.abs(x) < Vec.EPSILON ? 0 : x, Math.abs(y) < Vec.EPSILON ? 0 : y, Math.abs(z) < Vec.EPSILON ? 0 : z);
     }
 
-    private PhysicsUtils() {}
+    private PhysicsUtils() {
+    }
 }

--- a/src/main/java/net/minestom/server/collision/PhysicsUtils.java
+++ b/src/main/java/net/minestom/server/collision/PhysicsUtils.java
@@ -15,16 +15,16 @@ public final class PhysicsUtils {
      * current velocity passed in. Then adjusting the velocity by applying
      * air resistance and friction.
      *
-     * @param entityPosition        the current entity position
+     * @param entityPosition the current entity position
      * @param entityVelocityPerTick the current entity velocity in blocks/tick
-     * @param entityBoundingBox     the current entity bounding box
-     * @param worldBorder           the world border to test bounds against
-     * @param blockGetter           the block getter to test block collisions against
-     * @param aerodynamics          the current entity aerodynamics
-     * @param entityNoGravity       whether the entity has gravity
-     * @param entityHasPhysics      whether the entity has physics
-     * @param entityOnGround        whether the entity is on the ground
-     * @param entityFlying          whether the entity is flying
+     * @param entityBoundingBox the current entity bounding box
+     * @param worldBorder the world border to test bounds against
+     * @param blockGetter the block getter to test block collisions against
+     * @param aerodynamics the current entity aerodynamics
+     * @param entityNoGravity whether the entity has gravity
+     * @param entityHasPhysics whether the entity has physics
+     * @param entityOnGround whether the entity is on the ground
+     * @param entityFlying whether the entity is flying
      * @param previousPhysicsResult the physics result from the previous simulation or null
      * @return a {@link PhysicsResult} containing the resulting physics state of this simulation
      */
@@ -62,6 +62,5 @@ public final class PhysicsUtils {
         return new Vec(Math.abs(x) < Vec.EPSILON ? 0 : x, Math.abs(y) < Vec.EPSILON ? 0 : y, Math.abs(z) < Vec.EPSILON ? 0 : z);
     }
 
-    private PhysicsUtils() {
-    }
+    private PhysicsUtils() {}
 }

--- a/src/main/java/net/minestom/server/collision/RayUtils.java
+++ b/src/main/java/net/minestom/server/collision/RayUtils.java
@@ -174,6 +174,6 @@ final class RayUtils {
     }
 
     public static boolean BoundingBoxRayIntersectionCheck(Vec start, Vec direction, BoundingBox boundingBox, Pos position) {
-        return BoundingBoxIntersectionCheck(BoundingBox.ZERO, start, direction, boundingBox, position, new SweepResult(Double.MAX_VALUE, 0, 0, 0, null, 0, 0, 0));
+        return BoundingBoxIntersectionCheck(BoundingBox.ZERO, start, direction, boundingBox, position, new SweepResult(Double.MAX_VALUE, 0, 0, 0, null, 0, 0, 0, 0, 0, 0));
     }
 }

--- a/src/main/java/net/minestom/server/collision/ShapeImpl.java
+++ b/src/main/java/net/minestom/server/collision/ShapeImpl.java
@@ -185,7 +185,9 @@ public final class ShapeImpl implements Shape {
                 finalResult.collidedPositionX = rayStart.x() + rayDirection.x() * finalResult.res;
                 finalResult.collidedPositionY = rayStart.y() + rayDirection.y() * finalResult.res;
                 finalResult.collidedPositionZ = rayStart.z() + rayDirection.z() * finalResult.res;
-
+                finalResult.collidedShapeX = shapePos.x();
+                finalResult.collidedShapeY = shapePos.y();
+                finalResult.collidedShapeZ = shapePos.z();
                 finalResult.collidedShape = this;
                 hitBlock = true;
             }

--- a/src/main/java/net/minestom/server/collision/SweepResult.java
+++ b/src/main/java/net/minestom/server/collision/SweepResult.java
@@ -1,11 +1,12 @@
 package net.minestom.server.collision;
 
 public final class SweepResult {
-    public static SweepResult NO_COLLISION  = new SweepResult(Double.MAX_VALUE, 0, 0, 0, null, 0, 0, 0);
+    public static SweepResult NO_COLLISION  = new SweepResult(Double.MAX_VALUE, 0, 0, 0, null, 0, 0, 0, 0, 0, 0);
 
     double res;
     double normalX, normalY, normalZ;
     double collidedPositionX, collidedPositionY, collidedPositionZ;
+    double collidedShapeX, collidedShapeY, collidedShapeZ;
     Shape collidedShape;
 
     /**
@@ -16,7 +17,7 @@ public final class SweepResult {
      * @param normalY -1 if intersected on bottom, 1 if intersected on top
      * @param normalZ -1 if intersected on front, 1 if intersected on back
      */
-    public SweepResult(double res, double normalX, double normalY, double normalZ, Shape collidedShape, double collidedPosX, double collidedPosY, double collidedPosZ) {
+    public SweepResult(double res, double normalX, double normalY, double normalZ, Shape collidedShape, double collidedPosX, double collidedPosY, double collidedPosZ, double collidedShapeX, double collidedShapeY, double collidedShapeZ) {
         this.res = res;
         this.normalX = normalX;
         this.normalY = normalY;
@@ -25,5 +26,8 @@ public final class SweepResult {
         this.collidedPositionX = collidedPosX;
         this.collidedPositionY = collidedPosY;
         this.collidedPositionZ = collidedPosZ;
+        this.collidedShapeX = collidedShapeX;
+        this.collidedShapeY = collidedShapeY;
+        this.collidedShapeZ = collidedShapeZ;
     }
 }

--- a/src/test/java/net/minestom/server/collision/EntityBlockPhysicsIntegrationTest.java
+++ b/src/test/java/net/minestom/server/collision/EntityBlockPhysicsIntegrationTest.java
@@ -428,7 +428,7 @@ public class EntityBlockPhysicsIntegrationTest {
 
         BoundingBox bb = new Entity(EntityType.ZOMBIE).getBoundingBox();
 
-        SweepResult sweepResultFinal = new SweepResult(1, 0, 0, 0, null, 0, 0, 0);
+        SweepResult sweepResultFinal = new SweepResult(1, 0, 0, 0, null, 0, 0, 0, 0, 0, 0);
 
         bb.intersectBoxSwept(z1, movement, z2, bb, sweepResultFinal);
         bb.intersectBoxSwept(z1, movement, z3, bb, sweepResultFinal);


### PR DESCRIPTION
There is currently no way to get the position of the `Shape` (Block) in a `PhysicsResult`.
This PR adds `collisionShapePositions` in `PhysicsResult`.

Also fixes some issues with static analyzers and `@NotNull` for the arrays in `PhysicsResult`:

`@NullAnnotation1 Point @NullAnnotation2 []` gets analyzed like this:
`@NullAnnotation1` for the class `Point` (the element of the array)
`@NullAnnotation2` for the array instance itself.

Previous `@NotNull Point[]` implies that the array instance nullability is unknown, and the array element nullability is notnull, which is simply wrong. Also some [usages in `BlockCollision` use null](https://github.com/DasBabyPixel/Minestom/blob/99c7d48f320460e4a1062b7ecd53dc36c742c32e/src/main/java/net/minestom/server/collision/BlockCollision.java#L192), so I changed the nullability from `@NotNull` to `@UnknownNullability` for both the array as well as the elements.
I didn't mark the elements as `@Nullable`, because usually nullability for those elements is checked by `PhysicsResult#collisionX/Y/Z`