### PR TITLE
Remove jitpack from readme

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -37,7 +37,6 @@ and can be installed like the following (Gradle/Groovy):
 ```groovy
 repositories {
     mavenCentral()
-    maven { url 'https://jitpack.io' }
 }
 
 dependencies {


### PR DESCRIPTION
## Proposed changes

https://canary.discord.com/channels/706185253441634317/706186227493109860/1384649187429322894

cosmic said minestom doesn't need jitpack, so I removed it from the readme.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

just a small fix