### PR TITLE
fix: double sending of disconnect events

### DIFF
--- a/src/main/java/net/minestom/server/network/player/PlayerConnection.java
+++ b/src/main/java/net/minestom/server/network/player/PlayerConnection.java
@@ -141,9 +141,9 @@ public abstract class PlayerConnection {
      */
     public void disconnect() {
         this.online = false;
-        MinecraftServer.getConnectionManager().removePlayer(this);
-        final Player player = getPlayer();
+        final Player player = MinecraftServer.getConnectionManager().getPlayer(this);
         if (player != null) {
+            MinecraftServer.getConnectionManager().removePlayer(this);
             if (connectionState == ConnectionState.PLAY && !player.isRemoved())
                 player.scheduleNextTick(Entity::remove);
             else {


### PR DESCRIPTION
Fixes #2593 

Ensure that the player isn't already disconnected before calling a new PlayerDisconnectEvent