### PR TITLE
Update/Fix Gradle workflows

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -10,15 +10,16 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v3
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
           distribution: temurin
+          cache: gradle
           java-version: 21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Cache Gradle packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -14,16 +14,13 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          cache: gradle
           java-version: 21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-      - name: Cache Gradle packages
-        uses: actions/cache@v4
         with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
+          # Allow caching for all branches in our repo;
+          # this is so we don't get evicted, see Cache Optimization in action docs for more info
+          cache-read-only: ${{ github.repository_owner != 'Minestom' }}
       - name: Build on ${{ matrix.os }}
         run: ./gradlew test
   publish:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,16 +15,9 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          cache: gradle
           java-version: 21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-      - name: Cache Gradle packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
       - id: vars
         run: echo "short_commit_hash=${GITHUB_SHA::10}" >> $GITHUB_OUTPUT
       - name: Publish to Central via Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,16 +11,16 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v3
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           cache: gradle
           java-version: 21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Cache Gradle packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -15,8 +15,9 @@ jobs:
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4
         with:
+          distribution: temurin
+          cache: gradle
           java-version: ${{ env.JAVA_VERSION }}
-          distribution: 'zulu'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Build javadoc

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -16,7 +16,6 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          cache: gradle
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4


### PR DESCRIPTION
## Proposed changes

Currently, Minestom uses the `gradle/wrapper-validation-action@v3` action that has been deprecated, and [buggy](https://github.com/Minestom/Minestom/actions/runs/14998335627/job/42138209693); This has been superseded by `gradle/actions/setup-gradle@v4`, which does this automatically in v4. This action also takes care of caching, and we can remove duplicate caching found in the cache@v3 and the setup java action as they are not [recommended to use](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#incompatibility-with-other-caching-mechanisms).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
We are currently double caching with the gradle flag set in the setup java action