### PR TITLE
Use System.nanoTime() instead of System.currentTimeMillis()

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and deploy Javadoc
     env:
-      JAVA_VERSION: 23
+      JAVA_VERSION: 24
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ env.JAVA_VERSION }}

--- a/demo/src/main/java/net/minestom/demo/commands/RelightCommand.java
+++ b/demo/src/main/java/net/minestom/demo/commands/RelightCommand.java
@@ -4,15 +4,17 @@ import net.minestom.server.command.builder.Command;
 import net.minestom.server.entity.Player;
 import net.minestom.server.instance.LightingChunk;
 
+import java.util.concurrent.TimeUnit;
+
 public class RelightCommand extends Command {
     public RelightCommand() {
         super("relight");
         setDefaultExecutor((source, args) -> {
             if (source instanceof Player player) {
-                long start = System.currentTimeMillis();
+                long start = System.nanoTime();
                 source.sendMessage("Relighting...");
                 var relit = LightingChunk.relight(player.getInstance(), player.getInstance().getChunks());
-                source.sendMessage("Relighted " + player.getInstance().getChunks().size() + " chunks in " + (System.currentTimeMillis() - start) + "ms");
+                source.sendMessage("Relighted " + player.getInstance().getChunks().size() + " chunks in " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start) + "ms");
                 relit.forEach(chunk -> chunk.sendChunk(player));
                 source.sendMessage("Chunks Received");
             }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/net/minestom/server/ServerProcessImpl.java
+++ b/src/main/java/net/minestom/server/ServerProcessImpl.java
@@ -420,15 +420,13 @@ final class ServerProcessImpl implements ServerProcess {
     private final class TickerImpl implements Ticker {
         @Override
         public void tick(long nanoTime) {
-            final long nanoStart = System.nanoTime();
-
             scheduler().processTick();
 
             // Connection tick (let waiting clients in, send keep alives, handle configuration players packets)
-            connection().tick(nanoStart);
+            connection().tick(nanoTime);
 
             // Server tick (chunks/entities)
-            serverTick(nanoStart);
+            serverTick(nanoTime);
 
             scheduler().processTickEnd();
 

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -250,7 +250,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     /**
      * Called each tick.
      *
-     * @param time time of the update in milliseconds
+     * @param time time of the update in milliseconds. This may only be used as a delta and has no meaning in the real world
      */
     public void update(long time) {
 
@@ -585,7 +585,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
      * <p>
      * Ignored if {@link #getInstance()} returns null.
      *
-     * @param time the update time in milliseconds
+     * @param time the update time in milliseconds. This may only be used as a delta and has no meaning in the real world.
      */
     @Override
     public void tick(long time) {

--- a/src/main/java/net/minestom/server/entity/ItemEntity.java
+++ b/src/main/java/net/minestom/server/entity/ItemEntity.java
@@ -38,7 +38,9 @@ public class ItemEntity extends Entity {
     private float mergeRange = 1;
     private boolean previousOnGround = false;
 
+    // Spawn time in System#nanoTime
     private long spawnTime;
+    // pickup delay in nanos
     private long pickupDelay;
 
     public ItemEntity(@NotNull ItemStack itemStack) {
@@ -108,7 +110,7 @@ public class ItemEntity extends Entity {
 
     @Override
     public void spawn() {
-        this.spawnTime = System.currentTimeMillis();
+        this.spawnTime = System.nanoTime();
     }
 
     @Override
@@ -145,7 +147,7 @@ public class ItemEntity extends Entity {
      * @return true if the item is pickable, false otherwise
      */
     public boolean isPickable() {
-        return pickable && (System.currentTimeMillis() - getSpawnTime() >= pickupDelay);
+        return pickable && getTimeSinceSpawn() >= pickupDelay;
     }
 
     /**
@@ -223,12 +225,23 @@ public class ItemEntity extends Entity {
     }
 
     /**
-     * Used to know if the ItemEntity can be pickup.
+     * Used to know if the ItemEntity can be picked up.
      *
-     * @return the time in milliseconds since this entity has spawn
+     * @return the elapsed time in milliseconds since this entity has spawned
+     * @deprecated use {@link #getTimeSinceSpawn()} instead, does the same thing with better naming
      */
+    @Deprecated(forRemoval = true)
     public long getSpawnTime() {
-        return spawnTime;
+        return getTimeSinceSpawn();
+    }
+    
+    /**
+     * Used to know if the ItemEntity can be picked up.
+     *
+     * @return the elapsed time in milliseconds since this entity has spawned
+     */
+    public long getTimeSinceSpawn() {
+        return java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - spawnTime);
     }
 
     @ApiStatus.Experimental

--- a/src/main/java/net/minestom/server/entity/ai/goal/DoNothingGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/DoNothingGoal.java
@@ -5,6 +5,7 @@ import net.minestom.server.entity.ai.GoalSelector;
 import net.minestom.server.utils.MathUtils;
 
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 public class DoNothingGoal extends GoalSelector {
 
@@ -23,7 +24,7 @@ public class DoNothingGoal extends GoalSelector {
      */
     public DoNothingGoal(EntityCreature entityCreature, long time, float chance) {
         super(entityCreature);
-        this.time = time;
+        this.time = TimeUnit.MILLISECONDS.toNanos(time);
         this.chance = MathUtils.clamp(chance, 0, 1);
     }
 
@@ -34,7 +35,7 @@ public class DoNothingGoal extends GoalSelector {
 
     @Override
     public boolean shouldEnd() {
-        return System.currentTimeMillis() - startTime >= time;
+        return System.nanoTime() - startTime >= time;
     }
 
     @Override
@@ -44,7 +45,7 @@ public class DoNothingGoal extends GoalSelector {
 
     @Override
     public void start() {
-        this.startTime = System.currentTimeMillis();
+        this.startTime = System.nanoTime();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/ai/goal/RandomStrollGoal.java
+++ b/src/main/java/net/minestom/server/entity/ai/goal/RandomStrollGoal.java
@@ -8,10 +8,11 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 public class RandomStrollGoal extends GoalSelector {
 
-    private static final long DELAY = 2500;
+    private static final long DELAY = TimeUnit.MILLISECONDS.toNanos(2500);
 
     private final int radius;
     private final List<Vec> closePositions;
@@ -27,7 +28,7 @@ public class RandomStrollGoal extends GoalSelector {
 
     @Override
     public boolean shouldStart() {
-        return System.currentTimeMillis() - lastStroll >= DELAY;
+        return System.nanoTime() - lastStroll >= DELAY;
     }
 
     @Override
@@ -56,7 +57,7 @@ public class RandomStrollGoal extends GoalSelector {
 
     @Override
     public void end() {
-        this.lastStroll = System.currentTimeMillis();
+        this.lastStroll = System.nanoTime();
     }
 
     public int getRadius() {

--- a/src/main/java/net/minestom/server/extras/lan/OpenToLAN.java
+++ b/src/main/java/net/minestom/server/extras/lan/OpenToLAN.java
@@ -103,14 +103,14 @@ public class OpenToLAN {
      */
     private static void ping() {
         if (!MinecraftServer.getServer().isOpen()) return;
-        if (packet == null || eventCooldown.isReady(System.currentTimeMillis())) {
+        if (packet == null || eventCooldown.isReady(System.nanoTime())) {
             final ServerListPingEvent event = new ServerListPingEvent(OPEN_TO_LAN);
             EventDispatcher.call(event);
 
             final byte[] data = OPEN_TO_LAN.getPingResponse(event.getResponseData()).getBytes(StandardCharsets.UTF_8);
             packet = new DatagramPacket(data, data.length, PING_ADDRESS);
 
-            eventCooldown.refreshLastUpdate(System.currentTimeMillis());
+            eventCooldown.refreshLastUpdate(System.nanoTime());
         }
 
         try {

--- a/src/main/java/net/minestom/server/instance/Chunk.java
+++ b/src/main/java/net/minestom/server/instance/Chunk.java
@@ -123,17 +123,6 @@ public abstract class Chunk implements Block.Getter, Block.Setter, Biome.Getter,
     public abstract void tick(long time);
 
     /**
-     * Gets the last time that this chunk changed.
-     * <p>
-     * "Change" means here data used in {@link ChunkDataPacket}.
-     * It is necessary to see if the cached version of this chunk can be used
-     * instead of re-writing and compressing everything.
-     *
-     * @return the last change time in milliseconds
-     */
-    public abstract long getLastChangeTime();
-
-    /**
      * Sends the chunk data to {@code player}.
      *
      * @param player the player

--- a/src/main/java/net/minestom/server/instance/DynamicChunk.java
+++ b/src/main/java/net/minestom/server/instance/DynamicChunk.java
@@ -59,7 +59,6 @@ public class DynamicChunk extends Chunk {
     protected final Int2ObjectOpenHashMap<Block> entries = new Int2ObjectOpenHashMap<>(0);
     protected final Int2ObjectOpenHashMap<Block> tickableMap = new Int2ObjectOpenHashMap<>(0);
 
-    private long lastChange;
     final CachedPacket chunkCache = new CachedPacket(this::createChunkPacket);
     private static final DynamicRegistry<Biome> BIOME_REGISTRY = MinecraftServer.getBiomeRegistry();
 
@@ -88,7 +87,6 @@ public class DynamicChunk extends Chunk {
         }
         assertLock();
 
-        this.lastChange = System.currentTimeMillis();
         this.chunkCache.invalidate();
 
         Section section = getSectionAt(y);
@@ -231,11 +229,6 @@ public class DynamicChunk extends Chunk {
         RegistryKey<Biome> biome = BIOME_REGISTRY.getKey(id);
         Check.notNull(biome, "Biome with id {0} is not registered", id);
         return biome;
-    }
-
-    @Override
-    public long getLastChangeTime() {
-        return lastChange;
     }
 
     @Override

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -54,6 +54,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -97,7 +98,7 @@ public abstract class Instance implements Block.Getter, Block.Setter,
     private int remainingThunderTransitionTicks;
 
     // Field for tick events
-    private long lastTickAge = System.currentTimeMillis();
+    private long lastTickAge = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
 
     private final EntityTracker entityTracker = new EntityTrackerImpl();
 

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -772,7 +772,7 @@ public abstract class Instance implements Block.Getter, Block.Setter,
      * <p>
      * Warning: this does not update chunks and entities.
      *
-     * @param time the tick time in milliseconds
+     * @param time the tick time in milliseconds, which may only be used as a delta and has no meaning in real life
      */
     @Override
     public void tick(long time) {

--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -118,6 +118,8 @@ public class InstanceContainer extends Instance {
         setChunkSupplier(DynamicChunk::new);
         setChunkLoader(Objects.requireNonNullElse(loader, DEFAULT_LOADER));
         this.chunkLoader.loadInstance(this);
+        // last block change starts at instance creation time
+        refreshLastBlockChangeTime();
     }
 
     @Override
@@ -154,7 +156,7 @@ public class InstanceContainer extends Instance {
 
         synchronized (chunk) {
             // Refresh the last block change time
-            this.lastBlockChangeTime = System.currentTimeMillis();
+            this.lastBlockChangeTime = System.nanoTime();
             final Vec blockPosition = new Vec(x, y, z);
             if (isAlreadyChanged(blockPosition, block)) { // do NOT change the block again.
                 // Avoids StackOverflowExceptions when onDestroy tries to destroy the block itself
@@ -574,7 +576,7 @@ public class InstanceContainer extends Instance {
     /**
      * Gets the last time at which a block changed.
      *
-     * @return the time at which the last block changed in milliseconds, 0 if never
+     * @return the time at which the last block changed in nanoseconds. Only use this to calculate delta times
      */
     public long getLastBlockChangeTime() {
         return lastBlockChangeTime;
@@ -586,7 +588,7 @@ public class InstanceContainer extends Instance {
      * Useful if you change blocks values directly using a {@link Chunk} object.
      */
     public void refreshLastBlockChangeTime() {
-        this.lastBlockChangeTime = System.currentTimeMillis();
+        this.lastBlockChangeTime = System.nanoTime();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/instance/anvil/RegionFile.java
+++ b/src/main/java/net/minestom/server/instance/anvil/RegionFile.java
@@ -124,6 +124,7 @@ final class RegionFile implements AutoCloseable {
 
             // Update the header and write it
             locations[chunkIndex] = newLocation;
+            // store timestamps in seconds since epoch
             timestamps[chunkIndex] = (int) (System.currentTimeMillis() / 1000);
             writeHeader();
         } finally {

--- a/src/main/java/net/minestom/server/listener/common/KeepAliveListener.java
+++ b/src/main/java/net/minestom/server/listener/common/KeepAliveListener.java
@@ -5,6 +5,8 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.minestom.server.entity.Player;
 import net.minestom.server.network.packet.client.common.ClientKeepAlivePacket;
 
+import java.util.concurrent.TimeUnit;
+
 public final class KeepAliveListener {
     private static final Component KICK_MESSAGE = Component.text("Bad Keep Alive packet", NamedTextColor.RED);
 
@@ -16,7 +18,9 @@ public final class KeepAliveListener {
         }
         player.refreshAnswerKeepAlive(true);
         // Update latency
-        final int latency = (int) (System.currentTimeMillis() - packetId);
+        final long latencyNanos = System.nanoTime() - packetId;
+
+        final int latency = (int) TimeUnit.NANOSECONDS.toMillis(latencyNanos);
         player.refreshLatency(latency);
     }
 }

--- a/src/main/java/net/minestom/server/network/ConnectionManager.java
+++ b/src/main/java/net/minestom/server/network/ConnectionManager.java
@@ -377,7 +377,7 @@ public final class ConnectionManager {
             if (lastKeepAlive > TimeUnit.MILLISECONDS.toNanos(ServerFlag.KEEP_ALIVE_DELAY) && player.didAnswerKeepAlive()) {
                 player.refreshKeepAlive(tickStart);
                 player.sendPacket(keepAlivePacket);
-            } else if (lastKeepAlive >= TimeUnit.MICROSECONDS.toNanos(ServerFlag.KEEP_ALIVE_KICK)) {
+            } else if (lastKeepAlive >= TimeUnit.MILLISECONDS.toNanos(ServerFlag.KEEP_ALIVE_KICK)) {
                 player.kick(TIMEOUT_TEXT);
             }
         }

--- a/src/main/java/net/minestom/server/network/ConnectionManager.java
+++ b/src/main/java/net/minestom/server/network/ConnectionManager.java
@@ -368,16 +368,16 @@ public final class ConnectionManager {
     /**
      * Updates keep alive by checking the last keep alive packet and send a new one if needed.
      *
-     * @param tickStart the time of the update in milliseconds, forwarded to the packet
+     * @param tickStart the time of the update in nanoseconds, forwarded to the packet
      */
     private void handleKeepAlive(@NotNull Collection<Player> playerGroup, long tickStart) {
         final KeepAlivePacket keepAlivePacket = new KeepAlivePacket(tickStart);
         for (Player player : playerGroup) {
             final long lastKeepAlive = tickStart - player.getLastKeepAlive();
-            if (lastKeepAlive > ServerFlag.KEEP_ALIVE_DELAY && player.didAnswerKeepAlive()) {
+            if (lastKeepAlive > TimeUnit.MILLISECONDS.toNanos(ServerFlag.KEEP_ALIVE_DELAY) && player.didAnswerKeepAlive()) {
                 player.refreshKeepAlive(tickStart);
                 player.sendPacket(keepAlivePacket);
-            } else if (lastKeepAlive >= ServerFlag.KEEP_ALIVE_KICK) {
+            } else if (lastKeepAlive >= TimeUnit.MICROSECONDS.toNanos(ServerFlag.KEEP_ALIVE_KICK)) {
                 player.kick(TIMEOUT_TEXT);
             }
         }

--- a/src/main/java/net/minestom/server/thread/ThreadDispatcher.java
+++ b/src/main/java/net/minestom/server/thread/ThreadDispatcher.java
@@ -101,7 +101,7 @@ public final class ThreadDispatcher<P> {
     /**
      * Prepares the update by creating the {@link TickThread} tasks.
      *
-     * @param time the tick time in milliseconds
+     * @param time the tick time in nanos
      */
     public synchronized void updateAndAwait(long time) {
         // Update dispatcher

--- a/src/main/java/net/minestom/server/thread/TickThread.java
+++ b/src/main/java/net/minestom/server/thread/TickThread.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -26,7 +27,7 @@ public final class TickThread extends MinestomThread {
     private volatile boolean stop;
 
     private CountDownLatch latch;
-    private long tickTime;
+    private long tickTimeNanos;
     private long tickNum = 0;
     private final List<ThreadDispatcher.Partition> entries = new ArrayList<>();
 
@@ -63,7 +64,7 @@ public final class TickThread extends MinestomThread {
 
     private void tick() {
         final ReentrantLock lock = this.lock;
-        final long tickTime = this.tickTime;
+        final long tickTime = TimeUnit.NANOSECONDS.toMillis(this.tickTimeNanos);
         for (ThreadDispatcher.Partition entry : entries) {
             assert entry.thread() == this;
             final List<Tickable> elements = entry.elements();
@@ -83,14 +84,14 @@ public final class TickThread extends MinestomThread {
         }
     }
 
-    void startTick(CountDownLatch latch, long tickTime) {
+    void startTick(CountDownLatch latch, long tickTimeNanos) {
         if (stop || entries.isEmpty()) {
             // Nothing to tick
             latch.countDown();
             return;
         }
         this.latch = latch;
-        this.tickTime = tickTime;
+        this.tickTimeNanos = tickTimeNanos;
         this.tickNum += 1;
         this.stop = false;
         LockSupport.unpark(this);

--- a/src/main/java/net/minestom/server/utils/time/Cooldown.java
+++ b/src/main/java/net/minestom/server/utils/time/Cooldown.java
@@ -3,44 +3,81 @@ package net.minestom.server.utils.time;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
 
 public final class Cooldown {
     private final Duration duration;
+    private final TemporalUnit temporalUnit;
+    // if this cooldown object as a lastUpdate set
+    private boolean hasLastUpdate;
     private long lastUpdate;
 
-    public Cooldown(Duration duration) {
+    /**
+     * Creates a cooldown with a measurement unit of {@link ChronoUnit#MILLIS}
+     */
+    public Cooldown(@NotNull Duration duration) {
+        this(duration, ChronoUnit.MILLIS);
+    }
+
+    /**
+     * Creates a cooldown with a given unit of measurement.
+     * <p>
+     * All calls to {@link #refreshLastUpdate(long)} and {@link #isReady(long)} must pass values in the given unit.
+     *
+     * @param duration     the duration of the cooldown
+     * @param temporalUnit the unit of measurement
+     */
+    public Cooldown(@NotNull Duration duration, @NotNull TemporalUnit temporalUnit) {
         this.duration = duration;
-        this.lastUpdate = System.currentTimeMillis();
+        this.temporalUnit = temporalUnit;
+        this.hasLastUpdate = false;
+    }
+
+    /**
+     * @return the unit of measurement
+     */
+    public @NotNull TemporalUnit getTemporalUnit() {
+        return temporalUnit;
     }
 
     public Duration getDuration() {
         return this.duration;
     }
 
+    /**
+     * @param lastUpdate the time of the last update, in nanos
+     */
     public void refreshLastUpdate(long lastUpdate) {
+        this.hasLastUpdate = true;
         this.lastUpdate = lastUpdate;
     }
 
+    /**
+     * Checks if the cooldown is ready again
+     *
+     * @param time the time, in nanos
+     */
     public boolean isReady(long time) {
-        return !hasCooldown(time, lastUpdate, duration);
+        if (!hasLastUpdate) return true;
+        return !hasCooldown(temporalUnit, time, lastUpdate, duration);
     }
 
     /**
-     * Gets if something is in cooldown based on the current time.
+     * Gets if something is in cooldown based on a {@code currentTime}.
      *
      * @param currentTime  the current time in milliseconds
      * @param lastUpdate   the last update in milliseconds
-     * @param temporalUnit the time unit of the cooldown
+     * @param cooldownUnit the time unit of the cooldown
      * @param cooldown     the value of the cooldown
      * @return true if the cooldown is in progress, false otherwise
      */
-    public static boolean hasCooldown(long currentTime, long lastUpdate, @NotNull TemporalUnit temporalUnit, long cooldown) {
-        return hasCooldown(currentTime, lastUpdate, Duration.of(cooldown, temporalUnit));
+    public static boolean hasCooldown(long currentTime, long lastUpdate, @NotNull TemporalUnit cooldownUnit, long cooldown) {
+        return hasCooldown(currentTime, lastUpdate, Duration.of(cooldown, cooldownUnit));
     }
 
     /**
-     * Gets if something is in cooldown based on the current time.
+     * Gets if something is in cooldown based on a {@code currentTime}.
      *
      * @param currentTime the current time in milliseconds
      * @param lastUpdate  the last update in milliseconds
@@ -48,19 +85,45 @@ public final class Cooldown {
      * @return true if the cooldown is in progress, false otherwise
      */
     public static boolean hasCooldown(long currentTime, long lastUpdate, @NotNull Duration duration) {
-        final long cooldownMs = duration.toMillis();
-        return currentTime - lastUpdate < cooldownMs;
+        return hasCooldown(ChronoUnit.MILLIS, currentTime, lastUpdate, duration);
     }
 
     /**
-     * Gets if something is in cooldown based on the current time ({@link System#currentTimeMillis()}).
+     * Gets if something is in cooldown based on a {@code currentTime}.
      *
+     * @param temporalUnit the {@link TemporalUnit} of {@code currentTime} and {@code lastUpdate}
+     * @param currentTime  the current time in milliseconds
      * @param lastUpdate   the last update in milliseconds
+     * @param cooldownUnit the time unit of the cooldown
+     * @param cooldown     the value of the cooldown
+     * @return true if the cooldown is in progress, false otherwise
+     */
+    public static boolean hasCooldown(@NotNull TemporalUnit temporalUnit, long currentTime, long lastUpdate, @NotNull TemporalUnit cooldownUnit, long cooldown) {
+        return hasCooldown(temporalUnit, currentTime, lastUpdate, Duration.of(cooldown, cooldownUnit));
+    }
+
+    /**
+     * Gets if something is in cooldown based on a {@code currentTime}.
+     *
+     * @param temporalUnit the {@link TemporalUnit} of {@code currentTime} and {@code lastUpdate}
+     * @param currentTime  the current time in the given {@code temporalUnit}
+     * @param lastUpdate   the last update in the given {@code temporalUnit}
+     * @param duration     the cooldown
+     * @return true if the cooldown is in progress, false otherwise
+     */
+    public static boolean hasCooldown(@NotNull TemporalUnit temporalUnit, long currentTime, long lastUpdate, @NotNull Duration duration) {
+        return Duration.of(currentTime - lastUpdate, temporalUnit).compareTo(duration) < 0;
+    }
+
+    /**
+     * Gets if something is in cooldown based on the current time ({@link System#nanoTime()}).
+     *
+     * @param lastUpdate   the last update in {@link System#nanoTime()}
      * @param temporalUnit the time unit of the cooldown
      * @param cooldown     the value of the cooldown
      * @return true if the cooldown is in progress, false otherwise
      */
     public static boolean hasCooldown(long lastUpdate, @NotNull TemporalUnit temporalUnit, int cooldown) {
-        return hasCooldown(System.currentTimeMillis(), lastUpdate, temporalUnit, cooldown);
+        return hasCooldown(ChronoUnit.NANOS, System.nanoTime(), lastUpdate, temporalUnit, cooldown);
     }
 }

--- a/src/test/java/net/minestom/server/ServerProcessTest.java
+++ b/src/test/java/net/minestom/server/ServerProcessTest.java
@@ -31,7 +31,7 @@ public class ServerProcessTest {
         var process = MinecraftServer.updateProcess();
         process.start(new InetSocketAddress("localhost", 25565));
         var ticker = process.ticker();
-        assertDoesNotThrow(() -> ticker.tick(System.currentTimeMillis()));
+        assertDoesNotThrow(() -> ticker.tick(System.nanoTime()));
         assertDoesNotThrow(process::stop);
     }
 }

--- a/src/test/java/net/minestom/server/entity/EntityBoundingBoxIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/EntityBoundingBoxIntegrationTest.java
@@ -62,7 +62,8 @@ public class EntityBoundingBoxIntegrationTest {
         entity.setCanPickupItem(true);
         entity.setInstance(instance, spawnPos).join();
 
-        var time = System.currentTimeMillis();
+        // 0 is fine here, it's just a delta
+        var time = 0L;
 
         dropItem(instance, spawnPos);
         listener.followup();

--- a/src/test/java/net/minestom/server/entity/EntityTeleportIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/EntityTeleportIntegrationTest.java
@@ -114,7 +114,7 @@ public class EntityTeleportIntegrationTest {
         assertEquals(new Pos(0, 42, 0), entity.getPosition());
 
         entity.teleport(new Pos(Double.POSITIVE_INFINITY, 42, 52)).join();
-        CompletableFuture.runAsync(() -> entity.tick(System.currentTimeMillis()))
+        CompletableFuture.runAsync(() -> entity.tick(0 /* 0 is fine here, it's just a delta*/))
                 .get(10, TimeUnit.SECONDS);
         // This should not hang forever
 

--- a/src/test/java/net/minestom/server/instance/EntityTrackerTest.java
+++ b/src/test/java/net/minestom/server/instance/EntityTrackerTest.java
@@ -66,22 +66,6 @@ public class EntityTrackerTest {
     }
 
     @Test
-    public void clearing() {
-        var ent1 = new Entity(EntityType.ZOMBIE);
-        EntityTracker tracker = EntityTracker.newTracker();
-
-        for (var x = 0; x < 10000; x++) {
-            System.out.println("X: " + x);
-            for (var z = 0; z < 10000; z++) {
-                var point = new BlockVec(x << 4, 0, z << 4);
-                tracker.register(ent1, point, EntityTracker.Target.ENTITIES, null);
-                tracker.unregister(ent1, EntityTracker.Target.ENTITIES, null);
-            }
-        }
-        System.out.println("Done");
-    }
-
-    @Test
     public void tracking() {
         var ent1 = new Entity(EntityType.ZOMBIE);
         var ent2 = new Entity(EntityType.ZOMBIE);

--- a/src/test/java/net/minestom/server/instance/EntityTrackerTest.java
+++ b/src/test/java/net/minestom/server/instance/EntityTrackerTest.java
@@ -1,5 +1,6 @@
 package net.minestom.server.instance;
 
+import net.minestom.server.coordinate.BlockVec;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.EntityType;
@@ -62,6 +63,22 @@ public class EntityTrackerTest {
         tracker.move(ent1, new Vec(32, 0, 32), EntityTracker.Target.ENTITIES, updater);
         assertEquals(0, tracker.chunkEntities(Vec.ZERO, EntityTracker.Target.ENTITIES).size());
         assertEquals(1, tracker.chunkEntities(new Vec(32, 0, 32), EntityTracker.Target.ENTITIES).size());
+    }
+
+    @Test
+    public void clearing() {
+        var ent1 = new Entity(EntityType.ZOMBIE);
+        EntityTracker tracker = EntityTracker.newTracker();
+
+        for (var x = 0; x < 10000; x++) {
+            System.out.println("X: " + x);
+            for (var z = 0; z < 10000; z++) {
+                var point = new BlockVec(x << 4, 0, z << 4);
+                tracker.register(ent1, point, EntityTracker.Target.ENTITIES, null);
+                tracker.unregister(ent1, EntityTracker.Target.ENTITIES, null);
+            }
+        }
+        System.out.println("Done");
     }
 
     @Test

--- a/src/test/java/net/minestom/server/thread/AcquirableTest.java
+++ b/src/test/java/net/minestom/server/thread/AcquirableTest.java
@@ -29,13 +29,13 @@ public class AcquirableTest {
         dispatcher.createPartition(second);
 
         dispatcher.updateElement(entity, first);
-        dispatcher.updateAndAwait(System.currentTimeMillis());
+        dispatcher.updateAndAwait(System.nanoTime());
         TickThread firstThread = tickThread.get();
         assertNotNull(firstThread);
 
         tickThread.set(null);
         dispatcher.updateElement(entity, second);
-        dispatcher.updateAndAwait(System.currentTimeMillis());
+        dispatcher.updateAndAwait(System.nanoTime());
         TickThread secondThread = tickThread.get();
         assertNotNull(secondThread);
 

--- a/src/test/java/net/minestom/server/thread/ThreadDispatcherTest.java
+++ b/src/test/java/net/minestom/server/thread/ThreadDispatcherTest.java
@@ -29,16 +29,16 @@ public class ThreadDispatcherTest {
         dispatcher.updateElement(element, partition);
         assertEquals(0, counter.get());
 
-        dispatcher.updateAndAwait(System.currentTimeMillis());
+        dispatcher.updateAndAwait(System.nanoTime());
         dispatcher.updateElement(element, partition); // Should be ignored
         dispatcher.createPartition(partition); // Ignored too
         assertEquals(1, counter.get());
 
-        dispatcher.updateAndAwait(System.currentTimeMillis());
+        dispatcher.updateAndAwait(System.nanoTime());
         assertEquals(2, counter.get());
 
         dispatcher.removeElement(element);
-        dispatcher.updateAndAwait(System.currentTimeMillis());
+        dispatcher.updateAndAwait(System.nanoTime());
         assertEquals(2, counter.get());
 
         dispatcher.shutdown();
@@ -60,13 +60,13 @@ public class ThreadDispatcherTest {
         assertEquals(0, counter2.get());
 
         for (int i = 0; i < 100; i++) {
-            dispatcher.updateAndAwait(System.currentTimeMillis());
+            dispatcher.updateAndAwait(System.nanoTime());
             assertEquals(i + 1, counter1.get());
             assertEquals(i + 1, counter2.get());
         }
 
         dispatcher.deletePartition(partition);
-        dispatcher.updateAndAwait(System.currentTimeMillis());
+        dispatcher.updateAndAwait(System.nanoTime());
         assertEquals(100, counter1.get());
         assertEquals(100, counter2.get());
 
@@ -96,7 +96,7 @@ public class ThreadDispatcherTest {
         partitions.forEach(dispatcher::createPartition);
         assertEquals(0, counter.get());
 
-        dispatcher.updateAndAwait(System.currentTimeMillis());
+        dispatcher.updateAndAwait(System.nanoTime());
         assertEquals(threadCount, counter.get());
 
         dispatcher.shutdown();
@@ -151,11 +151,11 @@ public class ThreadDispatcherTest {
 
         partitions.forEach(dispatcher::createPartition);
 
-        dispatcher.updateAndAwait(System.currentTimeMillis());
+        dispatcher.updateAndAwait(System.nanoTime());
 
         dispatcher.refreshThreads();
 
-        dispatcher.updateAndAwait(System.currentTimeMillis());
+        dispatcher.updateAndAwait(System.nanoTime());
 
         assertEquals(threads2.size(), threads.size());
         assertNotEquals(threads, threads2, "Threads have not been updated at all");

--- a/src/test/java/net/minestom/server/utils/time/CooldownTest.java
+++ b/src/test/java/net/minestom/server/utils/time/CooldownTest.java
@@ -1,0 +1,41 @@
+package net.minestom.server.utils.time;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CooldownTest {
+    @Test
+    void testReadySinceBeginning() {
+        var cooldown = new Cooldown(Duration.ofSeconds(1));
+        assertTrue(cooldown.isReady(0));
+        assertTrue(cooldown.isReady(Long.MIN_VALUE));
+        assertTrue(cooldown.isReady(Long.MAX_VALUE));
+    }
+    @Test
+    void testConstructorAndIsReady() {
+        var beforeNanos = System.nanoTime() - 1;
+        var cooldown = new Cooldown(Duration.ofSeconds(1), ChronoUnit.NANOS);
+        cooldown.refreshLastUpdate(System.nanoTime());
+        var afterNanos = System.nanoTime() + 1;
+        assertFalse(cooldown.isReady(beforeNanos + TimeUnit.SECONDS.toNanos(1)));
+        assertTrue(cooldown.isReady(afterNanos + TimeUnit.SECONDS.toNanos(1)));
+        assertEquals(cooldown.getDuration(), Duration.ofSeconds(1));
+    }
+
+    @Test
+    void testHasCooldown() {
+        var nanoTime = System.nanoTime();
+        assertTrue(Cooldown.hasCooldown(ChronoUnit.NANOS, nanoTime, nanoTime - TimeUnit.SECONDS.toNanos(1) + 1, ChronoUnit.SECONDS, 1));
+        assertFalse(Cooldown.hasCooldown(ChronoUnit.NANOS, nanoTime, nanoTime - TimeUnit.SECONDS.toNanos(1), ChronoUnit.SECONDS, 1));
+
+        // we assume this test does not take longer than 1 hour
+        assertTrue(Cooldown.hasCooldown(nanoTime, ChronoUnit.HOURS, 1));
+
+        assertFalse(Cooldown.hasCooldown(nanoTime - TimeUnit.HOURS.toNanos(1), ChronoUnit.HOURS, 1));
+    }
+}


### PR DESCRIPTION
## Proposed changes

Change use of elapsed time from `System.currentTimeMillis()` to `System.nanoTime()`

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

- `Cooldown` starts by returning `true` for all #isReady calls until `refreshLastUpdate` is called
- `InstanceContainer#getLastBlockChangeTime()` is now nanos, so it's breaking
Also the `getLastBlockChangeTime()` is set at construction, so logic depending on it being 0 initially behaves differently
- `ItemEntity`'s documentation for `getSpawnTime()` said it returned a time since spawn (delta), which was not the case.
Existing logic using `getSpawnTime()` will not function identically, since I changed it to return a time delta. I also deprecated `getSpawnTime()` for removal in favor of `getTimeSinceSpawn()`. There may be an argument to have those two methods behave differently and getSpawnTime return the actual fixed time (in `System.nanoTime()`), but I'd say that is implementation specific so I'd rather just get rid of `getSpawnTime()` and just keep the delta method
- `Chunk#getLastChangeTime()` removed completely, had no usages and the usage according to docs is outdated anyway. Custom chunk implementations may break (if they don't extend DynamicChunk), otherwise I don't think there is any use of this method at all