### PR TITLE
feat: transient tag support on ItemStack

### DIFF
--- a/src/main/java/net/minestom/server/item/ItemStack.java
+++ b/src/main/java/net/minestom/server/item/ItemStack.java
@@ -223,6 +223,17 @@ public sealed interface ItemStack extends TagReadable, DataComponent.Holder, Hov
         return with(ItemComponent.MAX_STACK_SIZE, maxStackSize);
     }
 
+    /**
+     * Returns a new ItemStack with the specified tag and its associated value applied.
+     * This method is used to attach custom metadata or attributes to the item.
+     *
+     * @implNote When using transient tags, the item can't be moved by a player in creative mode. See #2396
+     *
+     * @param tag   The tag to apply to the item.
+     * @param value The value associated with the tag. Can be null to remove or reset the tag.
+     * @param <T>   The type of the tag value.
+     * @return A new ItemStack containing the specified tag and value.
+     */
     @Contract(value = "_, _ -> new", pure = true)
     <T> @NotNull ItemStack withTag(@NotNull Tag<T> tag, @Nullable T value);
 

--- a/src/main/java/net/minestom/server/item/ItemStack.java
+++ b/src/main/java/net/minestom/server/item/ItemStack.java
@@ -224,15 +224,7 @@ public sealed interface ItemStack extends TagReadable, DataComponent.Holder, Hov
     }
 
     @Contract(value = "_, _ -> new", pure = true)
-    default <T> @NotNull ItemStack withTag(@NotNull Tag<T> tag, @Nullable T value) {
-        return with(ItemComponent.CUSTOM_DATA, get(ItemComponent.CUSTOM_DATA, CustomData.EMPTY).withTag(tag, value));
-    }
-
-    @Override
-    @Contract(pure = true)
-    default <T> @UnknownNullability T getTag(@NotNull Tag<T> tag) {
-        return get(ItemComponent.CUSTOM_DATA, CustomData.EMPTY).getTag(tag);
-    }
+    <T> @NotNull ItemStack withTag(@NotNull Tag<T> tag, @Nullable T value);
 
     @Contract(value = "_, -> new", pure = true)
     @NotNull ItemStack consume(int amount);

--- a/src/main/java/net/minestom/server/tag/TagHandlerImpl.java
+++ b/src/main/java/net/minestom/server/tag/TagHandlerImpl.java
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.UnknownNullability;
 
 import java.lang.invoke.VarHandle;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.UnaryOperator;
 
 final class TagHandlerImpl implements TagHandler {
@@ -225,6 +226,18 @@ final class TagHandlerImpl implements TagHandler {
         } else {
             return new Entry<>(tag, tag.copyValue(value));
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        TagHandlerImpl that = (TagHandlerImpl) o;
+        return Objects.equals(root.compound(), that.root.compound());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(root.compound());
     }
 
     final class Node implements TagReadable {

--- a/src/test/java/net/minestom/server/item/ItemTest.java
+++ b/src/test/java/net/minestom/server/item/ItemTest.java
@@ -7,6 +7,7 @@ import net.minestom.server.component.DataComponent;
 import net.minestom.server.entity.EntityType;
 import net.minestom.server.item.component.EnchantmentList;
 import net.minestom.server.item.enchant.Enchantment;
+import net.minestom.server.tag.Tag;
 import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
 import org.junit.jupiter.api.Test;
@@ -135,6 +136,26 @@ public class ItemTest {
         var item2 = ItemStack.of(Material.CAMEL_SPAWN_EGG, 1);
         assertNotNull(item2.material().registry().spawnEntityType());
         assertEquals(EntityType.CAMEL, item2.material().registry().spawnEntityType());
+    }
+
+    @Test
+    public void testTagSerialization() {
+        var transientTag = Tag.Transient("test");
+        var tag = Tag.String("test2");
+
+        var item1 = ItemStack.of(Material.DIAMOND, 1)
+                .withTag(transientTag, "don't serialize me")
+                .withTag(tag, "serialize me");
+
+        assertTrue(item1.hasTag(transientTag));
+        assertTrue(item1.hasTag(tag));
+
+        var nbt = item1.toItemNBT();
+        var item2 = ItemStack.fromItemNBT(nbt);
+
+        assertFalse(item2.hasTag(transientTag));
+        assertTrue(item2.hasTag(tag));
+        assertEquals("serialize me", item2.getTag(tag));
     }
 
     static ItemStack createItem() {


### PR DESCRIPTION
## Proposed changes

> Tag.Transient currently does not work on ItemStack, since the ItemStack tag handler implementation serializes the tag's > contents in the CUSTOM_DATA component. The rationale for this behavior is proper creative mode handling.

This PR implements the changes by and should fix #2494 

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

None