### PR TITLE
ItemStack#damage(int)

### DIFF
--- a/src/main/java/net/minestom/server/item/ItemStack.java
+++ b/src/main/java/net/minestom/server/item/ItemStack.java
@@ -248,6 +248,9 @@ public sealed interface ItemStack extends TagReadable, DataComponent.Holder, Hov
     @Contract(value = "_, -> new", pure = true)
     @NotNull ItemStack consume(int amount);
 
+    @Contract(value = "_, -> new", pure = true)
+    @NotNull ItemStack damage(int amount);
+
     @Contract(pure = true)
     default boolean isAir() {
         return material() == Material.AIR;

--- a/src/main/java/net/minestom/server/item/ItemStackImpl.java
+++ b/src/main/java/net/minestom/server/item/ItemStackImpl.java
@@ -125,6 +125,18 @@ record ItemStackImpl(Material material, int amount, DataComponentMap components)
     }
 
     @Override
+    public @NotNull ItemStack damage(int amount) {
+        final Integer damage = get(DataComponents.DAMAGE);
+        if (damage == null) return this;
+        final Integer maxDamage = get(DataComponents.MAX_DAMAGE);
+        if (maxDamage != null && damage + amount >= maxDamage) {
+            return ItemStack.AIR;
+        } else {
+            return with(DataComponents.DAMAGE, damage + amount);
+        }
+    }
+
+    @Override
     public boolean isSimilar(@NotNull ItemStack itemStack) {
         return material == itemStack.material() && components.equals(((ItemStackImpl) itemStack).components);
     }


### PR DESCRIPTION
Boilerplate to simplify item damage management.

Didn't include `withDamage`/`damage` similarly to `amount` as it would have to be nullable