### PR TITLE
WeakRef all Entity targets in EntityMeta

### DIFF
--- a/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java
@@ -5,6 +5,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.EntityPose;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -16,7 +17,7 @@ public class EntityMeta {
     protected final MetadataHolder metadata;
 
     public EntityMeta(@Nullable Entity entity, @NotNull MetadataHolder metadata) {
-        this.entityRef = new WeakReference<>(entity);
+        this.entityRef = wrap(entity);
         this.metadata = metadata;
     }
 
@@ -152,10 +153,19 @@ public class EntityMeta {
     }
 
     protected void consumeEntity(Consumer<Entity> consumer) {
-        Entity entity = this.entityRef.get();
+        final var entity = unwrap(this.entityRef);
         if (entity != null) {
             consumer.accept(entity);
         }
     }
 
+    @ApiStatus.Internal
+    protected <E extends Entity> @Nullable WeakReference<@NotNull E> wrap(@Nullable E entity) {
+        return entity == null ? null : new WeakReference<>(entity);
+    }
+
+    @ApiStatus.Internal
+    protected <E extends Entity> @Nullable E unwrap(@Nullable WeakReference<E> entityRef) {
+        return entityRef == null ? null : entityRef.get();
+    }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/item/FireballMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/FireballMeta.java
@@ -5,13 +5,13 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.entity.metadata.ObjectDataProvider;
+import net.minestom.server.entity.metadata.projectile.ProjectileEntityMeta;
 import net.minestom.server.entity.metadata.projectile.ProjectileMeta;
 import net.minestom.server.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class FireballMeta extends EntityMeta implements ObjectDataProvider, ProjectileMeta {
-    private Entity shooter;
+public class FireballMeta extends ProjectileEntityMeta implements ObjectDataProvider {
 
     public FireballMeta(@NotNull Entity entity, @NotNull MetadataHolder metadata) {
         super(entity, metadata);
@@ -27,19 +27,10 @@ public class FireballMeta extends EntityMeta implements ObjectDataProvider, Proj
     }
 
     @Override
-    @Nullable
-    public Entity getShooter() {
-        return shooter;
-    }
-
-    @Override
-    public void setShooter(@Nullable Entity shooter) {
-        this.shooter = shooter;
-    }
-
-    @Override
     public int getObjectData() {
-        return this.shooter == null ? 0 : this.shooter.getEntityId();
+        final var shooter = getShooter();
+
+        return shooter == null ? 0 : shooter.getEntityId();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/item/SmallFireballMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/SmallFireballMeta.java
@@ -5,13 +5,13 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.entity.metadata.ObjectDataProvider;
+import net.minestom.server.entity.metadata.projectile.ProjectileEntityMeta;
 import net.minestom.server.entity.metadata.projectile.ProjectileMeta;
 import net.minestom.server.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class SmallFireballMeta extends EntityMeta implements ObjectDataProvider, ProjectileMeta {
-    private Entity shooter;
+public class SmallFireballMeta extends ProjectileEntityMeta implements ObjectDataProvider {
 
     public SmallFireballMeta(@NotNull Entity entity, @NotNull MetadataHolder metadata) {
         super(entity, metadata);
@@ -27,19 +27,10 @@ public class SmallFireballMeta extends EntityMeta implements ObjectDataProvider,
     }
 
     @Override
-    @Nullable
-    public Entity getShooter() {
-        return shooter;
-    }
-
-    @Override
-    public void setShooter(@Nullable Entity shooter) {
-        this.shooter = shooter;
-    }
-
-    @Override
     public int getObjectData() {
-        return this.shooter == null ? 0 : this.shooter.getEntityId();
+        final var shooter = getShooter();
+
+        return shooter == null ? 0 : shooter.getEntityId();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/monster/GuardianMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/GuardianMeta.java
@@ -7,8 +7,10 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.ref.WeakReference;
+
 public class GuardianMeta extends MonsterMeta {
-    private Entity target;
+    private WeakReference<Entity> targetRef;
 
     public GuardianMeta(@NotNull Entity entity, @NotNull MetadataHolder metadata) {
         super(entity, metadata);
@@ -31,12 +33,12 @@ public class GuardianMeta extends MonsterMeta {
         metadata.set(MetadataDef.Guardian.TARGET_EID, value);
     }
 
-    public Entity getTarget() {
-        return this.target;
+    public @Nullable Entity getTarget() {
+        return unwrap(this.targetRef);
     }
 
     public void setTarget(@Nullable Entity target) {
-        this.target = target;
+        this.targetRef = wrap(target);
         setTargetEntityId(target == null ? 0 : target.getEntityId());
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/WitherMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/WitherMeta.java
@@ -7,10 +7,12 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.ref.WeakReference;
+
 public class WitherMeta extends MonsterMeta {
-    private Entity centerHead;
-    private Entity leftHead;
-    private Entity rightHead;
+    private WeakReference<Entity> centerHeadRef;
+    private WeakReference<Entity> leftHeadRef;
+    private WeakReference<Entity> rightHeadRef;
 
     public WitherMeta(@NotNull Entity entity, @NotNull MetadataHolder metadata) {
         super(entity, metadata);
@@ -27,11 +29,11 @@ public class WitherMeta extends MonsterMeta {
 
     @Nullable
     public Entity getCenterHead() {
-        return this.centerHead;
+        return unwrap(centerHeadRef);
     }
 
     public void setCenterHead(@Nullable Entity value) {
-        this.centerHead = value;
+        this.centerHeadRef = wrap(value);
         setCenterHeadEntityId(value == null ? 0 : value.getEntityId());
     }
 
@@ -46,11 +48,11 @@ public class WitherMeta extends MonsterMeta {
 
     @Nullable
     public Entity getLeftHead() {
-        return this.leftHead;
+        return unwrap(this.leftHeadRef);
     }
 
     public void setLeftHead(@Nullable Entity value) {
-        this.leftHead = value;
+        this.leftHeadRef = wrap(value);
         setLeftHeadEntityId(value == null ? 0 : value.getEntityId());
     }
 
@@ -65,11 +67,11 @@ public class WitherMeta extends MonsterMeta {
 
     @Nullable
     public Entity getRightHead() {
-        return this.rightHead;
+        return unwrap(this.rightHeadRef);
     }
 
     public void setRightHead(@Nullable Entity value) {
-        this.rightHead = value;
+        this.rightHeadRef = wrap(value);
         setRightHeadEntityId(value == null ? 0 : value.getEntityId());
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/FishingHookMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/FishingHookMeta.java
@@ -9,9 +9,11 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.ref.WeakReference;
+
 public class FishingHookMeta extends EntityMeta implements ObjectDataProvider {
-    private Entity hooked;
-    private Entity owner;
+    private WeakReference<Entity> hookedRef;
+    private WeakReference<Entity> ownerRef;
 
     public FishingHookMeta(@NotNull Entity entity, @NotNull MetadataHolder metadata) {
         super(entity, metadata);
@@ -28,11 +30,11 @@ public class FishingHookMeta extends EntityMeta implements ObjectDataProvider {
 
     @Nullable
     public Entity getHookedEntity() {
-        return this.hooked;
+        return unwrap(this.hookedRef);
     }
 
     public void setHookedEntity(@Nullable Entity value) {
-        this.hooked = value;
+        this.hookedRef = wrap(value);
         int entityID = value == null ? 0 : value.getEntityId() + 1;
         setHookedEntityId(entityID);
     }
@@ -47,15 +49,17 @@ public class FishingHookMeta extends EntityMeta implements ObjectDataProvider {
 
     @Nullable
     public Entity getOwnerEntity() {
-        return owner;
+        return unwrap(this.ownerRef);
     }
 
     public void setOwnerEntity(@Nullable Entity value) {
-        this.owner = value;
+        this.ownerRef = wrap(value);
     }
 
     @Override
     public int getObjectData() {
+        final var owner = this.getOwnerEntity();
+
         return owner != null ? owner.getEntityId() : 0;
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/AbstractArrowMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/AbstractArrowMeta.java
@@ -6,7 +6,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import org.jetbrains.annotations.NotNull;
 
-public class AbstractArrowMeta extends EntityMeta {
+public class AbstractArrowMeta extends ProjectileEntityMeta {
     protected AbstractArrowMeta(@NotNull Entity entity, @NotNull MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/AbstractWindChargeMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/AbstractWindChargeMeta.java
@@ -7,26 +7,16 @@ import net.minestom.server.entity.metadata.ObjectDataProvider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class AbstractWindChargeMeta extends EntityMeta implements ObjectDataProvider, ProjectileMeta {
-    private Entity shooter;
-
+public class AbstractWindChargeMeta extends ProjectileEntityMeta implements ObjectDataProvider {
     public AbstractWindChargeMeta(@Nullable Entity entity, @NotNull MetadataHolder metadata) {
         super(entity, metadata);
     }
 
     @Override
-    public @Nullable Entity getShooter() {
-        return shooter;
-    }
-
-    @Override
-    public void setShooter(@Nullable Entity shooter) {
-        this.shooter = shooter;
-    }
-
-    @Override
     public int getObjectData() {
-        return this.shooter == null ? 0 : this.shooter.getEntityId();
+        final var shooter = getShooter();
+
+        return shooter == null ? 0 : shooter.getEntityId();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/ArrowMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/ArrowMeta.java
@@ -7,8 +7,7 @@ import net.minestom.server.entity.metadata.ObjectDataProvider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class ArrowMeta extends AbstractArrowMeta implements ObjectDataProvider, ProjectileMeta {
-    private Entity shooter;
+public class ArrowMeta extends AbstractArrowMeta implements ObjectDataProvider{
 
     public ArrowMeta(@NotNull Entity entity, @NotNull MetadataHolder metadata) {
         super(entity, metadata);
@@ -23,19 +22,10 @@ public class ArrowMeta extends AbstractArrowMeta implements ObjectDataProvider, 
     }
 
     @Override
-    @Nullable
-    public Entity getShooter() {
-        return this.shooter;
-    }
-
-    @Override
-    public void setShooter(@Nullable Entity shooter) {
-        this.shooter = shooter;
-    }
-
-    @Override
     public int getObjectData() {
-        return this.shooter == null ? 0 : this.shooter.getEntityId();
+        final var shooter = getShooter();
+
+        return shooter == null ? 0 : shooter.getEntityId();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/DragonFireballMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/DragonFireballMeta.java
@@ -7,27 +7,17 @@ import net.minestom.server.entity.metadata.ObjectDataProvider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class DragonFireballMeta extends EntityMeta implements ObjectDataProvider, ProjectileMeta {
-    private Entity shooter;
+public class DragonFireballMeta extends ProjectileEntityMeta implements ObjectDataProvider {
 
     public DragonFireballMeta(@NotNull Entity entity, @NotNull MetadataHolder metadata) {
         super(entity, metadata);
     }
 
     @Override
-    @Nullable
-    public Entity getShooter() {
-        return shooter;
-    }
-
-    @Override
-    public void setShooter(@Nullable Entity shooter) {
-        this.shooter = shooter;
-    }
-
-    @Override
     public int getObjectData() {
-        return this.shooter == null ? 0 : this.shooter.getEntityId();
+        final var shooter = getShooter();
+
+        return shooter == null ? 0 : shooter.getEntityId();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/FireworkRocketMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/FireworkRocketMeta.java
@@ -9,8 +9,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class FireworkRocketMeta extends EntityMeta implements ProjectileMeta {
-    private Entity shooter;
+public class FireworkRocketMeta extends ProjectileEntityMeta {
 
     public FireworkRocketMeta(@NotNull Entity entity, @NotNull MetadataHolder metadata) {
         super(entity, metadata);
@@ -36,14 +35,8 @@ public class FireworkRocketMeta extends EntityMeta implements ProjectileMeta {
     }
 
     @Override
-    @Nullable
-    public Entity getShooter() {
-        return this.shooter;
-    }
-
-    @Override
     public void setShooter(@Nullable Entity value) {
-        this.shooter = value;
+        super.setShooter(value);
         Integer entityID = value == null ? null : value.getEntityId();
         setShooterEntityId(entityID);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/ProjectileEntityMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/ProjectileEntityMeta.java
@@ -1,0 +1,27 @@
+package net.minestom.server.entity.metadata.projectile;
+
+import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.MetadataHolder;
+import net.minestom.server.entity.metadata.EntityMeta;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.ref.WeakReference;
+
+public class ProjectileEntityMeta extends EntityMeta implements ProjectileMeta {
+    private WeakReference<Entity> shooterRef;
+
+    public ProjectileEntityMeta(@Nullable Entity entity, @NotNull MetadataHolder metadata) {
+        super(entity, metadata);
+    }
+
+    @Override
+    public @Nullable Entity getShooter() {
+        return unwrap(this.shooterRef);
+    }
+
+    @Override
+    public void setShooter(@Nullable Entity shooter) {
+        this.shooterRef = wrap(shooter);
+    }
+}

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/ProjectileMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/ProjectileMeta.java
@@ -5,9 +5,22 @@ import org.jetbrains.annotations.Nullable;
 
 public interface ProjectileMeta {
 
-    @Nullable
-    Entity getShooter();
+    /**
+     * The projectile was shot from this entity
+     * <p>
+     * Stored as a weak reference.
+     *
+     * @return the entity
+     */
+    @Nullable Entity getShooter();
 
+    /**
+     * Set the shooter for #{@link #getShooter()}
+     * <p>
+     * Stored as a weak reference.
+     *
+     * @param shooter the shooter
+     */
     void setShooter(@Nullable Entity shooter);
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/SpectralArrowMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/SpectralArrowMeta.java
@@ -7,26 +7,16 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class SpectralArrowMeta extends AbstractArrowMeta implements ObjectDataProvider, ProjectileMeta {
-    private Entity shooter;
 
     public SpectralArrowMeta(@NotNull Entity entity, @NotNull MetadataHolder metadata) {
         super(entity, metadata);
     }
 
     @Override
-    @Nullable
-    public Entity getShooter() {
-        return this.shooter;
-    }
-
-    @Override
-    public void setShooter(@Nullable Entity shooter) {
-        this.shooter = shooter;
-    }
-
-    @Override
     public int getObjectData() {
-        return this.shooter == null ? 0 : this.shooter.getEntityId();
+        final var shooter = getShooter();
+
+        return shooter == null ? 0 : shooter.getEntityId();
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/WitherSkullMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/WitherSkullMeta.java
@@ -8,9 +8,7 @@ import net.minestom.server.entity.metadata.ObjectDataProvider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class WitherSkullMeta extends EntityMeta implements ObjectDataProvider, ProjectileMeta {
-    private Entity shooter;
-
+public class WitherSkullMeta extends ProjectileEntityMeta implements ObjectDataProvider {
     public WitherSkullMeta(@NotNull Entity entity, @NotNull MetadataHolder metadata) {
         super(entity, metadata);
     }
@@ -24,19 +22,10 @@ public class WitherSkullMeta extends EntityMeta implements ObjectDataProvider, P
     }
 
     @Override
-    @Nullable
-    public Entity getShooter() {
-        return shooter;
-    }
-
-    @Override
-    public void setShooter(@Nullable Entity shooter) {
-        this.shooter = shooter;
-    }
-
-    @Override
     public int getObjectData() {
-        return this.shooter == null ? 0 : this.shooter.getEntityId();
+        final var shooter = getShooter();
+
+        return shooter == null ? 0 : shooter.getEntityId();
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

It should allow entities to be garbage collected if they are no longer in the entity tracker but are a target/shooter/addition.

### Reason
For example, if you shoot an arrow as a player, you can always get a player object for as long as the arrow exists. This is a bad idea if the player left and is deregistered, and now you would have to check this edge case.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
It is a side effect of adding some comments and abstracting projectiles a bit more. Trident projectiles now have a shooter, which is not part of the protocol.

It's probably a breaking change if people usually get targets with deregistered entities, but that's not the case you should be doing.