### PR TITLE
Implement EventHandler in AbstractInventory adding convenient eventNode method.

### DIFF
--- a/demo/src/main/java/net/minestom/demo/Main.java
+++ b/demo/src/main/java/net/minestom/demo/Main.java
@@ -76,6 +76,7 @@ public class Main {
         commandManager.register(new CookieCommand());
         commandManager.register(new WorldBorderCommand());
         commandManager.register(new TestInstabreakCommand());
+        commandManager.register(new TestInventoryCommand());
         commandManager.register(new AttributeCommand());
         commandManager.register(new PrimedTNTCommand());
 

--- a/demo/src/main/java/net/minestom/demo/commands/TestInventoryCommand.java
+++ b/demo/src/main/java/net/minestom/demo/commands/TestInventoryCommand.java
@@ -1,0 +1,46 @@
+package net.minestom.demo.commands;
+
+import net.minestom.server.command.builder.Command;
+import net.minestom.server.entity.Player;
+import net.minestom.server.event.inventory.InventoryPreClickEvent;
+import net.minestom.server.inventory.Inventory;
+import net.minestom.server.inventory.InventoryType;
+import net.minestom.server.item.ItemStack;
+import net.minestom.server.item.Material;
+
+public class TestInventoryCommand extends Command {
+
+    private static final ItemStack UNSELECTED_SLOT = ItemStack.of(Material.GRAY_CONCRETE);
+    private static final ItemStack SELECTED_SLOT = ItemStack.of(Material.GREEN_CONCRETE);
+
+    private final Inventory testInventory;
+    private int selectedSlot = 4;
+
+    public TestInventoryCommand() {
+        super("testinventory");
+
+        testInventory = new Inventory(InventoryType.CHEST_1_ROW, "Test Inventory");
+
+        for (int i = 0; i < testInventory.getSize(); i++) {
+            testInventory.setItemStack(i, UNSELECTED_SLOT);
+        }
+        testInventory.setItemStack(selectedSlot, SELECTED_SLOT);
+
+        testInventory.eventNode().addListener(InventoryPreClickEvent.class, event -> {
+            int newSlot = event.getSlot();
+            testInventory.setItemStack(selectedSlot, UNSELECTED_SLOT);
+            testInventory.setItemStack(newSlot, SELECTED_SLOT);
+            selectedSlot = newSlot;
+            event.setCancelled(true);
+        });
+
+        setDefaultExecutor((sender, context) -> {
+            if (sender instanceof Player player) {
+                player.openInventory(testInventory);
+            } else {
+                sender.sendMessage("Only players can execute this command");
+            }
+        });
+    }
+
+}

--- a/src/main/java/net/minestom/server/inventory/AbstractInventory.java
+++ b/src/main/java/net/minestom/server/inventory/AbstractInventory.java
@@ -1,9 +1,15 @@
 package net.minestom.server.inventory;
 
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.ServerProcess;
 import net.minestom.server.Viewable;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.EventDispatcher;
+import net.minestom.server.event.EventFilter;
+import net.minestom.server.event.EventHandler;
+import net.minestom.server.event.EventNode;
 import net.minestom.server.event.inventory.InventoryItemChangeEvent;
+import net.minestom.server.event.trait.InventoryEvent;
 import net.minestom.server.inventory.click.InventoryClickProcessor;
 import net.minestom.server.inventory.condition.InventoryCondition;
 import net.minestom.server.item.ItemStack;
@@ -26,8 +32,8 @@ import java.util.function.UnaryOperator;
 /**
  * Represents an inventory where items can be modified/retrieved.
  */
-public sealed abstract class AbstractInventory implements InventoryClickHandler, Taggable, Viewable
-        permits Inventory, PlayerInventory {
+public sealed abstract class AbstractInventory implements InventoryClickHandler, Taggable, Viewable,
+        EventHandler<InventoryEvent> permits Inventory, PlayerInventory {
 
     private static final VarHandle ITEM_UPDATER = MethodHandles.arrayElementVarHandle(ItemStack[].class);
 
@@ -40,6 +46,7 @@ public sealed abstract class AbstractInventory implements InventoryClickHandler,
     protected final InventoryClickProcessor clickProcessor = new InventoryClickProcessor();
 
     private final TagHandler tagHandler = TagHandler.newHandler();
+    private final EventNode<InventoryEvent> eventNode;
 
     // the players currently viewing this inventory
     protected final Set<Player> viewers = new CopyOnWriteArraySet<>();
@@ -49,6 +56,13 @@ public sealed abstract class AbstractInventory implements InventoryClickHandler,
         this.size = size;
         this.itemStacks = new ItemStack[getSize()];
         Arrays.fill(itemStacks, ItemStack.AIR);
+
+        final ServerProcess process = MinecraftServer.process();
+        if (process != null) {
+            this.eventNode = process.eventHandler().map(this, EventFilter.INVENTORY);
+        } else {
+            this.eventNode = null;
+        }
     }
 
     /**
@@ -310,5 +324,10 @@ public sealed abstract class AbstractInventory implements InventoryClickHandler,
     @Override
     public @NotNull TagHandler tagHandler() {
         return tagHandler;
+    }
+
+    @Override
+    public @NotNull EventNode<InventoryEvent> eventNode() {
+        return eventNode;
     }
 }


### PR DESCRIPTION
## Proposed changes

Have AbstractInventory implement EventHandler like how Instance and Entity do. Adds convenient method `eventNode` for getting an event node that filters to only handle events pertaining to itself.

Example usage:

```java
inventory.eventNode().addListener(InventoryPreClickEvent.class, event -> {
    event.setCancelled(true);
});
```

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
