### PR TITLE
Fix damage invulnerablity checks

### DIFF
--- a/src/main/java/net/minestom/server/entity/GameMode.java
+++ b/src/main/java/net/minestom/server/entity/GameMode.java
@@ -30,7 +30,7 @@ public enum GameMode {
         return allowFlying;
     }
 
-    public boolean canTakeDamage() {
+    public boolean invulnerable() {
         return invulnerable;
     }
 

--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -326,7 +326,7 @@ public class LivingEntity extends Entity implements EquipmentHandler {
     public boolean damage(@NotNull Damage damage) {
         if (isDead())
             return false;
-        if (isInvulnerable() || isImmune(damage.getType())) {
+        if (isImmune(damage.getType())) {
             return false;
         }
 
@@ -384,7 +384,10 @@ public class LivingEntity extends Entity implements EquipmentHandler {
      * @return true if this entity is immune to the given type of damage
      */
     public boolean isImmune(@NotNull DynamicRegistry.Key<DamageType> type) {
-        return false;
+        if (isInvulnerable() && type == DamageType.OUT_OF_WORLD) {
+            return false;
+        }
+        return isInvulnerable();
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -384,7 +384,7 @@ public class LivingEntity extends Entity implements EquipmentHandler {
      * @return true if this entity is immune to the given type of damage
      */
     public boolean isImmune(@NotNull DynamicRegistry.Key<DamageType> type) {
-        if (isInvulnerable() && type == DamageType.OUT_OF_WORLD) {
+        if (type.equals(DamageType.OUT_OF_WORLD)) {
             return false;
         }
         return isInvulnerable();

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -1014,14 +1014,6 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
     }
 
     @Override
-    public boolean isImmune(@NotNull DynamicRegistry.Key<DamageType> type) {
-        if (!getGameMode().canTakeDamage()) {
-            return !DamageType.OUT_OF_WORLD.equals(type);
-        }
-        return super.isImmune(type);
-    }
-
-    @Override
     public void setHealth(float health) {
         sendPacket(new UpdateHealthPacket(health, food, foodSaturation));
         super.setHealth(health);
@@ -1634,7 +1626,7 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
         // The client updates their abilities based on the GameMode as follows
         this.allowFlying = gameMode.allowFlying();
         this.instantBreak = gameMode.instantBreak();
-        this.invulnerable = gameMode.canTakeDamage();
+        this.invulnerable = gameMode.invulnerable();
         // Spectator automatically enables flying
         // If new game mode cannot fly, disable it
         if (gameMode == GameMode.SPECTATOR || !gameMode.allowFlying()) {
@@ -1918,15 +1910,6 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
      */
     public boolean hasReducedDebugScreenInformation() {
         return reducedDebugScreenInformation;
-    }
-
-    /**
-     * The invulnerable field appear in the {@link PlayerAbilitiesPacket} packet.
-     *
-     * @return true if the player is invulnerable, false otherwise
-     */
-    public boolean isInvulnerable() {
-        return super.isInvulnerable();
     }
 
     /**


### PR DESCRIPTION
There are a couple of problems with the current damage checks:

1. The invulnerable field was named `canTakeDamage`, guaranteeing confusion, as if this was true, that means they cannot take damage.
2. The `damage()` function checked invulnerability before checking immunity, skipping the special case of OUT_OF_WORLD damage being able to damage players while invulnerable.

I have renamed the field and adjusted the damage function so it only performs the isImmune check, and moved the logic to the isImmune check.
Resolves #2466.