### PR TITLE
Add empty path check in PathGenerator

### DIFF
--- a/src/main/java/net/minestom/server/entity/pathfinding/PathGenerator.java
+++ b/src/main/java/net/minestom/server/entity/pathfinding/PathGenerator.java
@@ -88,13 +88,13 @@ public final class PathGenerator {
 
         PNode current = open.isEmpty() ? null : open.dequeue();
 
-        if (current == null || open.isEmpty() || !withinDistance(current, target, closeDistance)) {
+        if (current == null || !withinDistance(current, target, closeDistance)) {
             if (closestFoundNodes.isEmpty()) {
                 path.setState(PPath.State.INVALID);
                 return;
             }
 
-            current = closestFoundNodes.get(0);
+            current = closestFoundNodes.getFirst();
 
             if (!open.isEmpty()) {
                 current = buildRepathNode(current);
@@ -114,7 +114,12 @@ public final class PathGenerator {
             return;
         }
 
-        var lastNode = path.getNodes().get(path.getNodes().size() - 1);
+        if (path.getNodes().isEmpty()) {
+            path.setState(PPath.State.INVALID);
+            return;
+        }
+
+        var lastNode = path.getNodes().getLast();
         if (getDistanceSquared(lastNode.x(), lastNode.y(), lastNode.z(), target) > (closeDistance * closeDistance)) {
             path.setState(PPath.State.BEST_EFFORT);
             return;


### PR DESCRIPTION
I've run into IndexOutOfBounds several times when using PathGenerator, failing on the `var lastNode = path.getNodes().get(path.getNodes().size() - 1);` line. I've fixed it by adding a check to see if the path is empty before proceeding.
I've also changed a few surrounding statements to be a bit easier to read.