### PR TITLE
fix: client disconnect, server-side exceptions when changing entity type of a Player

### DIFF
--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -12,6 +12,7 @@ import net.minestom.server.entity.damage.Damage;
 import net.minestom.server.entity.damage.DamageType;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.entity.metadata.LivingEntityMeta;
+import net.minestom.server.entity.metadata.PlayerMeta;
 import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.entity.EntityDamageEvent;
 import net.minestom.server.event.entity.EntityDeathEvent;
@@ -344,14 +345,15 @@ public class LivingEntity extends Entity implements EquipmentHandler {
             sendPacketToViewersAndSelf(new DamageEventPacket(getEntityId(), damage.getTypeId(), damage.getAttacker() == null ? 0 : damage.getAttacker().getEntityId() + 1, damage.getSource() == null ? 0 : damage.getSource().getEntityId() + 1, damage.getSourcePosition()));
 
             // Additional hearts support
-            if (this instanceof Player player) {
-                final float additionalHearts = player.getAdditionalHearts();
+            if (getEntityMeta() instanceof PlayerMeta playerMeta) {
+                final float additionalHearts = playerMeta.getAdditionalHearts();
+
                 if (additionalHearts > 0) {
                     if (remainingDamage > additionalHearts) {
                         remainingDamage -= additionalHearts;
-                        player.setAdditionalHearts(0);
+                        playerMeta.setAdditionalHearts(0);
                     } else {
-                        player.setAdditionalHearts(additionalHearts - remainingDamage);
+                        playerMeta.setAdditionalHearts(additionalHearts - remainingDamage);
                         remainingDamage = 0;
                     }
                 }

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -35,6 +35,7 @@ import net.minestom.server.coordinate.Vec;
 import net.minestom.server.effects.Effects;
 import net.minestom.server.entity.attribute.Attribute;
 import net.minestom.server.entity.damage.DamageType;
+import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.entity.metadata.LivingEntityMeta;
 import net.minestom.server.entity.metadata.PlayerMeta;
 import net.minestom.server.entity.vehicle.PlayerVehicleInformation;
@@ -2510,14 +2511,18 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
                 // Else previous and current are equal, do nothing
             }
 
-            boolean isInPlayState = getPlayerConnection().getConnectionState() == ConnectionState.PLAY;
-            PlayerMeta playerMeta = getPlayerMeta();
-            if (isInPlayState) playerMeta.setNotifyAboutChanges(false);
-            playerMeta.setDisplayedSkinParts(displayedSkinParts);
-            playerMeta.setRightMainHand(this.mainHand == MainHand.RIGHT);
-            if (isInPlayState) playerMeta.setNotifyAboutChanges(true);
-        }
+            EntityMeta entityMeta = getEntityMeta();
 
+            // in case setEntityType was used
+            if (entityMeta instanceof PlayerMeta playerMeta) {
+                boolean isInPlayState = getPlayerConnection().getConnectionState() == ConnectionState.PLAY;
+
+                if (isInPlayState) playerMeta.setNotifyAboutChanges(false);
+                playerMeta.setDisplayedSkinParts(displayedSkinParts);
+                playerMeta.setRightMainHand(this.mainHand == MainHand.RIGHT);
+                if (isInPlayState) playerMeta.setNotifyAboutChanges(true);
+            }
+        }
     }
 
     private int compareChunkDistance(long chunkIndexA, long chunkIndexB) {

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -1443,7 +1443,12 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         // Update for viewers
         sendPacketToViewersAndSelf(getVelocityPacket());
         sendPacketToViewersAndSelf(getMetadataPacket());
-        sendPacketToViewersAndSelf(getPropertiesPacket());
+
+        // send attributes to everyone if our entity type is valid for it
+        // otherwise, just send to the player
+        if (shouldSendAttributes()) sendPacketToViewersAndSelf(getPropertiesPacket());
+        else sendPacket(getPropertiesPacket());
+
         sendPacketToViewersAndSelf(getEquipmentsPacket());
 
         getInventory().update();


### PR DESCRIPTION
Basically an extension of https://github.com/Minestom/Minestom/pull/2495, that also integrates https://github.com/Minestom/Minestom/pull/2421. Should fix crashes & some server-side errors when players are "disguised" as another entity.