### PR TITLE
Make entity interaction dependent on range

### DIFF
--- a/src/main/java/net/minestom/server/ServerFlag.java
+++ b/src/main/java/net/minestom/server/ServerFlag.java
@@ -56,10 +56,10 @@ public final class ServerFlag {
 
     // Maps
     public static final @NotNull String MAP_RGB_MAPPING = stringProperty("minestom.map.rgbmapping", "lazy");
-    public static final int MAP_RGB_REDUCTION = intProperty("minestom.map.rgbreduction", -1); // Only used if rgb mapping is "approximate"
+    public static final @Nullable String MAP_RGB_REDUCTION = stringProperty("minestom.map.rgbreduction"); // Only used if rgb mapping is "approximate"
 
     // Entities
-    public static final boolean ENFORCE_INTERACTION_LIMIT = booleanProperty("minestom.enforce-entity-interaction-range", false);
+    public static final boolean ENFORCE_INTERACTION_LIMIT = booleanProperty("minestom.enforce-entity-interaction-range", true);
 
     // Experimental/Unstable
     public static final boolean REGISTRY_LATE_REGISTER = booleanProperty("minestom.registry.late-register");

--- a/src/main/java/net/minestom/server/ServerFlag.java
+++ b/src/main/java/net/minestom/server/ServerFlag.java
@@ -56,7 +56,10 @@ public final class ServerFlag {
 
     // Maps
     public static final @NotNull String MAP_RGB_MAPPING = stringProperty("minestom.map.rgbmapping", "lazy");
-    public static final @Nullable String MAP_RGB_REDUCTION = stringProperty("minestom.map.rgbreduction"); // Only used if rgb mapping is "approximate"
+    public static final int MAP_RGB_REDUCTION = intProperty("minestom.map.rgbreduction", -1); // Only used if rgb mapping is "approximate"
+
+    // Entities
+    public static final boolean ENFORCE_INTERACTION_LIMIT = booleanProperty("minestom.enforce-entity-interaction-range", false);
 
     // Experimental/Unstable
     public static final boolean REGISTRY_LATE_REGISTER = booleanProperty("minestom.registry.late-register");

--- a/src/main/java/net/minestom/server/listener/UseEntityListener.java
+++ b/src/main/java/net/minestom/server/listener/UseEntityListener.java
@@ -1,10 +1,12 @@
 package net.minestom.server.listener;
 
+import net.minestom.server.ServerFlag;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.LivingEntity;
 import net.minestom.server.entity.Player;
+import net.minestom.server.entity.attribute.Attribute;
 import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.entity.EntityAttackEvent;
 import net.minestom.server.event.player.PlayerEntityInteractEvent;
@@ -14,8 +16,15 @@ public class UseEntityListener {
 
     public static void useEntityListener(ClientInteractEntityPacket packet, Player player) {
         final Entity entity = player.getInstance().getEntityById(packet.targetId());
-        if (entity == null || !entity.isViewer(player) || player.getDistanceSquared(entity) > 6 * 6)
+        if (entity == null || !entity.isViewer(player))
             return;
+
+        if (ServerFlag.ENFORCE_INTERACTION_LIMIT) {
+            double range = Math.pow(player.getAttributeValue(Attribute.PLAYER_ENTITY_INTERACTION_RANGE) + 1, 2); // Add 1 additional block for people with less than stellar ping
+            if (player.getDistanceSquared(entity) > range) {
+                return;
+            }
+        }
 
         ClientInteractEntityPacket.Type type = packet.type();
         if (type instanceof ClientInteractEntityPacket.Attack) {

--- a/src/main/java/net/minestom/server/map/MapColors.java
+++ b/src/main/java/net/minestom/server/map/MapColors.java
@@ -1,5 +1,6 @@
 package net.minestom.server.map;
 
+import net.minestom.server.MinecraftServer;
 import net.minestom.server.ServerFlag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,11 +92,16 @@ public enum MapColors {
         mappingStrategy = strategy;
 
         int reduction = 10;
-        if (ServerFlag.MAP_RGB_REDUCTION != -1) {
-            reduction = ServerFlag.MAP_RGB_REDUCTION;
+        if (ServerFlag.MAP_RGB_REDUCTION != null) {
+            try {
+                reduction = Integer.parseInt(ServerFlag.MAP_RGB_REDUCTION);
+            } catch (NumberFormatException e) {
+                logger.error("Invalid integer in reduction argument: {}", ServerFlag.MAP_RGB_REDUCTION);
+                MinecraftServer.getExceptionManager().handleException(e);
+            }
 
-            if (reduction < 0 || reduction > 255) {
-                logger.warn("MAP_RGB_REDUCTION was found to be invalid: {}. Must in 0-255, defaulting to 10.", reduction);
+            if (reduction < 0 || reduction >= 255) {
+                logger.warn("Reduction was found to be invalid: {}. Must in 0-255, defaulting to 10.", reduction);
                 reduction = 10;
             }
         }

--- a/src/main/java/net/minestom/server/map/MapColors.java
+++ b/src/main/java/net/minestom/server/map/MapColors.java
@@ -1,6 +1,5 @@
 package net.minestom.server.map;
 
-import net.minestom.server.MinecraftServer;
 import net.minestom.server.ServerFlag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,16 +91,11 @@ public enum MapColors {
         mappingStrategy = strategy;
 
         int reduction = 10;
-        if (ServerFlag.MAP_RGB_REDUCTION != null) {
-            try {
-                reduction = Integer.parseInt(ServerFlag.MAP_RGB_REDUCTION);
-            } catch (NumberFormatException e) {
-                logger.error("Invalid integer in reduction argument: {}", ServerFlag.MAP_RGB_REDUCTION);
-                MinecraftServer.getExceptionManager().handleException(e);
-            }
+        if (ServerFlag.MAP_RGB_REDUCTION != -1) {
+            reduction = ServerFlag.MAP_RGB_REDUCTION;
 
-            if (reduction < 0 || reduction >= 255) {
-                logger.warn("Reduction was found to be invalid: {}. Must in 0-255, defaulting to 10.", reduction);
+            if (reduction < 0 || reduction > 255) {
+                logger.warn("MAP_RGB_REDUCTION was found to be invalid: {}. Must in 0-255, defaulting to 10.", reduction);
                 reduction = 10;
             }
         }


### PR DESCRIPTION
- Makes entity interaction work with the interaction attribute
- Adds a server flag to disable checking of the range limit
- Change the MAP_RGB_REDUCTION flag to be an int so there is no int parsing messiness in MapColors.