### PR TITLE
Make PNode's getType method public

### DIFF
--- a/src/main/java/net/minestom/server/entity/pathfinding/PNode.java
+++ b/src/main/java/net/minestom/server/entity/pathfinding/PNode.java
@@ -95,7 +95,7 @@ public class PNode {
     }
 
     @ApiStatus.Internal
-    @NotNull Type getType() {
+    public @NotNull Type getType() {
         return type;
     }
 


### PR DESCRIPTION
This PR allows anyone to get the Type of a PNode.