### PR TITLE
Add state name method and log it when a packet isn't found.

### DIFF
--- a/src/main/java/net/minestom/server/network/packet/PacketRegistry.java
+++ b/src/main/java/net/minestom/server/network/packet/PacketRegistry.java
@@ -42,7 +42,7 @@ public interface PacketRegistry<T> {
     record PacketInfo<T>(Class<T> packetClass, int id, NetworkBuffer.Type<T> serializer) {
     }
 
-    sealed class Client extends PacketRegistryTemplate<ClientPacket> {
+    abstract sealed class Client extends PacketRegistryTemplate<ClientPacket> {
         @SafeVarargs
         Client(Entry<? extends ClientPacket>... suppliers) {
             super(suppliers);
@@ -192,7 +192,7 @@ public interface PacketRegistry<T> {
         }
     }
 
-    sealed class Server extends PacketRegistryTemplate<ServerPacket> {
+    abstract sealed class Server extends PacketRegistryTemplate<ServerPacket> {
         @SafeVarargs
         Server(Entry<? extends ServerPacket>... suppliers) {
             super(suppliers);
@@ -422,7 +422,7 @@ public interface PacketRegistry<T> {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    sealed class PacketRegistryTemplate<T> implements PacketRegistry<T> {
+    abstract sealed class PacketRegistryTemplate<T> implements PacketRegistry<T> {
         private final PacketInfo<? extends T>[] suppliers;
         private final ClassValue<PacketInfo<T>> packetIds = new ClassValue<>() {
             @Override
@@ -471,15 +471,7 @@ public interface PacketRegistry<T> {
             return info;
         }
 
-        @Override
-        public @NotNull ConnectionState state() {
-            return ConnectionState.STATUS;
-        }
 
-        @Override
-        public @NotNull ConnectionSide side() {
-            return ConnectionSide.SERVER;
-        }
 
         record Entry<T>(Class<T> type, NetworkBuffer.Type<T> reader) {
         }

--- a/src/main/java/net/minestom/server/network/packet/PacketRegistry.java
+++ b/src/main/java/net/minestom/server/network/packet/PacketRegistry.java
@@ -31,6 +31,8 @@ public interface PacketRegistry<T> {
         return packetInfo(packet.getClass());
     }
 
+    @NotNull String stateName();
+
     PacketInfo<T> packetInfo(int packetId);
 
     record PacketInfo<T>(Class<T> packetClass, int id, NetworkBuffer.Type<T> serializer) {
@@ -49,6 +51,11 @@ public interface PacketRegistry<T> {
                     entry(ClientHandshakePacket.class, ClientHandshakePacket.SERIALIZER)
             );
         }
+
+        @Override
+        public @NotNull String stateName() {
+            return "CLIENT_HANDSHAKE";
+        }
     }
 
     final class ClientStatus extends Client {
@@ -57,6 +64,11 @@ public interface PacketRegistry<T> {
                     entry(StatusRequestPacket.class, StatusRequestPacket.SERIALIZER),
                     entry(ClientPingRequestPacket.class, ClientPingRequestPacket.SERIALIZER)
             );
+        }
+
+        @Override
+        public @NotNull String stateName() {
+            return "CLIENT_STATUS";
         }
     }
 
@@ -69,6 +81,11 @@ public interface PacketRegistry<T> {
                     entry(ClientLoginAcknowledgedPacket.class, ClientLoginAcknowledgedPacket.SERIALIZER),
                     entry(ClientCookieResponsePacket.class, ClientCookieResponsePacket.SERIALIZER)
             );
+        }
+
+        @Override
+        public @NotNull String stateName() {
+            return "CLIENT_LOGIN";
         }
     }
 
@@ -84,6 +101,11 @@ public interface PacketRegistry<T> {
                     entry(ClientResourcePackStatusPacket.class, ClientResourcePackStatusPacket.SERIALIZER),
                     entry(ClientSelectKnownPacksPacket.class, ClientSelectKnownPacksPacket.SERIALIZER)
             );
+        }
+
+        @Override
+        public @NotNull String stateName() {
+            return "CLIENT_CONFIGURATION";
         }
     }
 
@@ -154,6 +176,11 @@ public interface PacketRegistry<T> {
                     entry(ClientUseItemPacket.class, ClientUseItemPacket.SERIALIZER)
             );
         }
+
+        @Override
+        public @NotNull String stateName() {
+            return "CLIENT_PLAY";
+        }
     }
 
     sealed class Server extends PacketRegistryTemplate<ServerPacket> {
@@ -169,6 +196,11 @@ public interface PacketRegistry<T> {
                     // Empty
             );
         }
+
+        @Override
+        public @NotNull String stateName() {
+            return "SERVER_HANDSHAKE";
+        }
     }
 
     final class ServerStatus extends Server {
@@ -177,6 +209,11 @@ public interface PacketRegistry<T> {
                     entry(ResponsePacket.class, ResponsePacket.SERIALIZER),
                     entry(PingResponsePacket.class, PingResponsePacket.SERIALIZER)
             );
+        }
+
+        @Override
+        public @NotNull String stateName() {
+            return "SERVER_STATUS";
         }
     }
 
