### PR TITLE
Extend known packs timeout & make it configurable

### DIFF
--- a/src/main/java/net/minestom/server/ServerFlag.java
+++ b/src/main/java/net/minestom/server/ServerFlag.java
@@ -20,7 +20,8 @@ public final class ServerFlag {
     public static final int ENTITY_SYNCHRONIZATION_TICKS = intProperty("minestom.entity-synchronization-ticks", 20);
     public static final int DISPATCHER_THREADS = intProperty("minestom.dispatcher-threads", 1);
     public static final int SEND_LIGHT_AFTER_BLOCK_PLACEMENT_DELAY = intProperty("minestom.send-light-after-block-placement-delay", 100);
-    public static final long LOGIN_PLUGIN_MESSAGE_TIMEOUT = longProperty("minestom.login-plugin-message-timeout", 5_000);
+    public static final long LOGIN_PLUGIN_MESSAGE_TIMEOUT = longProperty("minestom.login-plugin-message-timeout", 5_000); // 5s
+    public static final long KNOWN_PACKS_RESPONSE_TIMEOUT = longProperty("minestom.known-packs-response-timeout", 5 * 60_000); // 5m
 
     // Network rate limiting
     public static final int PLAYER_PACKET_PER_TICK = intProperty("minestom.packet-per-tick", 50);


### PR DESCRIPTION
## Proposed changes
It came up that when using a continuation in Velocity to wait for a resource pack the existing timeout window can be reached causing the player to be kicked.

This change extends the window to respond to 5m (OK since keep alive exists in config so we can wait). It is also configurable now as a system property (see ServerFlag).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
