### PR TITLE
Fix possible crasher & console spammer

### DIFF
--- a/src/main/java/net/minestom/server/listener/WindowListener.java
+++ b/src/main/java/net/minestom/server/listener/WindowListener.java
@@ -51,6 +51,7 @@ public class WindowListener {
         } else if (clickType == ClientClickWindowPacket.ClickType.QUICK_MOVE) {
             successful = inventory.shiftClick(player, slot);
         } else if (clickType == ClientClickWindowPacket.ClickType.SWAP) {
+            if (slot < 0 || button < 0) return;
             successful = inventory.changeHeld(player, slot, button);
         } else if (clickType == ClientClickWindowPacket.ClickType.CLONE) {
             successful = player.getGameMode() == GameMode.CREATIVE;


### PR DESCRIPTION
fixes an ArrayOutOfBounds packet exploit abusing  ClientClickWindowPacket that spams console and could lead to a crash due to excess cpu usage.

java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 46 at java.base/jdk.internal.util.Preconditions$2.apply(Preconditions.java:63) at java.base/jdk.internal.util.Preconditions$2.apply(Preconditions.java:60) at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:213) at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:210) at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:98) at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106) at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302) at java.base/java.lang.invoke.VarHandleReferences$Array.getVolatile(VarHandleReferences.java:604) at net.minestom.server.inventory.AbstractInventory.getItemStack(AbstractInventory.java:185) at net.minestom.server.inventory.PlayerInventory.changeHeld(PlayerInventory.java:250) at net.minestom.server.listener.WindowListener.clickWindowListener(WindowListener.java:54) at net.minestom.server.listener.manager.PacketListenerManager.lambda$setPlayListener$2(PacketListenerManager.java:163) at net.minestom.server.listener.manager.PacketListenerManager.processClientPacket(PacketListenerManager.java:132) at net.minestom.server.entity.Player.lambda$interpretPacketQueue$12(Player.java:2131) at org.jctools.queues.MpscArrayQueue.drain(MpscArrayQueue.java:512) at net.minestom.server.entity.Player.interpretPacketQueue(Player.java:2131) at java.base/java.util.concurrent.CopyOnWriteArrayList.forEach(CopyOnWriteArrayList.java:891) at java.base/java.util.concurrent.CopyOnWriteArraySet.forEach(CopyOnWriteArraySet.java:425) at net.minestom.server.network.ConnectionManager.tick(ConnectionManager.java:369) at net.minestom.server.ServerProcessImpl$TickerImpl.tick(ServerProcessImpl.java:37