### PR TITLE
feat: creative mode item creation event

### DIFF
--- a/demo/src/main/java/net/minestom/demo/PlayerInit.java
+++ b/demo/src/main/java/net/minestom/demo/PlayerInit.java
@@ -17,6 +17,7 @@ import net.minestom.server.entity.damage.Damage;
 import net.minestom.server.event.Event;
 import net.minestom.server.event.EventNode;
 import net.minestom.server.event.entity.EntityAttackEvent;
+import net.minestom.server.event.inventory.CreativeInventoryActionEvent;
 import net.minestom.server.event.item.*;
 import net.minestom.server.event.player.*;
 import net.minestom.server.event.server.ServerTickMonitorEvent;
@@ -206,6 +207,13 @@ public class PlayerInit {
 
                 if (block.id() == Block.CRAFTING_TABLE.id()) {
                     event.getPlayer().openInventory(new Inventory(InventoryType.CRAFTING, "Crafting"));
+                }
+            })
+            .addListener(CreativeInventoryActionEvent.class, event -> {
+                if (event.getClickedItem().material() == Material.APPLE) {
+                    event.setClickedItem(ItemStack.of(Material.GOLDEN_APPLE, event.getClickedItem().amount()));
+                } else if (event.getClickedItem().material() == Material.ENCHANTED_GOLDEN_APPLE) {
+                    event.setCancelled(true);
                 }
             });
 

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -420,7 +420,7 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
                 // has not changed the item (the default behavior) we need to refresh the slot.
                 if (itemStack.equals(getItemInHand(itemUseHand))) {
                     final int slot = isOffHand ? PlayerInventoryUtils.OFFHAND_SLOT : getHeldSlot();
-                    inventory.sendSlotRefresh(slot, itemStack, itemStack);
+                    inventory.sendSlotRefresh(slot, itemStack);
                 }
             }
         }

