### PR TITLE
Change Additional Hearts default to 0 instead of 1

### DIFF
--- a/src/main/java/net/minestom/server/entity/MetadataDef.java
+++ b/src/main/java/net/minestom/server/entity/MetadataDef.java
@@ -211,7 +211,7 @@ public sealed class MetadataDef {
     }
 
     public static final class Player extends LivingEntity {
-        public static final Entry<Float> ADDITIONAL_HEARTS = index(0, Metadata::Float, 1f);
+        public static final Entry<Float> ADDITIONAL_HEARTS = index(0, Metadata::Float, 0f);
         public static final Entry<Integer> SCORE = index(1, Metadata::VarInt, 0);
         public static final Entry<Byte> DISPLAYED_SKIN_PARTS_FLAGS = index(2, Metadata::Byte, (byte) 0);
         public static final Entry<Boolean> IS_CAPE_ENABLED = bitMask(2, (byte) 0x01, false);


### PR DESCRIPTION
Before the switch to use MetadataDef instead of Metadata (done in commit f4b32eddcf02174f842cb2ac5e1ccd6ed5815e5b), the default value for the ADDITIONAL_HEARTS field in PlayerMeta was 0 (indicated by [this line](https://github.com/Minestom/Minestom/commit/f4b32eddcf02174f842cb2ac5e1ccd6ed5815e5b#diff-3f119881a02c6face20cde30fb568adf048b1a503b38e208feab14754834def2L28), where the default value supplied is 0F).

Now it's 1f by default, which causes some confusion when applying damage to players, as the first time they are damaged it will be 1 less due to the additional heart field being set to 1.
This PR fixes that by changing the default to 0.