### PR TITLE
Implement Graph Cache in CommandManager

### DIFF
--- a/src/main/java/net/minestom/server/command/CommandManager.java
+++ b/src/main/java/net/minestom/server/command/CommandManager.java
@@ -32,6 +32,7 @@ public final class CommandManager {
     private final Set<Command> commands = new HashSet<>();
 
     private CommandCallback unknownCommandCallback;
+    private @Nullable Graph cachedGraph;
 
     public CommandManager() {
     }
@@ -55,6 +56,8 @@ public final class CommandManager {
         for (String name : command.getNames()) {
             commandMap.put(name, command);
         }
+
+        invalidateGraphCache();
     }
 
     /**
@@ -68,6 +71,8 @@ public final class CommandManager {
         for (String name : command.getNames()) {
             commandMap.remove(name);
         }
+
+        invalidateGraphCache();
     }
 
     /**
@@ -188,9 +193,18 @@ public final class CommandManager {
         return parser.parse(sender, getGraph(), input);
     }
 
-    private Graph getGraph() {
-        //todo cache
-        return Graph.merge(commands);
+    private @NotNull Graph getGraph() {
+        if (cachedGraph == null) {
+            synchronized (this) {
+                cachedGraph = Graph.merge(getCommands());
+            }
+        }
+
+        return cachedGraph;
+    }
+
+    private void invalidateGraphCache() {
+        cachedGraph = null;
     }
 
     private static CommandResult resultConverter(ExecutableCommand executable,

--- a/src/main/java/net/minestom/server/command/CommandManager.java
+++ b/src/main/java/net/minestom/server/command/CommandManager.java
@@ -32,7 +32,7 @@ public final class CommandManager {
     private final Set<Command> commands = new HashSet<>();
 
     private CommandCallback unknownCommandCallback;
-    private @Nullable Graph cachedGraph;
+    private volatile @Nullable Graph cachedGraph;
 
     public CommandManager() {
     }
@@ -194,13 +194,17 @@ public final class CommandManager {
     }
 
     private @NotNull Graph getGraph() {
-        if (cachedGraph == null) {
+        Graph graph = cachedGraph;
+        if (graph == null) {
             synchronized (this) {
-                cachedGraph = Graph.merge(getCommands());
+                graph = cachedGraph;
+                if (graph == null) {
+                    graph = cachedGraph = Graph.merge(getCommands());
+                }
             }
         }
 
-        return cachedGraph;
+        return graph;
     }
 
     private void invalidateGraphCache() {


### PR DESCRIPTION
Implemented the graph cache TODO in CommandManager#getCache

I changed the implementation sightly to make use of CommandManager#getCommands to ensure that any Graph implementation is not mutating commands.