### PR TITLE
[BUG] Fix sending invalid merchant_offers packet to client

### DIFF
--- a/demo/src/main/java/net/minestom/demo/Main.java
+++ b/demo/src/main/java/net/minestom/demo/Main.java
@@ -78,6 +78,7 @@ public class Main {
         commandManager.register(new TestInstabreakCommand());
         commandManager.register(new AttributeCommand());
         commandManager.register(new PrimedTNTCommand());
+        commandManager.register(new VillagerTradeCommand());
 
         commandManager.setUnknownCommandCallback((sender, command) -> sender.sendMessage(Component.text("Unknown command", NamedTextColor.RED)));
 

--- a/demo/src/main/java/net/minestom/demo/commands/VillagerTradeCommand.java
+++ b/demo/src/main/java/net/minestom/demo/commands/VillagerTradeCommand.java
@@ -1,0 +1,34 @@
+package net.minestom.demo.commands;
+
+import net.minestom.server.command.CommandSender;
+import net.minestom.server.command.builder.Command;
+import net.minestom.server.command.builder.CommandContext;
+import net.minestom.server.command.builder.condition.Conditions;
+import net.minestom.server.entity.Player;
+import net.minestom.server.inventory.type.VillagerInventory;
+import net.minestom.server.item.ItemStack;
+import net.minestom.server.item.Material;
+import net.minestom.server.network.packet.server.play.TradeListPacket;
+
+public class VillagerTradeCommand extends Command {
+    public VillagerTradeCommand() {
+        super("villagertrade");
+        setCondition(Conditions::playerOnly);
+
+        setDefaultExecutor(this::handleVillagerTrade);
+    }
+
+    private void handleVillagerTrade(CommandSender source, CommandContext context) {
+        Player player = (Player) source;
+
+        player.sendMessage("Opening Villager Inventory");
+
+        VillagerInventory inventory = new VillagerInventory("Villager Inventory");
+        inventory.addTrade(new TradeListPacket.Trade(ItemStack.of(Material.DIRT), ItemStack.of(Material.DIAMOND),
+                ItemStack.AIR, false, 0, 1, 0, 0, 0, 0));
+        inventory.addTrade(new TradeListPacket.Trade(ItemStack.of(Material.HONEY_BOTTLE), ItemStack.of(Material.SNIFFER_EGG),
+                ItemStack.of(Material.MAGENTA_TERRACOTTA), true, 1, 5, 99, 0, 9.5f, 127));
+
+        player.openInventory(inventory);
+    }
+}

--- a/src/main/java/net/minestom/server/component/DataComponentMap.java
+++ b/src/main/java/net/minestom/server/component/DataComponentMap.java
@@ -52,6 +52,14 @@ public sealed interface DataComponentMap extends DataComponent.Holder permits Da
      * Creates a network type for the given component type. For internal use only, get the value from the target component class.
      */
     @ApiStatus.Internal
+    static @NotNull NetworkBuffer.Type<DataComponentMap> tradeNetworkType(@NotNull IntFunction<DataComponent<?>> idToType) {
+        return new DataComponentMapImpl.TradePatchNetworkType(idToType);
+    }
+
+    /**
+     * Creates a network type for the given component type. For internal use only, get the value from the target component class.
+     */
+    @ApiStatus.Internal
     static @NotNull BinaryTagSerializer<DataComponentMap> patchNbtType(
             @NotNull IntFunction<DataComponent<?>> idToType,
             @NotNull Function<String, DataComponent<?>> nameToType

--- a/src/main/java/net/minestom/server/item/ItemComponent.java
+++ b/src/main/java/net/minestom/server/item/ItemComponent.java
@@ -104,6 +104,7 @@ public final class ItemComponent {
 
     public static final NetworkBuffer.Type<DataComponentMap> PATCH_NETWORK_TYPE = DataComponentMap.patchNetworkType(ItemComponent::fromId);
     public static final BinaryTagSerializer<DataComponentMap> PATCH_NBT_TYPE = DataComponentMap.patchNbtType(ItemComponent::fromId, ItemComponent::fromKey);
+    public static final NetworkBuffer.Type<DataComponentMap> TRADE_NETWORK_TYPE = DataComponentMap.tradeNetworkType(ItemComponent::fromId);
 
     public static @Nullable DataComponent<?> fromKey(@NotNull String key) {
         return NAMESPACES.get(key);

--- a/src/main/java/net/minestom/server/item/ItemStack.java
+++ b/src/main/java/net/minestom/server/item/ItemStack.java
@@ -70,6 +70,24 @@ public sealed interface ItemStack extends TagReadable, DataComponent.Holder, Hov
         return itemStack;
     });
     @NotNull BinaryTagSerializer<ItemStack> NBT_TYPE = BinaryTagSerializer.COMPOUND.map(ItemStackImpl::fromCompound, ItemStackImpl::toCompound);
+    @NotNull NetworkBuffer.Type<ItemStack> TRADE_NETWORK_TYPE = new NetworkBuffer.Type<>() {
+        @Override
+        public void write(@NotNull NetworkBuffer buffer, ItemStack value) {
+            buffer.write(NetworkBuffer.VAR_INT, value.material().id());
+            buffer.write(NetworkBuffer.VAR_INT, value.amount());
+            buffer.write(ItemComponent.TRADE_NETWORK_TYPE, ((ItemStackImpl) value).components());
+        }
+
+        @Override
+        public ItemStack read(@NotNull NetworkBuffer buffer) {
+            Material material = Material.fromId(buffer.read(NetworkBuffer.VAR_INT));
+            int amount = buffer.read(NetworkBuffer.VAR_INT);
+            if (amount <= 0) return ItemStack.AIR;
+
+            DataComponentMap components = buffer.read(ItemComponent.TRADE_NETWORK_TYPE);
+            return ItemStackImpl.create(material, amount, components);
+        }
+    };
 
     /**
      * Constant AIR item. Should be used instead of 'null'.

--- a/src/main/java/net/minestom/server/network/packet/server/play/TradeListPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/TradeListPacket.java
@@ -33,9 +33,9 @@ public record TradeListPacket(int windowId, @NotNull List<Trade> trades,
                         int tradeUsesNumber, int maxTradeUsesNumber, int exp,
                         int specialPrice, float priceMultiplier, int demand) {
         public static final NetworkBuffer.Type<Trade> SERIALIZER = NetworkBufferTemplate.template(
-                ItemStack.NETWORK_TYPE, Trade::inputItem1,
+                ItemStack.TRADE_NETWORK_TYPE, Trade::inputItem1,
                 ItemStack.NETWORK_TYPE, Trade::result,
-                ItemStack.NETWORK_TYPE.optional(), Trade::inputItem2,
+                ItemStack.TRADE_NETWORK_TYPE.optional(), Trade::inputItem2,
                 BOOLEAN, Trade::tradeDisabled,
                 INT, Trade::tradeUsesNumber,
                 INT, Trade::maxTradeUsesNumber,

--- a/src/test/java/net/minestom/server/network/PacketWriteReadTest.java
+++ b/src/test/java/net/minestom/server/network/PacketWriteReadTest.java
@@ -106,6 +106,11 @@ public class PacketWriteReadTest {
                 RecipeBookCategory.CRAFTING_MISC, List.of(new Ingredient(Material.STONE)), true, true)), false));
         SERVER_PACKETS.add(new RecipeBookRemovePacket(List.of(1)));
 
+        SERVER_PACKETS.add(new TradeListPacket(0, List.of(
+                new TradeListPacket.Trade(ItemStack.of(Material.DIRT), ItemStack.of(Material.DIAMOND), ItemStack.AIR, false, 0, 1, 5, 2, 1.5f, 1),
+                new TradeListPacket.Trade(ItemStack.of(Material.HONEY_BOTTLE), ItemStack.of(Material.SNIFFER_EGG), ItemStack.of(Material.MAGENTA_TERRACOTTA), true, 1, 5, 99, 0, 9.5f, 127)
+        ), 5, 64, true, false));
+
         SERVER_PACKETS.add(new DestroyEntitiesPacket(List.of(5, 5, 5)));
         SERVER_PACKETS.add(new DisconnectPacket(COMPONENT));
         SERVER_PACKETS.add(new DisplayScoreboardPacket((byte) 5, "scoreboard"));


### PR DESCRIPTION
## Proposed changes

Fixes #2637, this bug involves Minestom sending payment items in the merchant_offers packet as [Slot](https://minecraft.wiki/w/Java_Edition_protocol/Slot_Data) instead of [TradeItem](https://minecraft.wiki/w/Java_Edition_protocol#Merchant_Offers) which is needed.

Added a new packet format for ItemStacks and ItemComponent data which serialises the data into a TradeItem.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
