### PR TITLE
fix: "off-by-one" error in Suggestion

### DIFF
--- a/src/main/java/net/minestom/server/command/CommandParserImpl.java
+++ b/src/main/java/net/minestom/server/command/CommandParserImpl.java
@@ -247,7 +247,7 @@ final class CommandParserImpl implements CommandParser {
             final SuggestionCallback callback = suggestionCallback();
             if (callback == null) return null;
             final int lastSpace = input().lastIndexOf(" ");
-            final Suggestion suggestion = new Suggestion(input(), lastSpace + 2, input().length() - lastSpace - 1);
+            final Suggestion suggestion = new Suggestion(input(), lastSpace + 1, input().length() - lastSpace - 1);
             final CommandContext context = createCommandContext(input(), arguments());
             callback.apply(sender, context, suggestion);
             return suggestion;

--- a/src/main/java/net/minestom/server/command/builder/suggestion/Suggestion.java
+++ b/src/main/java/net/minestom/server/command/builder/suggestion/Suggestion.java
@@ -1,10 +1,16 @@
 package net.minestom.server.command.builder.suggestion;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * A class representing the tab completion of a command. Created by the command parser, and passed to user-defined
+ * {@link SuggestionCallback} instances when tab completion is requested by a client.
+ * Use {@link Suggestion#addEntry(SuggestionEntry)} to add a possible completion value.
+ */
 public class Suggestion {
 
     private final String input;
@@ -12,38 +18,109 @@ public class Suggestion {
     private int length;
     private final List<SuggestionEntry> suggestionEntries = new ArrayList<>();
 
+    /**
+     * Creates a new Suggestion; used by the command parser.
+     *
+     * @param input the input string (command that was typed so far)
+     * @param start the initial starting index of the argument to be completed
+     * @param length the initial length of the argument to be completed
+     */
+    @ApiStatus.Internal
     public Suggestion(@NotNull String input, int start, int length) {
+        validateSubstring(start, length, input.length());
+
         this.input = input;
         this.start = start;
         this.length = length;
     }
 
+    private static void validateSubstring(int start, int length, int totalLength) {
+        if (start < 0)
+            throw new IllegalArgumentException("negative start index " + start);
+
+        if (length < 0)
+            throw new IllegalArgumentException("negative length " + length);
+
+        if (start + length > totalLength)
+            throw new IllegalArgumentException("range [" + start + ", " + (start + length) +
+                    ") out of bounds for length " + totalLength);
+    }
+
+    /**
+     * Returns the input string. This is the entire command that has been typed so far, excluding the leading {@code /}.
+     *
+     * @return the command string
+     */
     @NotNull
     public String getInput() {
         return input;
     }
 
+    /**
+     * Returns the starting index of the argument that is being tab-completed.
+     *
+     * @return the starting index of the argument
+     */
     public int getStart() {
         return start;
     }
 
+    /**
+     * Sets the starting index of the argument being completed.
+     *
+     * @param start the starting index
+     * @throws IllegalArgumentException if {@code start < 0}, or {@code start + getLength()} &gt; {@code getInput().length()}
+     */
     public void setStart(int start) {
+        validateSubstring(start, length, input.length());
         this.start = start;
     }
 
+    /**
+     * Gets the length of the argument being completed.
+     *
+     * @return the length of the argument being completed
+     */
     public int getLength() {
         return length;
     }
 
+    /**
+     * Sets the length of the argument being completed.
+     *
+     * @param length the argument length
+     * @throws IllegalArgumentException if {@code length < 0}, or {@code getStart() + length} &gt; {@code getInput().length()}
+     */
     public void setLength(int length) {
+        validateSubstring(start, length, input.length());
         this.length = length;
     }
 
+    /**
+     * Gets the current substring of the input ({@link Suggestion#getInput()}) that is eligible for completion.
+     *
+     * @return a substring of {@code getInput()}
+     */
+    @NotNull
+    public String getCurrent() {
+        return input.substring(start, start + length);
+    }
+
+    /**
+     * Gets the mutable list of {@link SuggestionEntry}s that represent possible tab completion values.
+     *
+     * @return a mutable list of SuggestionEntry instances
+     */
     @NotNull
     public List<SuggestionEntry> getEntries() {
         return suggestionEntries;
     }
 
+    /**
+     * Adds a new {@link SuggestionEntry}, representing a possible tab completion value.
+     *
+     * @param entry the new entry
+     */
     public void addEntry(@NotNull SuggestionEntry entry) {
         this.suggestionEntries.add(entry);
     }

--- a/src/main/java/net/minestom/server/listener/TabCompleteListener.java
+++ b/src/main/java/net/minestom/server/listener/TabCompleteListener.java
@@ -13,10 +13,15 @@ public class TabCompleteListener {
     public static void listener(ClientTabCompletePacket packet, Player player) {
         final String text = packet.text();
         final Suggestion suggestion = getSuggestion(player, text);
+
         if (suggestion != null) {
+            // if the incoming ClientTabCompletePacket starts with a /, our Suggestion's start will be based off of the
+            // command string with the forward slash trimmed, and therefore off-by-one
+            final int startOffset = text.startsWith("/") ? 1 : 0;
+
             player.sendPacket(new TabCompletePacket(
                     packet.transactionId(),
-                    suggestion.getStart(),
+                    suggestion.getStart() + startOffset,
                     suggestion.getLength(),
                     suggestion.getEntries().stream()
                             .map(suggestionEntry -> new TabCompletePacket.Match(suggestionEntry.getEntry(), suggestionEntry.getTooltip()))

--- a/src/test/java/net/minestom/server/command/ArgumentTest.java
+++ b/src/test/java/net/minestom/server/command/ArgumentTest.java
@@ -48,7 +48,7 @@ public class ArgumentTest {
         arg.setSuggestionCallback((sender, context, suggestion) -> suggestion.addEntry(new SuggestionEntry("entry")));
         assertTrue(arg.hasSuggestion());
 
-        Suggestion suggestion = new Suggestion("input", 2, 4);
+        Suggestion suggestion = new Suggestion("input", 2, 3);
         arg.getSuggestionCallback().apply(new ServerSender(), new CommandContext("input"), suggestion);
 
         assertEquals(suggestion.getEntries(), List.of(new SuggestionEntry("entry")));

--- a/src/test/java/net/minestom/server/command/CommandSuggestionIntegrationTest.java
+++ b/src/test/java/net/minestom/server/command/CommandSuggestionIntegrationTest.java
@@ -7,19 +7,20 @@ import net.minestom.server.network.packet.client.play.ClientTabCompletePacket;
 import net.minestom.server.network.packet.server.play.TabCompletePacket;
 import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 
 import static net.minestom.server.command.builder.arguments.ArgumentType.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @EnvTest
 public class CommandSuggestionIntegrationTest {
 
-    @Test
-    public void suggestion(Env env) {
+    @ParameterizedTest
+    @ValueSource(strings = {"", "/"})
+    public void suggestion(String prefix, Env env) {
         var instance = env.createFlatInstance();
         var connection = env.createConnection();
         var player = connection.connect(instance, new Pos(0, 42, 0)).join();
@@ -38,19 +39,21 @@ public class CommandSuggestionIntegrationTest {
         env.process().command().register(command);
 
         var listener = connection.trackIncoming(TabCompletePacket.class);
-        player.addPacketToQueue(new ClientTabCompletePacket(3, "test te"));
+        player.addPacketToQueue(new ClientTabCompletePacket(3, prefix + "test te"));
         player.interpretPacketQueue();
 
+        int start = prefix.equals("/") ? 6 : 5;
         listener.assertSingle(tabCompletePacket -> {
             assertEquals(3, tabCompletePacket.transactionId());
-            assertEquals(6, tabCompletePacket.start());
+            assertEquals(start, tabCompletePacket.start());
             assertEquals(2, tabCompletePacket.length());
             assertEquals(List.of(new TabCompletePacket.Match("test1", null)), tabCompletePacket.matches());
         });
     }
 
-    @Test
-    public void suggestionWithDefaults(Env env) {
+    @ParameterizedTest
+    @ValueSource(strings = {"", "/"})
+    public void suggestionWithDefaults(String prefix, Env env) {
         var instance = env.createFlatInstance();
         var connection = env.createConnection();
         var player = connection.connect(instance, new Pos(0, 42, 0)).join();
@@ -66,7 +69,7 @@ public class CommandSuggestionIntegrationTest {
         env.process().command().register(command);
 
         var listener = connection.trackIncoming(TabCompletePacket.class);
-        player.addPacketToQueue(new ClientTabCompletePacket(1, "foo 1"));
+        player.addPacketToQueue(new ClientTabCompletePacket(1, prefix + "foo 1"));
         player.interpretPacketQueue();
 
         listener.assertSingle(tabCompletePacket -> {
@@ -74,8 +77,9 @@ public class CommandSuggestionIntegrationTest {
         });
     }
 
-    @Test
-    public void suggestionWithSubcommand(Env env) {
+    @ParameterizedTest
+    @ValueSource(strings = {"", "/"})
+    public void suggestionWithSubcommand(String prefix, Env env) {
         var instance = env.createFlatInstance();
         var connection = env.createConnection();
         var player = connection.connect(instance, new Pos(0, 42, 0)).join();
@@ -100,7 +104,7 @@ public class CommandSuggestionIntegrationTest {
         env.process().command().register(command);
 
         var listener = connection.trackIncoming(TabCompletePacket.class);
-        player.addPacketToQueue(new ClientTabCompletePacket(1, "foo bar "));
+        player.addPacketToQueue(new ClientTabCompletePacket(1, prefix + "foo bar "));
         player.interpretPacketQueue();
 
         listener.assertSingle(tabCompletePacket -> {
@@ -108,8 +112,9 @@ public class CommandSuggestionIntegrationTest {
         });
     }
 
-    @Test
-    public void suggestionWithTwoLiterals(Env env) {
+    @ParameterizedTest
+    @ValueSource(strings = {"", "/"})
+    public void suggestionWithTwoLiterals(String prefix, Env env) {
         var instance = env.createFlatInstance();
         var connection = env.createConnection();
         var player = connection.connect(instance, new Pos(0, 42, 0)).join();
@@ -130,7 +135,7 @@ public class CommandSuggestionIntegrationTest {
         env.process().command().register(command);
 
         var listener = connection.trackIncoming(TabCompletePacket.class);
-        player.addPacketToQueue(new ClientTabCompletePacket(1, "foo literal2 "));
+        player.addPacketToQueue(new ClientTabCompletePacket(1, prefix + "foo literal2 "));
         player.interpretPacketQueue();
 
         listener.assertSingle(tabCompletePacket -> {
@@ -138,4 +143,44 @@ public class CommandSuggestionIntegrationTest {
         });
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"", "/"})
+    public void suggestionSubstring(String prefix, Env env) {
+        var instance = env.createFlatInstance();
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0, 42, 0)).join();
+
+        var command = new Command("test");
+        command.addSyntax((sender, context) -> {
+
+        }, Literal("arg").setSuggestionCallback((sender, context, suggestion) -> {
+            assertEquals(player, sender);
+            assertNull(context.get("arg"));
+            assertEquals("test", context.getCommandName());
+            assertEquals("test te", context.getInput());
+            suggestion.addEntry(new SuggestionEntry("test1"));
+
+            assertEquals(5, suggestion.getStart());
+            assertEquals(2, suggestion.getLength());
+            assertEquals("te", context.getInput().substring(suggestion.getStart()));
+            assertEquals("te", suggestion.getCurrent());
+        }));
+
+        env.process().command().register(command);
+
+        var listener = connection.trackIncoming(TabCompletePacket.class);
+        player.addPacketToQueue(new ClientTabCompletePacket(3, prefix + "test te"));
+        player.interpretPacketQueue();
+
+        int start = prefix.equals("/") ? 6 : 5;
+        listener.assertSingle(tabCompletePacket -> {
+            assertEquals(2, tabCompletePacket.length(), "suggestion length");
+            assertEquals(start, tabCompletePacket.start(), "suggestion start");
+            assertFalse(tabCompletePacket.matches().isEmpty());
+
+            TabCompletePacket.Match match = tabCompletePacket.matches().getFirst();
+            assertEquals("test1", match.match());
+            assertTrue(match.components().isEmpty());
+        });
+    }
 }

--- a/src/test/java/net/minestom/server/command/builder/suggestion/SuggestionTest.java
+++ b/src/test/java/net/minestom/server/command/builder/suggestion/SuggestionTest.java
@@ -34,4 +34,23 @@ class SuggestionTest {
         String value = "test";
         assertEquals(Character.toString(value.charAt(index)), new Suggestion(value, index, 1).getCurrent());
     }
+
+    @Test
+    void setLengthOverflow() {
+        Suggestion suggestion = new Suggestion("test", 0, 0);
+        suggestion.setLength(4);
+        assertEquals("test", suggestion.getCurrent());
+        assertThrows(IllegalArgumentException.class, () -> suggestion.setLength(5));
+    }
+
+    @Test
+    void setIndexOverflow() {
+        Suggestion suggestion = new Suggestion("test", 0, 0);
+        suggestion.setStart(4);
+        assertThrows(IllegalArgumentException.class, () -> suggestion.setLength(1));
+        assertEquals("", suggestion.getCurrent());
+        suggestion.setStart(3);
+        suggestion.setLength(1);
+        assertEquals("t", suggestion.getCurrent());
+    }
 }

--- a/src/test/java/net/minestom/server/command/builder/suggestion/SuggestionTest.java
+++ b/src/test/java/net/minestom/server/command/builder/suggestion/SuggestionTest.java
@@ -1,0 +1,37 @@
+package net.minestom.server.command.builder.suggestion;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SuggestionTest {
+    @Test
+    void simpleRange() {
+        assertEquals("test", new Suggestion("test", 0, 4).getCurrent());
+    }
+
+    @Test
+    void rangeOverflowThrows() {
+        assertThrows(IllegalArgumentException.class, () -> new Suggestion("test", 0, 5));
+    }
+
+    @Test
+    void rangeUnderflowThrows() {
+        assertThrows(IllegalArgumentException.class, () -> new Suggestion("test", -1, 5));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 3})
+    void zeroLengthSubstring(int index) {
+        assertEquals(0, new Suggestion("test", index, 0).getCurrent().length());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2, 3})
+    void singleLengthSubstring(int index) {
+        String value = "test";
+        assertEquals(Character.toString(value.charAt(index)), new Suggestion(value, index, 1).getCurrent());
+    }
+}


### PR DESCRIPTION
Previously, `Suggestion#getStart` would report an index that was off-by-one. For example, given a command completable to `/example command`, a client typing `/example com` would result in a Suggestion with an input string `example com`, and a starting index of 9 (instead of 8). 

This PR fixes this surprising behavior, while still ensuring the client gets the value it expects by offsetting the `index` field of the `TabCompletePacket` sent by the server. It also adds additional documentation and bounds checks to Suggestion.