### PR TITLE
Make BlockManager's registerHandler use a bounded wildcard for the BlockHandler supplier

### DIFF
--- a/src/main/java/net/minestom/server/instance/block/BlockManager.java
+++ b/src/main/java/net/minestom/server/instance/block/BlockManager.java
@@ -19,17 +19,17 @@ import java.util.function.Supplier;
 public final class BlockManager {
     private final static Logger LOGGER = LoggerFactory.getLogger(BlockManager.class);
     // Namespace -> handler supplier
-    private final Map<String, Supplier<BlockHandler>> blockHandlerMap = new ConcurrentHashMap<>();
+    private final Map<String, Supplier<? extends BlockHandler>> blockHandlerMap = new ConcurrentHashMap<>();
     // block id -> block placement rule
     private final Int2ObjectMap<BlockPlacementRule> placementRuleMap = new Int2ObjectOpenHashMap<>();
 
     private final Set<String> dummyWarning = ConcurrentHashMap.newKeySet(); // Prevent warning spam
 
-    public void registerHandler(@NotNull String namespace, @NotNull Supplier<@NotNull BlockHandler> handlerSupplier) {
+    public void registerHandler(@NotNull String namespace, @NotNull Supplier<? extends @NotNull BlockHandler> handlerSupplier) {
         blockHandlerMap.put(namespace, handlerSupplier);
     }
 
-    public void registerHandler(@NotNull Key key, @NotNull Supplier<@NotNull BlockHandler> handlerSupplier) {
+    public void registerHandler(@NotNull Key key, @NotNull Supplier<? extends @NotNull BlockHandler> handlerSupplier) {
         registerHandler(key.toString(), handlerSupplier);
     }
 


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This just makes it easier to register a supplier for classes that extend `BlockHandler`, for example if you have a `Supplier<DirtBlockHandler>` you can register it directly instead of having to cast it to `Supplier<BlockHandler>`.