### PR TITLE
Remove reset of values from PaletteIndirect

### DIFF
--- a/src/main/java/net/minestom/server/instance/palette/PaletteIndirect.java
+++ b/src/main/java/net/minestom/server/instance/palette/PaletteIndirect.java
@@ -49,8 +49,6 @@ final class PaletteIndirect implements SpecializedPalette, Cloneable {
             this.paletteToValueList.add(palette[i]);
             this.valueToPaletteMap.put(palette[i], i);
         }
-
-        this.values = new long[arrayLength(dimension(), bitsPerEntry)];
     }
 
     PaletteIndirect(int dimension, int maxBitsPerEntry, byte bitsPerEntry) {

--- a/src/test/java/net/minestom/server/instance/palette/PaletteIndirectTest.java
+++ b/src/test/java/net/minestom/server/instance/palette/PaletteIndirectTest.java
@@ -1,0 +1,17 @@
+package net.minestom.server.instance.palette;
+
+import org.junit.jupiter.api.Test;
+
+public class PaletteIndirectTest {
+
+    @Test
+    public void constructor() {
+        var palette = new PaletteIndirect(16, 8, (byte) 4);
+        palette.set(0, 0, 1, 1);
+        var otherPalette = new PaletteIndirect(palette.dimension(), palette.maxBitsPerEntry(), (byte) palette.bitsPerEntry(), palette.count(), palette.paletteToValueList.toIntArray(), palette.values);
+
+        palette.getAll((x, y, z, value) -> {
+            assert value == otherPalette.get(x, y, z);
+        });
+    }
+}


### PR DESCRIPTION
Currently, PaletteIndirect resets the values at the end of the constructor. This is unexpected behaviour given the values are passed as a constructor parameter and results in incorrect reading of palettes from NetworkBuffer.