### PR TITLE
Update text component click and hover event serialization for 1.21.5

### DIFF
--- a/src/main/java/net/minestom/server/adventure/serializer/nbt/NbtComponentSerializerImpl.java
+++ b/src/main/java/net/minestom/server/adventure/serializer/nbt/NbtComponentSerializerImpl.java
@@ -388,9 +388,9 @@ final class NbtComponentSerializerImpl implements NbtComponentSerializer {
         var insertion = style.insertion();
         if (insertion != null) compound.putString("insertion", insertion);
         var clickEvent = style.clickEvent();
-        if (clickEvent != null) compound.put("clickEvent", serializeClickEvent(clickEvent));
+        if (clickEvent != null) compound.put("click_event", serializeClickEvent(clickEvent));
         var hoverEvent = style.hoverEvent();
-        if (hoverEvent != null) compound.put("hoverEvent", serializeHoverEvent(hoverEvent));
+        if (hoverEvent != null) compound.put("hover_event", serializeHoverEvent(hoverEvent));
 
         return compound.build();
     }

--- a/src/main/java/net/minestom/server/adventure/serializer/nbt/NbtComponentSerializerImpl.java
+++ b/src/main/java/net/minestom/server/adventure/serializer/nbt/NbtComponentSerializerImpl.java
@@ -141,9 +141,9 @@ final class NbtComponentSerializerImpl implements NbtComponentSerializer {
         // Interactivity
         var insertion = compound.getString("insertion");
         if (!insertion.isEmpty()) style.insertion(insertion);
-        var clickEvent = compound.getCompound("clickEvent");
+        var clickEvent = compound.getCompound("click_event");
         if (clickEvent.size() > 0) style.clickEvent(deserializeClickEvent(clickEvent));
-        var hoverEvent = compound.getCompound("hoverEvent");
+        var hoverEvent = compound.getCompound("hover_event");
         if (hoverEvent.size() > 0) style.hoverEvent(deserializeHoverEvent(hoverEvent));
 
         return style.build();
@@ -216,27 +216,52 @@ final class NbtComponentSerializerImpl implements NbtComponentSerializer {
         Check.notNull(actionName, "Click event must have an action field");
         var action = ClickEvent.Action.NAMES.value(actionName);
         Check.notNull(action, "Unknown click event action: " + actionName);
-        var value = compound.getString("value");
-        Check.notNull(value, "Click event must have a value field");
-        return ClickEvent.clickEvent(action, value);
+        switch (action) {
+            case OPEN_URL -> {
+                var value = compound.getString("url");
+                Check.notNull(value, "Click event of type open_url must have a url field");
+                return ClickEvent.clickEvent(action, value);
+            }
+            case OPEN_FILE -> {
+                var value = compound.getString("path");
+                Check.notNull(value, "Click event of type open_file must have a path field");
+                return ClickEvent.clickEvent(action, value);
+            }
+            case RUN_COMMAND, SUGGEST_COMMAND -> {
+                var value = compound.getString("command");
+                Check.notNull(value, "Click event of type run_command or suggest_command must have a command field");
+                return ClickEvent.clickEvent(action, value);
+            }
+            case CHANGE_PAGE -> {
+                var value = compound.getInt("page");
+                Check.notNull(value, "Click event of type change_page must have a page field");
+                return ClickEvent.clickEvent(action, String.valueOf(value));
+            }
+            case COPY_TO_CLIPBOARD -> {
+                var value = compound.getString("value");
+                Check.notNull(value, "Click event of type copy_to_clipboard must have a value field");
+                return ClickEvent.clickEvent(action, value);
+            }
+        }
+        throw new UnsupportedOperationException("Unknown click event action: " + action);
     }
 
     private @NotNull HoverEvent<?> deserializeHoverEvent(@NotNull CompoundBinaryTag compound) {
         var actionName = compound.getString("action");
         Check.notNull(actionName, "Hover event must have an action field");
-        var contents = compound.getCompound("contents");
-        Check.notNull(contents, "Hover event must have a contents field");
 
         var action = HoverEvent.Action.NAMES.value(actionName);
         if (action == HoverEvent.Action.SHOW_TEXT) {
+            var contents = compound.getCompound("value");
+            Check.notNull(contents, "Hover event of type show_text must have a value field");
             return HoverEvent.showText(deserializeComponent(contents));
         } else if (action == HoverEvent.Action.SHOW_ITEM) {
-            @Subst("minecraft:stick") var id = contents.getString("id");
+            @Subst("minecraft:stick") var id = compound.getString("id");
             Check.notNull(id, "Show item hover event must have an id field");
-            var count = contents.getInt("count", 1);
+            var count = compound.getInt("count", 1);
 
             final Map<Key, DataComponentValue> dataComponents = new HashMap<>();
-            final CompoundBinaryTag dataComponentsCompound = contents.getCompound("components");
+            final CompoundBinaryTag dataComponentsCompound = compound.getCompound("components");
             if (!dataComponentsCompound.isEmpty()) {
                 for (final Map.Entry<String, ? extends BinaryTag> entry : dataComponentsCompound) {
                     @KeyPattern final String name = entry.getKey();
@@ -250,13 +275,27 @@ final class NbtComponentSerializerImpl implements NbtComponentSerializer {
 
             return HoverEvent.showItem(Key.key(id), count, dataComponents);
         } else if (action == HoverEvent.Action.SHOW_ENTITY) {
-            var name = contents.getCompound("name");
+            var name = compound.getCompound("name");
             var nameComponent = name.size() == 0 ? null : deserializeComponent(name);
-            @Subst("minecraft:pig") var type = contents.getString("type");
+
+            @Subst("minecraft:pig") var type = compound.getString("id");
             Check.notNull(type, "Show entity hover event must have a type field");
-            var id = contents.getString("id");
-            Check.notNull(id, "Show entity hover event must have an id field");
-            return HoverEvent.showEntity(Key.key(type), UUID.fromString(id), nameComponent);
+
+            UUID uuid; // The UUID can be formatted as either an array of 4 integers or a string
+            BinaryTag uuidTag = compound.get("uuid");
+            Check.notNull(uuidTag, "Show entity hover event must have a uuid field");
+            switch (uuidTag) {
+                case IntArrayBinaryTag tag -> {
+                    Check.argCondition(tag.size() == 4, "Show entity hover event UUID must have a length of 4 when formatted as an array of integers");
+                    long mostSignificantBits = ((long) tag.get(0) << 32) | (tag.get(1) & 0xFFFFFFFFL);
+                    long leastSignificantBits = ((long) tag.get(2) << 32) | (tag.get(3) & 0xFFFFFFFFL);
+                    uuid = new UUID(mostSignificantBits, leastSignificantBits);
+                }
+                case StringBinaryTag tag -> uuid = UUID.fromString(tag.value());
+                default -> throw new IllegalArgumentException("Show entity hover event must have a uuid field");
+            }
+
+            return HoverEvent.showEntity(Key.key(type), uuid, nameComponent);
         } else {
             throw new UnsupportedOperationException("Unknown hover event action: " + actionName);
         }
@@ -364,10 +403,28 @@ final class NbtComponentSerializerImpl implements NbtComponentSerializer {
     }
 
     private @NotNull BinaryTag serializeClickEvent(@NotNull ClickEvent event) {
-        return CompoundBinaryTag.builder()
-                .putString("action", event.action().toString())
-                .putString("value", event.value())
-                .build();
+        CompoundBinaryTag.Builder compound = CompoundBinaryTag.builder()
+                .putString("action", event.action().toString());
+        switch (event.action()) {
+            case OPEN_URL -> {
+                return compound.putString("url", event.value()).build();
+            }
+            case OPEN_FILE -> {
+                return compound.putString("path", event.value()).build();
+            }
+            case RUN_COMMAND, SUGGEST_COMMAND -> {
+                return compound.putString("command", event.value()).build();
+            }
+            case CHANGE_PAGE -> {
+                return compound.putString("page", event.value()).build();
+            }
+            case COPY_TO_CLIPBOARD -> {
+                return compound.putString("value", event.value()).build();
+            }
+            default -> {
+                return compound.build();
+            }
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -377,13 +434,12 @@ final class NbtComponentSerializerImpl implements NbtComponentSerializer {
         compound.putString("action", event.action().toString());
         if (event.action() == HoverEvent.Action.SHOW_TEXT) {
             var value = ((HoverEvent<Component>) event).value();
-            compound.put("contents", serializeComponent(value));
+            compound.put("value", serializeComponent(value));
         } else if (event.action() == HoverEvent.Action.SHOW_ITEM) {
             var value = ((HoverEvent<HoverEvent.ShowItem>) event).value();
 
-            CompoundBinaryTag.Builder itemCompound = CompoundBinaryTag.builder();
-            itemCompound.putString("id", value.item().asString());
-            if (value.count() != 1) itemCompound.putInt("count", value.count());
+            compound.putString("id", value.item().asString());
+            if (value.count() != 1) compound.putInt("count", value.count());
 
             final Map<Key, NbtDataComponentValue> dataComponents = value.dataComponentsAs(NbtDataComponentValue.class);
             if (!dataComponents.isEmpty()) {
@@ -396,20 +452,15 @@ final class NbtComponentSerializerImpl implements NbtComponentSerializer {
                         dataComponentsCompound.put(entry.getKey().asString(), dataComponentValue);
                     }
                 }
-                itemCompound.put("components", dataComponentsCompound.build());
+                compound.put("components", dataComponentsCompound.build());
             }
-
-            compound.put("contents", itemCompound.build());
         } else if (event.action() == HoverEvent.Action.SHOW_ENTITY) {
             var value = ((HoverEvent<HoverEvent.ShowEntity>) event).value();
 
-            CompoundBinaryTag.Builder entityCompound = CompoundBinaryTag.builder();
             var name = value.name();
-            if (name != null) entityCompound.put("name", serializeComponent(name));
-            entityCompound.putString("type", value.type().asString());
-            entityCompound.putString("id", value.id().toString());
-
-            compound.put("contents", entityCompound.build());
+            if (name != null) compound.put("name", serializeComponent(name));
+            compound.putString("id", value.type().asString());
+            compound.putString("uuid", value.id().toString());
         } else {
             throw new UnsupportedOperationException("Unknown hover event action: " + event.action());
         }

--- a/src/main/java/net/minestom/server/network/ComponentNetworkBufferTypeImpl.java
+++ b/src/main/java/net/minestom/server/network/ComponentNetworkBufferTypeImpl.java
@@ -223,25 +223,34 @@ record ComponentNetworkBufferTypeImpl() implements NetworkBufferTypeImpl<Compone
         buffer.write(STRING_IO_UTF8, "action");
         buffer.write(STRING_IO_UTF8, clickEvent.action().name().toLowerCase(Locale.ROOT));
 
-        buffer.write(BYTE, TAG_STRING);
         switch (clickEvent.action()) {
             case OPEN_URL -> {
+                buffer.write(BYTE, TAG_STRING);
                 buffer.write(STRING_IO_UTF8, "url");
+                buffer.write(STRING_IO_UTF8, clickEvent.value());
             }
             case OPEN_FILE -> {
+                buffer.write(BYTE, TAG_STRING);
                 buffer.write(STRING_IO_UTF8, "path");
+                buffer.write(STRING_IO_UTF8, clickEvent.value());
             }
             case RUN_COMMAND, SUGGEST_COMMAND -> {
+                buffer.write(BYTE, TAG_STRING);
                 buffer.write(STRING_IO_UTF8, "command");
+                buffer.write(STRING_IO_UTF8, clickEvent.value());
             }
             case CHANGE_PAGE -> {
+                buffer.write(BYTE, TAG_INT);
                 buffer.write(STRING_IO_UTF8, "page");
+                int page = Integer.parseInt(clickEvent.value());
+                buffer.write(INT, page);
             }
             default -> { // Includes COPY_TO_CLIPBOARD
+                buffer.write(BYTE, TAG_STRING);
                 buffer.write(STRING_IO_UTF8, "value");
+                buffer.write(STRING_IO_UTF8, clickEvent.value());
             }
         }
-        buffer.write(STRING_IO_UTF8, clickEvent.value());
 
         buffer.write(BYTE, TAG_END);
     }

--- a/src/main/java/net/minestom/server/network/ComponentNetworkBufferTypeImpl.java
+++ b/src/main/java/net/minestom/server/network/ComponentNetworkBufferTypeImpl.java
@@ -259,7 +259,6 @@ record ComponentNetworkBufferTypeImpl() implements NetworkBufferTypeImpl<Compone
             buffer.write(BYTE, TAG_COMPOUND);
             buffer.write(STRING_IO_UTF8, "value");
             writeInnerComponent(buffer, (Component) hoverEvent.value());
-            buffer.write(BYTE, TAG_END);
         } else if (hoverEvent.action() == HoverEvent.Action.SHOW_ITEM) {
             var value = ((HoverEvent<HoverEvent.ShowItem>) hoverEvent).value();
 
@@ -303,7 +302,7 @@ record ComponentNetworkBufferTypeImpl() implements NetworkBufferTypeImpl<Compone
             }
 
             buffer.write(BYTE, TAG_STRING);
-            buffer.write(STRING_IO_UTF8, "type");
+            buffer.write(STRING_IO_UTF8, "id");
             buffer.write(STRING_IO_UTF8, value.type().asString());
 
             buffer.write(BYTE, TAG_STRING);


### PR DESCRIPTION
## Proposed changes

Updates the text component serialization and deserialization logic to match the new 1.21.5 format.

This PR is still a draft because I haven't tested most of the click/hover event types.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I used the Minecraft wiki as a reference:
- https://minecraft.wiki/w/Text_component_format#Java_Edition
- Changes from 1.21.4 to 1.21.5: https://minecraft.wiki/w/Java_Edition_1.21.5#General_4 (ctrl+f for "Text component format")