### PR TITLE
Fix anvil saving (minimum 4 bits per entry in block_states palette)

### DIFF
--- a/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
+++ b/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
@@ -464,7 +464,7 @@ public class AnvilLoader implements IChunkLoader {
                 blockStates.put("palette", ListBinaryTag.listBinaryTag(BinaryTagTypes.COMPOUND, blockPaletteEntries));
                 if (blockPaletteEntries.size() > 1) {
                     // If there is only one entry we do not need to write the packed indices
-                    var bitsPerEntry = (int) Math.max(1, Math.ceil(Math.log(blockPaletteEntries.size()) / Math.log(2)));
+                    var bitsPerEntry = (int) Math.max(4, Math.ceil(Math.log(blockPaletteEntries.size()) / Math.log(2)));
                     blockStates.putLongArray("data", ArrayUtils.pack(blockIndices, bitsPerEntry));
                 }
                 sectionData.put("block_states", blockStates.build());


### PR DESCRIPTION
It's documented in https://minecraft.wiki/w/Chunk_format. In NMS it's a bit convulated but it's there too exactly as explained in the wiki, where block_states has a minimum of 4 but biomes doesn't.

Long story short if you save a chunk section with 2 to 8 block states in its palette, nms will throw an exception and refuse to load it.