### PR TITLE
Remove tinylog.properties

### DIFF
--- a/src/main/resources/tinylog.properties
+++ b/src/main/resources/tinylog.properties
@@ -1,4 +1,0 @@
-autoshutdown=true
-writer=minestom console
-writer.level=info
-writer.format=[{thread}] [{date: HH:mm:ss}] ({class-name}.{method}) - {level} - {message}


### PR DESCRIPTION
## Proposed changes

Minestom no longer provides a logging implementation so a config file is no longer required. The existence of this file could cause issues with tinylog users since minestom console is no longer a thing.
```
LOGGER ERROR: Service implementation 'minestom console' not found
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
