### PR TITLE
Remove TinyLog service file

### DIFF
--- a/src/main/resources/META-INF/services/org.tinylog.writers.Writer
+++ b/src/main/resources/META-INF/services/org.tinylog.writers.Writer
@@ -1,8 +1,0 @@
-net.minestom.server.terminal.MinestomConsoleWriter
-org.tinylog.writers.ConsoleWriter
-org.tinylog.writers.FileWriter
-org.tinylog.writers.JdbcWriter
-org.tinylog.writers.LogcatWriter
-org.tinylog.writers.RollingFileWriter
-org.tinylog.writers.SharedFileWriter
-org.tinylog.writers.JsonWriter


### PR DESCRIPTION
Generally causes issues with TinyLog as the `MinestomConsoleWriter` class does not exist.