### PR TITLE
feat(process): Dont start disptacher threads until server start

### DIFF
--- a/src/main/java/net/minestom/server/MinecraftServer.java
+++ b/src/main/java/net/minestom/server/MinecraftServer.java
@@ -323,6 +323,7 @@ public final class MinecraftServer implements MinecraftConstants {
      */
     public void start(@NotNull SocketAddress address) {
         serverProcess.start(address);
+        serverProcess.dispatcher().start();
         new TickSchedulerThread(serverProcess).start();
     }
 

--- a/src/main/java/net/minestom/server/thread/ThreadDispatcher.java
+++ b/src/main/java/net/minestom/server/thread/ThreadDispatcher.java
@@ -4,6 +4,7 @@ import net.minestom.server.Tickable;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.MpscUnboundedArrayQueue;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Unmodifiable;
 
@@ -45,17 +46,18 @@ public final class ThreadDispatcher<P> {
         TickThread[] threads = new TickThread[threadCount];
         Arrays.setAll(threads, threadGenerator);
         this.threads = List.of(threads);
-        this.threads.forEach(Thread::start);
     }
 
     /**
      * Creates a new ThreadDispatcher using default thread names (ex. Ms-Tick-n).
+     * <p>Remember to start the dispatcher using {@link #start()}</p>
      *
      * @param provider the {@link ThreadProvider} instance to be used for defining thread IDs
      * @param threadCount the number of threads to create for this dispatcher
      * @return a new ThreadDispatcher instance
      * @param <P> the dispatcher partition type
      */
+    @Contract(pure = true)
     public static <P> @NotNull ThreadDispatcher<P> of(@NotNull ThreadProvider<P> provider, int threadCount) {
         return new ThreadDispatcher<>(provider, threadCount, TickThread::new);
     }
@@ -63,6 +65,7 @@ public final class ThreadDispatcher<P> {
     /**
      * Creates a new ThreadDispatcher using the caller-provided thread name generator {@code nameGenerator}. This is
      * useful to disambiguate custom ThreadDispatcher instances from ones used in core Minestom code.
+     * <p>Remember to start the dispatcher using {@link #start()}</p>
      *
      * @param provider the {@link ThreadProvider} instance to be used for defining thread IDs
      * @param nameGenerator a function that should return unique names, given a thread index
@@ -70,6 +73,7 @@ public final class ThreadDispatcher<P> {
      * @return a new ThreadDispatcher instance
      * @param <P> the dispatcher partition type
      */
+    @Contract(pure = true)
     public static <P> @NotNull ThreadDispatcher<P> of(@NotNull ThreadProvider<P> provider,
                                                       @NotNull IntFunction<String> nameGenerator, int threadCount) {
         return new ThreadDispatcher<>(provider, threadCount, index -> new TickThread(nameGenerator.apply(index)));
@@ -77,10 +81,12 @@ public final class ThreadDispatcher<P> {
 
     /**
      * Creates a single-threaded dispatcher that uses default thread names.
+     * <p>Remember to start the dispatcher using {@link #start()}</p>
      *
      * @return a new ThreadDispatcher instance
      * @param <P> the dispatcher partition type
      */
+    @Contract(pure = true)
     public static <P> @NotNull ThreadDispatcher<P> singleThread() {
         return of(ThreadProvider.counter(), 1);
     }
@@ -207,6 +213,24 @@ public final class ThreadDispatcher<P> {
      */
     public void removeElement(@NotNull Tickable tickable) {
         signalUpdate(new DispatchUpdate.ElementRemove<>(tickable));
+    }
+
+    /**
+     * Starts all the {@link TickThread tick threads}.
+     * <p>
+     * This will throw an {@link IllegalThreadStateException} if the threads have already been started.
+     */
+    public void start() {
+        this.threads.forEach(Thread::start);
+    }
+
+    /**
+     * Checks if all the {@link TickThread tick threads} are alive.
+     *
+     * @return true if all threads are alive, false otherwise
+     */
+    public boolean isAlive() {
+        return this.threads.stream().allMatch(Thread::isAlive);
     }
 
     /**

--- a/src/main/java/net/minestom/server/thread/ThreadDispatcher.java
+++ b/src/main/java/net/minestom/server/thread/ThreadDispatcher.java
@@ -230,7 +230,12 @@ public final class ThreadDispatcher<P> {
      * @return true if all threads are alive, false otherwise
      */
     public boolean isAlive() {
-        return this.threads.stream().allMatch(Thread::isAlive);
+        for (TickThread thread : threads) {
+            if (!thread.isAlive()) {
+                return false;
+            }
+        }
+        return !threads.isEmpty();
     }
 
     /**

--- a/src/main/java/net/minestom/server/thread/TickThread.java
+++ b/src/main/java/net/minestom/server/thread/TickThread.java
@@ -46,6 +46,7 @@ public final class TickThread extends MinestomThread {
 
     @Override
     public void run() {
+        // This is safe to do, as the thread will blow through this first lock during the race, see #park documentation.
         LockSupport.park(this);
         while (!stop) {
             this.lock.lock();

--- a/src/test/java/net/minestom/server/thread/AcquirableTest.java
+++ b/src/test/java/net/minestom/server/thread/AcquirableTest.java
@@ -25,6 +25,7 @@ public class AcquirableTest {
         Object second = new Object();
 
         ThreadDispatcher<Object> dispatcher = ThreadDispatcher.of(ThreadProvider.counter(), 2);
+        dispatcher.start();
         dispatcher.createPartition(first);
         dispatcher.createPartition(second);
 

--- a/src/test/java/net/minestom/server/thread/ThreadDispatcherTest.java
+++ b/src/test/java/net/minestom/server/thread/ThreadDispatcherTest.java
@@ -20,6 +20,7 @@ public class ThreadDispatcherTest {
     public void elementTick() {
         final AtomicInteger counter = new AtomicInteger();
         ThreadDispatcher<Object> dispatcher = ThreadDispatcher.singleThread();
+        dispatcher.start();
         assertEquals(1, dispatcher.threads().size());
         assertThrows(Exception.class, () -> dispatcher.threads().add(new TickThread(1)));
 
@@ -50,6 +51,7 @@ public class ThreadDispatcherTest {
         final AtomicInteger counter1 = new AtomicInteger();
         final AtomicInteger counter2 = new AtomicInteger();
         ThreadDispatcher<Tickable> dispatcher = ThreadDispatcher.singleThread();
+        dispatcher.start();
         assertEquals(1, dispatcher.threads().size());
 
         Tickable partition = (time) -> counter1.incrementAndGet();
@@ -79,6 +81,7 @@ public class ThreadDispatcherTest {
         final int threadCount = 10;
         ThreadDispatcher<Tickable> dispatcher = ThreadDispatcher.of(ThreadProvider.counter(), threadCount);
         assertEquals(threadCount, dispatcher.threads().size());
+        dispatcher.start();
 
         final AtomicInteger counter = new AtomicInteger();
         Set<Thread> threads = new CopyOnWriteArraySet<>();

--- a/src/test/java/net/minestom/server/thread/ThreadDispatcherTest.java
+++ b/src/test/java/net/minestom/server/thread/ThreadDispatcherTest.java
@@ -126,6 +126,7 @@ public class ThreadDispatcherTest {
             }
         }, threadCount);
         assertEquals(threadCount, dispatcher.threads().size());
+        dispatcher.start();
 
         Map<Updater, Thread> threads = new ConcurrentHashMap<>();
         Map<Updater, Thread> threads2 = new ConcurrentHashMap<>();

--- a/testing/src/main/java/net/minestom/testing/Env.java
+++ b/testing/src/main/java/net/minestom/testing/Env.java
@@ -22,11 +22,15 @@ public interface Env {
 
     <E extends Event> @NotNull FlexibleListener<E> listen(@NotNull Class<E> eventType);
 
+    void ensureDispatcherStarted();
+
     default void tick() {
+        this.ensureDispatcherStarted();
         process().ticker().tick(System.nanoTime());
     }
 
     default boolean tickWhile(BooleanSupplier condition, Duration timeout) {
+        this.ensureDispatcherStarted();
         var ticker = process().ticker();
         final long start = System.nanoTime();
         while (condition.getAsBoolean()) {

--- a/testing/src/main/java/net/minestom/testing/Env.java
+++ b/testing/src/main/java/net/minestom/testing/Env.java
@@ -22,15 +22,11 @@ public interface Env {
 
     <E extends Event> @NotNull FlexibleListener<E> listen(@NotNull Class<E> eventType);
 
-    void ensureDispatcherStarted();
-
     default void tick() {
-        this.ensureDispatcherStarted();
         process().ticker().tick(System.nanoTime());
     }
 
     default boolean tickWhile(BooleanSupplier condition, Duration timeout) {
-        this.ensureDispatcherStarted();
         var ticker = process().ticker();
         final long start = System.nanoTime();
         while (condition.getAsBoolean()) {

--- a/testing/src/main/java/net/minestom/testing/EnvImpl.java
+++ b/testing/src/main/java/net/minestom/testing/EnvImpl.java
@@ -52,6 +52,13 @@ final class EnvImpl implements Env {
         return flexible;
     }
 
+    @Override
+    public void ensureDispatcherStarted() {
+        // Start the tick threads if it is not already running.
+        if (!process().dispatcher().isAlive())
+            process().dispatcher().start();
+    }
+
     void cleanup() {
         this.listeners.forEach(FlexibleListenerImpl::check);
         this.process.stop();

--- a/testing/src/main/java/net/minestom/testing/EnvImpl.java
+++ b/testing/src/main/java/net/minestom/testing/EnvImpl.java
@@ -20,6 +20,9 @@ final class EnvImpl implements Env {
     public EnvImpl(ServerProcess process) {
         this.process = process;
 
+        // Start the dispatcher threads if not already started.
+        process().dispatcher().start();
+
         // Use player provider to disable queued chunk sending.
         // Set here to allow an individual test to override if they want.
         process.connection().setPlayerProvider(TestConnectionImpl.TestPlayerImpl::new);
@@ -50,13 +53,6 @@ final class EnvImpl implements Env {
         handler.addListener(listener);
         this.listeners.add(flexible);
         return flexible;
-    }
-
-    @Override
-    public void ensureDispatcherStarted() {
-        // Start the tick threads if it is not already running.
-        if (!process().dispatcher().isAlive())
-            process().dispatcher().start();
     }
 
     void cleanup() {


### PR DESCRIPTION
It should allow GraalVM native to build this path during build time, as it's not constrained by the Thread#start
## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
I marked this as breaking change, (cause it is); But Ive based this to master, because Im unsure the utilization of thread dispatchers in projects, apart from unit testing. (Will rebase to 1_21_6, if required)