### PR TITLE
remove unnecessary distance check

### DIFF
--- a/src/main/java/net/minestom/server/entity/ItemEntity.java
+++ b/src/main/java/net/minestom/server/entity/ItemEntity.java
@@ -77,7 +77,6 @@ public class ItemEntity extends Entity {
                     EntityTracker.Target.ITEMS, itemEntity -> {
                         if (itemEntity == this) return;
                         if (!itemEntity.isPickable() || !itemEntity.isMergeable()) return;
-                        if (getDistanceSquared(itemEntity) > mergeRange * mergeRange) return;
 
                         final ItemStack itemStackEntity = itemEntity.getItemStack();
                         final boolean canStack = itemStack.isSimilar(itemStackEntity);


### PR DESCRIPTION
Removed distance check which is always false because EntityTracker::nearbyEntities method already checks that for us and will not invoke our lambda with such entities