### PR TITLE
Fix EffectChance network writer

### DIFF
--- a/src/main/java/net/minestom/server/item/component/Food.java
+++ b/src/main/java/net/minestom/server/item/component/Food.java
@@ -74,7 +74,8 @@ public record Food(int nutrition, float saturationModifier, boolean canAlwaysEat
         public static final NetworkBuffer.Type<EffectChance> NETWORK_TYPE = new NetworkBuffer.Type<>() {
             @Override
             public void write(@NotNull NetworkBuffer buffer, EffectChance value) {
-
+                CustomPotionEffect.NETWORK_TYPE.write(buffer, value.effect);
+                buffer.write(NetworkBuffer.FLOAT, value.probability);
             }
 
             @Override


### PR DESCRIPTION
Relates to #2423.

Effect Chances were not written properly when sending them through a packet, resulting in a decoder exception whenever this list was not empty.