### PR TITLE
Fix missing inversion in DataComponentMap#diff handling for removed entries

### DIFF
--- a/src/main/java/net/minestom/server/component/DataComponentMap.java
+++ b/src/main/java/net/minestom/server/component/DataComponentMap.java
@@ -72,7 +72,7 @@ public sealed interface DataComponentMap extends DataComponent.Holder permits Da
             final var protoComp = protoImpl.components().get(entry.getIntKey()); // Entry in prototype
             if (entry.getValue() == null) {
                 // If the component is removed, remove it from the diff if it is not in the prototype
-                if (protoImpl.components().containsKey(entry.getIntKey())) {
+                if (!protoImpl.components().containsKey(entry.getIntKey())) {
                     iter.remove();
                 }
             } else if (protoComp != null && protoComp.equals(entry.getValue())) {


### PR DESCRIPTION
In `DataComponentMap#diff`, a patch will have a removal entry deleted if it is not present in the prototype. However, the condition for this is inverted, so it is only removed when it is present.