### PR TITLE
fix: ensure block is not in unloaded chunk in Player#canFitWithBoundingBox

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -860,7 +860,15 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
         var iter = bb.getBlocks(getPosition());
         while (iter.hasNext()) {
             var pos = iter.next();
-            var block = instance.getBlock(pos.blockX(), pos.blockY(), pos.blockZ(), Block.Getter.Condition.TYPE);
+            Block block;
+            try {
+                block = instance.getBlock(pos.blockX(), pos.blockY(), pos.blockZ(), Block.Getter.Condition.TYPE);
+            } catch (NullPointerException ignored) {
+                block = null;
+            }
+
+            // Block was in unloaded chunk, no bounding box.
+            if (block == null) continue;
 
             // For now just ignore scaffolding. It seems to have a dynamic bounding box, or is just parsed
             // incorrectly in MinestomDataGenerator.


### PR DESCRIPTION
This fixes https://github.com/Minestom/Minestom/blob/c976f345d10210642d13b280e38c5e47ec9c8bc1/src/main/java/net/minestom/server/listener/PlayerPositionListener.java#L64-L68 not working and throwing a NullPointerException