### PR TITLE
Fix shift-click armor equipping

### DIFF
--- a/src/main/java/net/minestom/server/registry/Registry.java
+++ b/src/main/java/net/minestom/server/registry/Registry.java
@@ -24,6 +24,7 @@ import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockSoundType;
 import net.minestom.server.item.ItemComponent;
 import net.minestom.server.item.Material;
+import net.minestom.server.item.component.Equippable;
 import net.minestom.server.message.ChatTypeDecoration;
 import net.minestom.server.sound.SoundEvent;
 import net.minestom.server.utils.collection.ObjectArray;
@@ -590,7 +591,6 @@ public final class Registry {
         private final Supplier<Block> blockSupplier;
         private DataComponentMap prototype;
 
-        private final EquipmentSlot equipmentSlot;
         private final EntityType entityType;
         private final Properties custom;
 
@@ -603,20 +603,6 @@ public final class Registry {
             {
                 final String blockNamespace = main.getString("correspondingBlock", null);
                 this.blockSupplier = blockNamespace != null ? () -> Block.fromKey(blockNamespace) : () -> null;
-            }
-            {
-                final Properties armorProperties = main.section("armorProperties");
-                if (armorProperties != null) {
-                    switch (armorProperties.getString("slot")) {
-                        case "feet" -> this.equipmentSlot = EquipmentSlot.BOOTS;
-                        case "legs" -> this.equipmentSlot = EquipmentSlot.LEGGINGS;
-                        case "chest" -> this.equipmentSlot = EquipmentSlot.CHESTPLATE;
-                        case "head" -> this.equipmentSlot = EquipmentSlot.HELMET;
-                        default -> this.equipmentSlot = null;
-                    }
-                } else {
-                    this.equipmentSlot = null;
-                }
             }
             {
                 final Properties spawnEggProperties = main.section("spawnEggProperties");
@@ -667,11 +653,12 @@ public final class Registry {
         }
 
         public boolean isArmor() {
-            return equipmentSlot != null;
+            return prototype.has(ItemComponent.EQUIPPABLE);
         }
 
         public @Nullable EquipmentSlot equipmentSlot() {
-            return equipmentSlot;
+            final Equippable equippableComponent = prototype.get(ItemComponent.EQUIPPABLE);
+            return equippableComponent == null ? null : equippableComponent.slot();
         }
 
         /**


### PR DESCRIPTION
## Proposed changes

You could not shift-click armor into your armor slot because the EquipmentSlot of armor wasn't properly being read in the registry since it used the old armorProperties instead of the new DataComponents. This means items didnt have any correct EquipmentSlot information.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...