### PR TITLE
fix: updating equipment would send the client the wrong item

### DIFF
--- a/src/main/java/net/minestom/server/entity/EquipmentSlot.java
+++ b/src/main/java/net/minestom/server/entity/EquipmentSlot.java
@@ -2,23 +2,26 @@ package net.minestom.server.entity;
 
 import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.utils.nbt.BinaryTagSerializer;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import net.minestom.server.item.component.Equippable;
+import net.minestom.server.network.packet.server.play.EntityEquipmentPacket;
 
 import static net.minestom.server.utils.inventory.PlayerInventoryUtils.*;
 
 public enum EquipmentSlot {
-    MAIN_HAND(false, -1, "mainhand"),
-    OFF_HAND(false, -1, "offhand"),
-    BOOTS(true, BOOTS_SLOT, "feet"),
-    LEGGINGS(true, LEGGINGS_SLOT, "legs"),
-    CHESTPLATE(true, CHESTPLATE_SLOT, "chest"),
-    HELMET(true, HELMET_SLOT, "head"),
-    BODY(false, -1, "body");
+    MAIN_HAND(false, -1, "mainhand", 0),
+    BOOTS(true, BOOTS_SLOT, "feet", 2),
+    LEGGINGS(true, LEGGINGS_SLOT, "legs", 3),
+    CHESTPLATE(true, CHESTPLATE_SLOT, "chest", 4),
+    HELMET(true, HELMET_SLOT, "head", 5),
+    OFF_HAND(false, -1, "offhand", 1),
+    BODY(false, -1, "body", 6);
 
     private static final List<EquipmentSlot> ARMORS = List.of(BOOTS, LEGGINGS, CHESTPLATE, HELMET);
     private static final Map<String, EquipmentSlot> BY_NBT_NAME = Arrays.stream(values())
@@ -31,11 +34,13 @@ public enum EquipmentSlot {
     private final boolean armor;
     private final int armorSlot;
     private final String nbtName;
+    private final  int equipmentSlot;
 
-    EquipmentSlot(boolean armor, int armorSlot, String nbtName) {
+    EquipmentSlot(boolean armor, int armorSlot, String nbtName, int equipmentSlot) {
         this.armor = armor;
         this.armorSlot = armorSlot;
         this.nbtName = nbtName;
+        this.equipmentSlot = equipmentSlot;
     }
 
     public boolean isHand() {
@@ -44,6 +49,16 @@ public enum EquipmentSlot {
 
     public boolean isArmor() {
         return armor;
+    }
+
+    /**
+     * Differs from the ordinal only slightly - the ordinal is used for sending components such as {@link Equippable},
+     * but this value needs to be used instead for {@link EntityEquipmentPacket}.
+     *
+     * @return the equipment slot
+     */
+    public int equipmentSlot() {
+        return equipmentSlot;
     }
 
     public int armorSlot() {
@@ -58,4 +73,17 @@ public enum EquipmentSlot {
         return ARMORS;
     }
 
+    @ApiStatus.Internal
+    public static @NotNull EquipmentSlot fromEquipmentSlot(int equipmentSlot) {
+        return switch (equipmentSlot) {
+            case 0 -> EquipmentSlot.MAIN_HAND;
+            case 1 -> EquipmentSlot.OFF_HAND;
+            case 2 -> EquipmentSlot.BOOTS;
+            case 3 -> EquipmentSlot.LEGGINGS;
+            case 4 -> EquipmentSlot.CHESTPLATE;
+            case 5 -> EquipmentSlot.HELMET;
+            case 6 -> EquipmentSlot.BODY;
+            default -> throw new IllegalStateException("Unexpected value: " + equipmentSlot);
+        };
+    }
 }

--- a/src/main/java/net/minestom/server/entity/EquipmentSlot.java
+++ b/src/main/java/net/minestom/server/entity/EquipmentSlot.java
@@ -13,11 +13,11 @@ import static net.minestom.server.utils.inventory.PlayerInventoryUtils.*;
 
 public enum EquipmentSlot {
     MAIN_HAND(0, 0, "mainhand", false, -1),
+    OFF_HAND(1, 5, "offhand", false, -1),
     BOOTS(2, 1, "feet", true, BOOTS_SLOT),
     LEGGINGS(3, 2, "legs", true, LEGGINGS_SLOT),
     CHESTPLATE(4, 3, "chest", true, CHESTPLATE_SLOT),
     HELMET(5, 4, "head", true, HELMET_SLOT),
-    OFF_HAND(1, 5, "offhand", false, -1),
     BODY(6, 6, "body", false, -1);
 
     private static final List<EquipmentSlot> ARMORS = List.of(BOOTS, LEGGINGS, CHESTPLATE, HELMET);

--- a/src/main/java/net/minestom/server/entity/EquipmentSlot.java
+++ b/src/main/java/net/minestom/server/entity/EquipmentSlot.java
@@ -57,6 +57,7 @@ public enum EquipmentSlot {
      *
      * @return the equipment slot
      */
+    @ApiStatus.Internal
     public int equipmentSlot() {
         return equipmentSlot;
     }

--- a/src/main/java/net/minestom/server/entity/EquipmentSlot.java
+++ b/src/main/java/net/minestom/server/entity/EquipmentSlot.java
@@ -2,45 +2,82 @@ package net.minestom.server.entity;
 
 import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.utils.nbt.BinaryTagSerializer;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import net.minestom.server.item.component.Equippable;
-import net.minestom.server.network.packet.server.play.EntityEquipmentPacket;
 
 import static net.minestom.server.utils.inventory.PlayerInventoryUtils.*;
 
 public enum EquipmentSlot {
-    MAIN_HAND(false, -1, "mainhand", 0),
-    BOOTS(true, BOOTS_SLOT, "feet", 2),
-    LEGGINGS(true, LEGGINGS_SLOT, "legs", 3),
-    CHESTPLATE(true, CHESTPLATE_SLOT, "chest", 4),
-    HELMET(true, HELMET_SLOT, "head", 5),
-    OFF_HAND(false, -1, "offhand", 1),
-    BODY(false, -1, "body", 6);
+    MAIN_HAND(0, 0, "mainhand", false, -1),
+    BOOTS(2, 1, "feet", true, BOOTS_SLOT),
+    LEGGINGS(3, 2, "legs", true, LEGGINGS_SLOT),
+    CHESTPLATE(4, 3, "chest", true, CHESTPLATE_SLOT),
+    HELMET(5, 4, "head", true, HELMET_SLOT),
+    OFF_HAND(1, 5, "offhand", false, -1),
+    BODY(6, 6, "body", false, -1);
 
     private static final List<EquipmentSlot> ARMORS = List.of(BOOTS, LEGGINGS, CHESTPLATE, HELMET);
     private static final Map<String, EquipmentSlot> BY_NBT_NAME = Arrays.stream(values())
             .collect(Collectors.toMap(EquipmentSlot::nbtName, slot -> slot));
+    private static final Map<Integer, EquipmentSlot> BY_PROTOCOL_ID = Arrays.stream(values())
+            .collect(Collectors.toMap(EquipmentSlot::protocolId, slot -> slot));
+    private static final Map<Integer, EquipmentSlot> BY_LEGACY_PROTOCOL_ID = Arrays.stream(values())
+            .collect(Collectors.toMap(EquipmentSlot::protocolId, slot -> slot));
 
-    public static final NetworkBuffer.Type<EquipmentSlot> NETWORK_TYPE = NetworkBuffer.Enum(EquipmentSlot.class);
+    public static final NetworkBuffer.Type<EquipmentSlot> NETWORK_TYPE = NetworkBuffer.VAR_INT.transform(
+            BY_PROTOCOL_ID::get, EquipmentSlot::protocolId);
     public static final BinaryTagSerializer<EquipmentSlot> NBT_TYPE = BinaryTagSerializer.STRING.map(
             BY_NBT_NAME::get, EquipmentSlot::nbtName);
 
+    public static @NotNull List<@NotNull EquipmentSlot> armors() {
+        return ARMORS;
+    }
+
+    @Deprecated
+    public static @NotNull EquipmentSlot fromLegacyProtocolId(int legacyProtocolId) {
+        final EquipmentSlot slot = BY_LEGACY_PROTOCOL_ID.get(legacyProtocolId);
+        if (slot != null) return slot;
+
+        throw new IllegalStateException("Unexpected value: " + legacyProtocolId);
+    }
+
+    private final int protocolId;
+    private final int legacyProtocolId;
+    private final String nbtName;
     private final boolean armor;
     private final int armorSlot;
-    private final String nbtName;
-    private final  int equipmentSlot;
 
-    EquipmentSlot(boolean armor, int armorSlot, String nbtName, int equipmentSlot) {
+    EquipmentSlot(int protocolId, int legacyProtocolId, @NotNull String nbtName, boolean armor, int armorSlot) {
+        this.protocolId = protocolId;
+        this.legacyProtocolId = legacyProtocolId;
+        this.nbtName = nbtName;
         this.armor = armor;
         this.armorSlot = armorSlot;
-        this.nbtName = nbtName;
-        this.equipmentSlot = equipmentSlot;
+    }
+
+    public int protocolId() {
+        return protocolId;
+    }
+
+    /**
+     * Legacy protocol ID exists because that format is used in EntityEquipmentPacket
+     * It is being referred to as the legacy ID here because newer components are using
+     * the equipment slot stream codec (the more modern mechanism for network serialization)
+     * The legacy ID is expected to be removed eventually.
+     *
+     * @return the equipment slot
+     */
+    @Deprecated
+    public int legacyProtocolId() {
+        return legacyProtocolId;
+    }
+
+    public @NotNull String nbtName() {
+        return nbtName;
     }
 
     public boolean isHand() {
@@ -51,40 +88,7 @@ public enum EquipmentSlot {
         return armor;
     }
 
-    /**
-     * Differs from the ordinal only slightly - the ordinal is used for sending components such as {@link Equippable},
-     * but this value needs to be used instead for {@link EntityEquipmentPacket}.
-     *
-     * @return the equipment slot
-     */
-    @ApiStatus.Internal
-    public int equipmentSlot() {
-        return equipmentSlot;
-    }
-
     public int armorSlot() {
         return armorSlot;
-    }
-
-    public @NotNull String nbtName() {
-        return nbtName;
-    }
-
-    public static @NotNull List<@NotNull EquipmentSlot> armors() {
-        return ARMORS;
-    }
-
-    @ApiStatus.Internal
-    public static @NotNull EquipmentSlot fromEquipmentSlot(int equipmentSlot) {
-        return switch (equipmentSlot) {
-            case 0 -> EquipmentSlot.MAIN_HAND;
-            case 1 -> EquipmentSlot.OFF_HAND;
-            case 2 -> EquipmentSlot.BOOTS;
-            case 3 -> EquipmentSlot.LEGGINGS;
-            case 4 -> EquipmentSlot.CHESTPLATE;
-            case 5 -> EquipmentSlot.HELMET;
-            case 6 -> EquipmentSlot.BODY;
-            default -> throw new IllegalStateException("Unexpected value: " + equipmentSlot);
-        };
     }
 }

--- a/src/main/java/net/minestom/server/inventory/EquipmentHandler.java
+++ b/src/main/java/net/minestom/server/inventory/EquipmentHandler.java
@@ -187,11 +187,14 @@ public interface EquipmentHandler {
      * @param slot the slot of the equipment
      */
     default void syncEquipment(@NotNull EquipmentSlot slot) {
+        syncEquipment(slot, getEquipment(slot));
+    }
+
+    default void syncEquipment(@NotNull EquipmentSlot slot, @NotNull ItemStack stack) {
         Check.stateCondition(!(this instanceof Entity), "Only accessible for Entity");
 
         Entity entity = (Entity) this;
-        final ItemStack itemStack = getEquipment(slot);
-        entity.sendPacketToViewers(new EntityEquipmentPacket(entity.getEntityId(), Map.of(slot, itemStack)));
+        entity.sendPacketToViewers(new EntityEquipmentPacket(entity.getEntityId(), Map.of(slot, stack)));
     }
 
     /**

--- a/src/main/java/net/minestom/server/inventory/PlayerInventory.java
+++ b/src/main/java/net/minestom/server/inventory/PlayerInventory.java
@@ -118,7 +118,7 @@ public non-sealed class PlayerInventory extends AbstractInventory {
             item = entityEquipEvent.getEquippedItem();
 
             player.updateEquipmentAttributes(previous, item, equipmentSlot);
-            player.syncEquipment(equipmentSlot);
+            player.syncEquipment(equipmentSlot, item);
         }
 
         super.UNSAFE_itemInsert(slot, item, previous, sendPacket);

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityEquipmentPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityEquipmentPacket.java
@@ -28,7 +28,7 @@ public record EntityEquipmentPacket(int entityId,
             int index = 0;
             for (var entry : value.equipments.entrySet()) {
                 final boolean last = index++ == value.equipments.size() - 1;
-                byte slotEnum = (byte) entry.getKey().ordinal();
+                byte slotEnum = (byte) entry.getKey().equipmentSlot();
                 if (!last) slotEnum |= 0x80;
                 buffer.write(BYTE, slotEnum);
                 buffer.write(ItemStack.NETWORK_TYPE, entry.getValue());
@@ -62,7 +62,7 @@ public record EntityEquipmentPacket(int entityId,
         byte slot;
         do {
             slot = reader.read(BYTE);
-            equipments.put(EquipmentSlot.values()[slot & 0x7F], reader.read(ItemStack.NETWORK_TYPE));
+            equipments.put(EquipmentSlot.fromEquipmentSlot(slot & 0x7F), reader.read(ItemStack.NETWORK_TYPE));
         } while ((slot & 0x80) == 0x80);
         return equipments;
     }

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityEquipmentPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityEquipmentPacket.java
@@ -28,7 +28,7 @@ public record EntityEquipmentPacket(int entityId,
             int index = 0;
             for (var entry : value.equipments.entrySet()) {
                 final boolean last = index++ == value.equipments.size() - 1;
-                byte slotEnum = (byte) entry.getKey().equipmentSlot();
+                byte slotEnum = (byte) entry.getKey().legacyProtocolId();
                 if (!last) slotEnum |= 0x80;
                 buffer.write(BYTE, slotEnum);
                 buffer.write(ItemStack.NETWORK_TYPE, entry.getValue());
@@ -62,7 +62,7 @@ public record EntityEquipmentPacket(int entityId,
         byte slot;
         do {
             slot = reader.read(BYTE);
-            equipments.put(EquipmentSlot.fromEquipmentSlot(slot & 0x7F), reader.read(ItemStack.NETWORK_TYPE));
+            equipments.put(EquipmentSlot.fromLegacyProtocolId(slot & 0x7F), reader.read(ItemStack.NETWORK_TYPE));
         } while ((slot & 0x80) == 0x80);
         return equipments;
     }


### PR DESCRIPTION
Fixes https://github.com/Minestom/Minestom/issues/2505, https://github.com/Minestom/Minestom/issues/2508.

The client expects `EntityEquipmentPacket` to have the old ordering of `EquipmentSlot`, but expects the *new* ordering in components like `Equippable`. This seems weird and Mojang might change it later, but for now this fixes the armor bug.