### PR TITLE
fix: synchronize item entity hitting ground to stop bouncing

### DIFF
--- a/src/main/java/net/minestom/server/entity/ItemEntity.java
+++ b/src/main/java/net/minestom/server/entity/ItemEntity.java
@@ -36,6 +36,7 @@ public class ItemEntity extends Entity {
     private boolean pickable = true;
     private boolean mergeable = true;
     private float mergeRange = 1;
+    private boolean previousOnGround = false;
 
     private long spawnTime;
     private long pickupDelay;
@@ -92,6 +93,18 @@ public class ItemEntity extends Entity {
                         });
                     });
         }
+    }
+
+    @Override
+    public void movementTick() {
+        super.movementTick();
+
+        if (!previousOnGround && onGround) {
+            synchronizePosition();
+            sendPacketToViewers(getVelocityPacket());
+        }
+
+        previousOnGround = onGround;
     }
 
     @Override


### PR DESCRIPTION
Currently item entities do not synchronize position and velocity with the client after hitting the ground, causing it to appear to bounce on the client side.

As seen in #2521

Although I have no idea about the second clip