### PR TITLE
Fix inventory event NPE

### DIFF
--- a/src/main/java/net/minestom/server/inventory/Inventory.java
+++ b/src/main/java/net/minestom/server/inventory/Inventory.java
@@ -283,7 +283,7 @@ public non-sealed class Inventory extends AbstractInventory {
                 ItemStack.AIR;
         final ItemStack cursor = playerInventory.getCursorItem();
         final InventoryClickResult clickResult = clickProcessor.dragging(player,
-                slot != -999 ? (isInWindow ? this : playerInventory) : null,
+                slot == -999 || isInWindow ? this : playerInventory,
                 clickSlot, button,
                 clicked, cursor);
         if (clickResult == null || clickResult.isCancel()) {

--- a/src/main/java/net/minestom/server/inventory/PlayerInventory.java
+++ b/src/main/java/net/minestom/server/inventory/PlayerInventory.java
@@ -165,7 +165,7 @@ public non-sealed class PlayerInventory extends AbstractInventory {
         }
         setItemStack(convertedSlot, clickResult.getClicked());
         setCursorItem(clickResult.getCursor());
-        callClickEvent(player, null, convertedSlot, ClickType.LEFT_CLICK, clicked, cursor);
+        callClickEvent(player, this, convertedSlot, ClickType.LEFT_CLICK, clicked, cursor);
         return true;
     }
 
@@ -181,7 +181,7 @@ public non-sealed class PlayerInventory extends AbstractInventory {
         }
         setItemStack(convertedSlot, clickResult.getClicked());
         setCursorItem(clickResult.getCursor());
-        callClickEvent(player, null, convertedSlot, ClickType.RIGHT_CLICK, clicked, cursor);
+        callClickEvent(player, this, convertedSlot, ClickType.RIGHT_CLICK, clicked, cursor);
         return true;
     }
 
@@ -249,7 +249,7 @@ public non-sealed class PlayerInventory extends AbstractInventory {
         }
         setItemStack(convertedSlot, clickResult.getClicked());
         setItemStack(convertedKey, clickResult.getCursor());
-        callClickEvent(player, null, convertedSlot, ClickType.CHANGE_HELD, clicked, cursorItem);
+        callClickEvent(player, this, convertedSlot, ClickType.CHANGE_HELD, clicked, cursorItem);
         return true;
     }
 

--- a/src/test/java/net/minestom/server/inventory/click/integration/HeldClickIntegrationTest.java
+++ b/src/test/java/net/minestom/server/inventory/click/integration/HeldClickIntegrationTest.java
@@ -35,7 +35,7 @@ public class HeldClickIntegrationTest {
         // Empty
         {
             listener.followup(event -> {
-                assertNull(event.getInventory()); // Player inventory
+                assertEquals(event.getInventory(), inventory);
                 assertTrue(event.getSlot() == 4 || event.getSlot() == 5);
                 assertEquals(ClickType.CHANGE_HELD, event.getClickType());
 
@@ -49,7 +49,7 @@ public class HeldClickIntegrationTest {
         // Swap air
         {
             listener.followup(event -> {
-                assertNull(event.getInventory()); // Player inventory
+                assertEquals(event.getInventory(), inventory);
                 assertTrue(event.getSlot() == 1 || event.getSlot() == 0);
                 assertEquals(ClickType.CHANGE_HELD, event.getClickType());
 

--- a/src/test/java/net/minestom/server/inventory/click/integration/LeftClickIntegrationTest.java
+++ b/src/test/java/net/minestom/server/inventory/click/integration/LeftClickIntegrationTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 @EnvTest
 public class LeftClickIntegrationTest {
@@ -34,7 +33,7 @@ public class LeftClickIntegrationTest {
         // Empty click
         {
             listener.followup(event -> {
-                assertNull(event.getInventory()); // Player inventory
+                assertEquals(event.getInventory(), inventory);
                 assertEquals(0, event.getSlot());
                 assertEquals(ClickType.LEFT_CLICK, event.getClickType());
                 assertEquals(ItemStack.AIR, inventory.getCursorItem());
@@ -93,7 +92,7 @@ public class LeftClickIntegrationTest {
         // Empty click in player inv
         {
             listener.followup(event -> {
-                assertNull(event.getInventory()); // Player inventory
+                assertEquals(player.getInventory(), event.getInventory());
                 assertEquals(0, event.getSlot());
                 assertEquals(ClickType.LEFT_CLICK, event.getClickType());
                 assertEquals(ItemStack.AIR, player.getInventory().getCursorItem());
@@ -136,7 +135,7 @@ public class LeftClickIntegrationTest {
         // Change items
         {
             listener.followup(event -> {
-                assertNull(event.getInventory());
+                assertEquals(player.getInventory(), event.getInventory());
                 assertEquals(9, event.getSlot());
                 event.setClickedItem(ItemStack.of(Material.DIAMOND, 5));
                 event.setCursorItem(ItemStack.of(Material.DIAMOND));

--- a/src/test/java/net/minestom/server/inventory/click/integration/RightClickIntegrationTest.java
+++ b/src/test/java/net/minestom/server/inventory/click/integration/RightClickIntegrationTest.java
@@ -34,7 +34,7 @@ public class RightClickIntegrationTest {
         // Empty click
         {
             listener.followup(event -> {
-                assertNull(event.getInventory()); // Player inventory
+                assertEquals(event.getInventory(), inventory);
                 assertEquals(0, event.getSlot());
                 assertEquals(ClickType.RIGHT_CLICK, event.getClickType());
                 assertEquals(ItemStack.AIR, inventory.getCursorItem());
@@ -115,7 +115,7 @@ public class RightClickIntegrationTest {
         // Empty click in player inv
         {
             listener.followup(event -> {
-                assertNull(event.getInventory()); // Player inventory
+                assertEquals(player.getInventory(), event.getInventory());
                 assertEquals(0, event.getSlot());
                 assertEquals(ClickType.RIGHT_CLICK, event.getClickType());
                 assertEquals(ItemStack.AIR, player.getInventory().getCursorItem());
@@ -137,7 +137,7 @@ public class RightClickIntegrationTest {
         // Place back to player inv
         {
             listener.followup(event -> {
-                assertNull(event.getInventory());
+                assertEquals(player.getInventory(), event.getInventory());
                 assertEquals(1, event.getSlot());
                 assertEquals(ItemStack.of(Material.DIAMOND), player.getInventory().getCursorItem());
                 assertEquals(ItemStack.AIR, inventory.getItemStack(1));
@@ -157,7 +157,7 @@ public class RightClickIntegrationTest {
         // Change items
         {
             listener.followup(event -> {
-                assertNull(event.getInventory());
+                assertEquals(player.getInventory(), event.getInventory());
                 assertEquals(9, event.getSlot());
                 event.setClickedItem(ItemStack.of(Material.DIAMOND, 5));
                 event.setCursorItem(ItemStack.of(Material.DIAMOND));


### PR DESCRIPTION
Incorrect logic (probably my fault) resulted in the source inventory for some `InventoryEvent`s being null sometimes. I fixed that here.

This also results in drag click endings being considered as a click inside the open inventory, but I think that doesn't really matter.