### PR TITLE
Rework LoginListener

### DIFF
--- a/src/main/java/net/minestom/server/ServerFlag.java
+++ b/src/main/java/net/minestom/server/ServerFlag.java
@@ -53,6 +53,7 @@ public final class ServerFlag {
 
     // Online Mode
     public static final @NotNull String AUTH_URL = stringProperty("minestom.auth.url", "https://sessionserver.mojang.com/session/minecraft/hasJoined");
+    public static final boolean AUTH_PREVENT_PROXY_CONNECTIONS = booleanProperty("minestom.auth.prevent-proxy-connections", false);
 
     // World
     public static final int WORLD_BORDER_SIZE = intProperty("minestom.world-border-size", 29999984);

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -1686,15 +1686,7 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
      * @param component the reason
      */
     public void kick(@NotNull Component component) {
-        // Packet type depends on the current player connection state
-        final ServerPacket disconnectPacket;
-        if (playerConnection.getConnectionState() == ConnectionState.LOGIN) {
-            disconnectPacket = new LoginDisconnectPacket(component);
-        } else {
-            disconnectPacket = new DisconnectPacket(component);
-        }
-        sendPacket(disconnectPacket);
-        playerConnection.disconnect();
+        this.getPlayerConnection().kick(component);
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -66,7 +66,6 @@ import net.minestom.server.network.packet.client.ClientPacket;
 import net.minestom.server.network.packet.server.SendablePacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.common.*;
-import net.minestom.server.network.packet.server.login.LoginDisconnectPacket;
 import net.minestom.server.network.packet.server.play.*;
 import net.minestom.server.network.packet.server.play.data.WorldPos;
 import net.minestom.server.network.player.ClientSettings;

--- a/src/main/java/net/minestom/server/extras/MojangAuth.java
+++ b/src/main/java/net/minestom/server/extras/MojangAuth.java
@@ -1,7 +1,6 @@
 package net.minestom.server.extras;
 
 import net.minestom.server.MinecraftServer;
-import net.minestom.server.ServerFlag;
 import net.minestom.server.extras.mojangAuth.MojangCrypt;
 import net.minestom.server.extras.velocity.VelocityProxy;
 import net.minestom.server.utils.validate.Check;
@@ -10,7 +9,6 @@ import org.jetbrains.annotations.Nullable;
 import java.security.KeyPair;
 
 public final class MojangAuth {
-    public static final String AUTH_URL = ServerFlag.AUTH_URL.concat("?username=%s&serverId=%s");
     private static volatile boolean enabled = false;
     private static volatile KeyPair keyPair;
 

--- a/src/main/java/net/minestom/server/listener/preplay/HandshakeListener.java
+++ b/src/main/java/net/minestom/server/listener/preplay/HandshakeListener.java
@@ -10,7 +10,6 @@ import net.minestom.server.MinecraftServer;
 import net.minestom.server.extras.bungee.BungeeCordProxy;
 import net.minestom.server.network.ConnectionState;
 import net.minestom.server.network.packet.client.handshake.ClientHandshakePacket;
-import net.minestom.server.network.packet.server.login.LoginDisconnectPacket;
 import net.minestom.server.network.player.GameProfile;
 import net.minestom.server.network.player.PlayerConnection;
 import net.minestom.server.network.player.PlayerSocketConnection;
@@ -18,6 +17,7 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,7 +45,7 @@ public final class HandshakeListener {
                 connection.setConnectionState(ConnectionState.LOGIN);
                 if (packet.protocolVersion() != MinecraftServer.PROTOCOL_VERSION) {
                     // Incorrect client version
-                    disconnect(connection, INVALID_VERSION_TEXT);
+                    connection.kick(INVALID_VERSION_TEXT);
                 }
 
                 // Bungee support (IP forwarding)
@@ -61,11 +61,11 @@ public final class HandshakeListener {
 
                         address = split[0];
 
-                        final SocketAddress socketAddress = new java.net.InetSocketAddress(split[1],
-                                ((java.net.InetSocketAddress) connection.getRemoteAddress()).getPort());
+                        final SocketAddress socketAddress = new InetSocketAddress(split[1],
+                                ((InetSocketAddress) connection.getRemoteAddress()).getPort());
                         socketConnection.setRemoteAddress(socketAddress);
 
-                        UUID playerUuid = java.util.UUID.fromString(
+                        UUID playerUuid = UUID.fromString(
                                 split[2]
                                         .replaceFirst(
                                                 "(\\p{XDigit}{8})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}+)", "$1-$2-$3-$4-$5"
@@ -128,14 +128,9 @@ public final class HandshakeListener {
         }
     }
 
-    private static void disconnect(@NotNull PlayerConnection connection, @NotNull Component reason) {
-        connection.sendPacket(new LoginDisconnectPacket(reason));
-        connection.disconnect();
-    }
-
     private static void bungeeDisconnect(@NotNull PlayerConnection connection) {
         LOGGER.warn("{} tried to log in without valid BungeeGuard forwarding information.", connection.getIdentifier());
-        disconnect(connection, INVALID_BUNGEE_FORWARDING);
+        connection.kick(INVALID_BUNGEE_FORWARDING);
     }
 
 }

--- a/src/main/java/net/minestom/server/listener/preplay/LoginListener.java
+++ b/src/main/java/net/minestom/server/listener/preplay/LoginListener.java
@@ -1,6 +1,5 @@
 package net.minestom.server.listener.preplay;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import net.kyori.adventure.text.Component;
@@ -18,22 +17,21 @@ import net.minestom.server.network.packet.client.login.ClientLoginAcknowledgedPa
 import net.minestom.server.network.packet.client.login.ClientLoginPluginResponsePacket;
 import net.minestom.server.network.packet.client.login.ClientLoginStartPacket;
 import net.minestom.server.network.packet.server.login.EncryptionRequestPacket;
-import net.minestom.server.network.packet.server.login.LoginDisconnectPacket;
 import net.minestom.server.network.player.GameProfile;
 import net.minestom.server.network.player.PlayerConnection;
 import net.minestom.server.network.player.PlayerSocketConnection;
 import net.minestom.server.network.plugin.LoginPlugin;
 import net.minestom.server.network.plugin.LoginPluginMessageProcessor;
 import net.minestom.server.utils.async.AsyncUtils;
+import net.minestom.server.utils.mojang.MojangUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.crypto.SecretKey;
 import java.math.BigInteger;
-import java.net.*;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.nio.charset.StandardCharsets;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.UnknownHostException;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -41,10 +39,13 @@ import static net.minestom.server.network.NetworkBuffer.STRING;
 
 public final class LoginListener {
     private static final ConnectionManager CONNECTION_MANAGER = MinecraftServer.getConnectionManager();
-    private static final Gson GSON = new Gson();
 
     private static final Component ALREADY_CONNECTED = Component.text("You are already on this server", NamedTextColor.RED);
     private static final Component ERROR_DURING_LOGIN = Component.text("Error during login!", NamedTextColor.RED);
+    private static final Component ERROR_MALFORMED_USERNAME = Component.text("Error malformed username", NamedTextColor.RED);
+    private static final Component ENCRYPTION_FAILED = Component.text("Encryption failed!", NamedTextColor.RED);
+    private static final Component ERROR_MOJANG_RESPONSE = Component.text("Failed to contact Mojang's Session Servers (Are they down?)", NamedTextColor.RED);
+
     public static final Component INVALID_PROXY_RESPONSE = Component.text("Invalid proxy response!", NamedTextColor.RED);
 
     public static void loginStartListener(@NotNull ClientLoginStartPacket packet, @NotNull PlayerConnection connection) {
@@ -64,8 +65,7 @@ public final class LoginListener {
         if (MojangAuth.isEnabled() && isSocketConnection) {
             // Mojang auth
             if (CONNECTION_MANAGER.getOnlinePlayerByUsername(packet.username()) != null) {
-                connection.sendPacket(new LoginDisconnectPacket(ALREADY_CONNECTED));
-                connection.disconnect();
+                connection.kick(ALREADY_CONNECTED);
                 return;
             }
             final PlayerSocketConnection socketConnection = (PlayerSocketConnection) connection;
@@ -87,8 +87,8 @@ public final class LoginListener {
                     CONNECTION_MANAGER.createPlayer(connection, playerUuid, packet.username());
 
                 } catch (Exception exception) {
-                    connection.sendPacket(new LoginDisconnectPacket(Component.text(exception.getClass().getSimpleName() + ": " + exception.getMessage())));
-                    connection.disconnect();
+                    MinecraftServer.getExceptionManager().handleException(exception);
+                    connection.kick(Component.text(exception.getClass().getSimpleName() + ": " + exception.getMessage()));
                 }
             });
         }
@@ -100,7 +100,8 @@ public final class LoginListener {
         AsyncUtils.runAsync(() -> {
             final String loginUsername = socketConnection.getLoginUsername();
             if (loginUsername == null || loginUsername.isEmpty()) {
-                // Shouldn't happen
+                // Shouldn't happen, but in case
+                connection.kick(ERROR_MALFORMED_USERNAME);
                 return;
             }
 
@@ -110,6 +111,7 @@ public final class LoginListener {
 
             if (verificationFailed) {
                 MinecraftServer.LOGGER.error("Encryption failed for {}", loginUsername);
+                connection.kick(ENCRYPTION_FAILED);
                 return;
             }
 
@@ -117,52 +119,38 @@ public final class LoginListener {
             if (digestedData == null) {
                 // Incorrect key, probably because of the client
                 MinecraftServer.LOGGER.error("Connection {} failed initializing encryption.", socketConnection.getRemoteAddress());
-                connection.disconnect();
+                connection.kick(ENCRYPTION_FAILED);
                 return;
             }
             // Query Mojang's session server.
             final String serverId = new BigInteger(digestedData).toString(16);
-            final String username = URLEncoder.encode(loginUsername, StandardCharsets.UTF_8);
 
-            final String url = String.format(MojangAuth.AUTH_URL, username, serverId);
-            // TODO: Add ability to add ip query tag. See: https://wiki.vg/Protocol_Encryption#Authentication
+            final JsonObject gameProfile = MojangUtils.authenticateSession(loginUsername, serverId, socketConnection.getRemoteAddress());
 
-            final HttpClient client = HttpClient.newHttpClient();
-            final HttpRequest request = HttpRequest.newBuilder(URI.create(url)).GET().build();
-            client.sendAsync(request, HttpResponse.BodyHandlers.ofString()).whenComplete((response, throwable) -> {
-                final boolean ok = throwable == null && response.statusCode() == 200 && response.body() != null && !response.body().isEmpty();
+            if (gameProfile == null) {
+                socketConnection.kick(ERROR_MOJANG_RESPONSE);
+                return;
+            }
 
-                if (!ok) {
-                    if (throwable != null) {
-                        MinecraftServer.getExceptionManager().handleException(throwable);
-                    }
+            // We have verified the session, parse response.
+            try {
+                socketConnection.setEncryptionKey(getSecretKey(packet.sharedSecret()));
+                final UUID profileUUID = UUID.fromString(gameProfile.get("id").getAsString()
+                        .replaceFirst("(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})", "$1-$2-$3-$4-$5"));
+                final String profileName = gameProfile.get("name").getAsString();
 
-                    if (socketConnection.getPlayer() != null) {
-                        socketConnection.getPlayer().kick(Component.text("Failed to contact Mojang's Session Servers (Are they down?)"));
-                    } else {
-                        socketConnection.disconnect();
-                    }
-                    return;
+                MinecraftServer.LOGGER.info("UUID of player {} is {}", profileName, profileUUID);
+                CONNECTION_MANAGER.createPlayer(connection, profileUUID, profileName);
+                List<GameProfile.Property> propertyList = new ArrayList<>();
+                for (JsonElement element : gameProfile.get("properties").getAsJsonArray()) {
+                    JsonObject object = element.getAsJsonObject();
+                    propertyList.add(new GameProfile.Property(object.get("name").getAsString(), object.get("value").getAsString(), object.get("signature").getAsString()));
                 }
-                try {
-                    final JsonObject gameProfile = GSON.fromJson(response.body(), JsonObject.class);
-                    socketConnection.setEncryptionKey(getSecretKey(packet.sharedSecret()));
-                    UUID profileUUID = java.util.UUID.fromString(gameProfile.get("id").getAsString()
-                            .replaceFirst("(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})", "$1-$2-$3-$4-$5"));
-                    final String profileName = gameProfile.get("name").getAsString();
-
-                    MinecraftServer.LOGGER.info("UUID of player {} is {}", loginUsername, profileUUID);
-                    CONNECTION_MANAGER.createPlayer(connection, profileUUID, profileName);
-                    List<GameProfile.Property> propertyList = new ArrayList<>();
-                    for (JsonElement element : gameProfile.get("properties").getAsJsonArray()) {
-                        JsonObject object = element.getAsJsonObject();
-                        propertyList.add(new GameProfile.Property(object.get("name").getAsString(), object.get("value").getAsString(), object.get("signature").getAsString()));
-                    }
-                    socketConnection.UNSAFE_setProfile(new GameProfile(profileUUID, profileName, propertyList));
-                } catch (Exception e) {
-                    MinecraftServer.getExceptionManager().handleException(e);
-                }
-            });
+                socketConnection.UNSAFE_setProfile(new GameProfile(profileUUID, profileName, propertyList));
+            } catch (Exception e) {
+                MinecraftServer.getExceptionManager().handleException(e);
+                socketConnection.kick(ERROR_DURING_LOGIN);
+            }
         });
     }
 
@@ -198,8 +186,7 @@ public final class LoginListener {
             socketConnection.UNSAFE_setProfile(gameProfile);
             CONNECTION_MANAGER.createPlayer(socketConnection, gameProfile.uuid(), gameProfile.name());
         } else {
-            LoginDisconnectPacket disconnectPacket = new LoginDisconnectPacket(INVALID_PROXY_RESPONSE);
-            socketConnection.sendPacket(disconnectPacket);
+            socketConnection.kick(INVALID_PROXY_RESPONSE);
         }
     }
 
@@ -209,9 +196,7 @@ public final class LoginListener {
             messageProcessor.handleResponse(packet.messageId(), packet.data());
         } catch (Throwable t) {
             MinecraftServer.LOGGER.error("Error handling Login Plugin Response", t);
-            LoginDisconnectPacket disconnectPacket = new LoginDisconnectPacket(ERROR_DURING_LOGIN);
-            connection.sendPacket(disconnectPacket);
-            connection.disconnect();
+            connection.kick(ERROR_DURING_LOGIN);
         }
     }
 

--- a/src/main/java/net/minestom/server/listener/preplay/LoginListener.java
+++ b/src/main/java/net/minestom/server/listener/preplay/LoginListener.java
@@ -87,8 +87,8 @@ public final class LoginListener {
                     CONNECTION_MANAGER.createPlayer(connection, playerUuid, packet.username());
 
                 } catch (Exception exception) {
-                    MinecraftServer.getExceptionManager().handleException(exception);
                     connection.kick(Component.text(exception.getClass().getSimpleName() + ": " + exception.getMessage()));
+                    MinecraftServer.getExceptionManager().handleException(exception);
                 }
             });
         }
@@ -148,8 +148,8 @@ public final class LoginListener {
                 }
                 socketConnection.UNSAFE_setProfile(new GameProfile(profileUUID, profileName, propertyList));
             } catch (Exception e) {
-                MinecraftServer.getExceptionManager().handleException(e);
                 socketConnection.kick(ERROR_DURING_LOGIN);
+                MinecraftServer.getExceptionManager().handleException(e);
             }
         });
     }
@@ -172,6 +172,7 @@ public final class LoginListener {
                 try {
                     address = InetAddress.getByName(buffer.read(STRING));
                 } catch (UnknownHostException e) {
+                    socketConnection.kick(INVALID_PROXY_RESPONSE);
                     MinecraftServer.getExceptionManager().handleException(e);
                     return;
                 }
@@ -195,8 +196,9 @@ public final class LoginListener {
             LoginPluginMessageProcessor messageProcessor = connection.loginPluginMessageProcessor();
             messageProcessor.handleResponse(packet.messageId(), packet.data());
         } catch (Throwable t) {
-            MinecraftServer.LOGGER.error("Error handling Login Plugin Response", t);
             connection.kick(ERROR_DURING_LOGIN);
+            MinecraftServer.LOGGER.error("Error handling Login Plugin Response", t);
+            MinecraftServer.getExceptionManager().handleException(t);
         }
     }
 

--- a/src/main/java/net/minestom/server/network/player/PlayerConnection.java
+++ b/src/main/java/net/minestom/server/network/player/PlayerConnection.java
@@ -1,14 +1,18 @@
 package net.minestom.server.network.player;
 
+import net.kyori.adventure.text.Component;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.crypto.PlayerPublicKey;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.Player;
 import net.minestom.server.network.ConnectionState;
 import net.minestom.server.network.packet.server.SendablePacket;
+import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.common.CookieRequestPacket;
 import net.minestom.server.network.packet.server.common.CookieStorePacket;
+import net.minestom.server.network.packet.server.common.DisconnectPacket;
 import net.minestom.server.network.packet.server.configuration.SelectKnownPacksPacket;
+import net.minestom.server.network.packet.server.login.LoginDisconnectPacket;
 import net.minestom.server.network.plugin.LoginPluginMessageProcessor;
 import net.minestom.server.utils.NamespaceID;
 import net.minestom.server.utils.validate.Check;
@@ -110,6 +114,24 @@ public abstract class PlayerConnection {
      */
     public int getServerPort() {
         return MinecraftServer.getServer().getPort();
+    }
+
+
+    /**
+     * Kicks the player with a reason.
+     *
+     * @param component the reason
+     */
+    public void kick(@NotNull Component component) {
+        // Packet type depends on the current player connection state
+        final ServerPacket disconnectPacket;
+        if (connectionState == ConnectionState.LOGIN) {
+            disconnectPacket = new LoginDisconnectPacket(component);
+        } else {
+            disconnectPacket = new DisconnectPacket(component);
+        }
+        sendPacket(disconnectPacket);
+        disconnect();
     }
 
     /**

--- a/src/main/java/net/minestom/server/utils/mojang/MojangUtils.java
+++ b/src/main/java/net/minestom/server/utils/mojang/MojangUtils.java
@@ -2,7 +2,6 @@ package net.minestom.server.utils.mojang;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import net.minestom.server.MinecraftServer;
 import net.minestom.server.ServerFlag;
 import net.minestom.server.utils.url.URLUtils;
 import org.jetbrains.annotations.ApiStatus;
@@ -104,7 +103,7 @@ public final class MojangUtils {
 
     @Blocking
     @ApiStatus.Internal
-    public static @Nullable JsonObject authenticateSession(String loginUsername, String serverId, @Nullable SocketAddress userSocket) {
+    public static @NotNull JsonObject authenticateSession(String loginUsername, String serverId, @Nullable SocketAddress userSocket) throws IOException {
         final String username = URLEncoder.encode(loginUsername, StandardCharsets.UTF_8);
 
         final String url;
@@ -117,12 +116,7 @@ public final class MojangUtils {
             url = String.format(BASE_AUTH_URL, username, serverId);
         }
 
-        try {
-            return retrieve(url);
-        } catch (IOException e) {
-            MinecraftServer.getExceptionManager().handleException(e);
-            return null;
-        }
+        return retrieve(url);
     }
 
     /**

--- a/src/main/java/net/minestom/server/utils/mojang/MojangUtils.java
+++ b/src/main/java/net/minestom/server/utils/mojang/MojangUtils.java
@@ -2,12 +2,20 @@ package net.minestom.server.utils.mojang;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.ServerFlag;
 import net.minestom.server.utils.url.URLUtils;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Blocking;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 /**
@@ -16,6 +24,10 @@ import java.util.UUID;
 public final class MojangUtils {
     private static final String FROM_UUID_URL = "https://sessionserver.mojang.com/session/minecraft/profile/%s?unsigned=false";
     private static final String FROM_USERNAME_URL = "https://api.mojang.com/users/profiles/minecraft/%s";
+
+    // Auth
+    private static final String BASE_AUTH_URL = ServerFlag.AUTH_URL.concat("?username=%s&serverId=%s");
+    private static final String PREVENT_PROXY_CONNECTIONS_AUTH_URL = BASE_AUTH_URL.concat("&ip=%s");
 
     /**
      * Gets a player's UUID from their username
@@ -86,6 +98,29 @@ public final class MojangUtils {
         try {
             return retrieve(String.format(FROM_USERNAME_URL, username));
         } catch (IOException e) {
+            return null;
+        }
+    }
+
+    @Blocking
+    @ApiStatus.Internal
+    public static @Nullable JsonObject authenticateSession(String loginUsername, String serverId, @Nullable SocketAddress userSocket) {
+        final String username = URLEncoder.encode(loginUsername, StandardCharsets.UTF_8);
+
+        final String url;
+        if (ServerFlag.AUTH_PREVENT_PROXY_CONNECTIONS
+                && userSocket instanceof InetSocketAddress inetSocketAddress
+                && inetSocketAddress.getAddress() instanceof InetAddress address
+        ) {
+            url = String.format(PREVENT_PROXY_CONNECTIONS_AUTH_URL, username, serverId, address.getHostAddress());
+        } else {
+            url = String.format(BASE_AUTH_URL, username, serverId);
+        }
+
+        try {
+            return retrieve(url);
+        } catch (IOException e) {
+            MinecraftServer.getExceptionManager().handleException(e);
             return null;
         }
     }


### PR DESCRIPTION
Currently the old Mojang login listener uses HTTPClient (Only use in the entire project, and doesn't even use it correctly)

This commit also moves the implementation of Player#kick to PlayerConnection#kick, I would like to know the feedback on this change or if this should be a separate PR.