### PR TITLE
Add effects and deathMessageType to DamageType

### DIFF
--- a/src/main/java/net/minestom/server/entity/damage/DamageType.java
+++ b/src/main/java/net/minestom/server/entity/damage/DamageType.java
@@ -9,22 +9,27 @@ import net.minestom.server.registry.RegistryData;
 import net.minestom.server.registry.RegistryKey;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public sealed interface DamageType extends DamageTypes permits DamageTypeImpl {
     @NotNull Codec<DamageType> REGISTRY_CODEC = StructCodec.struct(
-            "exhaustion", Codec.FLOAT, DamageType::exhaustion,
             "message_id", Codec.STRING, DamageType::messageId,
             "scaling", Codec.STRING, DamageType::scaling,
+            "exhaustion", Codec.FLOAT, DamageType::exhaustion,
+            "effects", Codec.STRING.optional("hurt"), DamageType::effects,
+            "death_message_type", Codec.STRING.optional("default"), DamageType::deathMessageType,
             DamageType::create);
 
     @NotNull Codec<RegistryKey<DamageType>> CODEC = RegistryKey.codec(Registries::damageType);
 
     static @NotNull DamageType create(
-            float exhaustion,
             @NotNull String messageId,
-            @NotNull String scaling
+            @NotNull String scaling,
+            float exhaustion,
+            @Nullable String effects,
+            @Nullable String deathMessageType
     ) {
-        return new DamageTypeImpl(exhaustion, messageId, scaling);
+        return new DamageTypeImpl(messageId, scaling, exhaustion, effects, deathMessageType);
     }
 
     static @NotNull Builder builder() {
@@ -41,23 +46,24 @@ public sealed interface DamageType extends DamageTypes permits DamageTypeImpl {
         return DynamicRegistry.create(Key.key("minecraft:damage_type"), REGISTRY_CODEC, RegistryData.Resource.DAMAGE_TYPES);
     }
 
-    float exhaustion();
-
     @NotNull String messageId();
 
     @NotNull String scaling();
 
+    float exhaustion();
+
+    @Nullable String effects();
+
+    @Nullable String deathMessageType();
+
     final class Builder {
-        private float exhaustion = 0f;
         private String messageId;
         private String scaling;
+        private float exhaustion = 0f;
+        private String effects;
+        private String deathMessageType;
 
         private Builder() {
-        }
-
-        public @NotNull Builder exhaustion(float exhaustion) {
-            this.exhaustion = exhaustion;
-            return this;
         }
 
         public @NotNull Builder messageId(@NotNull String messageId) {
@@ -70,8 +76,23 @@ public sealed interface DamageType extends DamageTypes permits DamageTypeImpl {
             return this;
         }
 
+        public @NotNull Builder exhaustion(float exhaustion) {
+            this.exhaustion = exhaustion;
+            return this;
+        }
+
+        public @NotNull Builder effects(@Nullable String effects) {
+            this.effects = effects;
+            return this;
+        }
+
+        public @NotNull Builder deathMessageType(@Nullable String deathMessageType) {
+            this.deathMessageType = deathMessageType;
+            return this;
+        }
+
         public @NotNull DamageType build() {
-            return new DamageTypeImpl(exhaustion, messageId, scaling);
+            return new DamageTypeImpl(messageId, scaling, exhaustion, effects, deathMessageType);
         }
     }
 

--- a/src/main/java/net/minestom/server/entity/damage/DamageTypeImpl.java
+++ b/src/main/java/net/minestom/server/entity/damage/DamageTypeImpl.java
@@ -2,11 +2,14 @@ package net.minestom.server.entity.damage;
 
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 record DamageTypeImpl(
-        float exhaustion,
         @NotNull String messageId,
-        @NotNull String scaling
+        @NotNull String scaling,
+        float exhaustion,
+        @Nullable String effects,
+        @Nullable String deathMessageType
 ) implements DamageType {
 
     @SuppressWarnings("ConstantValue") // The builder can violate the nullability constraints


### PR DESCRIPTION
## Proposed changes

The fields `effects` and `deathMessageType` were missing from the `DamageType` class.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

(edit: no I did not add a test, but I did test if it works)