### PR TITLE
added Block.Setter parameter in the BlockPlacementRule

### DIFF
--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -167,7 +167,7 @@ public class InstanceContainer extends Instance {
                 BlockPlacementRule.PlacementState rulePlacement;
                 if (placement instanceof BlockHandler.PlayerPlacement pp) {
                     rulePlacement = new BlockPlacementRule.PlacementState(
-                            this, block, pp.getBlockFace(), blockPosition,
+                            this, this, block, pp.getBlockFace(), blockPosition,
                             new Vec(pp.getCursorX(), pp.getCursorY(), pp.getCursorZ()),
                             pp.getPlayer().getPosition(),
                             pp.getPlayer().getItemInHand(pp.getHand()),
@@ -175,7 +175,7 @@ public class InstanceContainer extends Instance {
                     );
                 } else {
                     rulePlacement = new BlockPlacementRule.PlacementState(
-                            this, block, null, blockPosition,
+                            this, this, block, null, blockPosition,
                             null, null, null,
                             false
                     );

--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -677,6 +677,7 @@ public class InstanceContainer extends Instance {
             final Vec neighborPosition = new Vec(neighborX, neighborY, neighborZ);
             final Block newNeighborBlock = neighborBlockPlacementRule.blockUpdate(new BlockPlacementRule.UpdateState(
                     this,
+                    this,
                     neighborPosition,
                     neighborBlock,
                     updateFace.getOppositeFace()

--- a/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java
+++ b/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java
@@ -55,7 +55,8 @@ public abstract class BlockPlacementRule {
     }
 
     public record PlacementState(
-            @NotNull Block.Getter instance,
+            @NotNull Block.Getter blockGetter,
+            @NotNull Block.Setter blockSetter,
             @NotNull Block block,
             @Nullable BlockFace blockFace,
             @NotNull Point placePosition,
@@ -64,6 +65,10 @@ public abstract class BlockPlacementRule {
             @Nullable ItemStack usedItemStack,
             boolean isPlayerShifting
     ) {
+        @Deprecated
+        public Block.Getter instance() {
+            return this.blockGetter;
+        }
     }
 
     public record UpdateState(@NotNull Block.Getter instance,

--- a/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java
+++ b/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java
@@ -71,10 +71,15 @@ public abstract class BlockPlacementRule {
         }
     }
 
-    public record UpdateState(@NotNull Block.Getter instance,
+    public record UpdateState(@NotNull Block.Getter blockGetter,
+                              @NotNull Block.Setter blockSetter,
                               @NotNull Point blockPosition,
                               @NotNull Block currentBlock,
                               @NotNull BlockFace fromFace) {
+        @Deprecated
+        public Block.Getter instance() {
+            return this.blockGetter;
+        }
     }
 
     public record Replacement(


### PR DESCRIPTION
as talked about on discord, this pr adds the Block.Setter to the BlockPlacementRule so BlockPlacementRule's can set blocks. Useful for Doors to place the upper part or update nearby blocks if needed.

Additionally it also deprecates the instance() field because the naming does not make sense if both getter and setter fields are present there.