### PR TITLE
Update ClientVehicleMovePacket to 1.21.4

### DIFF
--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientVehicleMovePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientVehicleMovePacket.java
@@ -6,10 +6,11 @@ import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.client.ClientPacket;
 import org.jetbrains.annotations.NotNull;
 
-import static net.minestom.server.network.NetworkBuffer.POS;
+import static net.minestom.server.network.NetworkBuffer.*;
 
-public record ClientVehicleMovePacket(@NotNull Pos position) implements ClientPacket {
+public record ClientVehicleMovePacket(@NotNull Pos position, boolean onGround) implements ClientPacket {
     public static final NetworkBuffer.Type<ClientVehicleMovePacket> SERIALIZER = NetworkBufferTemplate.template(
             POS, ClientVehicleMovePacket::position,
+            BOOLEAN, ClientVehicleMovePacket::onGround,
             ClientVehicleMovePacket::new);
 }

--- a/src/test/java/net/minestom/server/network/PacketWriteReadTest.java
+++ b/src/test/java/net/minestom/server/network/PacketWriteReadTest.java
@@ -5,6 +5,7 @@ import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.nbt.CompoundBinaryTag;
 import net.kyori.adventure.text.Component;
 import net.minestom.server.MinecraftServer;
+import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.EquipmentSlot;
 import net.minestom.server.entity.GameMode;
@@ -14,6 +15,7 @@ import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
 import net.minestom.server.network.packet.client.ClientPacket;
 import net.minestom.server.network.packet.client.handshake.ClientHandshakePacket;
+import net.minestom.server.network.packet.client.play.ClientVehicleMovePacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.network.packet.server.common.DisconnectPacket;
 import net.minestom.server.network.packet.server.common.PingResponsePacket;
@@ -141,6 +143,8 @@ public class PacketWriteReadTest {
     @BeforeAll
     public static void setupClient() {
         CLIENT_PACKETS.add(new ClientHandshakePacket(755, "localhost", 25565, ClientHandshakePacket.Intent.LOGIN));
+        CLIENT_PACKETS.add(new ClientVehicleMovePacket(new Pos(5, 5, 5, 45f, 45f), true));
+        CLIENT_PACKETS.add(new ClientVehicleMovePacket(new Pos(6, 5, 6, 82f, 12.5f), false));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
When riding a boat, I got the following message from the demo server on the 1.21.4 branch:
`23:28:56.872 [] WARN net.minestom.server.network.packet.PacketReading - WARNING: Packet (ClientVehicleMovePacket) 0x20 not fully read (NetworkBuffer{r34|w35->16383, registries=true, autoResize=true, readOnly=false})`

It seems a new field got added to the packet in 1.21.4, this PR adds that field to the packet record.
[Packet on the Protocol Wiki for 1.21.4](https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Protocol?oldid=2821146#Move_Vehicle_2)