### PR TITLE
Fixed boundingBox.withOffset()

### DIFF
--- a/src/main/java/net/minestom/server/collision/BoundingBox.java
+++ b/src/main/java/net/minestom/server/collision/BoundingBox.java
@@ -21,11 +21,11 @@ public record BoundingBox(Vec relativeStart, Vec relativeEnd) implements Shape {
     final static BoundingBox ZERO = new BoundingBox(Vec.ZERO, Vec.ZERO);
 
     public BoundingBox(double width, double height, double depth, Point offset) {
-        this(Vec.fromPoint(offset), new Vec(width, height, depth).add(offset));
+        this(new Vec(-width / 2.0, 0.0, -depth / 2.0).add(offset), new Vec(width / 2.0, height, depth / 2.0).add(offset));
     }
 
     public BoundingBox(double width, double height, double depth) {
-        this(width, height, depth, new Vec(-width / 2, 0, -depth / 2));
+        this(width, height, depth, Vec.ZERO);
     }
 
     @Override


### PR DESCRIPTION
Previously `boundingBox.withOffset(point)` used the offset as relativeStart instead of applying the offset to the relativeStart and relativeEnd.

With these small changes the offset becomes the new center of the boundingBox instead of the corner. Which in my opinion makes more sense when moving something in a 3D space.