### PR TITLE
Fix boat metadata, and prevent packet spam when riding a boat

### DIFF
--- a/src/main/java/net/minestom/server/entity/MetadataDef.java
+++ b/src/main/java/net/minestom/server/entity/MetadataDef.java
@@ -141,10 +141,9 @@ public sealed class MetadataDef {
     }
 
     public static final class Boat extends AbstractVehicle {
-        public static final Entry<Integer> TYPE = index(0, Metadata::VarInt, 0);
-        public static final Entry<Boolean> IS_LEFT_PADDLE_TURNING = index(1, Metadata::Boolean, false);
-        public static final Entry<Boolean> IS_RIGHT_PADDLE_TURNING = index(2, Metadata::Boolean, false);
-        public static final Entry<Integer> SPLASH_TIMER = index(3, Metadata::VarInt, 0);
+        public static final Entry<Boolean> IS_LEFT_PADDLE_TURNING = index(0, Metadata::Boolean, false);
+        public static final Entry<Boolean> IS_RIGHT_PADDLE_TURNING = index(1, Metadata::Boolean, false);
+        public static final Entry<Integer> SPLASH_TIMER = index(2, Metadata::VarInt, 0);
     }
 
     public static sealed class AbstractMinecart extends AbstractVehicle {

--- a/src/main/java/net/minestom/server/entity/metadata/other/BoatMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/BoatMeta.java
@@ -11,15 +11,6 @@ public class BoatMeta extends AbstractVehicleMeta {
         super(entity, metadata);
     }
 
-    @NotNull
-    public Type getType() {
-        return Type.VALUES[metadata.get(MetadataDef.Boat.TYPE)];
-    }
-
-    public void setType(@NotNull Type value) {
-        metadata.set(MetadataDef.Boat.TYPE, value.ordinal());
-    }
-
     public boolean isLeftPaddleTurning() {
         return metadata.get(MetadataDef.Boat.IS_LEFT_PADDLE_TURNING);
     }
@@ -43,19 +34,4 @@ public class BoatMeta extends AbstractVehicleMeta {
     public void setSplashTimer(int value) {
         metadata.set(MetadataDef.Boat.SPLASH_TIMER, value);
     }
-
-    public enum Type {
-        OAK,
-        SPRUCE,
-        BIRCH,
-        JUNGLE,
-        ACACIA,
-        CHERRY,
-        DARK_OAK,
-        MANGROVE,
-        BAMBOO;
-
-        private final static Type[] VALUES = values();
-    }
-
 }

--- a/src/main/java/net/minestom/server/listener/PlayerVehicleListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerVehicleListener.java
@@ -32,7 +32,12 @@ public class PlayerVehicleListener {
         /* The packet may have been received after already exiting the vehicle. */
         if (vehicle == null) return;
         if (!(vehicle.getEntityMeta() instanceof BoatMeta boat)) return;
-        boat.setLeftPaddleTurning(packet.leftPaddleTurning());
-        boat.setRightPaddleTurning(packet.rightPaddleTurning());
+        // Only send metadata packet if there are changes
+        if (boat.isLeftPaddleTurning() != packet.leftPaddleTurning()) {
+            boat.setLeftPaddleTurning(packet.leftPaddleTurning());
+        }
+        if (boat.isRightPaddleTurning() != packet.rightPaddleTurning()) {
+            boat.setRightPaddleTurning(packet.rightPaddleTurning());
+        }
     }
 }


### PR DESCRIPTION
Fixes #2519.
Boats no longer have a type field, causing a Network Protocol Error when trying to ride them (which causes their metadata to be sent)
Additionally, I found that boats sent their metadata packet every tick due to the client sending the ClientBoatSteerPacket constantly, so I have changed that method to only send the metadata when it changes.