### PR TITLE
:goat: Block index speedup

### DIFF
--- a/jmh-benchmarks/src/jmh/java/net/minestom/server/coordinate/MultiCoordConversionTest.java
+++ b/jmh-benchmarks/src/jmh/java/net/minestom/server/coordinate/MultiCoordConversionTest.java
@@ -1,0 +1,63 @@
+package net.minestom.server.coordinate;
+
+import net.minestom.server.instance.Chunk;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@State(Scope.Thread)
+@Threads(2)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(time = 2, iterations = 5)
+@Measurement(time = 6, iterations = 8)
+public class MultiCoordConversionTest {
+    private static final int CHUNK_X = 0;
+    private static final int CHUNK_Y = 0;
+
+    @Param({"0", "-16", "-64"})
+    public int yMin;
+    @Param({"16", "64", "320"})
+    public int yMaX;
+
+    private int[] blockIndexes;
+
+    @Setup
+    public void setup() {
+        blockIndexes = new int[Chunk.CHUNK_SIZE_Z * (Math.abs(yMin) + yMaX) * Chunk.CHUNK_SIZE_X];
+
+        final int yMinAbs = Math.abs(yMin);
+        for (int z = 0; z < Chunk.CHUNK_SIZE_Z; z++) {
+            for (int y = yMin; y < yMaX; y++) {
+                for (int x = 0; x < Chunk.CHUNK_SIZE_X; x++) {
+                    blockIndexes[x + (y + yMinAbs) + z] = CoordConversion.chunkBlockIndex(x, y, z);
+                }
+            }
+        }
+    }
+
+    @Benchmark
+    public void chunkBlockIndexGetGlobalMulti(Blackhole blackhole) {
+        for (final int index : blockIndexes) {
+            blackhole.consume(CoordConversion.chunkBlockIndexGetGlobal(index, CHUNK_X, CHUNK_Y));
+        }
+    }
+
+    @Benchmark
+    public void chunkBlockIndexMulti(Blackhole blackhole) {
+        for (int z = 0; z < Chunk.CHUNK_SIZE_Z; z++) {
+            for (int y = yMin; y < yMaX; y++) {
+                for (int x = 0; x < Chunk.CHUNK_SIZE_X; x++) {
+                    blackhole.consume(CoordConversion.chunkBlockIndex(x, y, z));
+                }
+            }
+        }
+    }
+
+    @TearDown
+    public void teardown(Blackhole blackhole) {
+        blackhole.consume(blockIndexes);
+    }
+}

--- a/jmh-benchmarks/src/jmh/java/net/minestom/server/coordinate/SingleCoordConversionTest.java
+++ b/jmh-benchmarks/src/jmh/java/net/minestom/server/coordinate/SingleCoordConversionTest.java
@@ -1,0 +1,40 @@
+package net.minestom.server.coordinate;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@State(Scope.Thread)
+@Threads(2)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(time = 2, iterations = 10)
+@Measurement(time = 6, iterations = 100)
+public class SingleCoordConversionTest {
+    private static final int CHUNK_X = 0;
+    private static final int CHUNK_Y = 0;
+
+    private int zeroIndex;
+
+    @Setup
+    public void setup() {
+        zeroIndex = CoordConversion.chunkBlockIndex(0, 0, 0);
+    }
+
+    @Benchmark
+    public void chunkBlockIndexGetGlobalSingle(Blackhole blackhole) {
+        blackhole.consume(CoordConversion.chunkBlockIndexGetGlobal(zeroIndex, CHUNK_X, CHUNK_Y));
+    }
+
+    @Benchmark
+    public void chunkBlockIndexSingle(Blackhole blackhole) {
+        blackhole.consume(CoordConversion.chunkBlockIndex(0, 0, 0));
+    }
+
+    @TearDown
+    public void tearDown(Blackhole blackhole) {
+        blackhole.consume(zeroIndex);
+    }
+}

--- a/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
+++ b/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
@@ -167,4 +167,9 @@ public class CoordinateTest {
             }
         }
     }
+
+    @Test
+    public void blockIndexZero() {
+        assertEquals(0, CoordConversion.chunkBlockIndex(0, 0, 0), "Bad default index for zero case! Bad sign bit?");
+    }
 }


### PR DESCRIPTION
## Proposed changes

Change index to be faster by for around no branching for creating indexes; See commit message for more details on why.

### Benchmarks - ~42% faster
```
Benchmark                             (yMaX)  (yMin)  Mode  Cnt      Score    Error  Units
CoordConversionTest.currentImplIndex     320     -64  avgt   16  24085.554 ± 62.769  ns/op
CoordConversionTest.newImplIndex         320     -64  avgt   16  14024.720 ± 54.734  ns/op
``` 
## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [X] [:goat:](https://discord.com/channels/706185253441634317/706186227493109860/1332843569119236257)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Changes zero condition to be different, but logically, they should both be extracted to the vec. Not considering it a breaking change.
ZYX is confusing to users; maybe we should change it to XYZ by default; Or YXZ; Unsure how to do this as we are removing our only fingerprint with zeros in this PR. ServerFlag?