### PR TITLE
fix painting variants

### DIFF
--- a/src/main/java/net/minestom/server/entity/metadata/other/PaintingMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/PaintingMeta.java
@@ -18,6 +18,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import java.util.Comparator;
 
 public class PaintingMeta extends EntityMeta implements ObjectDataProvider {
     public static final byte OFFSET = EntityMeta.MAX_OFFSET;
@@ -104,7 +105,8 @@ public class PaintingMeta extends EntityMeta implements ObjectDataProvider {
         static @NotNull DynamicRegistry<Variant> createDefaultRegistry() {
             return DynamicRegistry.create(
                     "minecraft:painting_variant", VariantImpl.REGISTRY_NBT_TYPE, Registry.Resource.PAINTING_VARIANTS,
-                    (namespace, props) -> new VariantImpl(Registry.paintingVariant(namespace, props))
+                    (namespace, props) -> new VariantImpl(Registry.paintingVariant(namespace, props)),
+                    Comparator.naturalOrder()
             );
         }
 

--- a/src/main/java/net/minestom/server/network/NetworkBufferTypeImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferTypeImpl.java
@@ -631,8 +631,8 @@ interface NetworkBufferTypeImpl<T> extends NetworkBuffer.Type<T> {
         public void write(@NotNull NetworkBuffer buffer, DynamicRegistry.Key<T> value) {
             Check.stateCondition(buffer.registries == null, "Buffer does not have registries");
             final DynamicRegistry<T> registry = selector.apply(buffer.registries);
-            final int id = registry.getId(value);
-            Check.argCondition(id == -1, "Key is not registered: {0} > {1}", registry, value);
+            final int id = (registry.id() == "minecraft:painting_variant")?registry.getId(value)+1:registry.getId(value);
+            Check.argCondition(id == -1, "No such ID in registry: {0} > {1}", registry, value);
             buffer.write(VAR_INT, id);
         }
 


### PR DESCRIPTION
Fixes #2479.
Paintings appeared incorrectly and sometimes disconnected the client due to both the registry being incorrectly ordered (now ordered alphabetically with `Comparators.naturalOrder()` like vanilla) and the fact that, for whatever reason, the registry starts at 1 on the client (fixed by adding 1 to the value if the registry is `minecraft:painting_variant`).