### PR TITLE
refactor: move from getUniqueId() to getUuid() and related

### DIFF
--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -758,7 +758,7 @@ public abstract class Instance implements Block.Getter, Block.Setter,
      * Gets the instance unique id.
      *
      * @return the instance unique id
-     * @deprecated Use Instance#getUuid
+     * @deprecated Replace with Instance#getUuid
      */
     @Deprecated(forRemoval = true)
     public @NotNull UUID getUniqueId() {

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -755,6 +755,17 @@ public abstract class Instance implements Block.Getter, Block.Setter,
     }
 
     /**
+     * Gets the instance unique id.
+     *
+     * @return the instance unique id
+     * @deprecated Use Instance#getUuid
+     */
+    @Deprecated(forRemoval = true)
+    public @NotNull UUID getUniqueId() {
+        return uuid;
+    }
+
+    /**
      * Performs a single tick in the instance, including scheduled tasks from {@link #scheduleNextTick(Consumer)}.
      * <p>
      * Warning: this does not update chunks and entities.

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -758,7 +758,7 @@ public abstract class Instance implements Block.Getter, Block.Setter,
      * Gets the instance unique id.
      *
      * @return the instance unique id
-     * @deprecated Replace with Instance#getUuid
+     * @deprecated Replace with {@link Instance#getUuid()}
      */
     @Deprecated(forRemoval = true)
     public @NotNull UUID getUniqueId() {

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -103,7 +103,7 @@ public abstract class Instance implements Block.Getter, Block.Setter,
     private final ChunkCache blockRetriever = new ChunkCache(this, null, null);
 
     // the uuid of this instance
-    protected UUID uniqueId;
+    protected UUID uuid;
 
     // instance custom data
     protected TagHandler tagHandler = TagHandler.newHandler();
@@ -119,31 +119,31 @@ public abstract class Instance implements Block.Getter, Block.Setter,
     /**
      * Creates a new instance.
      *
-     * @param uniqueId      the {@link UUID} of the instance
+     * @param uuid      the {@link UUID} of the instance
      * @param dimensionType the {@link DimensionType} of the instance
      */
-    public Instance(@NotNull UUID uniqueId, @NotNull DynamicRegistry.Key<DimensionType> dimensionType) {
-        this(uniqueId, dimensionType, dimensionType.namespace());
+    public Instance(@NotNull UUID uuid, @NotNull DynamicRegistry.Key<DimensionType> dimensionType) {
+        this(uuid, dimensionType, dimensionType.namespace());
     }
 
     /**
      * Creates a new instance.
      *
-     * @param uniqueId      the {@link UUID} of the instance
+     * @param uuid      the {@link UUID} of the instance
      * @param dimensionType the {@link DimensionType} of the instance
      */
-    public Instance(@NotNull UUID uniqueId, @NotNull DynamicRegistry.Key<DimensionType> dimensionType, @NotNull NamespaceID dimensionName) {
-        this(MinecraftServer.getDimensionTypeRegistry(), uniqueId, dimensionType, dimensionName);
+    public Instance(@NotNull UUID uuid, @NotNull DynamicRegistry.Key<DimensionType> dimensionType, @NotNull NamespaceID dimensionName) {
+        this(MinecraftServer.getDimensionTypeRegistry(), uuid, dimensionType, dimensionName);
     }
 
     /**
      * Creates a new instance.
      *
-     * @param uniqueId      the {@link UUID} of the instance
+     * @param uuid      the {@link UUID} of the instance
      * @param dimensionType the {@link DimensionType} of the instance
      */
-    public Instance(@NotNull DynamicRegistry<DimensionType> dimensionTypeRegistry, @NotNull UUID uniqueId, @NotNull DynamicRegistry.Key<DimensionType> dimensionType, @NotNull NamespaceID dimensionName) {
-        this.uniqueId = uniqueId;
+    public Instance(@NotNull DynamicRegistry<DimensionType> dimensionTypeRegistry, @NotNull UUID uuid, @NotNull DynamicRegistry.Key<DimensionType> dimensionType, @NotNull NamespaceID dimensionName) {
+        this.uuid = uuid;
         this.dimensionType = dimensionType;
         this.cachedDimensionType = dimensionTypeRegistry.get(dimensionType);
         Check.argCondition(cachedDimensionType == null, "The dimension " + dimensionType + " is not registered! Please add it to the registry (`MinecraftServer.getDimensionTypeRegistry().registry(dimensionType)`).");
@@ -153,7 +153,7 @@ public abstract class Instance implements Block.Getter, Block.Setter,
         targetBorderDiameter = this.worldBorder.diameter();
 
         this.pointers = Pointers.builder()
-                .withDynamic(Identity.UUID, this::getUniqueId)
+                .withDynamic(Identity.UUID, this::getUuid)
                 .build();
 
         final ServerProcess process = MinecraftServer.process();
@@ -750,8 +750,8 @@ public abstract class Instance implements Block.Getter, Block.Setter,
      *
      * @return the instance unique id
      */
-    public @NotNull UUID getUniqueId() {
-        return uniqueId;
+    public @NotNull UUID getUuid() {
+        return uuid;
     }
 
     /**

--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -89,30 +89,30 @@ public class InstanceContainer extends Instance {
     protected InstanceContainer srcInstance; // only present if this instance has been created using a copy
     private long lastBlockChangeTime; // Time at which the last block change happened (#setBlock)
 
-    public InstanceContainer(@NotNull UUID uniqueId, @NotNull DynamicRegistry.Key<DimensionType> dimensionType) {
-        this(uniqueId, dimensionType, null, dimensionType.namespace());
+    public InstanceContainer(@NotNull UUID uuid, @NotNull DynamicRegistry.Key<DimensionType> dimensionType) {
+        this(uuid, dimensionType, null, dimensionType.namespace());
     }
 
-    public InstanceContainer(@NotNull UUID uniqueId, @NotNull DynamicRegistry.Key<DimensionType> dimensionType, @NotNull NamespaceID dimensionName) {
-        this(uniqueId, dimensionType, null, dimensionName);
+    public InstanceContainer(@NotNull UUID uuid, @NotNull DynamicRegistry.Key<DimensionType> dimensionType, @NotNull NamespaceID dimensionName) {
+        this(uuid, dimensionType, null, dimensionName);
     }
 
-    public InstanceContainer(@NotNull UUID uniqueId, @NotNull DynamicRegistry.Key<DimensionType> dimensionType, @Nullable IChunkLoader loader) {
-        this(uniqueId, dimensionType, loader, dimensionType.namespace());
+    public InstanceContainer(@NotNull UUID uuid, @NotNull DynamicRegistry.Key<DimensionType> dimensionType, @Nullable IChunkLoader loader) {
+        this(uuid, dimensionType, loader, dimensionType.namespace());
     }
 
-    public InstanceContainer(@NotNull UUID uniqueId, @NotNull DynamicRegistry.Key<DimensionType> dimensionType, @Nullable IChunkLoader loader, @NotNull NamespaceID dimensionName) {
-        this(MinecraftServer.getDimensionTypeRegistry(), uniqueId, dimensionType, loader, dimensionName);
+    public InstanceContainer(@NotNull UUID uuid, @NotNull DynamicRegistry.Key<DimensionType> dimensionType, @Nullable IChunkLoader loader, @NotNull NamespaceID dimensionName) {
+        this(MinecraftServer.getDimensionTypeRegistry(), uuid, dimensionType, loader, dimensionName);
     }
 
     public InstanceContainer(
             @NotNull DynamicRegistry<DimensionType> dimensionTypeRegistry,
-            @NotNull UUID uniqueId,
+            @NotNull UUID uuid,
             @NotNull DynamicRegistry.Key<DimensionType> dimensionType,
             @Nullable IChunkLoader loader,
             @NotNull NamespaceID dimensionName
     ) {
-        super(dimensionTypeRegistry, uniqueId, dimensionType, dimensionName);
+        super(dimensionTypeRegistry, uuid, dimensionType, dimensionName);
         setChunkSupplier(DynamicChunk::new);
         setChunkLoader(Objects.requireNonNullElse(loader, DEFAULT_LOADER));
         this.chunkLoader.loadInstance(this);

--- a/src/main/java/net/minestom/server/instance/InstanceManager.java
+++ b/src/main/java/net/minestom/server/instance/InstanceManager.java
@@ -151,7 +151,7 @@ public final class InstanceManager {
     public @Nullable Instance getInstance(@NotNull UUID uuid) {
         Optional<Instance> instance = getInstances()
                 .stream()
-                .filter(someInstance -> someInstance.getUniqueId().equals(uuid))
+                .filter(someInstance -> someInstance.getUuid().equals(uuid))
                 .findFirst();
         return instance.orElse(null);
     }

--- a/src/main/java/net/minestom/server/instance/SharedInstance.java
+++ b/src/main/java/net/minestom/server/instance/SharedInstance.java
@@ -21,8 +21,8 @@ import java.util.concurrent.CompletableFuture;
 public class SharedInstance extends Instance {
     private final InstanceContainer instanceContainer;
 
-    public SharedInstance(@NotNull UUID uniqueId, @NotNull InstanceContainer instanceContainer) {
-        super(uniqueId, instanceContainer.getDimensionType());
+    public SharedInstance(@NotNull UUID uuid, @NotNull InstanceContainer instanceContainer) {
+        super(uuid, instanceContainer.getDimensionType());
         this.instanceContainer = instanceContainer;
     }
 

--- a/src/main/java/net/minestom/server/instance/batch/ChunkBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/ChunkBatch.java
@@ -106,7 +106,7 @@ public class ChunkBatch implements Batch<ChunkCallback> {
         final Chunk chunk = instance.getChunk(chunkX, chunkZ);
         if (chunk == null) {
             LOGGER.warn("Unable to apply ChunkBatch to unloaded chunk ({}, {}) in {}.",
-                    chunkX, chunkZ, instance.getUniqueId());
+                    chunkX, chunkZ, instance.getUuid());
             return null;
         }
         return apply(instance, chunk, callback);
@@ -165,7 +165,7 @@ public class ChunkBatch implements Batch<ChunkCallback> {
         try {
             if (!chunk.isLoaded()) {
                 LOGGER.warn("Unable to apply ChunkBatch to unloaded chunk ({}, {}) in {}.",
-                        chunk.getChunkX(), chunk.getChunkZ(), instance.getUniqueId());
+                        chunk.getChunkX(), chunk.getChunkZ(), instance.getUuid());
                 return;
             }
 

--- a/src/main/java/net/minestom/server/listener/SpectateListener.java
+++ b/src/main/java/net/minestom/server/listener/SpectateListener.java
@@ -35,7 +35,7 @@ public class SpectateListener {
 
         // Ignore if they're not in the same instance. Vanilla actually allows for
         // cross-instance spectating, but it's not really a good idea for Minestom.
-        if (targetInstance.getUniqueId() != playerInstance.getUniqueId()) {
+        if (targetInstance.getUuid() != playerInstance.getUuid()) {
             return;
         }
 

--- a/src/main/java/net/minestom/server/scoreboard/TeamManager.java
+++ b/src/main/java/net/minestom/server/scoreboard/TeamManager.java
@@ -5,7 +5,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.minestom.server.entity.LivingEntity;
 import net.minestom.server.entity.Player;
 import net.minestom.server.utils.PacketSendingUtils;
-import net.minestom.server.utils.UniqueIdUtils;
+import net.minestom.server.utils.UUIDUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -158,7 +158,7 @@ public final class TeamManager {
     public List<String> getPlayers(Team team) {
         List<String> players = new ArrayList<>();
         for (String member : team.getMembers()) {
-            boolean match = UniqueIdUtils.isUniqueId(member);
+            boolean match = UUIDUtils.isUuid(member);
 
             if (!match) players.add(member);
         }
@@ -176,7 +176,7 @@ public final class TeamManager {
     public List<String> getEntities(Team team) {
         List<String> entities = new ArrayList<>();
         for (String member : team.getMembers()) {
-            boolean match = UniqueIdUtils.isUniqueId(member);
+            boolean match = UUIDUtils.isUuid(member);
 
             if (match) entities.add(member);
         }

--- a/src/main/java/net/minestom/server/tag/Serializers.java
+++ b/src/main/java/net/minestom/server/tag/Serializers.java
@@ -5,7 +5,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.minestom.server.ServerFlag;
 import net.minestom.server.item.ItemStack;
-import net.minestom.server.utils.UniqueIdUtils;
+import net.minestom.server.utils.UUIDUtils;
 
 import java.util.function.Function;
 
@@ -23,7 +23,7 @@ final class Serializers {
     static final Entry<String, StringBinaryTag> STRING = new Entry<>(BinaryTagTypes.STRING, StringBinaryTag::value, StringBinaryTag::stringBinaryTag);
     static final Entry<BinaryTag, BinaryTag> NBT_ENTRY = new Entry<>(null, Function.identity(), Function.identity());
 
-    static final Entry<java.util.UUID, IntArrayBinaryTag> UUID = new Entry<>(BinaryTagTypes.INT_ARRAY, UniqueIdUtils::fromNbt, UniqueIdUtils::toNbt);
+    static final Entry<java.util.UUID, IntArrayBinaryTag> UUID = new Entry<>(BinaryTagTypes.INT_ARRAY, UUIDUtils::fromNbt, UUIDUtils::toNbt);
     static final Entry<ItemStack, CompoundBinaryTag> ITEM = new Entry<>(BinaryTagTypes.COMPOUND, ItemStack::fromItemNBT, ItemStack::toItemNBT);
     static final Entry<Component, StringBinaryTag> COMPONENT = new Entry<>(BinaryTagTypes.STRING, input -> GsonComponentSerializer.gson().deserialize(input.value()),
             component -> StringBinaryTag.stringBinaryTag(GsonComponentSerializer.gson().serialize(component)));

--- a/src/main/java/net/minestom/server/utils/UUIDUtils.java
+++ b/src/main/java/net/minestom/server/utils/UUIDUtils.java
@@ -11,7 +11,7 @@ import java.util.regex.Pattern;
  * An utilities class for {@link UUID}.
  */
 @ApiStatus.Internal
-public final class UniqueIdUtils {
+public final class UUIDUtils {
     public static final Pattern UNIQUE_ID_PATTERN = Pattern.compile("\\b[0-9a-f]{8}\\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\\b[0-9a-f]{12}\\b");
 
     /**
@@ -20,7 +20,7 @@ public final class UniqueIdUtils {
      * @param input The input string to be checked
      * @return {@code true} if the input an unique identifier, otherwise {@code false}
      */
-    public static boolean isUniqueId(String input) {
+    public static boolean isUuid(String input) {
         return input.matches(UNIQUE_ID_PATTERN.pattern());
     }
 

--- a/src/main/java/net/minestom/server/utils/nbt/BinaryTagSerializer.java
+++ b/src/main/java/net/minestom/server/utils/nbt/BinaryTagSerializer.java
@@ -14,7 +14,7 @@ import net.minestom.server.registry.DynamicRegistry;
 import net.minestom.server.registry.ProtocolObject;
 import net.minestom.server.registry.Registries;
 import net.minestom.server.utils.NamespaceID;
-import net.minestom.server.utils.UniqueIdUtils;
+import net.minestom.server.utils.UUIDUtils;
 import net.minestom.server.utils.Unit;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.ApiStatus;
@@ -257,7 +257,7 @@ public interface BinaryTagSerializer<T> {
     BinaryTagSerializer<UUID> UUID = new BinaryTagSerializer<>() {
         @Override
         public @NotNull BinaryTag write(java.util.@NotNull UUID value) {
-            return UniqueIdUtils.toNbt(value);
+            return UUIDUtils.toNbt(value);
         }
 
         @Override
@@ -265,7 +265,7 @@ public interface BinaryTagSerializer<T> {
             if (!(tag instanceof IntArrayBinaryTag intArrayTag)) {
                 throw new IllegalArgumentException("unexpected uuid type: " + tag.type());
             }
-            return UniqueIdUtils.fromNbt(intArrayTag);
+            return UUIDUtils.fromNbt(intArrayTag);
         }
     };
 

--- a/src/test/java/net/minestom/server/instance/InstanceUnregisterIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/InstanceUnregisterIntegrationTest.java
@@ -99,7 +99,7 @@ public class InstanceUnregisterIntegrationTest {
 
     private void tmp(InstanceContainer instanceContainer) {
         instanceContainer.eventNode().addListener(InstanceTickEvent.class, (e) -> {
-            var uuid = instanceContainer.getUniqueId();
+            var uuid = instanceContainer.getUuid();
         });
     }
 }


### PR DESCRIPTION
This PR solves #1616. See that issue for more details.

closes #1616

CHANGE: Public API of Instance has changed! getUniqueId() -> getUuid()
Old version is deprecated