### PR TITLE
Add InstanceSectionInvalidateEvent

### DIFF
--- a/src/main/java/net/minestom/server/event/instance/InstanceBlockUpdateEvent.java
+++ b/src/main/java/net/minestom/server/event/instance/InstanceBlockUpdateEvent.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.NotNull;
  * Called when a block in an instance is updated.
  * <p>
  * This event is triggered when a block's state changes from its instance.
+ * If you wish to listen to all block updates, must be used in conjunction with {@link InstanceSectionInvalidateEvent}
  */
 public class InstanceBlockUpdateEvent implements InstanceEvent, BlockEvent {
     private final Instance instance;

--- a/src/main/java/net/minestom/server/event/instance/InstanceSectionInvalidateEvent.java
+++ b/src/main/java/net/minestom/server/event/instance/InstanceSectionInvalidateEvent.java
@@ -1,0 +1,39 @@
+package net.minestom.server.event.instance;
+
+import net.minestom.server.event.trait.InstanceEvent;
+import net.minestom.server.instance.Instance;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This event is triggered when a section of an instance is manually marked as invalid.
+ * <p>
+ * Changes in this case are not known but indicate that its content must be reinterpreted.
+ */
+public class InstanceSectionInvalidateEvent implements InstanceEvent {
+    private final Instance instance;
+    private final int sectionX, sectionY, sectionZ;
+
+    public InstanceSectionInvalidateEvent(Instance instance, int sectionX, int sectionY, int sectionZ) {
+        this.instance = instance;
+        this.sectionX = sectionX;
+        this.sectionY = sectionY;
+        this.sectionZ = sectionZ;
+    }
+
+    @Override
+    public @NotNull Instance getInstance() {
+        return instance;
+    }
+
+    public int sectionX() {
+        return sectionX;
+    }
+
+    public int sectionY() {
+        return sectionY;
+    }
+
+    public int sectionZ() {
+        return sectionZ;
+    }
+}

--- a/src/main/java/net/minestom/server/event/instance/InstanceSectionInvalidateEvent.java
+++ b/src/main/java/net/minestom/server/event/instance/InstanceSectionInvalidateEvent.java
@@ -2,17 +2,21 @@ package net.minestom.server.event.instance;
 
 import net.minestom.server.event.trait.InstanceEvent;
 import net.minestom.server.instance.Instance;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * This event is triggered when a section of an instance is manually marked as invalid.
  * <p>
  * Changes in this case are not known but indicate that its content must be reinterpreted.
+ * <p>
+ * Can be triggered using {@link Instance#invalidateSection(int, int, int)}
  */
 public class InstanceSectionInvalidateEvent implements InstanceEvent {
     private final Instance instance;
     private final int sectionX, sectionY, sectionZ;
 
+    @ApiStatus.Internal
     public InstanceSectionInvalidateEvent(Instance instance, int sectionX, int sectionY, int sectionZ) {
         this.instance = instance;
         this.sectionX = sectionX;

--- a/src/main/java/net/minestom/server/instance/DynamicChunk.java
+++ b/src/main/java/net/minestom/server/instance/DynamicChunk.java
@@ -259,8 +259,8 @@ public class DynamicChunk extends Chunk {
 
     @Override
     public void invalidate() {
-        this.chunkCache.invalidate();
         this.needsCompleteHeightmapRefresh = true;
+        this.chunkCache.invalidate();
     }
 
     private @NotNull ChunkDataPacket createChunkPacket() {

--- a/src/main/java/net/minestom/server/instance/DynamicChunk.java
+++ b/src/main/java/net/minestom/server/instance/DynamicChunk.java
@@ -260,6 +260,7 @@ public class DynamicChunk extends Chunk {
     @Override
     public void invalidate() {
         this.chunkCache.invalidate();
+        this.needsCompleteHeightmapRefresh = true;
     }
 
     private @NotNull ChunkDataPacket createChunkPacket() {

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -284,6 +284,9 @@ public abstract class Instance implements Block.Getter, Block.Setter,
         final Chunk chunk = getChunk(sectionX, sectionZ);
         if (chunk != null) {
             chunk.invalidate();
+            Section section = chunk.getSection(sectionY);
+            section.skyLight().invalidate();
+            section.blockLight().invalidate();
             EventDispatcher.call(new InstanceSectionInvalidateEvent(this, sectionX, sectionY, sectionZ));
         }
     }

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -283,10 +283,10 @@ public abstract class Instance implements Block.Getter, Block.Setter,
     public void invalidateSection(int sectionX, int sectionY, int sectionZ) {
         final Chunk chunk = getChunk(sectionX, sectionZ);
         if (chunk != null) {
-            chunk.invalidate();
             Section section = chunk.getSection(sectionY);
             section.skyLight().invalidate();
             section.blockLight().invalidate();
+            chunk.invalidate();
             EventDispatcher.call(new InstanceSectionInvalidateEvent(this, sectionX, sectionY, sectionZ));
         }
     }

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -23,6 +23,7 @@ import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.EventFilter;
 import net.minestom.server.event.EventHandler;
 import net.minestom.server.event.EventNode;
+import net.minestom.server.event.instance.InstanceSectionInvalidateEvent;
 import net.minestom.server.event.instance.InstanceTickEvent;
 import net.minestom.server.event.trait.InstanceEvent;
 import net.minestom.server.instance.block.Block;
@@ -277,6 +278,14 @@ public abstract class Instance implements Block.Getter, Block.Setter,
         final Chunk chunk = getChunk(chunkX, chunkZ);
         Check.notNull(chunk, "The chunk at {0}:{1} is already unloaded", chunkX, chunkZ);
         unloadChunk(chunk);
+    }
+
+    public void invalidateSection(int sectionX, int sectionY, int sectionZ) {
+        final Chunk chunk = getChunk(sectionX, sectionZ);
+        if (chunk != null) {
+            chunk.invalidate();
+            EventDispatcher.call(new InstanceSectionInvalidateEvent(this, sectionX, sectionY, sectionZ));
+        }
     }
 
     /**


### PR DESCRIPTION
Let users manually mess with palette and let the instance be responsible for ensuring players get up-to-date packets.

The event also prevent keeping outdated state.