### PR TITLE
Add Instance.setWorldAge()

### DIFF
--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -435,6 +435,17 @@ public abstract class Instance implements Block.Getter, Block.Setter,
     }
 
     /**
+     * Sets the age of this instance in tick. It will send the age to all players.
+     * Will send new age to all players in the instance, unaffected by {@link #getTimeSynchronizationTicks()}
+     * 
+     * @param worldAge the age of this instance in tick
+     */
+    public void setWorldAge(long worldAge) {
+        this.worldAge = worldAge;
+        PacketUtils.sendGroupedPacket(getPlayers(), createTimePacket());
+    }
+
+    /**
      * Gets the current time in the instance (sun/moon).
      *
      * @return the time in the instance


### PR DESCRIPTION
Implement `Instance.setWorldAge()` to set the world age of an instance and send it to players. I do not know why this was not implemented before, so if there was a reason, lmk.