### PR TITLE
Skip size varint when reading single palette

### DIFF
--- a/src/main/java/net/minestom/server/instance/palette/Palette.java
+++ b/src/main/java/net/minestom/server/instance/palette/Palette.java
@@ -115,6 +115,7 @@ public interface Palette {
                 if (bitsPerEntry == 0) {
                     // Single valued 0-0
                     final int value = buffer.read(VAR_INT);
+                    buffer.read(VAR_INT); // Skip size
                     return new PaletteSingle((byte) dimension, value);
                 } else if (bitsPerEntry >= minIndirect && bitsPerEntry <= maxIndirect) {
                     // Indirect palette


### PR DESCRIPTION
The read method for palettes does not skip the unused (always 0) size varint of single palettes. This results in incorrect parsing of packets when data is present after the palette and constitutes and inconsistency between the read and write methods of the type.