### PR TITLE
Fix a few item component issues

### DIFF
--- a/src/main/java/net/minestom/server/item/book/FilteredText.java
+++ b/src/main/java/net/minestom/server/item/book/FilteredText.java
@@ -36,7 +36,7 @@ public record FilteredText<T>(@NotNull T text, @Nullable T filtered) {
             @Override
             public @NotNull BinaryTag write(@NotNull FilteredText<T> value) {
                 CompoundBinaryTag.Builder builder = CompoundBinaryTag.builder();
-                builder.put("text", inner.write(value.text));
+                builder.put("raw", inner.write(value.text));
                 if (value.filtered != null) {
                     builder.put("filtered", inner.write(value.filtered));
                 }
@@ -46,7 +46,7 @@ public record FilteredText<T>(@NotNull T text, @Nullable T filtered) {
             @Override
             public @NotNull FilteredText<T> read(@NotNull BinaryTag tag) {
                 if (tag instanceof CompoundBinaryTag compound) {
-                    BinaryTag textTag = compound.get("text");
+                    BinaryTag textTag = compound.get("raw");
                     if (textTag != null) {
                         BinaryTag filteredTag = compound.get("filtered");
                         T filtered = filteredTag == null ? null : inner.read(filteredTag);

--- a/src/main/java/net/minestom/server/item/component/DyedItemColor.java
+++ b/src/main/java/net/minestom/server/item/component/DyedItemColor.java
@@ -23,7 +23,7 @@ public record DyedItemColor(@NotNull RGBLike color, boolean showInTooltip) {
         @Override
         public @NotNull BinaryTag write(@NotNull DyedItemColor value) {
             return CompoundBinaryTag.builder()
-                    .putInt("color", Color.fromRGBLike(value.color).asRGB())
+                    .putInt("rgb", Color.fromRGBLike(value.color).asRGB())
                     .putBoolean("show_in_tooltip", value.showInTooltip)
                     .build();
         }
@@ -31,7 +31,7 @@ public record DyedItemColor(@NotNull RGBLike color, boolean showInTooltip) {
         @Override
         public @NotNull DyedItemColor read(@NotNull BinaryTag tag) {
             if (tag instanceof CompoundBinaryTag compoundTag) {
-                int color = compoundTag.getInt("color");
+                int color = compoundTag.getInt("rgb");
                 boolean showInTooltip = compoundTag.getBoolean("show_in_tooltip", true);
                 return new DyedItemColor(new Color(color), showInTooltip);
             } else if (tag instanceof IntBinaryTag intTag) {


### PR DESCRIPTION
The `color` field doesn't actually exist, it's called `rgb`
https://minecraft.wiki/w/Data_component_format#dyed_color
![image](https://github.com/user-attachments/assets/0af69551-0074-486a-9716-ffe9af8f9347)

Book pages don't have a `text` field, but they do have a `raw` field
https://minecraft.wiki/w/Data_component_format#written_book_content
![image](https://github.com/user-attachments/assets/364d6e31-309f-4929-99e1-eab080013932)
