### PR TITLE
Dispatch InventoryCloseEvent after Player#closeInventory

### DIFF
--- a/src/main/java/net/minestom/server/command/CommandManager.java
+++ b/src/main/java/net/minestom/server/command/CommandManager.java
@@ -61,13 +61,13 @@ public final class CommandManager {
     }
 
     /**
-     * Register multiple {@link Command}.
+     * Register multiple {@link Command}s.
      *
      * @param commands the array of commands
      * @throws IllegalStateException if a command with the same name already exists
      */
-    public synchronized void register(@NotNull Command ...commands) {
-        for(Command command : commands) {
+    public synchronized void register(@NotNull Command... commands) {
+        for (Command command : commands) {
             register(command);
         }
     }

--- a/src/main/java/net/minestom/server/command/CommandManager.java
+++ b/src/main/java/net/minestom/server/command/CommandManager.java
@@ -61,6 +61,18 @@ public final class CommandManager {
     }
 
     /**
+     * Register multiple {@link Command}.
+     *
+     * @param commands the array of commands
+     * @throws IllegalStateException if a command with the same name already exists
+     */
+    public synchronized void register(@NotNull Command ...commands) {
+        for(Command command : commands) {
+            register(command);
+        }
+    }
+
+    /**
      * Removes a command from the currently registered commands.
      * Does nothing if the command was not registered before
      *

--- a/src/main/java/net/minestom/server/listener/WindowListener.java
+++ b/src/main/java/net/minestom/server/listener/WindowListener.java
@@ -87,10 +87,10 @@ public class WindowListener {
 
     public static void closeWindowListener(ClientCloseWindowPacket packet, Player player) {
         // if windowId == 0 then it is player's inventory, meaning that they hadn't been any open inventory packet
+        player.closeInventory(true);
+
         InventoryCloseEvent inventoryCloseEvent = new InventoryCloseEvent(player.getOpenInventory(), player);
         EventDispatcher.call(inventoryCloseEvent);
-
-        player.closeInventory(true);
 
         Inventory newInventory = inventoryCloseEvent.getNewInventory();
         if (newInventory != null)


### PR DESCRIPTION
Dispatches `InventoryCloseEvent` after the inventory for the player has been closed so `Inventory#viewers` is the appropriate value without needing to wait a single tick.