### PR TITLE
Improved docs in TagReadable

### DIFF
--- a/src/main/java/net/minestom/server/tag/TagReadable.java
+++ b/src/main/java/net/minestom/server/tag/TagReadable.java
@@ -18,10 +18,10 @@ public interface TagReadable {
     <T> @UnknownNullability T getTag(@NotNull Tag<T> tag);
 
     /**
-     * Returns if a tag is present.
+     * Returns if a tag is present or has a default value, returning true in both cases.
      *
      * @param tag the tag to check
-     * @return true if the tag is present, false otherwise
+     * @return true if the tag is explicitly present or has a default value, false only if the tag is not present and has no default value
      */
     default boolean hasTag(@NotNull Tag<?> tag) {
         return getTag(tag) != null;


### PR DESCRIPTION
Edited the docs to tell that if a Tag has default value then TagReadable#hasTag will always return true even if the tag is not present on the item

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)