### PR TITLE
Fix empty cursor drops not being handled

### DIFF
--- a/src/main/java/net/minestom/server/inventory/click/ClickPreprocessor.java
+++ b/src/main/java/net/minestom/server/inventory/click/ClickPreprocessor.java
@@ -75,7 +75,7 @@ public final class ClickPreprocessor {
      */
     private @Nullable Click processInvalidSlot(@NotNull ClientClickWindowPacket.ClickType type, byte button) {
         return switch (type) {
-            case PICKUP -> {
+            case PICKUP, THROW -> {
                 if (button == 0) yield new Click.LeftDropCursor();
                 if (button == 1) yield new Click.RightDropCursor();
                 yield null;

--- a/src/test/java/net/minestom/server/inventory/click/ClickPreprocessorTest.java
+++ b/src/test/java/net/minestom/server/inventory/click/ClickPreprocessorTest.java
@@ -60,6 +60,9 @@ public class ClickPreprocessorTest {
 
     @Test
     public void testThrowType() {
+        assertProcessed(new Click.LeftDropCursor(), clickPacket(THROW, 1, 0, -999));
+        assertProcessed(new Click.RightDropCursor(), clickPacket(THROW, 1, 1, -999));
+
         assertProcessed(new Click.DropSlot(0, true), clickPacket(THROW, 1, 1, 0));
 
         assertProcessed(new Click.DropSlot(0, false), clickPacket(THROW, 1, 0, 0));


### PR DESCRIPTION
## Proposed changes

In their infinite wisdom, Mojang made empty cursor drops (clicks on the outside of the window) use click type THROW instead of PICKUP. For some reason I caught a bunch of other obscure cases when writing the original code, but not this one.

Thanks to Blu on Discord for pointing this out.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...