### PR TITLE
feat: add basic bed and sleep functionality

### DIFF
--- a/demo/src/main/java/net/minestom/demo/Main.java
+++ b/demo/src/main/java/net/minestom/demo/Main.java
@@ -6,6 +6,7 @@ import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.TextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.minestom.demo.block.TestBlockHandler;
+import net.minestom.demo.block.placement.BedPlacementRule;
 import net.minestom.demo.block.placement.DripstonePlacementRule;
 import net.minestom.demo.commands.*;
 import net.minestom.demo.recipe.ShapelessRecipe;
@@ -15,7 +16,9 @@ import net.minestom.server.component.DataComponents;
 import net.minestom.server.event.server.ServerListPingEvent;
 import net.minestom.server.extras.lan.OpenToLAN;
 import net.minestom.server.extras.lan.OpenToLANConfig;
+import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockManager;
+import net.minestom.server.instance.block.predicate.BlockTypeFilter;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
 import net.minestom.server.ping.ResponseData;
@@ -35,6 +38,8 @@ public class Main {
 
         BlockManager blockManager = MinecraftServer.getBlockManager();
         blockManager.registerBlockPlacementRule(new DripstonePlacementRule());
+        var beds = Block.values().stream().filter(block -> block.registry().blockEntityId() == 25).toList();
+        beds.forEach(block -> blockManager.registerBlockPlacementRule(new BedPlacementRule(block)));
         blockManager.registerHandler(TestBlockHandler.INSTANCE.getKey(), () -> TestBlockHandler.INSTANCE);
 
         CommandManager commandManager = MinecraftServer.getCommandManager();
@@ -77,6 +82,7 @@ public class Main {
         commandManager.register(new TestInstabreakCommand());
         commandManager.register(new AttributeCommand());
         commandManager.register(new PrimedTNTCommand());
+        commandManager.register(new SleepCommand());
 
         commandManager.setUnknownCommandCallback((sender, command) -> sender.sendMessage(Component.text("Unknown command", NamedTextColor.RED)));
 

--- a/demo/src/main/java/net/minestom/demo/PlayerInit.java
+++ b/demo/src/main/java/net/minestom/demo/PlayerInit.java
@@ -26,6 +26,7 @@ import net.minestom.server.instance.InstanceContainer;
 import net.minestom.server.instance.InstanceManager;
 import net.minestom.server.instance.LightingChunk;
 import net.minestom.server.instance.block.Block;
+import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.inventory.Inventory;
 import net.minestom.server.inventory.InventoryType;
 import net.minestom.server.inventory.PlayerInventory;
@@ -137,6 +138,7 @@ public class PlayerInit {
                 inventory.addItemStack(getFoodItem(20));
                 inventory.addItemStack(getFoodItem(10000));
                 inventory.addItemStack(getFoodItem(Integer.MAX_VALUE));
+                inventory.addItemStack(ItemStack.of(Material.PURPLE_BED));
 
                 if (event.isFirstSpawn()) {
                     event.getPlayer().sendNotification(new Notification(
@@ -156,6 +158,40 @@ public class PlayerInit {
             .addListener(PlayerPacketEvent.class, event -> {
 
                 //System.out.println("in " + event.getPacket().getClass().getSimpleName());
+            })
+            .addListener(PlayerBlockBreakEvent.class, event -> {
+                var instance = event.getInstance();
+                var block = event.getBlock();
+                var pos = event.getBlockPosition();
+                if (block.getProperty("part") == null || block.getProperty("facing") == null) return;
+                var isHead = "head".equals(block.getProperty("part"));
+                var facing = BlockFace.valueOf(block.getProperty("facing").toUpperCase());
+                var other = (isHead ? pos.add(facing.getOppositeFace().toDirection().vec().asPosition()) : pos.add(facing.toDirection().vec().asPosition()));
+                var otherBlock = instance.getBlock(other);
+                if (otherBlock.id() == block.id()) {
+                    instance.setBlock(other, Block.AIR);
+                }
+            })
+            .addListener(PlayerBlockInteractEvent.class, event -> {
+                var player = event.getPlayer();
+                var instance = event.getInstance();
+                var block = event.getBlock();
+                if (event.getBlock().key().asMinimalString().endsWith("_bed")) {
+                    var pos = event.getBlockPosition();
+                    if (block.getProperty("part") == null || block.getProperty("facing") == null) return;
+                    var isHead = "head".equals(block.getProperty("part"));
+                    var facing = BlockFace.valueOf(block.getProperty("facing").toUpperCase());
+                    var other = (isHead ? pos.add(facing.getOppositeFace().toDirection().vec().asPosition()) : pos.add(facing.toDirection().vec().asPosition()));
+                    var otherBlock = instance.getBlock(other);
+                    if (otherBlock.id() == block.id()) {
+                        player.setVelocity(Vec.ZERO);
+                        player.swingMainHand();
+                        player.getLivingEntityMeta().setBedInWhichSleepingPosition((isHead ? pos : other));
+                    }
+                }
+            })
+            .addListener(PlayerLeaveBedEvent.class, event -> {
+                event.setCancelled(ThreadLocalRandom.current().nextFloat() < 0.7f);
             })
             .addListener(PlayerUseItemOnBlockEvent.class, event -> {
                 if (event.getHand() != PlayerHand.MAIN) return;

--- a/demo/src/main/java/net/minestom/demo/PlayerInit.java
+++ b/demo/src/main/java/net/minestom/demo/PlayerInit.java
@@ -186,12 +186,20 @@ public class PlayerInit {
                     if (otherBlock.id() == block.id()) {
                         player.setVelocity(Vec.ZERO);
                         player.swingMainHand();
-                        player.getLivingEntityMeta().setBedInWhichSleepingPosition((isHead ? pos : other));
+                        player.enterBed((isHead ? pos : other));
                     }
                 }
             })
             .addListener(PlayerLeaveBedEvent.class, event -> {
-                event.setCancelled(ThreadLocalRandom.current().nextFloat() < 0.7f);
+                var player = event.getPlayer();
+                boolean snooze = ThreadLocalRandom.current().nextFloat() < 0.7f;
+                if (snooze) {
+                    event.setCancelled(true);
+                    player.playSound(Sound.sound(SoundEvent.ENTITY_ALLAY_ITEM_THROWN, Sound.Source.PLAYER, 1f, 0.6f));
+                    player.sendActionBar(Component.text("I'm too tired to stand up!"));
+                } else {
+                    player.sendActionBar(Component.empty());
+                }
             })
             .addListener(PlayerUseItemOnBlockEvent.class, event -> {
                 if (event.getHand() != PlayerHand.MAIN) return;

--- a/demo/src/main/java/net/minestom/demo/block/placement/BedPlacementRule.java
+++ b/demo/src/main/java/net/minestom/demo/block/placement/BedPlacementRule.java
@@ -1,0 +1,44 @@
+package net.minestom.demo.block.placement;
+
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.instance.block.Block;
+import net.minestom.server.instance.block.BlockFace;
+import net.minestom.server.instance.block.rule.BlockPlacementRule;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+/**
+ * https://gist.github.com/mworzala/0676c28343310458834d70ed29b11a37
+ */
+public class BedPlacementRule extends BlockPlacementRule {
+
+
+    private static final String PROP_PART = "part";
+    private static final String PROP_FACING = "facing";
+
+    public BedPlacementRule(@NotNull Block block) {
+        super(block);
+    }
+
+    @Override
+    public @Nullable Block blockPlace(@NotNull PlacementState placementState) {
+        var playerPosition = Objects.requireNonNullElse(placementState.playerPosition(), Pos.ZERO);
+        var facing = BlockFace.fromYaw(playerPosition.yaw());
+
+        //todo bad code using instance directly
+        if (!(placementState.instance() instanceof Instance instance)) return null;
+
+        var headPosition = placementState.placePosition().relative(facing);
+        if (!instance.getBlock(headPosition, Block.Getter.Condition.TYPE).isAir())
+            return null;
+
+        var headBlock = this.block.withProperty(PROP_PART, "head")
+                .withProperty(PROP_FACING, facing.name().toLowerCase());
+        instance.setBlock(headPosition, headBlock);
+
+        return headBlock.withProperty(PROP_PART, "foot");
+    }
+}

--- a/demo/src/main/java/net/minestom/demo/commands/SleepCommand.java
+++ b/demo/src/main/java/net/minestom/demo/commands/SleepCommand.java
@@ -1,0 +1,19 @@
+package net.minestom.demo.commands;
+
+import net.minestom.server.command.builder.Command;
+import net.minestom.server.command.builder.condition.Conditions;
+import net.minestom.server.entity.Player;
+
+public class SleepCommand extends Command {
+
+    public SleepCommand() {
+        super("sleep");
+
+        setCondition(Conditions::playerOnly);
+        setDefaultExecutor((sender, context) -> {
+            Player player = (Player) sender;
+            player.getLivingEntityMeta().setBedInWhichSleepingPosition(player.getPosition());
+        });
+
+    }
+}

--- a/demo/src/main/java/net/minestom/demo/commands/SleepCommand.java
+++ b/demo/src/main/java/net/minestom/demo/commands/SleepCommand.java
@@ -12,7 +12,7 @@ public class SleepCommand extends Command {
         setCondition(Conditions::playerOnly);
         setDefaultExecutor((sender, context) -> {
             Player player = (Player) sender;
-            player.getLivingEntityMeta().setBedInWhichSleepingPosition(player.getPosition());
+            player.enterBed(player.getPosition());
         });
 
     }

--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -607,6 +607,13 @@ public class LivingEntity extends Entity implements EquipmentHandler {
         }
     }
 
+    public void leaveBed() {
+        LivingEntityMeta meta = getLivingEntityMeta();
+        if (meta != null) {
+            meta.setBedInWhichSleepingPosition(null);
+        }
+    }
+
     public boolean isFlyingWithElytra() {
         return this.entityMeta.isFlyingWithElytra();
     }

--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -5,6 +5,7 @@ import net.kyori.adventure.sound.Sound.Source;
 import net.minestom.server.collision.BoundingBox;
 import net.minestom.server.component.DataComponents;
 import net.minestom.server.coordinate.Point;
+import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.attribute.Attribute;
 import net.minestom.server.entity.attribute.AttributeInstance;
@@ -607,10 +608,25 @@ public class LivingEntity extends Entity implements EquipmentHandler {
         }
     }
 
+    /**
+     * Kicks the entity out of the bed.
+     */
     public void leaveBed() {
         LivingEntityMeta meta = getLivingEntityMeta();
         if (meta != null) {
             meta.setBedInWhichSleepingPosition(null);
+        }
+    }
+
+    /**
+     * Sets the {@code point} of the bed in which the entity is sleeping in.
+     *
+     * @param point the position of the bed
+     */
+    public void enterBed(@NotNull Point point) {
+        LivingEntityMeta meta = getLivingEntityMeta();
+        if (meta != null) {
+            meta.setBedInWhichSleepingPosition(point);
         }
     }
 

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -821,7 +821,7 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
         var meta = getEntityMeta();
         if (meta.isFlyingWithElytra()) {
             newPose = EntityPose.FALL_FLYING;
-        } else if (false) { // When should they be sleeping? We don't have any in-bed state...
+        } else if (meta instanceof LivingEntityMeta livingMeta && livingMeta.getBedInWhichSleepingPosition() != null) {
             newPose = EntityPose.SLEEPING;
         } else if (meta.isSwimming()) {
             newPose = EntityPose.SWIMMING;
@@ -945,7 +945,7 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
     /**
      * Plays a given worldEvent at the given position for this player.
      *
-     * @param worldEvent                the worldEvent to play
+     * @param worldEvent            the worldEvent to play
      * @param x                     x position of the worldEvent
      * @param y                     y position of the worldEvent
      * @param z                     z position of the worldEvent
@@ -2322,6 +2322,16 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
     public void sendNotification(@NotNull Notification notification) {
         sendPacket(notification.buildAddPacket());
         sendPacket(notification.buildRemovePacket());
+    }
+
+    /**
+     * Sends a {@link EntityAnimationPacket} to clear remove the sleep darkness.
+     */
+    @Override
+    public void leaveBed() {
+        EntityAnimationPacket packet = new EntityAnimationPacket(getEntityId(), EntityAnimationPacket.Animation.LEAVE_BED);
+        sendPacket(packet);
+        super.leaveBed();
     }
 
     public enum FacePoint {

--- a/src/main/java/net/minestom/server/event/player/PlayerLeaveBedEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerLeaveBedEvent.java
@@ -1,0 +1,35 @@
+package net.minestom.server.event.player;
+
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.Player;
+import net.minestom.server.event.trait.CancellableEvent;
+import net.minestom.server.event.trait.PlayerInstanceEvent;
+import net.minestom.server.instance.block.Block;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class PlayerLeaveBedEvent implements CancellableEvent, PlayerInstanceEvent {
+
+    private final Player player;
+    private boolean cancelled = false;
+
+    public PlayerLeaveBedEvent(Player player) {
+        this.player = player;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public @NotNull Player getPlayer() {
+        return player;
+    }
+
+}

--- a/src/main/java/net/minestom/server/listener/EntityActionListener.java
+++ b/src/main/java/net/minestom/server/listener/EntityActionListener.java
@@ -14,6 +14,7 @@ public class EntityActionListener {
             case START_SPRINTING -> EntityActionListener.setSprinting(player, true);
             case STOP_SPRINTING -> EntityActionListener.setSprinting(player, false);
             case START_FLYING_ELYTRA -> EntityActionListener.startFlyingElytra(player);
+            case LEAVE_BED -> EntityActionListener.onLeaveBed(player);
 
             // TODO do remaining actions
         }
@@ -49,5 +50,13 @@ public class EntityActionListener {
     private static void startFlyingElytra(Player player) {
         player.setFlyingWithElytra(true);
         EventDispatcher.call(new PlayerStartFlyingWithElytraEvent(player));
+    }
+
+    private static void onLeaveBed(Player player) {
+        var event = new PlayerLeaveBedEvent(player);
+        EventDispatcher.callCancellable(event, () -> {
+            player.getLivingEntityMeta().setBedInWhichSleepingPosition(null);
+            player.leaveBed();
+        });
     }
 }


### PR DESCRIPTION
## Proposed changes

This PR introduces a basic implementation of bed interaction in Minestom. It allows players to interact with bed blocks and simulates entering the sleeping state. This lays the groundwork for future support of Minecraft’s sleep mechanics and potential multiplayer sleep synchronization.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
