### PR TITLE
Only use default value for optional struct codecs when key is not present

### DIFF
--- a/src/main/java/net/minestom/server/codec/StructCodec.java
+++ b/src/main/java/net/minestom/server/codec/StructCodec.java
@@ -1639,8 +1639,13 @@ public interface StructCodec<R> extends Codec<R> {
 
             return decodeResult.mapError(e -> key + ": " + e);
         }
-        if (codec instanceof CodecImpl.OptionalImpl<T> optional && !map.hasValue(key))
-            return new Result.Ok<>(optional.defaultValue());
+        if (codec instanceof CodecImpl.OptionalImpl<T>(Codec<T> inner, T defaultValue)) {
+            return switch (map.getValue(key)) {
+                case Result.Ok(D innerValue) -> inner.decode(coder, innerValue)
+                        .mapError(e -> key + ": " + e);
+                case Result.Error(String ignored) -> new Result.Ok<>(defaultValue);
+            };
+        }
         return map.getValue(key)
                 .map(innerValue -> codec.decode(coder, innerValue))
                 .mapError(e -> key + ": " + e);

--- a/src/main/java/net/minestom/server/item/enchant/EntityEffect.java
+++ b/src/main/java/net/minestom/server/item/enchant/EntityEffect.java
@@ -163,7 +163,7 @@ public non-sealed interface EntityEffect extends Enchantment.Effect {
             @NotNull Codec.RawValue pitch
     ) implements EntityEffect, LocationEffect {
         public static final StructCodec<PlaySound> CODEC = StructCodec.struct(
-                "sound_event", SoundEvent.CODEC, PlaySound::soundEvent,
+                "sound", SoundEvent.CODEC, PlaySound::soundEvent,
                 "volume", Codec.RAW_VALUE, PlaySound::volume,
                 "pitch", Codec.RAW_VALUE, PlaySound::pitch,
                 PlaySound::new);
@@ -274,7 +274,7 @@ public non-sealed interface EntityEffect extends Enchantment.Effect {
             boolean joinTeam
     ) implements EntityEffect, LocationEffect {
         public static final StructCodec<SummonEntity> CODEC = StructCodec.struct(
-                "entity_types", Codec.RAW_VALUE, SummonEntity::entityTypes,
+                "entity", Codec.RAW_VALUE, SummonEntity::entityTypes,
                 "join_team", Codec.BOOLEAN.optional(false), SummonEntity::joinTeam,
                 SummonEntity::new);
 

--- a/src/test/java/net/minestom/server/codec/StructCodecTest.java
+++ b/src/test/java/net/minestom/server/codec/StructCodecTest.java
@@ -7,8 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import static net.minestom.server.codec.CodecAssertions.assertError;
 import static net.minestom.server.codec.CodecAssertions.assertOk;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class StructCodecTest {
 
@@ -68,6 +67,19 @@ public class StructCodecTest {
                 TheObject::new);
         var result = codec.decode(TranscoderNbtImpl.INSTANCE, snbt("{}"));
         assertEquals(new TheObject("defaultValue"), assertOk(result));
+    }
+
+    @Test
+    void singleFieldOptionalIncorrectTypeButNotMissing() {
+        record TheObject(String name) {
+        }
+
+        var codec = StructCodec.struct(
+                "name", Codec.STRING.optional(), TheObject::name,
+                TheObject::new
+        );
+        var result = codec.decode(TranscoderNbtImpl.INSTANCE, snbt("{\"name\": 2}"));
+        assertError("name: Not a string: BinaryTagType[IntBinaryTag 3 (numeric)]{value=2}", result);
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

Struct codecs entirely hide decoding failures that occur with optionals, when in reality a much saner default is to only skip the inner codec when there is no value present at all under the given key. This implements that change, which also happened to have the side effect of uncovering a few issues in existing codecs (due to errors no longer being hidden).

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...