### PR TITLE
Fix re-registering vanilla registry objects not working properly

### DIFF
--- a/src/main/java/net/minestom/server/registry/DynamicRegistryImpl.java
+++ b/src/main/java/net/minestom/server/registry/DynamicRegistryImpl.java
@@ -137,12 +137,16 @@ final class DynamicRegistryImpl<T> implements DynamicRegistry<T> {
         lock.lock();
         try {
             int id = idByName.indexOf(namespaceId);
-            if (id == -1) id = entryById.size();
-
-            entryById.add(id, object);
             entryByName.put(namespaceId, object);
-            idByName.add(namespaceId);
-            packById.add(id, pack);
+            if (id == -1) {
+                idByName.add(namespaceId);
+                entryById.add(object);
+                packById.add(pack);
+            } else {
+                idByName.set(id, namespaceId);
+                entryById.set(id, object);
+                packById.set(id, pack);
+            }
             if (vanillaRegistryDataPacket != null) {
                 vanillaRegistryDataPacket.invalidate();
             }


### PR DESCRIPTION
Encountered this issue while working on updating to 1.21.3 as my client was crashing from protocol errors constantly.

We edit the main plains biome to change its properties by re-registering it, and the old implementation would cause the biome to be included in the registry twice, causing a protocol error on modern clients.

This PR fixes it by updating the logic of the register method to properly replace the data instead of appending only.