### PR TITLE
Added offset indication to BlockPlacementRule Replacement record

### DIFF
--- a/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java
+++ b/src/main/java/net/minestom/server/instance/block/rule/BlockPlacementRule.java
@@ -76,6 +76,11 @@ public abstract class BlockPlacementRule {
             @NotNull Block block,
             @NotNull BlockFace blockFace,
             @NotNull Point cursorPosition,
+            /**
+			 * Whether or not the placement position is offset from the clicked block
+			 * position.
+			 */
+            @NotNull boolean isOffset,
             @NotNull Material material
     ) {
     }

--- a/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
+++ b/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
@@ -20,7 +20,6 @@ import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.instance.block.BlockHandler;
 import net.minestom.server.instance.block.BlockManager;
 import net.minestom.server.instance.block.rule.BlockPlacementRule;
-import net.minestom.server.inventory.PlayerInventory;
 import net.minestom.server.item.ItemComponent;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
@@ -102,17 +101,14 @@ public class BlockPlacementListener {
         Point placementPosition = blockPosition;
         var interactedPlacementRule = BLOCK_MANAGER.getBlockPlacementRule(interactedBlock);
         if (!interactedBlock.isAir() && (interactedPlacementRule == null || !interactedPlacementRule.isSelfReplaceable(
-                new BlockPlacementRule.Replacement(interactedBlock, blockFace, cursorPosition, useMaterial)))) {
+                new BlockPlacementRule.Replacement(interactedBlock, blockFace, cursorPosition, false, useMaterial)))) {
             // If the block is not replaceable, try to place next to it.
-            final int offsetX = blockFace == BlockFace.WEST ? -1 : blockFace == BlockFace.EAST ? 1 : 0;
-            final int offsetY = blockFace == BlockFace.BOTTOM ? -1 : blockFace == BlockFace.TOP ? 1 : 0;
-            final int offsetZ = blockFace == BlockFace.NORTH ? -1 : blockFace == BlockFace.SOUTH ? 1 : 0;
-            placementPosition = blockPosition.add(offsetX, offsetY, offsetZ);
+            placementPosition = blockPosition.relative(blockFace);
 
             var placementBlock = instance.getBlock(placementPosition);
             var placementRule = BLOCK_MANAGER.getBlockPlacementRule(placementBlock);
             if (!placementBlock.registry().isReplaceable() && !(placementRule != null && placementRule.isSelfReplaceable(
-                    new BlockPlacementRule.Replacement(placementBlock, blockFace, cursorPosition, useMaterial)))) {
+                    new BlockPlacementRule.Replacement(placementBlock, blockFace, cursorPosition, true, useMaterial)))) {
                 // If the block is still not replaceable, cancel the placement
                 canPlaceBlock = false;
             }


### PR DESCRIPTION
## Proposed changes

Added a Boolean to the Replacement record used in the #isSelfReplaceable() method of BlockPlacementRule that indicates whether the block placement position was offset from the clicked position. This is necessary because it is not possible to make a BlockPlacementRule function properly for slabs without this information.

The video demonstrates the issue

https://github.com/user-attachments/assets/6335a071-d422-4081-9175-9bf16d824fe1

There was no way of knowing whether the #isSelfReplaceable() method was being called for the slab that is clicked on or the one above it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)