### PR TITLE
fix: Add simple boat meta check for velocity fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,8 @@ dependencies {
 
     // Testing
     testImplementation(libs.bundles.junit)
+    testImplementation(platform(libs.mockito.bom))
+    testImplementation(libs.bundles.mockito)
     testImplementation(project(":testing"))
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ jcTools = "4.0.5"
 
 # Quality
 junit-jupiter = "5.9.3"
+junit-pioneer = "2.3.0"
 junit-platform = "1.9.3"
 jmh = "1.36"
 jcstress = "0.16"
@@ -59,6 +60,7 @@ jcTools = { group = "org.jctools", name = "jctools-core", version.ref = "jcTools
 junit-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit-jupiter" }
 junit-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit-jupiter" }
 junit-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junit-jupiter" }
+junit-pioneer = { group = "org.junit-pioneer", name = "junit-pioneer", version.ref = "junit-pioneer" }
 junit-suite-api = { group = "org.junit.platform", name = "junit-platform-suite-api", version.ref = "junit-platform" }
 junit-suite-engine = { group = "org.junit.platform", name = "junit-platform-suite-engine", version.ref = "junit-platform" }
 jmh-core = { group = "org.openjdk.jmh", name = "jmh-core", version.ref = "jmh" }
@@ -79,7 +81,7 @@ logback-classic = { group = "ch.qos.logback", name = "logback-classic", version.
 
 flare = ["flare", "flare-fastutil"]
 adventure = ["adventure-api", "adventure-nbt", "adventure-serializer-gson", "adventure-serializer-legacy", "adventure-serializer-plain", "adventure-text-logger-slf4j"]
-junit = ["junit-api", "junit-engine", "junit-params", "junit-suite-api", "junit-suite-engine"]
+junit = ["junit-api", "junit-engine", "junit-params", "junit-suite-api", "junit-suite-engine", "junit-pioneer"]
 mockito = ["mockito-core", "mockito-junit-jupiter"]
 logback = ["logback-core", "logback-classic"]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ junit-jupiter = "5.9.3"
 junit-platform = "1.9.3"
 jmh = "1.36"
 jcstress = "0.16"
+mockito-bom = "5.15.2"
 
 # Code Generation
 javaPoet = "1.13.0"
@@ -63,6 +64,9 @@ junit-suite-engine = { group = "org.junit.platform", name = "junit-platform-suit
 jmh-core = { group = "org.openjdk.jmh", name = "jmh-core", version.ref = "jmh" }
 jmh-annotationprocessor = { group = "org.openjdk.jmh", name = "jmh-generator-annprocess", version.ref = "jmh" }
 jcstress-core = { group = "org.openjdk.jcstress", name = "jcstress-core", version.ref = "jcstress" }
+mockito-bom = { group = "org.mockito", name = "mockito-bom", version.ref = "mockito-bom" }
+mockito-core = { group = "org.mockito", name = "mockito-core" }
+mockito-junit-jupiter = { group = "org.mockito", name = "mockito-junit-jupiter" }
 
 # Code Generation
 javaPoet = { group = "com.squareup", name = "javapoet", version.ref = "javaPoet" }
@@ -76,6 +80,7 @@ logback-classic = { group = "ch.qos.logback", name = "logback-classic", version.
 flare = ["flare", "flare-fastutil"]
 adventure = ["adventure-api", "adventure-nbt", "adventure-serializer-gson", "adventure-serializer-legacy", "adventure-serializer-plain", "adventure-text-logger-slf4j"]
 junit = ["junit-api", "junit-engine", "junit-params", "junit-suite-api", "junit-suite-engine"]
+mockito = ["mockito-core", "mockito-junit-jupiter"]
 logback = ["logback-core", "logback-classic"]
 
 [plugins]

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -14,6 +14,7 @@ import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.entity.metadata.LivingEntityMeta;
 import net.minestom.server.entity.metadata.other.ArmorStandMeta;
+import net.minestom.server.entity.metadata.other.BoatMeta;
 import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.EventFilter;
 import net.minestom.server.event.EventHandler;
@@ -590,7 +591,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
             effectTick();
         }
         // Scheduled synchronization
-        if (vehicle == null && ticks >= nextSynchronizationTick) {
+        if (vehicle == null && ticks >= nextSynchronizationTick && !(entityMeta instanceof BoatMeta)) {
             synchronizePosition();
             sendPacketToViewers(getVelocityPacket());
         }

--- a/src/test/java/net/minestom/server/entity/BoatEntityTest.java
+++ b/src/test/java/net/minestom/server/entity/BoatEntityTest.java
@@ -45,7 +45,7 @@ class BoatEntityTest {
     @DisplayName("Test if velocity packet is not sent after 20 ticks if the entity a boat")
     @Issue("1880")
     void testIfVelocityPacketIsNotSent(EntityType entityType, Env env) {
-        final Entity entity = Mockito.spy(new Entity(EntityTypes.ACACIA_BOAT));
+        final Entity entity = Mockito.spy(new Entity(entityType));
         Instance flatInstance = env.createFlatInstance();
         entity.setInstance(flatInstance, Pos.ZERO).join();
         for (int i = 0; i < 21; i++) {

--- a/src/test/java/net/minestom/server/entity/BoatEntityTest.java
+++ b/src/test/java/net/minestom/server/entity/BoatEntityTest.java
@@ -4,13 +4,17 @@ import net.minestom.server.coordinate.Pos;
 import net.minestom.server.instance.Instance;
 import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.Issue;
 import org.mockito.Mockito;
 
 @EnvTest
 class BoatEntityTest {
 
     @Test
+    @DisplayName("Test if velocity packet is not sent after 20 ticks if the entity a boat")
+    @Issue("1880")
     void testIfVelocityPacketIsNotSent(Env env) {
         final Entity entity = Mockito.spy(new Entity(EntityTypes.ACACIA_BOAT));
         Instance flatInstance = env.createFlatInstance();
@@ -22,6 +26,8 @@ class BoatEntityTest {
     }
 
     @Test
+    @DisplayName("Test if velocity packet is sent after 20 ticks if the entity is not a boat")
+    @Issue("1880")
     void testIfVelocityPacketGetSent(Env env) {
         Instance flatInstance = env.createFlatInstance();
         final Entity entity = Mockito.spy(new Entity(EntityTypes.ZOMBIE));

--- a/src/test/java/net/minestom/server/entity/BoatEntityTest.java
+++ b/src/test/java/net/minestom/server/entity/BoatEntityTest.java
@@ -6,16 +6,45 @@ import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junitpioneer.jupiter.Issue;
 import org.mockito.Mockito;
+
+import java.util.stream.Stream;
 
 @EnvTest
 class BoatEntityTest {
 
-    @Test
+    private static final Stream<Arguments> TEST_TYPES = Stream.of(
+            Arguments.of(EntityType.ACACIA_BOAT),
+            Arguments.of(EntityType.ACACIA_CHEST_BOAT),
+            Arguments.of(EntityType.BIRCH_BOAT),
+            Arguments.of(EntityType.BIRCH_CHEST_BOAT),
+            Arguments.of(EntityType.CHERRY_BOAT),
+            Arguments.of(EntityType.CHERRY_CHEST_BOAT),
+            Arguments.of(EntityType.DARK_OAK_BOAT),
+            Arguments.of(EntityType.DARK_OAK_CHEST_BOAT),
+            Arguments.of(EntityType.JUNGLE_BOAT),
+            Arguments.of(EntityType.JUNGLE_CHEST_BOAT),
+            Arguments.of(EntityType.MANGROVE_BOAT),
+            Arguments.of(EntityType.MANGROVE_CHEST_BOAT),
+            Arguments.of(EntityType.OAK_BOAT),
+            Arguments.of(EntityType.OAK_CHEST_BOAT),
+            Arguments.of(EntityType.PALE_OAK_BOAT),
+            Arguments.of(EntityType.PALE_OAK_CHEST_BOAT),
+            Arguments.of(EntityType.SPRUCE_BOAT),
+            Arguments.of(EntityType.SPRUCE_CHEST_BOAT),
+            Arguments.of(EntityType.BAMBOO_CHEST_RAFT),
+            Arguments.of(EntityType.BAMBOO_RAFT)
+    );
+
+    @ParameterizedTest
+    @MethodSource("getTestTypes")
     @DisplayName("Test if velocity packet is not sent after 20 ticks if the entity a boat")
     @Issue("1880")
-    void testIfVelocityPacketIsNotSent(Env env) {
+    void testIfVelocityPacketIsNotSent(EntityType entityType, Env env) {
         final Entity entity = Mockito.spy(new Entity(EntityTypes.ACACIA_BOAT));
         Instance flatInstance = env.createFlatInstance();
         entity.setInstance(flatInstance, Pos.ZERO).join();
@@ -36,5 +65,11 @@ class BoatEntityTest {
             env.tick();
         }
         Mockito.verify(entity, Mockito.times(1)).sendPacketToViewers(Mockito.any());
+    }
+
+
+
+    private static Stream<Arguments> getTestTypes() {
+        return TEST_TYPES;
     }
 }

--- a/src/test/java/net/minestom/server/entity/BoatEntityTest.java
+++ b/src/test/java/net/minestom/server/entity/BoatEntityTest.java
@@ -1,0 +1,34 @@
+package net.minestom.server.entity;
+
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.instance.Instance;
+import net.minestom.testing.Env;
+import net.minestom.testing.EnvTest;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+@EnvTest
+class BoatEntityTest {
+
+    @Test
+    void testIfVelocityPacketIsNotSent(Env env) {
+        final Entity entity = Mockito.spy(new Entity(EntityTypes.ACACIA_BOAT));
+        Instance flatInstance = env.createFlatInstance();
+        entity.setInstance(flatInstance, Pos.ZERO).join();
+        for (int i = 0; i < 21; i++) {
+            env.tick();
+        }
+        Mockito.verify(entity, Mockito.never()).sendPacketToViewers(Mockito.any());
+    }
+
+    @Test
+    void testIfVelocityPacketGetSent(Env env) {
+        Instance flatInstance = env.createFlatInstance();
+        final Entity entity = Mockito.spy(new Entity(EntityTypes.ZOMBIE));
+        entity.setInstance(flatInstance, Pos.ZERO).join();
+        for (int i = 0; i < 21; i++) {
+            env.tick();
+        }
+        Mockito.verify(entity, Mockito.times(1)).sendPacketToViewers(Mockito.any());
+    }
+}


### PR DESCRIPTION
This pr fixes #1880 and add a additional check into a entity to prevent the velocity is send to the client if the type a boat.