### PR TITLE
Fix & Update RelativeVec

### DIFF
--- a/src/main/java/net/minestom/server/command/builder/arguments/relative/ArgumentRelativeVec.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/relative/ArgumentRelativeVec.java
@@ -8,7 +8,6 @@ import net.minestom.server.utils.StringUtils;
 import net.minestom.server.utils.location.RelativeVec;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Set;
 import java.util.function.Function;
 
 import static net.minestom.server.utils.location.RelativeVec.CoordinateType.*;
@@ -20,7 +19,6 @@ abstract class ArgumentRelativeVec extends Argument<RelativeVec> {
 
     private static final char RELATIVE_CHAR = '~';
     private static final char LOCAL_CHAR = '^';
-    private static final Set<Character> MODIFIER_CHARS = Set.of(RELATIVE_CHAR, LOCAL_CHAR);
 
     public static final int INVALID_NUMBER_COUNT_ERROR = 1;
     public static final int INVALID_NUMBER_ERROR = 2;
@@ -47,41 +45,56 @@ abstract class ArgumentRelativeVec extends Argument<RelativeVec> {
 
         double[] coordinates = new double[split.length];
         boolean[] isRelative = new boolean[split.length];
-        RelativeVec.CoordinateType type = null;
+        boolean isLocalType = false;
+
         for (int i = 0; i < split.length; i++) {
             final String element = split[i];
             try {
                 final char modifierChar = element.charAt(0);
-                if (MODIFIER_CHARS.contains(modifierChar)) {
-                    isRelative[i] = true;
 
-                    if (type == null) {
-                        type = modifierChar == LOCAL_CHAR ? LOCAL : RELATIVE;
-                    } else if ((type == LOCAL) != (modifierChar == LOCAL_CHAR)) {
-                        throw new ArgumentSyntaxException("Cannot mix world & local coordinates (everything must either use ^ or not)", input, MIXED_TYPE_ERROR);
+                if (isLocalType && modifierChar != LOCAL_CHAR) {
+                    throw new ArgumentSyntaxException("Cannot mix world & local coordinates (everything must either use ^ or not)", input, MIXED_TYPE_ERROR);
+                }
+
+                switch (modifierChar) {
+                    case LOCAL_CHAR: {
+                        isLocalType = true;
+                        // Everything in local has to be relative. Fall through.
                     }
-
-                    if (element.length() > 1) {
+                    case RELATIVE_CHAR: {
+                        isRelative[i] = true;
+                        if (element.length() == 1) break;
                         final String potentialNumber = element.substring(1);
                         coordinates[i] = getRelativeNumberParser().apply(potentialNumber).doubleValue();
+                        break;
                     }
-                } else {
-                    if (type == null) {
-                        type = ABSOLUTE;
-                    } else if (type == LOCAL) {
-                        throw new ArgumentSyntaxException("Cannot mix world & local coordinates (everything must either use ^ or not)", input, MIXED_TYPE_ERROR);
+                    default: {
+                        coordinates[i] = getAbsoluteNumberParser().apply(element).doubleValue();
+                        break;
                     }
-                    coordinates[i] = getAbsoluteNumberParser().apply(element).doubleValue();
                 }
             } catch (NumberFormatException e) {
                 throw new ArgumentSyntaxException("Invalid number", input, INVALID_NUMBER_ERROR);
             }
         }
 
+        final boolean xRelative = isRelative[0];
+        final boolean yRelative = split.length == 3 && isRelative[1];
+        final boolean zRelative = isRelative[split.length == 3 ? 2 : 1];
+
+        final RelativeVec.CoordinateType type;
+        if (isLocalType) {
+            type = LOCAL;
+        } else if (xRelative || yRelative || zRelative) {
+            type = RELATIVE;
+        } else {
+            type = ABSOLUTE;
+        }
+
         return new RelativeVec(split.length == 3 ?
                 new Vec(coordinates[0], coordinates[1], coordinates[2]) : new Vec(coordinates[0], coordinates[1]),
                 type,
-                isRelative[0], split.length == 3 && isRelative[1], isRelative[split.length == 3 ? 2 : 1]);
+                xRelative, yRelative, zRelative);
     }
 
     /**

--- a/src/main/java/net/minestom/server/utils/location/RelativeVec.java
+++ b/src/main/java/net/minestom/server/utils/location/RelativeVec.java
@@ -5,6 +5,7 @@ import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.Player;
+import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,26 +13,22 @@ import java.util.Objects;
 
 /**
  * Represents a location which can have fields relative to an {@link Entity} position.
+ * <p>
+ * Useful for parsing Vec2 or Vec3 types
  */
-public final class RelativeVec {
-    private final Vec vec;
-    private final CoordinateType coordinateType;
-    private final boolean relativeX, relativeY, relativeZ;
+public record RelativeVec(@NotNull Vec vec, @NotNull CoordinateType coordinateType, boolean relativeX, boolean relativeY, boolean relativeZ) {
 
-    public RelativeVec(@NotNull Vec vec, @NotNull CoordinateType coordinateType, boolean relativeX, boolean relativeY, boolean relativeZ) {
-        this.vec = vec;
-        this.coordinateType = coordinateType;
-        this.relativeX = relativeX;
-        this.relativeY = relativeY;
-        this.relativeZ = relativeZ;
-    }
+    public RelativeVec {
+        Check.argCondition(relativeX && coordinateType == CoordinateType.ABSOLUTE, "RelativeVec `x` cannot have relativity while coordinateType is absolute.");
+        Check.argCondition(relativeY && coordinateType == CoordinateType.ABSOLUTE, "RelativeVec `y` cannot have relativity while coordinateType is absolute.");
+        Check.argCondition(relativeZ && coordinateType == CoordinateType.ABSOLUTE, "RelativeVec `z` cannot have relativity while coordinateType is absolute.");
 
-    public @NotNull CoordinateType coordinateType() {
-        return this.coordinateType;
+        // Only XZ for Vec2 types, so we need to check y as well.
+        Check.argCondition(coordinateType == CoordinateType.LOCAL && !(relativeX && (relativeY || vec.y() == 0) && relativeZ), "RelativeVec is always relative while coordinateType is local.");
     }
 
     /**
-     * Gets the location based on the relative fields and {@code position}.
+     * Gets the location based on the relative fields and {@link #vec()}.
      *
      * @param origin the origin position, null if none
      * @return the location
@@ -41,18 +38,8 @@ public final class RelativeVec {
         return coordinateType.convert(vec, origin, relativeX, relativeY, relativeZ);
     }
 
-    public Vec fromView(@Nullable Pos point) {
-        if (!relativeX && !relativeY && !relativeZ) {
-            return vec;
-        }
-        final var absolute = Objects.requireNonNullElse(point, Pos.ZERO);
-        final double x = vec.x() + (relativeX ? absolute.yaw() : 0);
-        final double z = vec.z() + (relativeZ ? absolute.pitch() : 0);
-        return new Vec(x, 0, z);
-    }
-
     /**
-     * Gets the location based on the relative fields and {@code entity}.
+     * Gets the location based on the relative fields.
      *
      * @param entity the entity to get the relative position from
      * @return the location
@@ -65,11 +52,40 @@ public final class RelativeVec {
         }
     }
 
+    /**
+     * Shorthand for {@link #from(Pos)}
+     * If player uses their position otherwise, {@link Vec#ZERO}
+     *
+     * @param sender entity
+     * @return the position with any relativity
+     */
     public @NotNull Vec fromSender(@Nullable CommandSender sender) {
         final var entityPosition = sender instanceof Player ? ((Player) sender).getPosition() : Pos.ZERO;
         return from(entityPosition);
     }
 
+    /**
+     * Computes a view {@link Vec} based on the given point's yaw and pitch.
+     * If no point is null, a default position {@link Pos#ZERO} is used.
+     *
+     * @param point The reference position used for computing relative coordinates. If null {@link Pos#ZERO}
+     * @return A {@link Vec} with XZ based on the provided position. Y is ignored.
+     */
+    public Vec fromView(@Nullable Pos point) {
+        if (!relativeX && !relativeY && !relativeZ) {
+            return vec;
+        }
+        final var absolute = Objects.requireNonNullElse(point, Pos.ZERO);
+        final double x = vec.x() + (relativeX ? absolute.yaw() : 0);
+        final double z = vec.z() + (relativeZ ? absolute.pitch() : 0);
+        return new Vec(x, 0, z);
+    }
+
+    /**
+     * Shorthand for {@link #fromView(Pos)}
+     * @param entity to get the position from, otherwise {@link Pos#ZERO}
+     * @return the view.
+     */
     public @NotNull Vec fromView(@Nullable Entity entity) {
         final var entityPosition = entity != null ? entity.getPosition() : Pos.ZERO;
         return fromView(entityPosition);
@@ -103,6 +119,9 @@ public final class RelativeVec {
     }
 
     public enum CoordinateType {
+        /**
+         * Relative when any XYZ have the relative flag; unless local.
+         */
         RELATIVE((relative, origin, relativeX, relativeY, relativeZ) -> {
             final var absolute = Objects.requireNonNullElse(origin, Vec.ZERO);
             final double x = relative.x() + (relativeX ? absolute.x() : 0);
@@ -110,6 +129,9 @@ public final class RelativeVec {
             final double z = relative.z() + (relativeZ ? absolute.z() : 0);
             return new Vec(x, y, z);
         }),
+        /**
+         * Local type used in direction, requires full relatively on XZ/XYZ
+         */
         LOCAL((local, origin, relativeX, relativeY, relativeZ) -> {
             final Vec vec1 = new Vec(Math.cos(Math.toRadians(origin.yaw() + 90.0f)), 0, Math.sin(Math.toRadians(origin.yaw() + 90.0f)));
             final Vec a = vec1.mul(Math.cos(Math.toRadians(-origin.pitch()))).withY(Math.sin(Math.toRadians(-origin.pitch())));
@@ -118,6 +140,9 @@ public final class RelativeVec {
             final Vec relativePos = a.mul(local.z()).add(b.mul(local.y())).add(c.mul(local.x()));
             return origin.add(relativePos).asVec();
         }),
+        /**
+         * Absolute just returns the original vector.
+         */
         ABSOLUTE(((vec, origin, relativeX1, relativeY1, relativeZ1) -> vec));
 
         private final CoordinateConverter converter;
@@ -131,20 +156,8 @@ public final class RelativeVec {
         }
     }
 
+    @FunctionalInterface
     private interface CoordinateConverter {
         @NotNull Vec convert(Vec vec, Pos origin, boolean relativeX, boolean relativeY, boolean relativeZ);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        RelativeVec that = (RelativeVec) o;
-        return relativeX == that.relativeX && relativeY == that.relativeY && relativeZ == that.relativeZ && Objects.equals(vec, that.vec) && coordinateType == that.coordinateType;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(vec, coordinateType, relativeX, relativeY, relativeZ);
     }
 }

--- a/src/test/java/net/minestom/server/command/ArgumentTypeTest.java
+++ b/src/test/java/net/minestom/server/command/ArgumentTypeTest.java
@@ -282,8 +282,8 @@ public class ArgumentTypeTest {
 
         assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.ABSOLUTE, false, false, false), "-3 14 +255");
         assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.RELATIVE, true, false, false), "~-3 14 +255");
-        assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.ABSOLUTE, false, true, false), "-3 ~14 +255");
-        assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.ABSOLUTE, false, false, true), "-3 14 ~+255");
+        assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.RELATIVE, false, true, false), "-3 ~14 +255");
+        assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.RELATIVE, false, false, true), "-3 14 ~+255");
         assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.RELATIVE, true, true, true), "~-3 ~14 ~+255");
         assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.LOCAL, true, true, true), "^-3 ^14 ^+255");
 