--- a/src/main/java/net/minestom/server/event/inventory/CreativeInventoryActionEvent.java
+++ b/src/main/java/net/minestom/server/event/inventory/CreativeInventoryActionEvent.java
@@ -1,0 +1,75 @@
+package net.minestom.server.event.inventory;
+
+import net.minestom.server.entity.Player;
+import net.minestom.server.event.trait.CancellableEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
+import net.minestom.server.inventory.click.ClickType;
+import net.minestom.server.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called when a player interacts with an item in the creative menu
+ */
+public class CreativeInventoryActionEvent implements PlayerInstanceEvent, CancellableEvent {
+    private final Player player;
+    private final int slot;
+    private ItemStack clickedItem;
+    private boolean cancelled;
+
+    public CreativeInventoryActionEvent(@NotNull Player player,
+                                        int slot,
+                                        @NotNull ItemStack clicked) {
+        this.player = player;
+        this.slot = slot;
+        this.clickedItem = clicked;
+        this.cancelled = false;
+    }
+
+    /**
+     * Gets the player who is trying to click on the inventory.
+     *
+     * @return the player who clicked
+     */
+    @NotNull
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * Gets the clicked slot number.
+     *
+     * @return the clicked slot number
+     */
+    public int getSlot() {
+        return slot;
+    }
+
+    /**
+     * Gets the item which has been clicked.
+     *
+     * @return the clicked item
+     */
+    @NotNull
+    public ItemStack getClickedItem() {
+        return clickedItem;
+    }
+
+    /**
+     * Changes the clicked item.
+     *
+     * @param clickedItem the clicked item
+     */
+    public void setClickedItem(@NotNull ItemStack clickedItem) {
+        this.clickedItem = clickedItem;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+}

--- a/src/main/java/net/minestom/server/inventory/AbstractInventory.java
+++ b/src/main/java/net/minestom/server/inventory/AbstractInventory.java
@@ -126,10 +126,10 @@ public sealed abstract class AbstractInventory implements InventoryClickHandler,
 
     protected void UNSAFE_itemInsert(int slot, @NotNull ItemStack item, @NotNull ItemStack previous, boolean sendPacket) {
         itemStacks[slot] = item;
-        if (sendPacket) sendSlotRefresh(slot, item, previous);
+        if (sendPacket) sendSlotRefresh(slot, item);
     }
 
-    public void sendSlotRefresh(int slot, @NotNull ItemStack item, @NotNull ItemStack previous) {
+    public void sendSlotRefresh(int slot, @NotNull ItemStack item) {
         sendPacketToViewers(new SetSlotPacket(getWindowId(), 0, (short) slot, item));
     }
 

--- a/src/main/java/net/minestom/server/inventory/PlayerInventory.java
+++ b/src/main/java/net/minestom/server/inventory/PlayerInventory.java
@@ -136,7 +136,7 @@ public non-sealed class PlayerInventory extends AbstractInventory {
     }
 
     @Override
-    public void sendSlotRefresh(int slot, @NotNull ItemStack item, @NotNull ItemStack previous) {
+    public void sendSlotRefresh(int slot, @NotNull ItemStack item) {
         if (slot < 0 || slot > INVENTORY_SIZE)
             return; // Sanity check
         // See note in PlayerInventoryUtils about why we do this conversion

--- a/src/main/java/net/minestom/server/listener/CreativeInventoryActionListener.java
+++ b/src/main/java/net/minestom/server/listener/CreativeInventoryActionListener.java
@@ -2,6 +2,8 @@ package net.minestom.server.listener;
 
 import net.minestom.server.entity.GameMode;
 import net.minestom.server.entity.Player;
+import net.minestom.server.event.EventDispatcher;
+import net.minestom.server.event.inventory.CreativeInventoryActionEvent;
 import net.minestom.server.inventory.PlayerInventory;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.network.packet.client.play.ClientCreativeInventoryActionPacket;
@@ -13,10 +15,13 @@ public final class CreativeInventoryActionListener {
     public static void listener(ClientCreativeInventoryActionPacket packet, Player player) {
         if (player.getGameMode() != GameMode.CREATIVE) return;
         short slot = packet.slot();
-        final ItemStack item = packet.item();
+        final ItemStack sentItem = packet.item();
         if (slot == -1) {
             // Drop item
-            player.dropItem(item);
+            CreativeInventoryActionEvent event = new CreativeInventoryActionEvent(player, slot, sentItem);
+            EventDispatcher.call(event);
+            if (event.isCancelled()) return;
+            player.dropItem(event.getClickedItem());
             return;
         }
         // Bounds check
@@ -27,10 +32,29 @@ public final class CreativeInventoryActionListener {
         // Set item
         slot = (short) PlayerInventoryUtils.convertWindow0SlotToMinestomSlot(slot);
         PlayerInventory inventory = player.getInventory();
-        if (Objects.equals(inventory.getItemStack(slot), item)) {
+
+        CreativeInventoryActionEvent event = new CreativeInventoryActionEvent(player, slot, sentItem);
+        EventDispatcher.call(event);
+        final ItemStack setItem = event.getClickedItem();
+        final ItemStack previousItem = inventory.getItemStack(slot);
+
+        if (event.isCancelled()) {
+            // Event is cancelled, keep the old item
+            player.getInventory().sendSlotRefresh(slot, previousItem);
+            return;
+        }
+
+        final boolean isEqualToSentItem = Objects.equals(setItem, sentItem);
+
+        if (Objects.equals(previousItem, sentItem) && isEqualToSentItem) {
             // Item is already present, ignore
             return;
         }
-        inventory.setItemStack(slot, item);
+
+        inventory.setItemStack(slot, setItem);
+
+        if (!isEqualToSentItem) {
+            player.getInventory().sendSlotRefresh(slot, setItem);
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes
Add a new event called `CreativeInventoryActionEvent` that allows users to modify items moved by players in creative mode. This is the easiest way to implement functionality like adding tags to track the origin of items or similar functionality. This is similar to [this](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/inventory/InventoryCreativeEvent.html) Spigot event. 

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If you got any comments or ideas, feel free to tell me! 

[BREAKING CHANGE](https://discord.com/channels/706185253441634317/706186227493109860/1354891091178160431): Public API Signature change in [AbstractInventory#sendSlotRefresh](https://github.com/Minestom/Minestom/blob/0366b58bfe496059784b3333889602429ae5d771/src/main/java/net/minestom/server/inventory/PlayerInventory.java) (removes an unused argument) 