### PR TITLE
Make MinecraftServer static

### DIFF
--- a/demo/src/main/java/net/minestom/demo/Main.java
+++ b/demo/src/main/java/net/minestom/demo/Main.java
@@ -34,7 +34,7 @@ public class Main {
 
         MinecraftServer.setCompressionThreshold(0);
 
-        MinecraftServer minecraftServer = MinecraftServer.init();
+        MinecraftServer.init();
 
         BlockManager blockManager = MinecraftServer.getBlockManager();
         blockManager.registerBlockPlacementRule(new DripstonePlacementRule());
@@ -138,8 +138,8 @@ public class Main {
         // useful for testing - we don't need to worry about event calls so just set this to a long time
         OpenToLAN.open(new OpenToLANConfig().eventCallDelay(Duration.of(1, TimeUnit.DAY)));
 
-        minecraftServer.start("0.0.0.0", 25565);
-//        minecraftServer.start(java.net.UnixDomainSocketAddress.of("minestom-demo.sock"));
+        MinecraftServer.start();
+//        MinecraftServer.start(java.net.UnixDomainSocketAddress.of("minestom-demo.sock"));
         //Runtime.getRuntime().addShutdownHook(new Thread(MinecraftServer::stopCleanly));
     }
 }

--- a/src/main/java/net/minestom/server/MinecraftServer.java
+++ b/src/main/java/net/minestom/server/MinecraftServer.java
@@ -73,9 +73,8 @@ public final class MinecraftServer implements MinecraftConstants {
     private static String brandName = "Minestom";
     private static Difficulty difficulty = Difficulty.NORMAL;
 
-    public static MinecraftServer init() {
+    public static void init() {
         updateProcess();
-        return new MinecraftServer();
     }
 
     @ApiStatus.Internal
@@ -321,15 +320,19 @@ public final class MinecraftServer implements MinecraftConstants {
      * @param address the server address
      * @throws IllegalStateException if called before {@link #init()} or if the server is already running
      */
-    public void start(@NotNull SocketAddress address) {
+    public static void start(@NotNull SocketAddress address) {
         serverProcess.start(address);
         new TickSchedulerThread(serverProcess).start();
     }
 
-    public void start(@NotNull String address, int port) {
+    public static void start(@NotNull String address, int port) {
         start(new InetSocketAddress(address, port));
     }
-
+    
+    public static void start() {
+        start(new InetSocketAddress(25565));
+    }
+    
     /**
      * Stops this server properly (saves if needed, kicking players, etc.)
      */


### PR DESCRIPTION
MinecraftServer is fully static internally but you still need a variable to start the server, this is kind of annoying and would be better as a static function.
This PR also adds a start() that automatically chooses the right local address/port.