### PR TITLE
Send AcknowledgeBlockChangePacket in all cases

### DIFF
--- a/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
+++ b/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
@@ -41,147 +41,147 @@ public class BlockPlacementListener {
         final BlockFace blockFace = packet.blockFace();
         Point blockPosition = packet.blockPosition();
 
-        final Instance instance = player.getInstance();
-        if (instance == null)
-            return;
+        try {
+            final Instance instance = player.getInstance();
+            if (instance == null)
+                return;
 
-        // Prevent outdated/modified client data
-        final Chunk interactedChunk = instance.getChunkAt(blockPosition);
-        if (!ChunkUtils.isLoaded(interactedChunk)) {
-            // Client tried to place a block in an unloaded chunk, ignore the request
-            return;
-        }
-
-        final ItemStack usedItem = player.getItemInHand(hand);
-        final Block interactedBlock = instance.getBlock(blockPosition);
-
-        final Point cursorPosition = new Vec(packet.cursorPositionX(), packet.cursorPositionY(), packet.cursorPositionZ());
-
-        // Interact at block
-        // FIXME: onUseOnBlock
-        PlayerBlockInteractEvent playerBlockInteractEvent = new PlayerBlockInteractEvent(player, hand, interactedBlock, new BlockVec(blockPosition), cursorPosition, blockFace);
-        EventDispatcher.call(playerBlockInteractEvent);
-        boolean blockUse = playerBlockInteractEvent.isBlockingItemUse();
-        if (!playerBlockInteractEvent.isCancelled()) {
-            final var handler = interactedBlock.handler();
-            if (handler != null) {
-                blockUse |= !handler.onInteract(new BlockHandler.Interaction(interactedBlock, instance, blockFace, blockPosition, cursorPosition, player, hand));
+            // Prevent outdated/modified client data
+            final Chunk interactedChunk = instance.getChunkAt(blockPosition);
+            if (!ChunkUtils.isLoaded(interactedChunk)) {
+                // Client tried to place a block in an unloaded chunk, ignore the request
+                return;
             }
-        }
-        if (blockUse) {
-            // If the usage was blocked then the world is already up-to-date (from the prior handlers),
-            // So ack the change with the current world state.
-            player.sendPacket(new AcknowledgeBlockChangePacket(packet.sequence()));
-            return;
-        }
 
-        final Material useMaterial = usedItem.material();
-        if (!useMaterial.isBlock()) {
-            // Player didn't try to place a block but interacted with one
-            PlayerUseItemOnBlockEvent event = new PlayerUseItemOnBlockEvent(player, hand, usedItem, blockPosition, cursorPosition, blockFace);
-            EventDispatcher.call(event);
-            // Ack the block change. This is required to reset the client prediction to the server state.
-            player.sendPacket(new AcknowledgeBlockChangePacket(packet.sequence()));
-            return;
-        }
+            final ItemStack usedItem = player.getItemInHand(hand);
+            final Block interactedBlock = instance.getBlock(blockPosition);
 
-        // Verify if the player can place the block
-        boolean canPlaceBlock = true;
-        // Check if the player is allowed to place blocks based on their game mode
-        if (player.getGameMode() == GameMode.SPECTATOR) {
-            canPlaceBlock = false; // Spectators can't place blocks
-        } else if (player.getGameMode() == GameMode.ADVENTURE) {
-            //Check if the block can be placed on the block
-            BlockPredicates placePredicate = usedItem.get(ItemComponent.CAN_PLACE_ON, BlockPredicates.NEVER);
-            canPlaceBlock = placePredicate.test(interactedBlock);
-        }
+            final Point cursorPosition = new Vec(packet.cursorPositionX(), packet.cursorPositionY(), packet.cursorPositionZ());
+
+            // Interact at block
+            // FIXME: onUseOnBlock
+            PlayerBlockInteractEvent playerBlockInteractEvent = new PlayerBlockInteractEvent(player, hand, interactedBlock, new BlockVec(blockPosition), cursorPosition, blockFace);
+            EventDispatcher.call(playerBlockInteractEvent);
+            boolean blockUse = playerBlockInteractEvent.isBlockingItemUse();
+            if (!playerBlockInteractEvent.isCancelled()) {
+                final var handler = interactedBlock.handler();
+                if (handler != null) {
+                    blockUse |= !handler.onInteract(new BlockHandler.Interaction(interactedBlock, instance, blockFace, blockPosition, cursorPosition, player, hand));
+                }
+            }
+            if (blockUse) {
+                // If the usage was blocked then the world is already up-to-date (from the prior handlers),
+                return;
+            }
+
+            final Material useMaterial = usedItem.material();
+            if (!useMaterial.isBlock()) {
+                // Player didn't try to place a block but interacted with one
+                PlayerUseItemOnBlockEvent event = new PlayerUseItemOnBlockEvent(player, hand, usedItem, blockPosition, cursorPosition, blockFace);
+                EventDispatcher.call(event);
+                return;
+            }
+
+            // Verify if the player can place the block
+            boolean canPlaceBlock = true;
+            // Check if the player is allowed to place blocks based on their game mode
+            if (player.getGameMode() == GameMode.SPECTATOR) {
+                canPlaceBlock = false; // Spectators can't place blocks
+            } else if (player.getGameMode() == GameMode.ADVENTURE) {
+                //Check if the block can be placed on the block
+                BlockPredicates placePredicate = usedItem.get(ItemComponent.CAN_PLACE_ON, BlockPredicates.NEVER);
+                canPlaceBlock = placePredicate.test(interactedBlock);
+            }
 
 
-        // Get the newly placed block position
-        //todo it feels like it should be possible to have better replacement rules than this, feels pretty scuffed.
-        Point placementPosition = blockPosition;
-        var interactedPlacementRule = BLOCK_MANAGER.getBlockPlacementRule(interactedBlock);
-        if (!interactedBlock.isAir() && (interactedPlacementRule == null || !interactedPlacementRule.isSelfReplaceable(
-                new BlockPlacementRule.Replacement(interactedBlock, blockFace, cursorPosition, useMaterial)))) {
-            // If the block is not replaceable, try to place next to it.
-            final int offsetX = blockFace == BlockFace.WEST ? -1 : blockFace == BlockFace.EAST ? 1 : 0;
-            final int offsetY = blockFace == BlockFace.BOTTOM ? -1 : blockFace == BlockFace.TOP ? 1 : 0;
-            final int offsetZ = blockFace == BlockFace.NORTH ? -1 : blockFace == BlockFace.SOUTH ? 1 : 0;
-            placementPosition = blockPosition.add(offsetX, offsetY, offsetZ);
+            // Get the newly placed block position
+            //todo it feels like it should be possible to have better replacement rules than this, feels pretty scuffed.
+            Point placementPosition = blockPosition;
+            var interactedPlacementRule = BLOCK_MANAGER.getBlockPlacementRule(interactedBlock);
+            if (!interactedBlock.isAir() && (interactedPlacementRule == null || !interactedPlacementRule.isSelfReplaceable(
+                    new BlockPlacementRule.Replacement(interactedBlock, blockFace, cursorPosition, useMaterial)))) {
+                // If the block is not replaceable, try to place next to it.
+                final int offsetX = blockFace == BlockFace.WEST ? -1 : blockFace == BlockFace.EAST ? 1 : 0;
+                final int offsetY = blockFace == BlockFace.BOTTOM ? -1 : blockFace == BlockFace.TOP ? 1 : 0;
+                final int offsetZ = blockFace == BlockFace.NORTH ? -1 : blockFace == BlockFace.SOUTH ? 1 : 0;
+                placementPosition = blockPosition.add(offsetX, offsetY, offsetZ);
 
-            var placementBlock = instance.getBlock(placementPosition);
-            var placementRule = BLOCK_MANAGER.getBlockPlacementRule(placementBlock);
-            if (!placementBlock.registry().isReplaceable() && !(placementRule != null && placementRule.isSelfReplaceable(
-                    new BlockPlacementRule.Replacement(placementBlock, blockFace, cursorPosition, useMaterial)))) {
-                // If the block is still not replaceable, cancel the placement
+                var placementBlock = instance.getBlock(placementPosition);
+                var placementRule = BLOCK_MANAGER.getBlockPlacementRule(placementBlock);
+                if (!placementBlock.registry().isReplaceable() && !(placementRule != null && placementRule.isSelfReplaceable(
+                        new BlockPlacementRule.Replacement(placementBlock, blockFace, cursorPosition, useMaterial)))) {
+                    // If the block is still not replaceable, cancel the placement
+                    canPlaceBlock = false;
+                }
+            }
+
+            final DimensionType instanceDim = instance.getCachedDimensionType();
+            if (placementPosition.y() >= instanceDim.maxY() || placementPosition.y() < instanceDim.minY()) {
+                return;
+            }
+
+            // Ensure that the final placement position is inside the world border.
+            if (!instance.getWorldBorder().inBounds(placementPosition)) {
                 canPlaceBlock = false;
             }
-        }
 
-        final DimensionType instanceDim = instance.getCachedDimensionType();
-        if (placementPosition.y() >= instanceDim.maxY() || placementPosition.y() < instanceDim.minY()) {
-            return;
-        }
+            if (!canPlaceBlock) {
+                // Send a block change with the real block in the instance to keep the client in sync,
+                // using refreshChunk results in the client not being in sync
+                // after rapid invalid block placements
+                final Block block = instance.getBlock(placementPosition);
+                player.sendPacket(new BlockChangePacket(placementPosition, block));
+                return;
+            }
 
-        // Ensure that the final placement position is inside the world border.
-        if (!instance.getWorldBorder().inBounds(placementPosition)) {
-            canPlaceBlock = false;
-        }
-
-        if (!canPlaceBlock) {
-            // Send a block change with the real block in the instance to keep the client in sync,
-            // using refreshChunk results in the client not being in sync
-            // after rapid invalid block placements
-            final Block block = instance.getBlock(placementPosition);
-            player.sendPacket(new BlockChangePacket(placementPosition, block));
-            return;
-        }
-
-        final Chunk chunk = instance.getChunkAt(placementPosition);
-        Check.stateCondition(!ChunkUtils.isLoaded(chunk),
-                "A player tried to place a block in the border of a loaded chunk {0}", placementPosition);
-        if (chunk.isReadOnly()) {
-            refresh(player, chunk);
-            return;
-        }
-
-        final ItemBlockState blockState = usedItem.get(ItemComponent.BLOCK_STATE, ItemBlockState.EMPTY);
-        final Block placedBlock = blockState.apply(useMaterial.block());
-
-        Entity collisionEntity = CollisionUtils.canPlaceBlockAt(instance, placementPosition, placedBlock);
-        if (collisionEntity != null) {
-            // If a player is trying to place a block on themselves, the client will send a block change but will not set the block on the client
-            // For this reason, the block doesn't need to be updated for the client
-
-            // Client also doesn't predict placement of blocks on entities, but we need to refresh for cases where bounding boxes on the server don't match the client
-            if (collisionEntity != player)
+            final Chunk chunk = instance.getChunkAt(placementPosition);
+            Check.stateCondition(!ChunkUtils.isLoaded(chunk),
+                    "A player tried to place a block in the border of a loaded chunk {0}", placementPosition);
+            if (chunk.isReadOnly()) {
                 refresh(player, chunk);
-            
-            return;
-        }
+                return;
+            }
 
-        // BlockPlaceEvent check
-        PlayerBlockPlaceEvent playerBlockPlaceEvent = new PlayerBlockPlaceEvent(player, placedBlock, blockFace, new BlockVec(placementPosition), cursorPosition, packet.hand());
-        playerBlockPlaceEvent.consumeBlock(player.getGameMode() != GameMode.CREATIVE);
-        EventDispatcher.call(playerBlockPlaceEvent);
-        if (playerBlockPlaceEvent.isCancelled()) {
-            refresh(player, chunk);
-            return;
-        }
+            final ItemBlockState blockState = usedItem.get(ItemComponent.BLOCK_STATE, ItemBlockState.EMPTY);
+            final Block placedBlock = blockState.apply(useMaterial.block());
 
-        // Place the block
-        Block resultBlock = playerBlockPlaceEvent.getBlock();
-        instance.placeBlock(new BlockHandler.PlayerPlacement(resultBlock, instance, placementPosition, player, hand, blockFace,
-                packet.cursorPositionX(), packet.cursorPositionY(), packet.cursorPositionZ()), playerBlockPlaceEvent.shouldDoBlockUpdates());
-        player.sendPacket(new AcknowledgeBlockChangePacket(packet.sequence()));
-        // Block consuming
-        if (playerBlockPlaceEvent.doesConsumeBlock()) {
-            // Consume the block in the player's hand
-            final ItemStack newUsedItem = usedItem.consume(1);
-            player.setItemInHand(hand, newUsedItem);
-        } else {
-            // Prevent invisible item on client
-            player.getInventory().update();
+            Entity collisionEntity = CollisionUtils.canPlaceBlockAt(instance, placementPosition, placedBlock);
+            if (collisionEntity != null) {
+                // If a player is trying to place a block on themselves, the client will send a block change but will not set the block on the client
+                // For this reason, the block doesn't need to be updated for the client
+
+                // Client also doesn't predict placement of blocks on entities, but we need to refresh for cases where bounding boxes on the server don't match the client
+                if (collisionEntity != player)
+                    refresh(player, chunk);
+
+                return;
+            }
+
+            // BlockPlaceEvent check
+            PlayerBlockPlaceEvent playerBlockPlaceEvent = new PlayerBlockPlaceEvent(player, placedBlock, blockFace, new BlockVec(placementPosition), cursorPosition, packet.hand());
+            playerBlockPlaceEvent.consumeBlock(player.getGameMode() != GameMode.CREATIVE);
+            EventDispatcher.call(playerBlockPlaceEvent);
+            if (playerBlockPlaceEvent.isCancelled()) {
+                refresh(player, chunk);
+                return;
+            }
+
+            // Place the block
+            Block resultBlock = playerBlockPlaceEvent.getBlock();
+            instance.placeBlock(new BlockHandler.PlayerPlacement(resultBlock, instance, placementPosition, player, hand, blockFace,
+                    packet.cursorPositionX(), packet.cursorPositionY(), packet.cursorPositionZ()), playerBlockPlaceEvent.shouldDoBlockUpdates());
+            // Block consuming
+            if (playerBlockPlaceEvent.doesConsumeBlock()) {
+                // Consume the block in the player's hand
+                final ItemStack newUsedItem = usedItem.consume(1);
+                player.setItemInHand(hand, newUsedItem);
+            } else {
+                // Prevent invisible item on client
+                player.getInventory().update();
+            }
+        } finally {
+            // Ack the block change. This is required to reset the client prediction to the server state.
+            player.sendPacket(new AcknowledgeBlockChangePacket(packet.sequence()));
         }
     }
 


### PR DESCRIPTION
## Proposed changes

Use try-finally to send AcknowledgeBlockChangePacket in all cases.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

I spent the entire day searching for the reason my blocks weren't updating.

Following code pattern is (was, after this PR) illegal:
```
.addListener(PlayerBlockPlaceEvent.class, event -> {
                event.setCancelled(true);
                event.getInstance().setBlock(event.getBlockPosition(), Block.STONE.withHandler(h));
            });
```

The `setBlock` call can also be at a later point in time, it still doesn't update on the client, because the client thinks it has the correct state, because we never said "hey, we got your packet".

To make sure this doesn't happen again (when one of these methods gets changed) I used try-finally. Also makes things easier with return statements.