@@ -306,8 +306,8 @@ public class ArgumentTypeTest {
 
         assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.ABSOLUTE, false, false, false), "-3 14.25");
         assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.RELATIVE, true, false, false), "~-3 14.25");
-        assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.ABSOLUTE, false, false, true), "-3 ~14.25");
-        assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.ABSOLUTE, false, false, true), "-3 ~14.25");
+        assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.RELATIVE, false, false, true), "-3 ~14.25");
+        assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.RELATIVE, false, false, true), "-3 ~14.25");
         assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.RELATIVE, true, false, true), "~-3 ~14.25");
         assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.LOCAL, true, false, true), "^-3 ^14.25");
 
@@ -327,8 +327,8 @@ public class ArgumentTypeTest {
 
         assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.ABSOLUTE, false, false, false), "-3 14.25 +255");
         assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.RELATIVE, true, false, false), "~-3 14.25 +255");
-        assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.ABSOLUTE, false, true, false), "-3 ~14.25 +255");
-        assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.ABSOLUTE, false, false, true), "-3 14.25 ~+255");
+        assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.RELATIVE, false, true, false), "-3 ~14.25 +255");
+        assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.RELATIVE, false, false, true), "-3 14.25 ~+255");
         assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.RELATIVE, true, true, true), "~-3 ~14.25 ~+255");
         assertArg(arg, new RelativeVec(vec, RelativeVec.CoordinateType.LOCAL, true, true, true), "^-3 ^14.25 ^+255");
 


### PR DESCRIPTION
## Proposed changes
I found the bug when the demo teleport command was not working when given a relative coordinate where relativity was not the first argument. For example, `/tp 100 ~ ~` would send you to `(100, 0, 0)` even if your position was not `(0, 0, 0)`
 
This PR should fix that by enforcing argument conditions for `RelativeVec` and by fixing the implementation of the `ArgumentRelativeVec` & relevant tests

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Breaking change as conversion to record.  (Requires recompile)
Also fixes and adds some more comments to `RelativeVec`
`ArgumentRelativeVec` changes shouldn't be a breaking change to backport