### PR TITLE
Fix: Correct return type of PlayerChangeHeldSlotEvent#getOldSlot()

### DIFF
--- a/src/main/java/net/minestom/server/event/player/PlayerChangeHeldSlotEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerChangeHeldSlotEvent.java
@@ -40,7 +40,7 @@ public class PlayerChangeHeldSlotEvent implements PlayerInstanceEvent, Cancellab
      *
      * @return The slot index that the player currently is holding
      */
-    public int getOldSlot() {
+    public byte getOldSlot() {
         return oldSlot;
     }
 


### PR DESCRIPTION
Changed the return type of PlayerChangeHeldSlotEvent#getOldSlot() from int to byte for consistency