### PR TITLE
Fix cat metadata values being shifted over by one

### DIFF
--- a/src/main/java/net/minestom/server/entity/MetadataDef.java
+++ b/src/main/java/net/minestom/server/entity/MetadataDef.java
@@ -432,9 +432,9 @@ public sealed class MetadataDef {
 
     public static final class Cat extends TameableAnimal {
         public static final Entry<CatMeta.Variant> VARIANT = index(0, Metadata::CatVariant, CatMeta.Variant.BLACK);
-        public static final Entry<Boolean> IS_LYING = index(2, Metadata::Boolean, false);
-        public static final Entry<Boolean> IS_RELAXED = index(3, Metadata::Boolean, false);
-        public static final Entry<Integer> COLLAR_COLOR = index(4, Metadata::VarInt, 14);
+        public static final Entry<Boolean> IS_LYING = index(1, Metadata::Boolean, false);
+        public static final Entry<Boolean> IS_RELAXED = index(2, Metadata::Boolean, false);
+        public static final Entry<Integer> COLLAR_COLOR = index(3, Metadata::VarInt, 14);
     }
 
     public static final class Wolf extends TameableAnimal {


### PR DESCRIPTION
## Proposed changes

Fixes cat metadata offsets being incorrect (previously it would kick for 'Network Protocol Error'). This change makes features work as expected and is also backed up by wiki.vg, so I am pretty confident in this.
(thank you @GoldenCookieGIT for reporting this and helping with the very brief debugging)

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~ client issue and involves incorrect numbers (not logic), so cannot really be tested (and is not necessary regardless)
- [x] I have added necessary documentation (if appropriate)
