### PR TITLE
Add missing `@n` selector to ArgumentEntity

### DIFF
--- a/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentEntity.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentEntity.java
@@ -32,9 +32,9 @@ public class ArgumentEntity extends Argument<EntityFinder> {
 
     private static final Pattern USERNAME_PATTERN = Pattern.compile("[a-zA-Z0-9_]{1,16}");
     private static final String SELECTOR_PREFIX = "@";
-    private static final List<String> SELECTOR_VARIABLES = Arrays.asList("@p", "@r", "@a", "@e", "@s");
+    private static final List<String> SELECTOR_VARIABLES = Arrays.asList("@p", "@r", "@a", "@e", "@s", "@n");
     private static final List<String> PLAYERS_ONLY_SELECTOR = Arrays.asList("@p", "@r", "@a", "@s");
-    private static final List<String> SINGLE_ONLY_SELECTOR = Arrays.asList("@p", "@r", "@s");
+    private static final List<String> SINGLE_ONLY_SELECTOR = Arrays.asList("@p", "@r", "@s", "@n");
     // List with all the valid arguments
     private static final List<String> VALID_ARGUMENTS = Arrays.asList(
             "x", "y", "z",
@@ -297,6 +297,8 @@ public class ArgumentEntity extends Argument<EntityFinder> {
     private static EntityFinder.TargetSelector toTargetSelector(@NotNull String selectorVariable) {
         if (selectorVariable.equals("@p"))
             return EntityFinder.TargetSelector.NEAREST_PLAYER;
+        if (selectorVariable.equals("@n"))
+            return EntityFinder.TargetSelector.NEAREST_ENTITY;
         if (selectorVariable.equals("@r"))
             return EntityFinder.TargetSelector.RANDOM_PLAYER;
         if (selectorVariable.equals("@a"))

--- a/src/main/java/net/minestom/server/utils/entity/EntityFinder.java
+++ b/src/main/java/net/minestom/server/utils/entity/EntityFinder.java
@@ -283,7 +283,7 @@ public class EntityFinder {
     }
 
     public enum TargetSelector {
-        NEAREST_PLAYER, RANDOM_PLAYER, ALL_PLAYERS, ALL_ENTITIES, SELF, MINESTOM_USERNAME, MINESTOM_UUID
+        NEAREST_PLAYER, RANDOM_PLAYER, ALL_PLAYERS, ALL_ENTITIES, SELF, MINESTOM_USERNAME, MINESTOM_UUID, NEAREST_ENTITY
     }
 
     public enum EntitySort {
@@ -315,6 +315,12 @@ public class EntityFinder {
             return players.stream()
                     .min(Comparator.comparingDouble(p -> p.getPosition().distanceSquared(startPosition)))
                     .<List<Entity>>map(Collections::singletonList).orElse(List.of());
+        } else if (targetSelector == TargetSelector.NEAREST_ENTITY) {
+            List<Entity> entities = findTarget(instance, TargetSelector.ALL_ENTITIES, startPosition, self);
+
+            return entities.stream()
+                    .min(Comparator.comparingDouble(p -> p.getPosition().distanceSquared(startPosition)))
+                    .map(Collections::singletonList).orElse(List.of());
         } else if (targetSelector == TargetSelector.RANDOM_PLAYER) {
             final int index = ThreadLocalRandom.current().nextInt(players.size());
             final Player player = players.stream().skip(index).findFirst().orElseThrow();


### PR DESCRIPTION
## Proposed changes

This adds the `@n` selector that was added in 1.21 (24w21a)
This selector selects the nearest entity to the invoking location.

Reference:
[minecraft.wiki](https://minecraft.wiki/w/Target_selectors#:~:text=%40n%E2%80%8C%5BJava%20Edition%20only%5D)

## Types of changes

What types of changes does your code introduce to this project?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)