### PR TITLE
Fix potential NullPointerException in light calculation

### DIFF
--- a/src/main/java/net/minestom/server/instance/LightingChunk.java
+++ b/src/main/java/net/minestom/server/instance/LightingChunk.java
@@ -1,6 +1,7 @@
 package net.minestom.server.instance;
 
 import net.kyori.adventure.key.Key;
+import net.minestom.server.MinecraftServer;
 import net.minestom.server.ServerFlag;
 import net.minestom.server.collision.Shape;
 import net.minestom.server.coordinate.CoordConversion;
@@ -387,20 +388,24 @@ public class LightingChunk extends DynamicChunk {
 
             final Palette blockPalette = section.blockPalette();
             CompletableFuture<Void> task = CompletableFuture.runAsync(() -> {
-                final Set<Point> toAdd = switch (queueType) {
-                    case INTERNAL -> light.calculateInternal(blockPalette,
-                            chunk.getChunkX(), point.blockY(), chunk.getChunkZ(),
-                            lightingChunk.getOcclusionMap(), chunk.instance.getCachedDimensionType().maxY(),
-                            lightLookup);
-                    case EXTERNAL -> light.calculateExternal(blockPalette,
-                            Light.getNeighbors(chunk, point.blockY()),
-                            lightLookup, paletteLookup);
-                };
+                try {
+                    final Set<Point> toAdd = switch (queueType) {
+                        case INTERNAL -> light.calculateInternal(blockPalette,
+                                chunk.getChunkX(), point.blockY(), chunk.getChunkZ(),
+                                lightingChunk.getOcclusionMap(), chunk.instance.getCachedDimensionType().maxY(),
+                                lightLookup);
+                        case EXTERNAL -> light.calculateExternal(blockPalette,
+                                Light.getNeighbors(chunk, point.blockY()),
+                                lightLookup, paletteLookup);
+                    };
 
-                sections.add(light);
+                    sections.add(light);
 
-                light.flip();
-                newQueue.addAll(toAdd);
+                    light.flip();
+                    newQueue.addAll(toAdd);
+                } catch (Exception e) {
+                    MinecraftServer.getExceptionManager().handleException(e);
+                }
             }, pool);
 
             tasks.add(task);

--- a/src/main/java/net/minestom/server/instance/light/BlockLight.java
+++ b/src/main/java/net/minestom/server/instance/light/BlockLight.java
@@ -57,7 +57,10 @@ final class BlockLight implements Light {
             if (neighborSection == null) continue;
 
             Palette otherPalette = paletteLookup.palette(neighborSection.blockX(), neighborSection.blockY(), neighborSection.blockZ());
+            if (otherPalette == null) continue;
+
             Light otherLight = lightLookup.light(neighborSection.blockX(), neighborSection.blockY(), neighborSection.blockZ());
+            if (otherLight == null) continue;
 
             for (int bx = 0; bx < 16; bx++) {
                 for (int by = 0; by < 16; by++) {

--- a/src/main/java/net/minestom/server/instance/light/Light.java
+++ b/src/main/java/net/minestom/server/instance/light/Light.java
@@ -7,6 +7,7 @@ import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.instance.palette.Palette;
 import net.minestom.server.utils.Direction;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Set;
 
@@ -70,11 +71,11 @@ public interface Light {
 
     @FunctionalInterface
     interface LightLookup {
-        Light light(int x, int y, int z);
+        @Nullable Light light(int x, int y, int z);
     }
 
     @FunctionalInterface
     interface PaletteLookup {
-        Palette palette(int x, int y, int z);
+        @Nullable Palette palette(int x, int y, int z);
     }
 }

--- a/src/main/java/net/minestom/server/instance/light/SkyLight.java
+++ b/src/main/java/net/minestom/server/instance/light/SkyLight.java
@@ -59,7 +59,10 @@ final class SkyLight implements Light {
             if (neighborSection == null) continue;
 
             Palette otherPalette = paletteLookup.palette(neighborSection.blockX(), neighborSection.blockY(), neighborSection.blockZ());
+            if (otherPalette == null) continue;
+
             Light otherLight = lightLookup.light(neighborSection.blockX(), neighborSection.blockY(), neighborSection.blockZ());
+            if (otherLight == null) continue;
 
             for (int bx = 0; bx < 16; bx++) {
                 for (int by = 0; by < 16; by++) {


### PR DESCRIPTION
## Proposed changes

I was running into an issue when using `LightingChunk`s with a world generator where the player would get timed out when joining the server. This stack trace was printed in the console:
```
java.util.concurrent.CompletionException: java.lang.NullPointerException: Cannot invoke "net.minestom.server.instance.light.Light.getLevel(int, int, int)" because "otherLight" is null
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.exec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
Caused by: java.lang.NullPointerException: Cannot invoke "net.minestom.server.instance.light.Light.getLevel(int, int, int)" because "otherLight" is null
	at net.minestom.server.instance.light.BlockLight.buildExternalQueue(BlockLight.java:72)
	at net.minestom.server.instance.light.BlockLight.calculateExternal(BlockLight.java:198)
	at net.minestom.server.instance.LightingChunk.lambda$flushQueue$2(LightingChunk.java:395)
	... 7 more
```

`otherLight` can be null because the result of `Light.LightLookup#light` can be null:
https://github.com/Minestom/Minestom/blob/d1634fb586dcc0baddb1acef25fc4c945a0b57fc/src/main/java/net/minestom/server/instance/LightingChunk.java#L358-L360
and the same applies for `Light.PaletteLookup#palette`:
https://github.com/Minestom/Minestom/blob/d1634fb586dcc0baddb1acef25fc4c945a0b57fc/src/main/java/net/minestom/server/instance/LightingChunk.java#L370-L372

This PR adds null checks, marks the methods' return types as `@Nullable`, and surrounds the async Runnable in `flushQueue` with a try-catch block to make future errors a bit easier to diagnose.

Related issues:
- Fixes #2513
- Fixes #2380

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)