### PR TITLE
Fix invalid shift-clicking predictions

### DIFF
--- a/src/main/java/net/minestom/server/inventory/Inventory.java
+++ b/src/main/java/net/minestom/server/inventory/Inventory.java
@@ -197,20 +197,40 @@ public non-sealed class Inventory extends AbstractInventory {
         final int clickSlot = isInWindow ? slot : slot - offset;
         final ItemStack clicked = isInWindow ? getItemStack(slot) : playerInventory.getItemStack(clickSlot);
         final ItemStack cursor = playerInventory.getCursorItem(); // Isn't used in the algorithm
-        final InventoryClickResult clickResult = clickProcessor.shiftClick(
-                isInWindow ? this : playerInventory,
-                isInWindow ? playerInventory : this,
-                0, isInWindow ? playerInventory.getInnerSize() : getInnerSize(), 1,
-                player, clickSlot, clicked, cursor);
+
+        InventoryClickResult clickResult;
+        if (isInWindow) {
+            // The player shift-clicked an item in this GUI into their inventory.
+            // Prioritize the hotbar (8->0), then their regular inventory (35->9).
+            clickResult = clickProcessor.shiftClick(
+                    this, playerInventory,
+                    8, 0, -1,
+                    player, clickSlot, clicked, cursor);
+
+            if (clickResult.isCancel()) {
+                clickResult = clickProcessor.shiftClick(
+                        this, playerInventory,
+                        playerInventory.getInnerSize() - 1, 0, -1,
+                        player, clickSlot, clicked, cursor);
+            }
+        } else {
+            clickResult = clickProcessor.shiftClick(
+                    playerInventory, this,
+                    0, getInnerSize(), 1,
+                    player, clickSlot, clicked, cursor);
+        }
+
         if (clickResult.isCancel()) {
             updateAll(player);
             return false;
         }
+
         if (isInWindow) {
             setItemStack(slot, clickResult.getClicked());
         } else {
             playerInventory.setItemStack(clickSlot, clickResult.getClicked());
         }
+
         updateAll(player); // FIXME: currently not properly client-predicted
         playerInventory.setCursorItem(clickResult.getCursor());
         return true;

--- a/src/main/java/net/minestom/server/inventory/TransactionType.java
+++ b/src/main/java/net/minestom/server/inventory/TransactionType.java
@@ -22,11 +22,12 @@ public interface TransactionType {
     TransactionType ADD = (inventory, itemStack, slotPredicate, start, end, step) -> {
         Int2ObjectMap<ItemStack> itemChangesMap = new Int2ObjectOpenHashMap<>();
         // Check filled slot (not air)
-        for (int i = start; i < end; i += step) {
+        for (int i = start; step > 0 ? i < end : i > end; i += step) {
             ItemStack inventoryItem = inventory.getItemStack(i);
             if (inventoryItem.isAir()) {
                 continue;
             }
+
             if (itemStack.isSimilar(inventoryItem)) {
                 final int itemAmount = inventoryItem.amount();
                 final int maxSize = inventoryItem.maxStackSize();
@@ -50,8 +51,9 @@ public interface TransactionType {
                 }
             }
         }
+
         // Check air slot to fill
-        for (int i = start; i < end; i += step) {
+        for (int i = start; step > 0 ? i < end : i > end; i += step) {
             ItemStack inventoryItem = inventory.getItemStack(i);
             if (!inventoryItem.isAir()) continue;
             if (!slotPredicate.test(i, inventoryItem)) {
@@ -73,6 +75,7 @@ public interface TransactionType {
                 break;
             }
         }
+
         return Pair.of(itemStack, itemChangesMap);
     };
 
@@ -82,7 +85,7 @@ public interface TransactionType {
      */
     TransactionType TAKE = (inventory, itemStack, slotPredicate, start, end, step) -> {
         Int2ObjectMap<ItemStack> itemChangesMap = new Int2ObjectOpenHashMap<>();
-        for (int i = start; i < end; i += step) {
+        for (int i = start; step > 0 ? i < end : i > end; i += step) {
             final ItemStack inventoryItem = inventory.getItemStack(i);
             if (inventoryItem.isAir()) continue;
             if (itemStack.isSimilar(inventoryItem)) {


### PR DESCRIPTION
## Proposed changes

This fixes a few cases of invalid shift-clicking prediction such as:
Shift-click to the off-hand slot (for shields)
Shift-click armor slots with armor into the hotbar or inventory
Shift-click crafting grid or crafting grid result slots into the hotbar or inventory

This also incorporates #2710 which has not been pulled into the project yet.

Tests are written for most shift-clicking behavior now (although not all edge-cases are covered)

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)