### PR TITLE
Add events for item picking functionality

### DIFF
--- a/src/main/java/net/minestom/server/event/player/PlayerPickBlockEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerPickBlockEvent.java
@@ -1,0 +1,63 @@
+package net.minestom.server.event.player;
+
+import net.minestom.server.coordinate.BlockVec;
+import net.minestom.server.entity.Player;
+import net.minestom.server.event.trait.BlockEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
+import net.minestom.server.instance.block.Block;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called when a player tries to pick a block (middle-click).
+ */
+public class PlayerPickBlockEvent implements PlayerInstanceEvent, BlockEvent {
+
+    private final Player player;
+
+    private final Block block;
+    private final BlockVec blockPosition;
+    private final boolean includeData;
+
+    public PlayerPickBlockEvent(@NotNull Player player, @NotNull Block block,
+                                @NotNull BlockVec blockPosition, boolean includeData) {
+        this.player = player;
+
+        this.block = block;
+        this.blockPosition = blockPosition;
+        this.includeData = includeData;
+    }
+
+    /**
+     * Gets the block which was picked.
+     *
+     * @return the block which was picked
+     */
+    @Override
+    public @NotNull Block getBlock() {
+        return block;
+    }
+
+    /**
+     * Gets the picked block position.
+     *
+     * @return the picked block position
+     */
+    @Override
+    public @NotNull BlockVec getBlockPosition() {
+        return blockPosition;
+    }
+
+    /**
+     * Get if the entity data should be included in the result (control middle-click).
+     *
+     * @return if the entity data should be included.
+     */
+    public boolean isIncludeData() {
+        return this.includeData;
+    }
+
+    @Override
+    public @NotNull Player getPlayer() {
+        return player;
+    }
+}

--- a/src/main/java/net/minestom/server/event/player/PlayerPickEntityEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerPickEntityEvent.java
@@ -1,0 +1,48 @@
+package net.minestom.server.event.player;
+
+import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.Player;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called when a player tries to pick an entity (middle-click).
+ */
+public class PlayerPickEntityEvent implements PlayerInstanceEvent {
+
+    private final Player player;
+
+    private final Entity entityTarget;
+    private final boolean includeData;
+
+    public PlayerPickEntityEvent(@NotNull Player player, @NotNull Entity entityTarget,
+                                 boolean includeData) {
+        this.player = player;
+
+        this.entityTarget = entityTarget;
+        this.includeData = includeData;
+    }
+
+    /**
+     * Gets the entity which was picked.
+     *
+     * @return the entity which was picked
+     */
+    public @NotNull Entity getTarget() {
+        return entityTarget;
+    }
+
+    /**
+     * Get if the entity data should be included in the result (control middle-click).
+     *
+     * @return if the entity data should be included.
+     */
+    public boolean isIncludeData() {
+        return this.includeData;
+    }
+
+    @Override
+    public @NotNull Player getPlayer() {
+        return player;
+    }
+}

--- a/src/main/java/net/minestom/server/listener/PlayerPickListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerPickListener.java
@@ -1,0 +1,37 @@
+package net.minestom.server.listener;
+
+import net.minestom.server.coordinate.BlockVec;
+import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.Player;
+import net.minestom.server.event.EventDispatcher;
+import net.minestom.server.event.player.PlayerPickBlockEvent;
+import net.minestom.server.event.player.PlayerPickEntityEvent;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.instance.block.Block;
+import net.minestom.server.network.packet.client.play.ClientPickItemFromBlockPacket;
+import net.minestom.server.network.packet.client.play.ClientPickItemFromEntityPacket;
+
+public class PlayerPickListener {
+
+    public static void playerPickBlockListener(ClientPickItemFromBlockPacket packet, Player player) {
+        final Instance instance = player.getInstance();
+        if (instance == null) return;
+        final Block block = instance.getBlock(packet.pos());
+        if (block.isAir()) return;
+        final boolean includeData = packet.includeData();
+
+        PlayerPickBlockEvent playerPickBlockEvent = new PlayerPickBlockEvent(player, block, new BlockVec(packet.pos()), includeData);
+        EventDispatcher.call(playerPickBlockEvent);
+    }
+
+    public static void playerPickEntityListener(ClientPickItemFromEntityPacket packet, Player player) {
+        final Instance instance = player.getInstance();
+        if (instance == null) return;
+        final Entity entity = instance.getEntityById(packet.entityId());
+        if (entity == null) return;
+        final boolean includeData = packet.includeData();
+
+        PlayerPickEntityEvent playerPickEntityEvent = new PlayerPickEntityEvent(player, entity, includeData);
+        EventDispatcher.call(playerPickEntityEvent);
+    }
+}

--- a/src/main/java/net/minestom/server/listener/manager/PacketListenerManager.java
+++ b/src/main/java/net/minestom/server/listener/manager/PacketListenerManager.java
@@ -81,6 +81,8 @@ public final class PacketListenerManager {
         setPlayListener(ClientAnimationPacket.class, AnimationListener::animationListener);
         setPlayListener(ClientInteractEntityPacket.class, UseEntityListener::useEntityListener);
         setPlayListener(ClientUseItemPacket.class, UseItemListener::useItemListener);
+        setPlayListener(ClientPickItemFromBlockPacket.class, PlayerPickListener::playerPickBlockListener);
+        setPlayListener(ClientPickItemFromEntityPacket.class, PlayerPickListener::playerPickEntityListener);
         setPlayListener(ClientStatusPacket.class, PlayStatusListener::listener);
         setPlayListener(ClientSettingsPacket.class, SettingsListener::listener);
         setPlayListener(ClientCreativeInventoryActionPacket.class, CreativeInventoryActionListener::listener);


### PR DESCRIPTION
## Proposed changes

I have added listeners for the `ClientPickItemFromBlockPacket` and `ClientPickItemFromEntityPacket` that call the non-cancelable events `PlayerPickBlockEvent` and `PlayerPickEntityEvent` respectively.

This also fixes the following message when a player tries to pick a block/entity without this pr.
![image](https://github.com/user-attachments/assets/20bf71cd-86f2-4a91-86ff-913d6bd3531d)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

I may have missed them but I didn't see any similar tests for stuff like this so I didn't make any.