### PR TITLE
fix: chunk history desyncing from actual state of loaded chunks

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -167,6 +167,7 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
     };
     final IntegerBiConsumer chunkRemover = (chunkX, chunkZ) -> {
         // Unload old chunks
+        this.chunkUpdateLimitChecker.removeFromHistory(ChunkUtils.getChunkIndex(chunkX, chunkZ));
         sendPacket(new UnloadChunkPacket(chunkX, chunkZ));
         EventDispatcher.call(new PlayerChunkUnloadEvent(this, chunkX, chunkZ));
     };

--- a/src/main/java/net/minestom/server/utils/chunk/ChunkUpdateLimitChecker.java
+++ b/src/main/java/net/minestom/server/utils/chunk/ChunkUpdateLimitChecker.java
@@ -36,6 +36,23 @@ public final class ChunkUpdateLimitChecker {
         return result;
     }
 
+    /**
+     * Removes the chunk from the history
+     *
+     * @param index index of chunk to remove
+     * @return {@code true} if the chunk existed in the history
+     */
+    public boolean removeFromHistory(long index) {
+        final int lastIndex = historySize - 1;
+        for (int i = 0; i < lastIndex; i++) {
+            if (chunkHistory[i] == index) {
+                chunkHistory[i] = Long.MAX_VALUE;
+                return true;
+            }
+        }
+        return false;
+    }
+
     public void clearHistory() {
         Arrays.fill(this.chunkHistory, Long.MAX_VALUE);
     }


### PR DESCRIPTION
This PR fixes an issue with the player auto chunk loader where chunks would be marked as loaded but never marked as unloaded.

**This bug can be reproduced by**:
* Enabling automatic chunk loading
* Adding code to unload chunks within the events provided by the Player class

**Expected behaviour** (should also be provided by this patch):
* A chunk that has been unloaded due to exiting a player's view distance is able to be reloaded when the player goes near it again.

**Actual behaviour**:
* Loading, unloading, and then attempting to load again any given chunk with a player will fail when trying to reload the chunk after an unload.