### PR TITLE
Use URI method instead of the deprecated URL method

### DIFF
--- a/src/main/java/net/minestom/server/utils/url/URLUtils.java
+++ b/src/main/java/net/minestom/server/utils/url/URLUtils.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 
 public final class URLUtils {
 
@@ -14,7 +14,7 @@ public final class URLUtils {
     }
 
     public static String getText(String url) throws IOException {
-        HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+        HttpURLConnection connection = (HttpURLConnection) URI.create(url).toURL().openConnection();
         //add headers to the connection, or check the status if desired..
 
         // handle error response code it occurs


### PR DESCRIPTION
## Proposed changes

Changed `new URL(url).openConnection()` to `URI.create(url).toURL().openConnection()` because `URL(java.lang.String)` is deprecated since Java version 20

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)