### PR TITLE
fix: ArgumentCallback wasn't executed when an Argument failed during …

### DIFF
--- a/src/main/java/net/minestom/server/command/CommandParserImpl.java
+++ b/src/main/java/net/minestom/server/command/CommandParserImpl.java
@@ -118,7 +118,8 @@ final class CommandParserImpl implements CommandParser {
             return ValidCommand.defaultExecutor(input, chain);
         }
 
-        return InvalidCommand.invalid(input, chain);
+        ArgumentCallback argumentCallback = lastNode.argument().getCallback();
+        return InvalidCommand.invalid(input, chain, argumentCallback);
     }
 
     @Contract("null, _ -> null; !null, null -> fail; !null, !null -> _")
@@ -275,9 +276,9 @@ final class CommandParserImpl implements CommandParser {
                           @Nullable SuggestionCallback suggestionCallback, List<Argument<?>> args)
             implements InternalKnownCommand, Result.KnownCommand.Invalid {
 
-        static InvalidCommand invalid(String input, Chain chain) {
+        static InvalidCommand invalid(String input, Chain chain, @Nullable ArgumentCallback argumentCallback) {
             return new InvalidCommand(input, chain.mergedConditions(),
-                    null/*todo command syntax callback*/,
+                    argumentCallback,
                     new ArgumentResult.SyntaxError<>("Command has trailing data.", null, -1),
                     chain.collectArguments(), chain.mergedGlobalExecutors(), chain.suggestionCallback, chain.getArgs());
         }


### PR DESCRIPTION
I tried to run the ArgumentCallback of this command but seems that ArgumentCallback execution wasn't finished.

```java
Command test = new Command("test-argument-callback");

Argument<Integer> argument = ArgumentType.Integer("number");
argument.setCallback((sender, exception) -> sender.sendMessage("Are you fucking dumb?"));
test.addSyntax((sender, context) -> {
        sender.sendMessage(Component.text(context.get(argument)));
}, argument, ArgumentType.Integer("number2"));

commandManager.register(test);
```