### PR TITLE
fix position used in the 'onPlace' method when loading

### DIFF
--- a/src/main/java/net/minestom/server/instance/DynamicChunk.java
+++ b/src/main/java/net/minestom/server/instance/DynamicChunk.java
@@ -119,9 +119,11 @@ public class DynamicChunk extends Chunk {
         }
         if (handler != null) {
             // New placement
+
+            var absoluteBlockPosition = new Vec(getChunkX() * 16 + x, y, getChunkZ() * 16 + z);
             final Block finalBlock = block;
             handler.onPlace(Objects.requireNonNullElseGet(placement,
-                    () -> new BlockHandler.Placement(finalBlock, instance, blockPosition)));
+                    () -> new BlockHandler.Placement(finalBlock, instance, absoluteBlockPosition)));
         }
 
         // UpdateHeightMaps
@@ -268,7 +270,8 @@ public class DynamicChunk extends Chunk {
         );
     }
 
-    @NotNull UpdateLightPacket createLightPacket() {
+    @NotNull
+    UpdateLightPacket createLightPacket() {
         return new UpdateLightPacket(chunkX, chunkZ, createLightData(false));
     }
 

--- a/src/main/java/net/minestom/server/instance/DynamicChunk.java
+++ b/src/main/java/net/minestom/server/instance/DynamicChunk.java
@@ -270,8 +270,7 @@ public class DynamicChunk extends Chunk {
         );
     }
 
-    @NotNull
-    UpdateLightPacket createLightPacket() {
+    @NotNull UpdateLightPacket createLightPacket() {
         return new UpdateLightPacket(chunkX, chunkZ, createLightData(false));
     }
 


### PR DESCRIPTION
When loading a chunk, the BlockHandler#onPlace() method returns the incorrect coordinates (chunk space instead of world space), this pr adds the chunk offset to correct the position to world space.

Before:
![image](https://github.com/user-attachments/assets/688cb233-2413-4740-8615-c158ac974953)
After:
![image](https://github.com/user-attachments/assets/4b31cf44-859d-4af8-8d0a-7ad0d77e4f83)

