### PR TITLE
feat(adventure): Update to use pointered suppliers & identity

### DIFF
--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -52,6 +52,7 @@ import net.minestom.server.utils.chunk.ChunkSupplier;
 import net.minestom.server.utils.validate.Check;
 import net.minestom.server.world.DimensionType;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -970,11 +971,13 @@ public abstract class Instance implements Block.Getter, Block.Setter,
     }
 
     @Override
+    @Contract(pure = true)
     public @NotNull Pointers pointers() {
         return INSTANCE_POINTERS_SUPPLIER.view(this);
     }
 
     @Override
+    @Contract(pure = true)
     public @NotNull Identity identity() {
         return Identity.identity(this.uuid);
     }

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -979,7 +979,7 @@ public abstract class Instance implements Block.Getter, Block.Setter,
     @Override
     @Contract(pure = true)
     public @NotNull Identity identity() {
-        return Identity.identity(this.uuid);
+        return Identity.identity(this.uuid); // Warning, do not pull up until this.uuid is final
     }
 
     public int getBlockLight(int blockX, int blockY, int blockZ) {

--- a/src/main/java/net/minestom/server/scoreboard/Team.java
+++ b/src/main/java/net/minestom/server/scoreboard/Team.java
@@ -13,6 +13,7 @@ import net.minestom.server.network.packet.server.play.TeamsPacket;
 import net.minestom.server.network.packet.server.play.TeamsPacket.CollisionRule;
 import net.minestom.server.network.packet.server.play.TeamsPacket.NameTagVisibility;
 import net.minestom.server.utils.PacketSendingUtils;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -484,6 +485,7 @@ public class Team implements PacketGroupingAudience {
     }
 
     @Override
+    @Contract(pure = true)
     public @NotNull Pointers pointers() {
         return TEAM_POINTERS_SUPPLIER.view(this);
     }

--- a/src/main/java/net/minestom/server/scoreboard/Team.java
+++ b/src/main/java/net/minestom/server/scoreboard/Team.java
@@ -2,6 +2,7 @@ package net.minestom.server.scoreboard;
 
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.pointer.Pointers;
+import net.kyori.adventure.pointer.PointersSupplier;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.minestom.server.MinecraftServer;
@@ -27,6 +28,11 @@ import java.util.concurrent.CopyOnWriteArraySet;
 public class Team implements PacketGroupingAudience {
     private static final byte ALLOW_FRIENDLY_FIRE_BIT = 0x01;
     private static final byte SEE_INVISIBLE_PLAYERS_BIT = 0x02;
+
+    protected static final PointersSupplier<Team> TEAM_POINTERS_SUPPLIER = PointersSupplier.<Team>builder()
+            .resolving(Identity.NAME, Team::getTeamName)
+            .resolving(Identity.DISPLAY_NAME, Team::getTeamDisplayName)
+            .build();
 
     /**
      * A collection of all registered entities who are on the team.
@@ -72,9 +78,6 @@ public class Team implements PacketGroupingAudience {
     private final Set<Player> playerMembers = ConcurrentHashMap.newKeySet();
     private boolean isPlayerMembersUpToDate;
 
-    // Adventure
-    private final Pointers pointers;
-
     /**
      * Default constructor to creates a team.
      *
@@ -93,11 +96,6 @@ public class Team implements PacketGroupingAudience {
         this.suffix = Component.empty();
 
         this.members = new CopyOnWriteArraySet<>();
-
-        this.pointers = Pointers.builder()
-                .withDynamic(Identity.NAME, this::getTeamName)
-                .withDynamic(Identity.DISPLAY_NAME, this::getTeamDisplayName)
-                .build();
     }
 
     /**
@@ -487,6 +485,6 @@ public class Team implements PacketGroupingAudience {
 
     @Override
     public @NotNull Pointers pointers() {
-        return this.pointers;
+        return TEAM_POINTERS_SUPPLIER.view(this);
     }
 }


### PR DESCRIPTION
## Proposed changes
We can use adventure pointers suppliers instead of storing them. We can also not store identity, just a wrapper around uuid, I would have extended Identity if it didnt have static pollution.
## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
Shouldnt be an observable breaking change unless you depend on the java identity of identity objects.