### PR TITLE
Add Block::nbtOrEmpty

### DIFF
--- a/src/main/java/net/minestom/server/instance/block/Block.java
+++ b/src/main/java/net/minestom/server/instance/block/Block.java
@@ -92,6 +92,16 @@ public sealed interface Block extends StaticProtocolObject, TagReadable, Blocks 
     @Contract(pure = true)
     @Nullable CompoundBinaryTag nbt();
 
+    /**
+     * Returns an unmodifiable view of the block nbt or an empty compound.
+     *
+     * @return the block nbt or an empty compound if not present
+     */
+    default @Nullable CompoundBinaryTag nbtOrEmpty() {
+        CompoundBinaryTag nbt = nbt();
+        return nbt == null ? CompoundBinaryTag.empty() : nbt;
+    }
+
     @Contract(pure = true)
     default boolean hasNbt() {
         return nbt() != null;

--- a/src/main/java/net/minestom/server/instance/block/Block.java
+++ b/src/main/java/net/minestom/server/instance/block/Block.java
@@ -97,9 +97,8 @@ public sealed interface Block extends StaticProtocolObject, TagReadable, Blocks 
      *
      * @return the block nbt or an empty compound if not present
      */
-    default @Nullable CompoundBinaryTag nbtOrEmpty() {
-        CompoundBinaryTag nbt = nbt();
-        return nbt == null ? CompoundBinaryTag.empty() : nbt;
+    default @NotNull CompoundBinaryTag nbtOrEmpty() {
+        return Objects.requireNonNullElse(nbt(), CompoundBinaryTag.empty());
     }
 
     @Contract(pure = true)


### PR DESCRIPTION
It's a common pattern when implementing BlockHandlers.

Only somewhat related rant (so matt sees):
![image](https://github.com/user-attachments/assets/2827b493-c70e-4cdf-b445-559af7f30080)

From: https://discord.com/channels/706185253441634317/706186227493109860/1282587137681784882