### PR TITLE
Remove reset of values from PaletteIndirect

### DIFF
--- a/src/main/java/net/minestom/server/instance/palette/PaletteIndirect.java
+++ b/src/main/java/net/minestom/server/instance/palette/PaletteIndirect.java
@@ -49,8 +49,6 @@ final class PaletteIndirect implements SpecializedPalette, Cloneable {
             this.paletteToValueList.add(palette[i]);
             this.valueToPaletteMap.put(palette[i], i);
         }
-
-        this.values = new long[arrayLength(dimension(), bitsPerEntry)];
     }
 
     PaletteIndirect(int dimension, int maxBitsPerEntry, byte bitsPerEntry) {


### PR DESCRIPTION
Currently, PaletteIndirect resets the values at the end of the constructor. This is unexpected behaviour given the values are passed as a constructor parameter and results in incorrect reading of palettes from NetworkBuffer.