### PR TITLE
Fix shift clicking in last hotbar slot

### DIFF
--- a/src/main/java/net/minestom/server/inventory/PlayerInventory.java
+++ b/src/main/java/net/minestom/server/inventory/PlayerInventory.java
@@ -219,7 +219,7 @@ public non-sealed class PlayerInventory extends AbstractInventory {
         final ItemStack clicked = getItemStack(convertedSlot);
         final boolean hotBarClick = convertWindowSlotToMinestomSlot(slot, WINDOW_0_OFFSET) < 9;
         final int start = hotBarClick ? 9 : 0;
-        final int end = hotBarClick ? getSize() - 9 : 8;
+        final int end = hotBarClick ? getSize() - 9 : 9;
         final InventoryClickResult clickResult = clickProcessor.shiftClick(
                 this, this,
                 start, end, 1,


### PR DESCRIPTION
Shift clicking into the last hotbar slot doesn't work because the ending slot is marked as 8, but the ending slot is exclusive. Increasing this from 8 to 9 fixes it.

This fixes blobfish's issue (mentioned on Discord).