### PR TITLE
Update Inventory test and sending

### DIFF
--- a/src/main/java/net/minestom/server/inventory/AbstractInventory.java
+++ b/src/main/java/net/minestom/server/inventory/AbstractInventory.java
@@ -112,7 +112,7 @@ public sealed abstract class AbstractInventory implements InventoryClickHandler,
      * @param sendPacket whether or not to send packets
      */
     public void setItemStack(int slot, @NotNull ItemStack itemStack, boolean sendPacket) {
-        Check.argCondition(!MathUtils.isBetween(slot, 0, getSize()),
+        Check.argCondition(!MathUtils.isBetween(slot, 0, getSize() - 1), // Subtract 1 because MathUtils is <= max, instead of strictly less than
                 "Inventory does not have the slot " + slot);
 
         ItemStack previous;

--- a/src/main/java/net/minestom/server/inventory/PlayerInventory.java
+++ b/src/main/java/net/minestom/server/inventory/PlayerInventory.java
@@ -9,7 +9,6 @@ import net.minestom.server.inventory.click.InventoryClickResult;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.network.packet.server.play.SetCursorItemPacket;
 import net.minestom.server.network.packet.server.play.SetPlayerInventorySlotPacket;
-import net.minestom.server.network.packet.server.play.SetSlotPacket;
 import net.minestom.server.network.packet.server.play.WindowItemsPacket;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/net/minestom/server/inventory/PlayerInventory.java
+++ b/src/main/java/net/minestom/server/inventory/PlayerInventory.java
@@ -131,13 +131,8 @@ public non-sealed class PlayerInventory extends AbstractInventory {
                 player.syncEquipment(equipmentSlot);
             }
 
-            // Slot handling
-            AbstractInventory openInventory = player.getOpenInventory();
-            if (openInventory != null && slot >= OFFSET && slot < OFFSET + INNER_INVENTORY_SIZE) {
-                player.sendPacket(new SetSlotPacket(openInventory.getWindowId(), 0, (short) (slot + openInventory.getSize() - OFFSET), item));
-            } else if (openInventory == null || slot == OFFHAND_SLOT) {
-                player.sendPacket(new SetPlayerInventorySlotPacket(slot, item));
-            }
+            // Update client
+            player.sendPacket(new SetPlayerInventorySlotPacket(slot, item));
         }
     }
 

--- a/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java
+++ b/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java
@@ -194,8 +194,6 @@ public class InventoryIntegrationTest {
         player.openInventory(inventory);
         assertEquals(inventory, player.getOpenInventory());
 
-        var overallTracker = connection.trackIncoming();
-
         // Ensure that slots not in the inner inventory are sent separately
         var packetTracker = connection.trackIncoming(SetPlayerInventorySlotPacket.class);
         player.getInventory().setItemStack(PlayerInventoryUtils.OFFHAND_SLOT, MAGIC_STACK);

--- a/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java
+++ b/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java
@@ -185,7 +185,6 @@ public class InventoryIntegrationTest {
     public void testInnerInventorySlotSending(Env env) {
         // Inner inventory changes are sent along with the open inventory
         // Otherwise, they are sent separately
-        assumeFalse(true, "TODO(1.21.2)");
 
         var instance = env.createFlatInstance();
         var connection = env.createConnection();
@@ -195,6 +194,8 @@ public class InventoryIntegrationTest {
         Inventory inventory = new Inventory(InventoryType.CHEST_6_ROW, Component.empty());
         player.openInventory(inventory);
         assertEquals(inventory, player.getOpenInventory());
+
+        var overallTracker = connection.trackIncoming();
 
         // Ensure that slots not in the inner inventory are sent separately
         var packetTracker = connection.trackIncoming(SetPlayerInventorySlotPacket.class);
@@ -208,14 +209,14 @@ public class InventoryIntegrationTest {
         packetTracker = connection.trackIncoming(SetPlayerInventorySlotPacket.class);
         player.getInventory().setItemStack(0, MAGIC_STACK); // Test with first inner inventory slot
         packetTracker.assertSingle(slot -> {
-            assertEquals(PlayerInventoryUtils.convertToPacketSlot(0) - PlayerInventoryUtils.OFFSET + inventory.getSize(), slot.slot());
+            assertEquals(0, slot.slot());
             assertEquals(MAGIC_STACK, slot.itemStack());
         });
 
         packetTracker = connection.trackIncoming(SetPlayerInventorySlotPacket.class);
         player.getInventory().setItemStack(35, MAGIC_STACK); // Test with last inner inventory slot
         packetTracker.assertSingle(slot -> {
-            assertEquals(PlayerInventoryUtils.convertToPacketSlot(35) - PlayerInventoryUtils.OFFSET + inventory.getSize(), slot.slot());
+            assertEquals(35, slot.slot());
             assertEquals(MAGIC_STACK, slot.itemStack());
         });
     }

--- a/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java
+++ b/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java
@@ -12,7 +12,6 @@ import net.minestom.testing.EnvTest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @EnvTest
 public class InventoryIntegrationTest {


### PR DESCRIPTION
Due to the introduction of the SetPlayerInventorySlotPacket, we can simplify the sending logic in PlayerInventory.

Additionally, the tests were broken due to the inventory offset calculations no longer being necessary since we aren't using SetSlotPacket.