### PR TITLE
Fix block replacement within onPlace desync

### DIFF
--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -188,6 +188,14 @@ public class InstanceContainer extends Instance {
             // Set the block
             chunk.setBlock(x, y, z, block, placement, destroy);
 
+            /* Check if the block was altered, cancel the rest of the operation.
+            Because the block might be changed by block handlers,
+            This is done so only the innermost setBlock handles the update.
+             */
+            if (chunk.getBlock(x, y, z) != block) {
+                return;
+            }
+
             // Refresh neighbors since a new block has been placed
             if (doBlockUpdates) {
                 executeNeighboursBlockPlacementRule(blockPosition, updateDistance);


### PR DESCRIPTION
solves https://github.com/Minestom/Minestom/issues/2598

InstanceContainer#setBlock calls InstanceContainer#UNSAFE_setBlock, which first calls Chunk#setBlock and then sends the updated block to the viewers. Ff the block is changed via InstanceContainer#setBlock inside the block's BlockHandler#onPlace, the inner setBlock (which happens after the outer setBlock) will send its update before the outer setBlock, which leads to the update being overwritten by its outer and former update.
With this PR only the innermost setBlock will send its update, so only the last update is sent to the viewers.