### PR TITLE
feat: Optional instance based threading

### DIFF
--- a/src/main/java/net/minestom/server/ServerFlag.java
+++ b/src/main/java/net/minestom/server/ServerFlag.java
@@ -69,6 +69,7 @@ public final class ServerFlag {
     public static final boolean REGISTRY_LATE_REGISTER = booleanProperty("minestom.registry.late-register");
     public static final boolean REGISTRY_UNSAFE_OPS = booleanProperty("minestom.registry.unsafe-ops");
     public static final boolean EVENT_NODE_ALLOW_MULTIPLE_PARENTS = booleanProperty("minestom.event.multiple-parents");
+    public static final boolean INSTANCE_BASED_DISPATCHER = booleanProperty("minestom.instance-based-dispatcher");
 
     public static boolean INSIDE_TEST = booleanProperty("minestom.inside-test", false);
 

--- a/src/main/java/net/minestom/server/ServerProcess.java
+++ b/src/main/java/net/minestom/server/ServerProcess.java
@@ -6,7 +6,6 @@ import net.minestom.server.command.CommandManager;
 import net.minestom.server.event.GlobalEventHandler;
 import net.minestom.server.exception.ExceptionManager;
 import net.minestom.server.gamedata.tags.TagManager;
-import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.InstanceManager;
 import net.minestom.server.instance.block.BlockManager;
 import net.minestom.server.instance.block.rule.BlockPlacementRule;
@@ -114,7 +113,7 @@ public interface ServerProcess extends Registries, Snapshotable {
     /**
      * Dispatcher for tickable game objects.
      */
-    @NotNull ThreadDispatcher<Chunk> dispatcher();
+    @NotNull ThreadDispatcher<? extends Tickable> dispatcher();
 
     /**
      * Handles the server ticks.

--- a/src/main/java/net/minestom/server/ServerProcessImpl.java
+++ b/src/main/java/net/minestom/server/ServerProcessImpl.java
@@ -13,7 +13,6 @@ import net.minestom.server.event.GlobalEventHandler;
 import net.minestom.server.event.server.ServerTickMonitorEvent;
 import net.minestom.server.exception.ExceptionManager;
 import net.minestom.server.gamedata.tags.TagManager;
-import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.InstanceManager;
 import net.minestom.server.instance.block.BlockManager;
@@ -37,7 +36,6 @@ import net.minestom.server.scoreboard.TeamManager;
 import net.minestom.server.snapshot.*;
 import net.minestom.server.thread.Acquirable;
 import net.minestom.server.thread.ThreadDispatcher;
-import net.minestom.server.thread.ThreadProvider;
 import net.minestom.server.timer.SchedulerManager;
 import net.minestom.server.utils.PacketViewableUtils;
 import net.minestom.server.utils.collection.MappedCollection;
@@ -94,7 +92,7 @@ final class ServerProcessImpl implements ServerProcess {
 
     private final Server server;
 
-    private final ThreadDispatcher<Chunk> dispatcher;
+    private final ThreadDispatcher<? extends Tickable> dispatcher;
     private final Ticker ticker;
 
     private final AtomicBoolean started = new AtomicBoolean();
@@ -139,7 +137,7 @@ final class ServerProcessImpl implements ServerProcess {
 
         this.server = new Server(packetParser);
 
-        this.dispatcher = ThreadDispatcher.of(ThreadProvider.counter(), ServerFlag.DISPATCHER_THREADS);
+        this.dispatcher = ThreadDispatcher.serverProcess();
         this.ticker = new TickerImpl();
     }
 
@@ -299,7 +297,7 @@ final class ServerProcessImpl implements ServerProcess {
     }
 
     @Override
-    public @NotNull ThreadDispatcher<Chunk> dispatcher() {
+    public @NotNull ThreadDispatcher<? extends Tickable> dispatcher() {
         return dispatcher;
     }
 

--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -272,7 +272,11 @@ public class InstanceContainer extends Instance {
         chunk.unload();
         chunkLoader.unloadChunk(chunk);
         var dispatcher = MinecraftServer.process().dispatcher();
-        dispatcher.deletePartition(chunk);
+        switch (dispatcher.getPartitionType()) {
+            case CHUNK -> dispatcher.asChunk().deletePartition(chunk);
+            case INSTANCE -> dispatcher.asInstance().removeElement(chunk);
+            case null -> {}
+        }
     }
 
     @Override
@@ -702,6 +706,10 @@ public class InstanceContainer extends Instance {
     private void cacheChunk(@NotNull Chunk chunk) {
         this.chunks.put(CoordConversion.chunkIndex(chunk.getChunkX(), chunk.getChunkZ()), chunk);
         var dispatcher = MinecraftServer.process().dispatcher();
-        dispatcher.createPartition(chunk);
+        switch (dispatcher.getPartitionType()) {
+            case CHUNK -> dispatcher.asChunk().createPartition(chunk);
+            case INSTANCE -> dispatcher.asInstance().updateElement(chunk, this);
+            case null -> {}
+        }
     }
 }

--- a/src/main/java/net/minestom/server/thread/ThreadDispatcher.java
+++ b/src/main/java/net/minestom/server/thread/ThreadDispatcher.java
@@ -1,15 +1,20 @@
 package net.minestom.server.thread;
 
+import net.minestom.server.ServerFlag;
 import net.minestom.server.Tickable;
+import net.minestom.server.instance.Chunk;
+import net.minestom.server.instance.Instance;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.MpscUnboundedArrayQueue;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.IntFunction;
+import java.util.stream.IntStream;
 
 /**
  * ThreadDispatcher can be used to dispatch updates (ticks) across a number of "partitions" (such as chunks) that
@@ -27,6 +32,7 @@ import java.util.function.IntFunction;
 public final class ThreadDispatcher<P> {
     private final ThreadProvider<P> provider;
     private final List<TickThread> threads;
+    private final PartitionType partitionType;
 
     // Partition -> dispatching context
     // Defines how computation is dispatched to the threads
@@ -40,12 +46,21 @@ public final class ThreadDispatcher<P> {
     private final MessagePassingQueue<DispatchUpdate<P>> updates = new MpscUnboundedArrayQueue<>(1024);
 
     private ThreadDispatcher(ThreadProvider<P> provider, int threadCount,
-                             @NotNull IntFunction<? extends TickThread> threadGenerator) {
+                             @NotNull IntFunction<? extends TickThread> threadGenerator,
+                             PartitionType partitionType) {
         this.provider = provider;
+        this.partitionType = partitionType;
         TickThread[] threads = new TickThread[threadCount];
         Arrays.setAll(threads, threadGenerator);
         this.threads = List.of(threads);
         this.threads.forEach(Thread::start);
+    }
+
+    public static <P> @NotNull ThreadDispatcher<P> serverProcess() {
+        PartitionType partitionType = ServerFlag.INSTANCE_BASED_DISPATCHER ? PartitionType.INSTANCE
+                : PartitionType.CHUNK;
+        ThreadProvider<P> threadProvider = ServerFlag.INSTANCE_BASED_DISPATCHER ? ThreadProvider.leastOccupiedThread() : ThreadProvider.counter();
+        return new ThreadDispatcher<>(threadProvider, ServerFlag.DISPATCHER_THREADS, TickThread::new, partitionType);
     }
 
     /**
@@ -57,7 +72,7 @@ public final class ThreadDispatcher<P> {
      * @param <P> the dispatcher partition type
      */
     public static <P> @NotNull ThreadDispatcher<P> of(@NotNull ThreadProvider<P> provider, int threadCount) {
-        return new ThreadDispatcher<>(provider, threadCount, TickThread::new);
+        return new ThreadDispatcher<>(provider, threadCount, TickThread::new, null);
     }
 
     /**
@@ -72,7 +87,7 @@ public final class ThreadDispatcher<P> {
      */
     public static <P> @NotNull ThreadDispatcher<P> of(@NotNull ThreadProvider<P> provider,
                                                       @NotNull IntFunction<String> nameGenerator, int threadCount) {
-        return new ThreadDispatcher<>(provider, threadCount, index -> new TickThread(nameGenerator.apply(index)));
+        return new ThreadDispatcher<>(provider, threadCount, index -> new TickThread(nameGenerator.apply(index)), null);
     }
 
     /**
@@ -209,6 +224,16 @@ public final class ThreadDispatcher<P> {
         signalUpdate(new DispatchUpdate.ElementRemove<>(tickable));
     }
 
+    @SuppressWarnings("unchecked")
+    public ThreadDispatcher<Instance> asInstance() {
+        return (ThreadDispatcher<Instance>) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public ThreadDispatcher<Chunk> asChunk() {
+        return (ThreadDispatcher<Chunk>) this;
+    }
+
     /**
      * Shutdowns all the {@link TickThread tick threads}.
      * <p>
@@ -236,7 +261,9 @@ public final class ThreadDispatcher<P> {
         this.partitions.put(partition, partitionEntry);
         this.partitionUpdateQueue.add(partition);
         if (partition instanceof Tickable tickable) {
-            processUpdatedElement(tickable, partition);
+            if (!(tickable instanceof Instance)) { // Instances are ticked by server process
+                processUpdatedElement(tickable, partition);
+            }
         }
     }
 
@@ -276,6 +303,24 @@ public final class ThreadDispatcher<P> {
                 ((AcquirableImpl<?>) acquirableSource.acquirable()).updateThread(partitionEntry.thread());
             }
         }
+    }
+
+    /**
+     * Finds the thread with the least amount of partitions assigned.
+     * <p>
+     * Useful for thread providers.
+     *
+     * @return null Integer if there are no threads, otherwise Integer of the index of the thread with the least amount of partitions assigned.
+     */
+    public @Nullable Integer getIndexOfLeastOccupiedThread() {
+        return IntStream.range(0, threads.size())
+                .boxed()
+                .min(Comparator.comparingInt(i -> threads.get(i).entries().size()))
+                .orElse(null);
+    }
+
+    public @Nullable PartitionType getPartitionType() {
+        return this.partitionType;
     }
 
     /**
@@ -326,5 +371,10 @@ public final class ThreadDispatcher<P> {
 
         record ElementRemove<P>(@NotNull Tickable tickable) implements DispatchUpdate<P> {
         }
+    }
+
+    public enum PartitionType {
+        CHUNK,
+        INSTANCE
     }
 }

--- a/src/main/java/net/minestom/server/thread/ThreadProvider.java
+++ b/src/main/java/net/minestom/server/thread/ThreadProvider.java
@@ -1,5 +1,6 @@
 package net.minestom.server.thread;
 
+import net.minestom.server.MinecraftServer;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -16,6 +17,15 @@ public interface ThreadProvider<T> {
             public int findThread(@NotNull T partition) {
                 return counter.getAndIncrement();
             }
+        };
+    }
+
+    static <T> @NotNull ThreadProvider<T> leastOccupiedThread() {
+        return partition -> {
+            Integer index = MinecraftServer.process().dispatcher().getIndexOfLeastOccupiedThread();
+            if (index == null)
+                throw new IllegalStateException("No threads available");
+            return index;
         };
     }
 


### PR DESCRIPTION
Added a boolean server flag `minestom.instance-based-dispatcher` to enable instance based threading.

I'm not really sure if this goes against how Minestom should be threaded, and if not I will keep a fork for this, but I was porting a minigame from Paper and keeping each instance single threaded was a much nicer option for me.

With the flag set, `minestom.dispatcher-threads` are still the total amount of dispatcher threads and are spread efficiently across instances (uses a new `leastOccupiedThread` ThreadProvider, which finds the thread with the least amount of partitions)

Partitions become instances instead of chunks being the partitions, and chunks and entities are the elements of the partitions.

Here's what I used to test it in the demo (there is instance unregistering testing in PlayerInit as well):

https://github.com/user-attachments/assets/ec28201e-387d-4bc3-9931-428eb4db24b7


```java
// Main.java
System.setProperty("minestom.instance-based-dispatcher", "true");
System.setProperty("minestom.dispatcher-threads", "3");
```

```java
// PlayerInit.java
private static InstanceContainer makeInstanceContainer() {
    InstanceContainer instanceContainer = MinecraftServer.getInstanceManager().createInstanceContainer();
    instanceContainer.setGenerator(unit -> {
        unit.modifier().fillHeight(0, 40, Block.STONE);
    
        if (unit.absoluteStart().blockY() < 40 && unit.absoluteEnd().blockY() > 40) {
            unit.modifier().setBlock(unit.absoluteStart().blockX(), 40, unit.absoluteStart().blockZ(), Block.TORCH);
        }
    });
    instanceContainer.setChunkSupplier(LightingChunk::new);
    instanceContainer.setTimeRate(0);
    instanceContainer.setTime(ThreadLocalRandom.current().nextInt(20000));
    return instanceContainer;
}

{
    InstanceManager instanceManager = MinecraftServer.getInstanceManager();
    
    for (int i = 0; i < 16; i++) {
        InstanceContainer instanceContainer = makeInstanceContainer();
        if (ThreadLocalRandom.current().nextDouble() < 0.75) // Unregister most instances
            instanceManager.unregisterInstance(instanceContainer);
    }
    
    for (int i = 0; i < 8; i++) {
        makeInstanceContainer();
    }
}
```

```java
// InstanceCommand.java
public class InstanceCommand extends Command {

    public InstanceCommand() {
        super("instance");

        ArgumentInteger argumentInteger = ArgumentType.Integer("index");

        addSyntax((sender, context) -> {
            Player player = (Player) sender;
            List<Instance> instances = MinecraftServer.getInstanceManager().getInstances().stream().toList();
            player.setInstance(instances.get(context.get(argumentInteger)), new Pos(0, 41, 0)).thenRun(()
                    -> player.scheduler().scheduleNextTick(() -> player.sendMessage("Your new ticking thread: " + player.acquirable().assignedThread().getName())));
        }, argumentInteger);
    }

}
```