### PR TITLE
Duplicate block property ID fix + unit test

### DIFF
--- a/src/main/java/net/minestom/server/instance/block/BlockImpl.java
+++ b/src/main/java/net/minestom/server/instance/block/BlockImpl.java
@@ -28,7 +28,7 @@ record BlockImpl(@NotNull Registry.BlockEntry registry,
      * <p>
      * Block states are all stored within a single number.
      */
-    private static final int BITS_PER_INDEX = 4;
+    private static final int BITS_PER_INDEX = 5;
 
     private static final int MAX_STATES = Integer.SIZE / BITS_PER_INDEX;
 

--- a/src/test/java/net/minestom/server/instance/BlockTest.java
+++ b/src/test/java/net/minestom/server/instance/BlockTest.java
@@ -7,10 +7,12 @@ import net.minestom.server.instance.block.Block;
 import net.minestom.server.tag.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BlockTest {
 
@@ -83,5 +85,15 @@ public class BlockTest {
 
         assertEquals(start, new Vec(0.3125, 0, 0.3125));
         assertEquals(end, new Vec(0.6875, 0.5625, 0.6875));
+    }
+
+    @Test
+    public void testDuplicateProperties() {
+        HashSet<Integer> assignedStates = new HashSet<>();
+        for (Block block : Block.values()) {
+            for (Block blockWithState : block.possibleStates()) {
+                assertTrue(assignedStates.add(blockWithState.stateId()));
+            }
+        }
     }
 }


### PR DESCRIPTION
[This earlier commit](https://github.com/Minestom/Minestom/commit/a3dec124aaf20a0f4dadf0df7caeaa0aee4ff90a) does not properly account for the number of properties of blocks like noteblocks.

This hopefully fixes it.