### PR TITLE
fix: saturation not working in food item component

### DIFF
--- a/src/main/java/net/minestom/server/item/component/Food.java
+++ b/src/main/java/net/minestom/server/item/component/Food.java
@@ -42,7 +42,7 @@ public record Food(int nutrition, float saturationModifier, boolean canAlwaysEat
     public static final BinaryTagSerializer<Food> NBT_TYPE = BinaryTagSerializer.COMPOUND.map(
             tag -> new Food(
                     tag.getInt("nutrition"),
-                    tag.getFloat("saturation_modifier"),
+                    tag.getFloat("saturation"),
                     tag.getBoolean("can_always_eat"),
                     tag.getFloat("eat_seconds", DEFAULT_EAT_SECONDS),
                     tag.get("using_converts_to") instanceof BinaryTag usingConvertsTo
@@ -51,7 +51,7 @@ public record Food(int nutrition, float saturationModifier, boolean canAlwaysEat
             value -> {
                 CompoundBinaryTag.Builder builder = CompoundBinaryTag.builder()
                         .putInt("nutrition", value.nutrition)
-                        .putFloat("saturation_odifier", value.saturationModifier)
+                        .putFloat("saturation", value.saturationModifier)
                         .putBoolean("can_always_eat", value.canAlwaysEat)
                         .putFloat("eat_seconds", value.eatSeconds)
                         .put("effects", EffectChance.NBT_LIST_TYPE.write(value.effects));


### PR DESCRIPTION
I am using the food implementation of MinestomPvP and noticed that eating food only applied nutrition, not saturation, to the player.

While searching for the cause of the issue, I found a typo in the Food ItemComponent, where the `saturation_modifier` tag was misspelled as `saturation_odifier`. Correcting the typo did not fix the issue, however.
Upon further inspection, I noticed that the tag is actually labeled as just `saturation` in the item data:

![screenshot](https://github.com/user-attachments/assets/24212b5a-fcc2-4a1b-8935-ff39c08d38c2)

I renamed the tag to `saturation` in the Food ItemComponent and now saturation gets correctly applied to the player, so this seems to resolve the issue.