### PR TITLE
fix LoginListener.enterConfig

### DIFF
--- a/src/main/java/net/minestom/server/listener/preplay/LoginListener.java
+++ b/src/main/java/net/minestom/server/listener/preplay/LoginListener.java
@@ -215,10 +215,16 @@ public final class LoginListener {
     }
 
     private static void enterConfig(PlayerConnection connection, GameProfile gameProfile) {
-        gameProfile = MinecraftServer.getConnectionManager().transitionLoginToConfig(connection, gameProfile);
-        if (connection instanceof PlayerSocketConnection socketConnection) {
-            socketConnection.UNSAFE_setProfile(gameProfile);
-        }
+        Thread.startVirtualThread(() -> {
+            try {
+                var newGameProfile = MinecraftServer.getConnectionManager().transitionLoginToConfig(connection, gameProfile);
+                if (connection instanceof PlayerSocketConnection socketConnection) {
+                    socketConnection.UNSAFE_setProfile(newGameProfile);
+                }
+            } catch (Throwable t) {
+                MinecraftServer.getExceptionManager().handleException(t);
+            }
+        });
     }
 
     private static void executeConfig(Player player, boolean isFirstConfig) {


### PR DESCRIPTION
Blocking the AsyncPlayerPreLoginEvent event blocks receiving a cookie response from the client