### PR TITLE
Remove legacy protocol IDs for equipment slots

### DIFF
--- a/src/main/java/net/minestom/server/entity/EquipmentSlot.java
+++ b/src/main/java/net/minestom/server/entity/EquipmentSlot.java
@@ -12,13 +12,13 @@ import java.util.stream.Collectors;
 import static net.minestom.server.utils.inventory.PlayerInventoryUtils.*;
 
 public enum EquipmentSlot {
-    MAIN_HAND(0, 0, "mainhand", false, -1),
-    OFF_HAND(1, 5, "offhand", false, -1),
-    BOOTS(2, 1, "feet", true, BOOTS_SLOT),
-    LEGGINGS(3, 2, "legs", true, LEGGINGS_SLOT),
-    CHESTPLATE(4, 3, "chest", true, CHESTPLATE_SLOT),
-    HELMET(5, 4, "head", true, HELMET_SLOT),
-    BODY(6, 6, "body", false, -1);
+    MAIN_HAND(0, "mainhand", false, -1),
+    OFF_HAND(1, "offhand", false, -1),
+    BOOTS(2, "feet", true, BOOTS_SLOT),
+    LEGGINGS(3, "legs", true, LEGGINGS_SLOT),
+    CHESTPLATE(4, "chest", true, CHESTPLATE_SLOT),
+    HELMET(5, "head", true, HELMET_SLOT),
+    BODY(6, "body", false, -1);
 
     private static final List<EquipmentSlot> ARMORS = List.of(BOOTS, LEGGINGS, CHESTPLATE, HELMET);
     private static final Map<String, EquipmentSlot> BY_NBT_NAME = Arrays.stream(values())
@@ -46,14 +46,12 @@ public enum EquipmentSlot {
     }
 
     private final int protocolId;
-    private final int legacyProtocolId;
     private final String nbtName;
     private final boolean armor;
     private final int armorSlot;
 
-    EquipmentSlot(int protocolId, int legacyProtocolId, @NotNull String nbtName, boolean armor, int armorSlot) {
+    EquipmentSlot(int protocolId, @NotNull String nbtName, boolean armor, int armorSlot) {
         this.protocolId = protocolId;
-        this.legacyProtocolId = legacyProtocolId;
         this.nbtName = nbtName;
         this.armor = armor;
         this.armorSlot = armorSlot;
@@ -61,19 +59,6 @@ public enum EquipmentSlot {
 
     public int protocolId() {
         return protocolId;
-    }
-
-    /**
-     * Legacy protocol ID exists because that format is used in EntityEquipmentPacket
-     * It is being referred to as the legacy ID here because newer components are using
-     * the equipment slot stream codec (the more modern mechanism for network serialization)
-     * The legacy ID is expected to be removed eventually.
-     *
-     * @return the equipment slot
-     */
-    @Deprecated
-    public int legacyProtocolId() {
-        return legacyProtocolId;
     }
 
     public @NotNull String nbtName() {

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityEquipmentPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityEquipmentPacket.java
@@ -28,7 +28,7 @@ public record EntityEquipmentPacket(int entityId,
             int index = 0;
             for (var entry : value.equipments.entrySet()) {
                 final boolean last = index++ == value.equipments.size() - 1;
-                byte slotEnum = (byte) entry.getKey().legacyProtocolId();
+                byte slotEnum = (byte) entry.getKey().protocolId();
                 if (!last) slotEnum |= 0x80;
                 buffer.write(BYTE, slotEnum);
                 buffer.write(ItemStack.NETWORK_TYPE, entry.getValue());


### PR DESCRIPTION
Removes legacy protocol IDs for equipment slots.
Their existence was causing issues, since apparently the client started using normal equipment slot IDs.

Fixes #2515.