### PR TITLE
fix tag path

### DIFF
--- a/src/main/java/net/minestom/server/item/component/CustomData.java
+++ b/src/main/java/net/minestom/server/item/component/CustomData.java
@@ -4,6 +4,7 @@ import net.kyori.adventure.nbt.CompoundBinaryTag;
 import net.minestom.server.codec.Codec;
 import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.tag.Tag;
+import net.minestom.server.tag.TagHandler;
 import net.minestom.server.tag.TagReadable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.UnknownNullability;
@@ -25,16 +26,16 @@ public record CustomData(@NotNull CompoundBinaryTag nbt) implements TagReadable 
 
     public static final Codec<CustomData> CODEC = Codec.NBT_COMPOUND
             .transform(CustomData::new, CustomData::nbt);
-    
+
     @Override
     public <T> @UnknownNullability T getTag(@NotNull Tag<T> tag) {
-        return tag.read(nbt);
+        final TagHandler tagHandler = TagHandler.fromCompound(nbt);
+        return tagHandler.getTag(tag);
     }
 
     public <T> @NotNull CustomData withTag(@NotNull Tag<T> tag, T value) {
-        CompoundBinaryTag.Builder builder = CompoundBinaryTag.builder();
-        builder.put(nbt);
-        tag.write(builder, value);
-        return new CustomData(builder.build());
+        TagHandler tagHandler = TagHandler.fromCompound(nbt);
+        tagHandler.setTag(tag, value);
+        return new CustomData(tagHandler.asCompound());
     }
 }

--- a/src/test/java/net/minestom/server/item/component/CustomDataTest.java
+++ b/src/test/java/net/minestom/server/item/component/CustomDataTest.java
@@ -1,14 +1,20 @@
 package net.minestom.server.item.component;
 
 import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.kyori.adventure.nbt.TagStringIOExt;
 import net.minestom.server.component.DataComponent;
 import net.minestom.server.component.DataComponents;
+import net.minestom.server.item.ItemStack;
+import net.minestom.server.item.Material;
+import net.minestom.server.tag.Tag;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
 
 import static java.util.Map.entry;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CustomDataTest extends AbstractItemComponentTest<CustomData> {
     // This is not a test, but it creates a compile error if the component type is changed away,
@@ -35,5 +41,14 @@ public class CustomDataTest extends AbstractItemComponentTest<CustomData> {
                                 .build())
                         .build()))
         );
+    }
+
+    @Test
+    void customDataTagPath() {
+        final ItemStack item = ItemStack.builder(Material.STICK)
+                .set(Tag.Integer("num").path("test"), 5)
+                .build();
+        final String snbt = TagStringIOExt.writeTag(item.get(DataComponents.CUSTOM_DATA).nbt());
+        assertEquals("{test:{num:5}}", snbt, "CustomData serialization should match expected SNBT format");
     }
 }

--- a/src/test/java/net/minestom/server/item/component/CustomDataTest.java
+++ b/src/test/java/net/minestom/server/item/component/CustomDataTest.java
@@ -49,6 +49,6 @@ public class CustomDataTest extends AbstractItemComponentTest<CustomData> {
                 .set(Tag.Integer("num").path("test"), 5)
                 .build();
         final String snbt = TagStringIOExt.writeTag(item.get(DataComponents.CUSTOM_DATA).nbt());
-        assertEquals("{test:{num:5}}", snbt, "CustomData serialization should match expected SNBT format");
+        assertEquals("{test:{num:5}}", snbt);
     }
 }


### PR DESCRIPTION
Fix `Tag#path` on items
```java
ItemStack item = ItemStack.builder(Material.STICK)
        .set(Tag.Integer("num").path("test"), 5)
        .build();
System.out.println(TagStringIOExt.writeTag(item.get(DataComponents.CUSTOM_DATA).nbt()));
```

I alternatively thought about adding an `WeakReference<TagHandler>` field or simply replacing the binary tag by an handler, but for now at least fixing the issue and adding a test.