### PR TITLE
fix: Add checksum to ClientSignedCommandChatPacket

### DIFF
--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientSignedCommandChatPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientSignedCommandChatPacket.java
@@ -8,18 +8,19 @@ import net.minestom.server.network.packet.client.ClientPacket;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.NotNull;
 
-import static net.minestom.server.network.NetworkBuffer.LONG;
-import static net.minestom.server.network.NetworkBuffer.STRING;
+import static net.minestom.server.network.NetworkBuffer.*;
 
 public record ClientSignedCommandChatPacket(@NotNull String message, long timestamp,
                                             long salt, @NotNull ArgumentSignatures signatures,
-                                            LastSeenMessages.@NotNull Update lastSeenMessages) implements ClientPacket {
+                                            LastSeenMessages.@NotNull Update lastSeenMessages,
+                                            byte checksum) implements ClientPacket {
     public static final NetworkBuffer.Type<ClientSignedCommandChatPacket> SERIALIZER = NetworkBufferTemplate.template(
             STRING, ClientSignedCommandChatPacket::message,
             LONG, ClientSignedCommandChatPacket::timestamp,
             LONG, ClientSignedCommandChatPacket::salt,
             ArgumentSignatures.SERIALIZER, ClientSignedCommandChatPacket::signatures,
             LastSeenMessages.Update.SERIALIZER, ClientSignedCommandChatPacket::lastSeenMessages,
+            BYTE, ClientSignedCommandChatPacket::checksum,
             ClientSignedCommandChatPacket::new
     );
 


### PR DESCRIPTION
## Proposed changes

This is just, post accidental deletion #2746

Add the checksum byte to ClientSignedCommandChatPacket.
Preventing the following warning when sending commands: WARNING: Packet (ClientSignedCommandChatPacket) 0x6 not fully read (NetworkBuffer{r32|w33->16383, registries=true, autoResize=true, readOnly=false})

This was specifically an issue when connecting through a proxy (more specifically, Gate)
I've not written any tests, but I have confirmed the fix works, and doesn't (*seem to*) cause problems when not connecting through the proxy.

Fixes: #2745

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...