### PR TITLE
Fix server freeze at extreme positions

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -590,7 +590,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         final int minX = (int) Math.floor(boundingBox.minX() + position.x());
         final int maxX = (int) Math.ceil(boundingBox.maxX() + position.x());
         final int minY = (int) Math.floor(boundingBox.minY() + position.y());
-        final int maxY = (int) Math.ceil(boundingBox.maxY() + position.y());
+        final int maxY = Math.min((int) Math.ceil(boundingBox.maxY() + position.y()), Integer.MAX_VALUE-1);
         final int minZ = (int) Math.floor(boundingBox.minZ() + position.z());
         final int maxZ = (int) Math.ceil(boundingBox.maxZ() + position.z());
 

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -588,11 +588,11 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         ChunkCache cache = new ChunkCache(instance, currentChunk);
 
         final int minX = (int) Math.floor(boundingBox.minX() + position.x());
-        final int maxX = (int) Math.ceil(boundingBox.maxX() + position.x());
+        final int maxX = Math.min((int) Math.ceil(boundingBox.maxX() + position.x()), Integer.MAX_VALUE - 1);
         final int minY = (int) Math.floor(boundingBox.minY() + position.y());
-        final int maxY = Math.min((int) Math.ceil(boundingBox.maxY() + position.y()), Integer.MAX_VALUE-1);
+        final int maxY = Math.min((int) Math.ceil(boundingBox.maxY() + position.y()), Integer.MAX_VALUE - 1);
         final int minZ = (int) Math.floor(boundingBox.minZ() + position.z());
-        final int maxZ = (int) Math.ceil(boundingBox.maxZ() + position.z());
+        final int maxZ = Math.min((int) Math.ceil(boundingBox.maxZ() + position.z()), Integer.MAX_VALUE - 1);
 
         for (int y = minY; y <= maxY; y++) {
             for (int x = minX; x <= maxX; x++) {


### PR DESCRIPTION
This pull request fixes a critical exploit in the library which allows clients to crash servers by setting their positions to above the 32bit integer limit, which is possible via a cheat client.

You don't have to keep this, but at least have it until a solution can be found to the problem of integer limits as a whole.