### PR TITLE
perf: registry key speed improvements

### DIFF
--- a/jmh-benchmarks/src/jmh/java/net/minestom/server/registry/DynamicRegistryGetIdBenchmark.java
+++ b/jmh-benchmarks/src/jmh/java/net/minestom/server/registry/DynamicRegistryGetIdBenchmark.java
@@ -1,8 +1,8 @@
 package net.minestom.server.registry;
 
-import net.minestom.server.MinecraftServer;
 import net.minestom.server.world.biome.Biome;
 import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
 
 import java.util.concurrent.TimeUnit;
 
@@ -14,7 +14,6 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Benchmark)
 public class DynamicRegistryGetIdBenchmark {
     private DynamicRegistry<Biome> registry;
-    private final RegistryKey<Biome> biome = Biome.PALE_GARDEN;
 
     @Setup
     public void setup() {
@@ -22,7 +21,7 @@ public class DynamicRegistryGetIdBenchmark {
     }
 
     @Benchmark
-    public int getId() {
-        return registry.getId(biome);
+    public void getId(Blackhole blackhole) {
+        blackhole.consume(registry.getId(RegistryKey.unsafeOf("pale_garden")));
     }
 }

--- a/jmh-benchmarks/src/jmh/java/net/minestom/server/registry/DynamicRegistryGetIdBenchmark.java
+++ b/jmh-benchmarks/src/jmh/java/net/minestom/server/registry/DynamicRegistryGetIdBenchmark.java
@@ -1,0 +1,28 @@
+package net.minestom.server.registry;
+
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.world.biome.Biome;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class DynamicRegistryGetIdBenchmark {
+    private DynamicRegistry<Biome> registry;
+    private final RegistryKey<Biome> biome = Biome.PALE_GARDEN;
+
+    @Setup
+    public void setup() {
+        registry = Biome.createDefaultRegistry();
+    }
+
+    @Benchmark
+    public int getId() {
+        return registry.getId(biome);
+    }
+}

--- a/src/main/java/net/minestom/server/registry/DynamicRegistryImpl.java
+++ b/src/main/java/net/minestom/server/registry/DynamicRegistryImpl.java
@@ -37,6 +37,7 @@ final class DynamicRegistryImpl<T> implements DynamicRegistry<T> {
 
     private final List<T> idToValue;
     private final List<RegistryKey<T>> idToKey;
+    private final Map<RegistryKey<T>, Integer> keyToId;
     private final Map<Key, T> keyToValue;
     private final Map<T, RegistryKey<T>> valueToKey;
     private final List<DataPack> packById;
@@ -52,6 +53,7 @@ final class DynamicRegistryImpl<T> implements DynamicRegistry<T> {
         // Expect stale data possibilities with unsafe ops.
         this.idToValue = new ArrayList<>();
         this.idToKey = new ArrayList<>();
+        this.keyToId = new HashMap<>();
         this.keyToValue = new HashMap<>();
         this.valueToKey = new HashMap<>();
         this.packById = new ArrayList<>();
@@ -68,10 +70,15 @@ final class DynamicRegistryImpl<T> implements DynamicRegistry<T> {
         this.codec = codec;
         this.idToValue = idToValue;
         this.idToKey = idToKey;
+        this.keyToId = new HashMap<>();
         this.keyToValue = keyToValue;
         this.valueToKey = valueToKey;
         this.packById = packById;
         this.tags = tags;
+
+        for (int id = 0; id < idToKey.size(); id++) {
+            keyToId.put(idToKey.get(id), id);
+        }
     }
 
     @Override
@@ -116,7 +123,7 @@ final class DynamicRegistryImpl<T> implements DynamicRegistry<T> {
 
     @Override
     public int getId(@NotNull RegistryKey<T> key) {
-        return idToKey.indexOf(key);
+        return keyToId.get(key);
     }
 
     @Override
@@ -125,16 +132,18 @@ final class DynamicRegistryImpl<T> implements DynamicRegistry<T> {
 
         final RegistryKey<T> registryKey = new RegistryKeyImpl<>(key);
         synchronized (REGISTRY_LOCK) {
-            int id = idToKey.indexOf(registryKey); // Array set at home
+            Integer id = keyToId.get(registryKey); // Array set at home
             keyToValue.put(key, object);
             valueToKey.put(object, registryKey);
-            if (id == -1) {
+            if (id == null) {
                 idToValue.add(object);
                 idToKey.add(registryKey);
+                keyToId.put(registryKey, idToValue.size() - 1);
                 packById.add(pack);
             } else {
                 idToValue.set(id, object);
                 idToKey.set(id, registryKey);
+                keyToId.put(registryKey, id);
                 packById.set(id, pack);
             }
 
@@ -149,12 +158,14 @@ final class DynamicRegistryImpl<T> implements DynamicRegistry<T> {
 
         final RegistryKey<T> registryKey = new RegistryKeyImpl<>(key);
         synchronized (REGISTRY_LOCK) {
-            int id = idToKey.indexOf(registryKey);
-            if (id == -1) return false;
+            Integer idObject = keyToId.get(registryKey);
+            if (idObject == null) return false;
+            int id = idObject;
 
             // Remove value from all mappings (shifting down indices)
             idToValue.remove(id);
             idToKey.remove(registryKey);
+            keyToId.remove(registryKey);
             var value = keyToValue.remove(key);
             valueToKey.remove(value);
             packById.remove(id);
@@ -239,7 +250,7 @@ final class DynamicRegistryImpl<T> implements DynamicRegistry<T> {
             final int[] entries = new int[tag.size()];
             int i = 0;
             for (var registryKey : tag)
-                entries[i++] = idToKey.indexOf(registryKey);
+                entries[i++] = keyToId.get(registryKey);
             tagList.add(new TagsPacket.Tag(tag.key().key().asString(), entries));
         }
         return new TagsPacket.Registry(key().asString(), tagList);

--- a/src/main/java/net/minestom/server/registry/DynamicRegistryImpl.java
+++ b/src/main/java/net/minestom/server/registry/DynamicRegistryImpl.java
@@ -63,22 +63,18 @@ final class DynamicRegistryImpl<T> implements DynamicRegistry<T> {
 
     // Used to create compressed registries
     DynamicRegistryImpl(@NotNull Key key, @Nullable Codec<T> codec, @NotNull List<T> idToValue,
-                        @NotNull List<RegistryKey<T>> idToKey, @NotNull Map<Key, T> keyToValue,
-                        @NotNull Map<T, RegistryKey<T>> valueToKey, @NotNull List<DataPack> packById,
-                        @NotNull Map<TagKey<T>, RegistryTagImpl.Backed<T>> tags) {
+                        @NotNull Map<RegistryKey<T>, Integer> keyToId, @NotNull List<RegistryKey<T>> idToKey,
+                        @NotNull Map<Key, T> keyToValue, @NotNull Map<T, RegistryKey<T>> valueToKey,
+                        @NotNull List<DataPack> packById, @NotNull Map<TagKey<T>, RegistryTagImpl.Backed<T>> tags) {
         this.key = key;
         this.codec = codec;
         this.idToValue = idToValue;
         this.idToKey = idToKey;
-        this.keyToId = new HashMap<>();
+        this.keyToId = keyToId;
         this.keyToValue = keyToValue;
         this.valueToKey = valueToKey;
         this.packById = packById;
         this.tags = tags;
-
-        for (int id = 0; id < idToKey.size(); id++) {
-            keyToId.put(idToKey.get(id), id);
-        }
     }
 
     @Override
@@ -123,7 +119,7 @@ final class DynamicRegistryImpl<T> implements DynamicRegistry<T> {
 
     @Override
     public int getId(@NotNull RegistryKey<T> key) {
-        return keyToId.get(key);
+        return keyToId.getOrDefault(key, -1);
     }
 
     @Override
@@ -308,6 +304,7 @@ final class DynamicRegistryImpl<T> implements DynamicRegistry<T> {
         // Create new instances so they are trimmed to size without downcasting.
         return new DynamicRegistryImpl<>(key, codec,
                 new ArrayList<>(idToValue),
+                new HashMap<>(keyToId),
                 new ArrayList<>(idToKey),
                 new HashMap<>(keyToValue),
                 new HashMap<>(valueToKey),


### PR DESCRIPTION
## Proposed changes

Speed up DynamicRegistry#getId() dramatically

```
DynamicRegistryGetIdBenchmark.getId:before  avgt   30  679.928 ± 10.940  ns/op
DynamicRegistryGetIdBenchmark.getId:map     avgt   30   21.094 ±  0.209  ns/op
```

This is specifically done to enhance biome setting in generators. It's now about the same speed as setAllRelative when executed for every fourth block (best possible way to execute it)

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Performance boost

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added benchmarks that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I have no idea why, but for tests to pass, the dimension type registry can't be static. If you know why, please let me know