@@ -190,6 +227,11 @@ public interface PacketRegistry<T> {
                     entry(LoginPluginRequestPacket.class, LoginPluginRequestPacket.SERIALIZER),
                     entry(CookieRequestPacket.class, CookieRequestPacket.SERIALIZER)
             );
+        }
+
+        @Override
+        public @NotNull String stateName() {
+            return "SERVER_LOGIN";
         }
     }
 
@@ -214,6 +256,11 @@ public interface PacketRegistry<T> {
                     entry(CustomReportDetailsPacket.class, CustomReportDetailsPacket.SERIALIZER),
                     entry(ServerLinksPacket.class, ServerLinksPacket.SERIALIZER)
             );
+        }
+
+        @Override
+        public @NotNull String stateName() {
+            return "SERVER_CONFIGURATION";
         }
     }
 
@@ -353,6 +400,11 @@ public interface PacketRegistry<T> {
                     entry(ServerLinksPacket.class, ServerLinksPacket.SERIALIZER)
             );
         }
+
+        @Override
+        public @NotNull String stateName() {
+            return "SERVER_PLAY";
+        }
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -366,7 +418,7 @@ public interface PacketRegistry<T> {
                         return (PacketInfo<T>) info;
                     }
                 }
-                throw new IllegalStateException("Packet type " + type + " isn't registered!");
+                throw new IllegalStateException("Packet type " + type + " isn't registered for state " + stateName() + "!");
             }
         };
 
@@ -394,6 +446,11 @@ public interface PacketRegistry<T> {
         @Override
         public PacketInfo<T> packetInfo(@NotNull Class<?> packetClass) {
             return packetIds.get(packetClass);
+        }
+
+        @Override
+        public @NotNull String stateName() {
+            return "UNKNOWN";
         }
 
         @Override

--- a/src/main/java/net/minestom/server/network/packet/PacketRegistry.java
+++ b/src/main/java/net/minestom/server/network/packet/PacketRegistry.java
@@ -432,7 +432,7 @@ public interface PacketRegistry<T> {
                         return (PacketInfo<T>) info;
                     }
                 }
-                throw new IllegalStateException("Packet type " + type + " isn't registered for state " + side().name() + "_" + state().name() + "!");
+                throw new IllegalStateException("Packet type " + type + " cannot be sent in state " + side().name() + "_" + state().name() + "!");
             }
         };
 


### PR DESCRIPTION
## Proposed changes

Display the state name when the server cannot find a registered packet.
This should hopefully cut down on instances where developers are confused when they try do to something in an invalid client/server state (e.g. set gamemode when in config state).

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
I would have liked to do it through `getClass().getSimpleName()` instead of having to manually type it out, but those were empty strings due to java shenanigans.