### PR TITLE
Remove tinylog.properties

### DIFF
--- a/src/main/resources/tinylog.properties
+++ b/src/main/resources/tinylog.properties
@@ -1,4 +1,0 @@
-autoshutdown=true
-writer=minestom console
-writer.level=info
-writer.format=[{thread}] [{date: HH:mm:ss}] ({class-name}.{method}) - {level} - {message}


### PR DESCRIPTION
Minestom no longer provides a logging implementation so a config file is no longer required. The existence of this file could cause issues with tinylog users.