### PR TITLE
Add brightness helpers for AbstractDisplayMeta

### DIFF
--- a/src/main/java/net/minestom/server/entity/metadata/display/AbstractDisplayMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/display/AbstractDisplayMeta.java
@@ -87,6 +87,26 @@ public class AbstractDisplayMeta extends EntityMeta {
         metadata.set(MetadataDef.Display.BRIGHTNESS_OVERRIDE, value);
     }
 
+    public void setBrightness(int blockLight, int skyLight) {
+        setBrightnessOverride((blockLight & 0xF) << 4 | (skyLight & 0xF) << 20);
+    }
+
+    public int getBlockLight() {
+        return getLight(4);
+    }
+
+    public int getSkyLight() {
+        return getLight(20);
+    }
+
+    private int getLight(int shift) {
+        int brightnessOverride = getBrightnessOverride();
+        if (brightnessOverride <= 0)
+            return 0;
+        else
+            return (brightnessOverride >> shift) & 0xF;
+    }
+
     public float getViewRange() {
         return metadata.get(MetadataDef.Display.VIEW_RANGE);
     }


### PR DESCRIPTION
`setBrightnessOverride(int value)` can be a bit confusing, as it could seem it takes in a light level but takes in the combined block light and sky light in a single int.