### PR TITLE
Add Point#samePoint(Point, epsilon)

### DIFF
--- a/src/main/java/net/minestom/server/coordinate/Point.java
+++ b/src/main/java/net/minestom/server/coordinate/Point.java
@@ -242,19 +242,19 @@ public sealed interface Point permits Vec, Pos, BlockVec {
      * @param x the x coordinate to compare
      * @param y the y coordinate to compare
      * @param z the z coordinate to compare
-     * @param epsilon the maximum difference allowed between the two points (inclusive)
+     * @param epsilon the maximum difference allowed between the two points (exclusive)
      * @throws IllegalArgumentException if epsilon is less than or equal to 0
      * @return true if the two positions are similar within the epsilon
      */
     default boolean samePoint(double x, double y, double z, double epsilon) {
         Check.argCondition(epsilon <= 0, "Epsilon must be greater than 0 but found {0}", epsilon);
-        return Math.abs(x - x()) <= epsilon && Math.abs(y - y()) <= epsilon && Math.abs(z - z()) <= epsilon;
+        return Math.abs(x - x()) < epsilon && Math.abs(y - y()) < epsilon && Math.abs(z - z()) < epsilon;
     }
 
     /**
      * Checks it two points have similar (x/y/z) coordinates within a given epsilon.
      * @param point the point to compare
-     * @param epsilon the maximum difference allowed between the two points (inclusive)
+     * @param epsilon the maximum difference allowed between the two points (exclusive)
      * @throws IllegalArgumentException if epsilon is less than or equal to 0
      * @return true if the two positions are similar within the epsilon
      */

--- a/src/main/java/net/minestom/server/coordinate/Point.java
+++ b/src/main/java/net/minestom/server/coordinate/Point.java
@@ -2,6 +2,7 @@ package net.minestom.server.coordinate;
 
 import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.utils.MathUtils;
+import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
@@ -234,6 +235,31 @@ public sealed interface Point permits Vec, Pos, BlockVec {
      */
     default boolean samePoint(@NotNull Point point) {
         return samePoint(point.x(), point.y(), point.z());
+    }
+
+    /**
+     * Checks it two points have similar (x/y/z) coordinates within a given epsilon.
+     * @param x the x coordinate to compare
+     * @param y the y coordinate to compare
+     * @param z the z coordinate to compare
+     * @param epsilon the maximum difference allowed between the two points (inclusive)
+     * @throws IllegalArgumentException if epsilon is less than or equal to 0
+     * @return true if the two positions are similar within the epsilon
+     */
+    default boolean samePoint(double x, double y, double z, double epsilon) {
+        Check.argCondition(epsilon <= 0, "Epsilon must be greater than 0 but found {0}", epsilon);
+        return Math.abs(x - x()) <= epsilon && Math.abs(y - y()) <= epsilon && Math.abs(z - z()) <= epsilon;
+    }
+
+    /**
+     * Checks it two points have similar (x/y/z) coordinates within a given epsilon.
+     * @param point the point to compare
+     * @param epsilon the maximum difference allowed between the two points (inclusive)
+     * @throws IllegalArgumentException if epsilon is less than or equal to 0
+     * @return true if the two positions are similar within the epsilon
+     */
+    default boolean samePoint(@NotNull Point point, double epsilon) {
+        return samePoint(point.x(), point.y(), point.z(), epsilon);
     }
 
     /**

--- a/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
+++ b/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
@@ -139,12 +139,10 @@ public class CoordinateTest {
         assertTrue(v1.samePoint(v2, Vec.EPSILON));
         assertTrue(v2.samePoint(v3, Vec.EPSILON));
         assertTrue(v1.samePoint(v3, Vec.EPSILON));
+        assertTrue(v5.samePoint(v1, Vec.EPSILON));
 
         // Vectors with larger differences should not be considered the same
         assertFalse(v1.samePoint(v4, Vec.EPSILON));
-
-        // Vectors that are exactly the epsilon should be considered the same
-        assertTrue(v5.samePoint(v1, Vec.EPSILON));
 
         // 0 epsilon should throw an exception
         assertThrows(IllegalArgumentException.class, () -> v5.samePoint(v5, 0));

--- a/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
+++ b/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
@@ -127,6 +127,27 @@ public class CoordinateTest {
     }
 
     @Test
+    public void vecSameEpsilon() {
+        Vec v1 = new Vec(Vec.EPSILON, 0, 0);
+        Vec v2 = new Vec(0, 0, 0);
+        Vec v3 = new Vec(Vec.EPSILON, -Vec.EPSILON, Vec.EPSILON);
+        Vec v4 = new Vec(0.001, 0, 0);
+        Vec v5 = v1.add(Vec.EPSILON);
+
+        // Vectors with small differences should be considered the same under epsilon
+        assertTrue(v1.samePoint(v2, Vec.EPSILON));
+        assertTrue(v2.samePoint(v3, Vec.EPSILON));
+        assertTrue(v1.samePoint(v3, Vec.EPSILON));
+
+        // Vectors with larger differences should not be considered the same
+        assertFalse(v1.samePoint(v4, Vec.EPSILON));
+
+        // Vectors that are exactly the epsilon should be considered the same
+        assertTrue(v5.samePoint(v1, Vec.EPSILON));
+        assertTrue(v5.samePoint(v5, Vec.EPSILON));
+    }
+
+    @Test
     public void toSectionRelativeCoordinate() {
         assertEquals(8, CoordConversion.globalToSectionRelative(-40));
         assertEquals(12, CoordConversion.globalToSectionRelative(-20));

--- a/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
+++ b/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
@@ -128,11 +128,12 @@ public class CoordinateTest {
 
     @Test
     public void vecSameEpsilon() {
-        Vec v1 = new Vec(Vec.EPSILON, 0, 0);
+        final double TEST_EPSILON = 0.000000999999; // Less than 1e-6
+        Vec v1 = new Vec(TEST_EPSILON, 0, 0);
         Vec v2 = new Vec(0, 0, 0);
-        Vec v3 = new Vec(Vec.EPSILON, -Vec.EPSILON, Vec.EPSILON);
+        Vec v3 = new Vec(TEST_EPSILON, -TEST_EPSILON, TEST_EPSILON);
         Vec v4 = new Vec(0.001, 0, 0);
-        Vec v5 = v1.add(Vec.EPSILON);
+        Vec v5 = v1.add(TEST_EPSILON);
 
         // Vectors with small differences should be considered the same under epsilon
         assertTrue(v1.samePoint(v2, Vec.EPSILON));

--- a/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
+++ b/src/test/java/net/minestom/server/coordinate/CoordinateTest.java
@@ -144,7 +144,9 @@ public class CoordinateTest {
 
         // Vectors that are exactly the epsilon should be considered the same
         assertTrue(v5.samePoint(v1, Vec.EPSILON));
-        assertTrue(v5.samePoint(v5, Vec.EPSILON));
+
+        // 0 epsilon should throw an exception
+        assertThrows(IllegalArgumentException.class, () -> v5.samePoint(v5, 0));
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

Simple PR to add Point#samePoint(Point, epsilon), to compare two points, same thing kind of exists already if you applied the epsilon operator, but its simplified here, and allows custom epsilons. Talked about in the discord.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
Searched for usages of Vec.EPSILON, and didnt replace them as most of them were in tick loops.
Realistaclly this should be the default samePoint, and the other one should be samePointExact or something.