### PR TITLE
Avoid supplier in StructCodec/NetworkTemplate

### DIFF
--- a/src/main/java/net/minestom/server/codec/Codec.java
+++ b/src/main/java/net/minestom/server/codec/Codec.java
@@ -42,7 +42,7 @@ public interface Codec<T> extends Encoder<T>, Decoder<T> {
 
     @NotNull Codec<RawValue> RAW_VALUE = new CodecImpl.RawValueCodecImpl();
 
-    @NotNull Codec<Unit> UNIT = StructCodec.struct(() -> Unit.INSTANCE);
+    @NotNull Codec<Unit> UNIT = StructCodec.struct(Unit.INSTANCE);
 
     @NotNull Codec<Boolean> BOOLEAN = new PrimitiveImpl<>(Transcoder::createBoolean, Transcoder::getBoolean);
 

--- a/src/main/java/net/minestom/server/codec/StructCodec.java
+++ b/src/main/java/net/minestom/server/codec/StructCodec.java
@@ -55,6 +55,21 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
+    static <R> StructCodec<R> struct(R value) {
+        final Result<R> ok = new Result.Ok<>(value);
+        return new StructCodec<>() {
+            @Override
+            public @NotNull <D> Result<R> decodeFromMap(@NotNull Transcoder<D> coder, @NotNull MapLike<D> map) {
+                return ok;
+            }
+
+            @Override
+            public <D> @NotNull Result<D> encodeToMap(@NotNull Transcoder<D> coder, @NotNull R value, @NotNull MapBuilder<D> map) {
+                return new Result.Ok<>(map.build());
+            }
+        };
+    }
+
     static <R> StructCodec<R> struct(Supplier<R> ctor) {
         return new StructCodec<>() {
             @Override

--- a/src/main/java/net/minestom/server/instance/block/predicate/DataComponentPredicates.java
+++ b/src/main/java/net/minestom/server/instance/block/predicate/DataComponentPredicates.java
@@ -17,7 +17,7 @@ public class DataComponentPredicates {
             NetworkBuffer.UNIT.list(), DataComponentPredicates::exact,
             NetworkBuffer.UNIT.list(), DataComponentPredicates::partial,
             DataComponentPredicates::new);
-    public static final Codec<DataComponentPredicates> CODEC = StructCodec.struct(DataComponentPredicates::new);
+    public static final Codec<DataComponentPredicates> CODEC = StructCodec.struct(new DataComponentPredicates());
 
     private DataComponentPredicates() {
     }

--- a/src/main/java/net/minestom/server/item/component/AttributeList.java
+++ b/src/main/java/net/minestom/server/item/component/AttributeList.java
@@ -78,15 +78,15 @@ public record AttributeList(@NotNull List<Modifier> modifiers) {
         record Default() implements Display {
             public static final Default INSTANCE = new Default();
 
-            public static final NetworkBuffer.Type<Default> NETWORK_TYPE = NetworkBufferTemplate.template(() -> INSTANCE);
-            public static final StructCodec<Default> CODEC = StructCodec.struct(() -> INSTANCE);
+            public static final NetworkBuffer.Type<Default> NETWORK_TYPE = NetworkBufferTemplate.template(INSTANCE);
+            public static final StructCodec<Default> CODEC = StructCodec.struct(INSTANCE);
         }
 
         record Hidden() implements Display {
             public static final Hidden INSTANCE = new Hidden();
 
-            public static final NetworkBuffer.Type<Hidden> NETWORK_TYPE = NetworkBufferTemplate.template(() -> INSTANCE);
-            public static final StructCodec<Hidden> CODEC = StructCodec.struct(() -> INSTANCE);
+            public static final NetworkBuffer.Type<Hidden> NETWORK_TYPE = NetworkBufferTemplate.template(INSTANCE);
+            public static final StructCodec<Hidden> CODEC = StructCodec.struct(INSTANCE);
         }
 
         record Override(@NotNull Component component) implements Display {

--- a/src/main/java/net/minestom/server/item/component/ConsumeEffect.java
+++ b/src/main/java/net/minestom/server/item/component/ConsumeEffect.java
@@ -9,7 +9,6 @@ import net.minestom.server.potion.PotionEffect;
 import net.minestom.server.registry.Registries;
 import net.minestom.server.registry.RegistryTag;
 import net.minestom.server.sound.SoundEvent;
-import net.minestom.server.utils.Unit;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.NotNull;
 
@@ -55,8 +54,7 @@ public sealed interface ConsumeEffect {
     final class ClearAllEffects implements ConsumeEffect {
         public static final ClearAllEffects INSTANCE = new ClearAllEffects();
 
-        public static final NetworkBuffer.Type<ClearAllEffects> NETWORK_TYPE = NetworkBuffer.UNIT
-                .transform(buffer -> INSTANCE, ignored -> Unit.INSTANCE);
+        public static final NetworkBuffer.Type<ClearAllEffects> NETWORK_TYPE = NetworkBufferTemplate.template(INSTANCE);
         public static final StructCodec<ClearAllEffects> CODEC = StructCodec.struct(INSTANCE);
 
         private ClearAllEffects() {

--- a/src/main/java/net/minestom/server/item/component/ConsumeEffect.java
+++ b/src/main/java/net/minestom/server/item/component/ConsumeEffect.java
@@ -57,7 +57,7 @@ public sealed interface ConsumeEffect {
 
         public static final NetworkBuffer.Type<ClearAllEffects> NETWORK_TYPE = NetworkBuffer.UNIT
                 .transform(buffer -> INSTANCE, ignored -> Unit.INSTANCE);
-        public static final StructCodec<ClearAllEffects> CODEC = StructCodec.struct(() -> INSTANCE);
+        public static final StructCodec<ClearAllEffects> CODEC = StructCodec.struct(INSTANCE);
 
         private ClearAllEffects() {
         }

--- a/src/main/java/net/minestom/server/item/enchant/DamageImmunityEffect.java
+++ b/src/main/java/net/minestom/server/item/enchant/DamageImmunityEffect.java
@@ -1,14 +1,12 @@
 package net.minestom.server.item.enchant;
 
 import net.minestom.server.codec.Codec;
-import net.minestom.server.utils.Unit;
+import net.minestom.server.codec.StructCodec;
 import org.jetbrains.annotations.NotNull;
 
 public final class DamageImmunityEffect implements Enchantment.Effect {
     public static final DamageImmunityEffect INSTANCE = new DamageImmunityEffect();
-
-    public static final @NotNull Codec<DamageImmunityEffect> CODEC = Codec.UNIT
-            .transform(ignored -> DamageImmunityEffect.INSTANCE, ignored -> Unit.INSTANCE);
+    public static final @NotNull Codec<DamageImmunityEffect> CODEC = StructCodec.struct(INSTANCE);
 
     private DamageImmunityEffect() {
     }

--- a/src/main/java/net/minestom/server/item/enchant/DamageImmunityEffect.java
+++ b/src/main/java/net/minestom/server/item/enchant/DamageImmunityEffect.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.NotNull;
 
 public final class DamageImmunityEffect implements Enchantment.Effect {
     public static final DamageImmunityEffect INSTANCE = new DamageImmunityEffect();
+
     public static final @NotNull Codec<DamageImmunityEffect> CODEC = StructCodec.struct(INSTANCE);
 
     private DamageImmunityEffect() {

--- a/src/main/java/net/minestom/server/network/NetworkBufferTemplate.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferTemplate.java
@@ -107,6 +107,19 @@ public final class NetworkBufferTemplate {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17, P18 p18, P19 p19, P20 p20);
     }
 
+    public static <R> Type<R> template(R value) {
+        return new NetworkBufferTypeImpl<>() {
+            @Override
+            public void write(@NotNull NetworkBuffer buffer, R value) {
+            }
+
+            @Override
+            public R read(@NotNull NetworkBuffer buffer) {
+                return value;
+            }
+        };
+    }
+
     public static <R> Type<R> template(Supplier<R> supplier) {
         return new NetworkBufferTypeImpl<>() {
             @Override

--- a/src/main/java/net/minestom/server/network/packet/client/configuration/ClientFinishConfigurationPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/configuration/ClientFinishConfigurationPacket.java
@@ -5,5 +5,5 @@ import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.client.ClientPacket;
 
 public record ClientFinishConfigurationPacket() implements ClientPacket {
-    public static final NetworkBuffer.Type<ClientFinishConfigurationPacket> SERIALIZER = NetworkBufferTemplate.template(ClientFinishConfigurationPacket::new);
+    public static final NetworkBuffer.Type<ClientFinishConfigurationPacket> SERIALIZER = NetworkBufferTemplate.template(new ClientFinishConfigurationPacket());
 }

--- a/src/main/java/net/minestom/server/network/packet/client/login/ClientLoginAcknowledgedPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/login/ClientLoginAcknowledgedPacket.java
@@ -5,5 +5,5 @@ import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.client.ClientPacket;
 
 public record ClientLoginAcknowledgedPacket() implements ClientPacket {
-    public static final NetworkBuffer.Type<ClientLoginAcknowledgedPacket> SERIALIZER = NetworkBufferTemplate.template(ClientLoginAcknowledgedPacket::new);
+    public static final NetworkBuffer.Type<ClientLoginAcknowledgedPacket> SERIALIZER = NetworkBufferTemplate.template(new ClientLoginAcknowledgedPacket());
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientConfigurationAckPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientConfigurationAckPacket.java
@@ -5,5 +5,5 @@ import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.client.ClientPacket;
 
 public record ClientConfigurationAckPacket() implements ClientPacket {
-    public static final NetworkBuffer.Type<ClientConfigurationAckPacket> SERIALIZER = NetworkBufferTemplate.template(ClientConfigurationAckPacket::new);
+    public static final NetworkBuffer.Type<ClientConfigurationAckPacket> SERIALIZER = NetworkBufferTemplate.template(new ClientConfigurationAckPacket());
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientInteractEntityPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientInteractEntityPacket.java
@@ -55,7 +55,7 @@ public record ClientInteractEntityPacket(int targetId, @NotNull Type type, boole
     }
 
     public record Attack() implements Type {
-        public static final NetworkBuffer.Type<Attack> SERIALIZER = NetworkBufferTemplate.template(Attack::new);
+        public static final NetworkBuffer.Type<Attack> SERIALIZER = NetworkBufferTemplate.template(new Attack());
 
         @Override
         public int id() {

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerLoadedPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerLoadedPacket.java
@@ -6,5 +6,5 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 public record ClientPlayerLoadedPacket() implements ClientPacket {
     public static final NetworkBuffer.Type<ClientPlayerLoadedPacket> SERIALIZER = NetworkBufferTemplate
-            .template(ClientPlayerLoadedPacket::new);
+            .template(new ClientPlayerLoadedPacket());
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientTickEndPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientTickEndPacket.java
@@ -6,6 +6,6 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 public record ClientTickEndPacket() implements ClientPacket {
     public static final NetworkBuffer.Type<ClientTickEndPacket> SERIALIZER =
-            NetworkBufferTemplate.template(ClientTickEndPacket::new);
+            NetworkBufferTemplate.template(new ClientTickEndPacket());
 
 }

--- a/src/main/java/net/minestom/server/network/packet/client/status/StatusRequestPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/status/StatusRequestPacket.java
@@ -5,5 +5,5 @@ import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.client.ClientPacket;
 
 public record StatusRequestPacket() implements ClientPacket {
-    public static final NetworkBuffer.Type<StatusRequestPacket> SERIALIZER = NetworkBufferTemplate.template(StatusRequestPacket::new);
+    public static final NetworkBuffer.Type<StatusRequestPacket> SERIALIZER = NetworkBufferTemplate.template(new StatusRequestPacket());
 }

--- a/src/main/java/net/minestom/server/network/packet/server/common/ClearDialogPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/common/ClearDialogPacket.java
@@ -5,5 +5,5 @@ import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.server.ServerPacket;
 
 public record ClearDialogPacket() implements ServerPacket.Configuration, ServerPacket.Play {
-    public static final NetworkBuffer.Type<ClearDialogPacket> SERIALIZER = NetworkBufferTemplate.template(ClearDialogPacket::new);
+    public static final NetworkBuffer.Type<ClearDialogPacket> SERIALIZER = NetworkBufferTemplate.template(new ClearDialogPacket());
 }

--- a/src/main/java/net/minestom/server/network/packet/server/configuration/FinishConfigurationPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/configuration/FinishConfigurationPacket.java
@@ -5,5 +5,5 @@ import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.server.ServerPacket;
 
 public record FinishConfigurationPacket() implements ServerPacket.Configuration {
-    public static final NetworkBuffer.Type<FinishConfigurationPacket> SERIALIZER = NetworkBufferTemplate.template(FinishConfigurationPacket::new);
+    public static final NetworkBuffer.Type<FinishConfigurationPacket> SERIALIZER = NetworkBufferTemplate.template(new FinishConfigurationPacket());
 }

--- a/src/main/java/net/minestom/server/network/packet/server/configuration/ResetChatPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/configuration/ResetChatPacket.java
@@ -5,5 +5,5 @@ import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.server.ServerPacket;
 
 public record ResetChatPacket() implements ServerPacket.Configuration {
-    public static final NetworkBuffer.Type<ResetChatPacket> SERIALIZER = NetworkBufferTemplate.template(ResetChatPacket::new);
+    public static final NetworkBuffer.Type<ResetChatPacket> SERIALIZER = NetworkBufferTemplate.template(new ResetChatPacket());
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/BossBarPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/BossBarPacket.java
@@ -102,7 +102,7 @@ public record BossBarPacket(@NotNull UUID uuid,
     }
 
     public record RemoveAction() implements Action {
-        public static final NetworkBuffer.Type<RemoveAction> SERIALIZER = NetworkBufferTemplate.template(RemoveAction::new);
+        public static final NetworkBuffer.Type<RemoveAction> SERIALIZER = NetworkBufferTemplate.template(new RemoveAction());
 
         @Override
         public int id() {

--- a/src/main/java/net/minestom/server/network/packet/server/play/BundlePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/BundlePacket.java
@@ -5,5 +5,5 @@ import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.server.ServerPacket;
 
 public record BundlePacket() implements ServerPacket.Play {
-    public static final NetworkBuffer.Type<BundlePacket> SERIALIZER = NetworkBufferTemplate.template(BundlePacket::new);
+    public static final NetworkBuffer.Type<BundlePacket> SERIALIZER = NetworkBufferTemplate.template(new BundlePacket());
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/ChunkBatchStartPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/ChunkBatchStartPacket.java
@@ -5,5 +5,5 @@ import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.server.ServerPacket;
 
 public record ChunkBatchStartPacket() implements ServerPacket.Play {
-    public static final NetworkBuffer.Type<ChunkBatchStartPacket> SERIALIZER = NetworkBufferTemplate.template(ChunkBatchStartPacket::new);
+    public static final NetworkBuffer.Type<ChunkBatchStartPacket> SERIALIZER = NetworkBufferTemplate.template(new ChunkBatchStartPacket());
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/EnterCombatEventPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EnterCombatEventPacket.java
@@ -5,5 +5,5 @@ import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.server.ServerPacket;
 
 public record EnterCombatEventPacket() implements ServerPacket.Play {
-    public static final NetworkBuffer.Type<EnterCombatEventPacket> SERIALIZER = NetworkBufferTemplate.template(EnterCombatEventPacket::new);
+    public static final NetworkBuffer.Type<EnterCombatEventPacket> SERIALIZER = NetworkBufferTemplate.template(new EnterCombatEventPacket());
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/StartConfigurationPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/StartConfigurationPacket.java
@@ -5,5 +5,5 @@ import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.server.ServerPacket;
 
 public record StartConfigurationPacket() implements ServerPacket.Play {
-    public static final NetworkBuffer.Type<StartConfigurationPacket> SERIALIZER = NetworkBufferTemplate.template(StartConfigurationPacket::new);
+    public static final NetworkBuffer.Type<StartConfigurationPacket> SERIALIZER = NetworkBufferTemplate.template(new StartConfigurationPacket());
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/TeamsPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/TeamsPacket.java
@@ -126,7 +126,7 @@ public record TeamsPacket(String teamName, Action action) implements ServerPacke
     }
 
     public record RemoveTeamAction() implements Action {
-        public static final NetworkBuffer.Type<RemoveTeamAction> SERIALIZER = NetworkBufferTemplate.template(RemoveTeamAction::new);
+        public static final NetworkBuffer.Type<RemoveTeamAction> SERIALIZER = NetworkBufferTemplate.template(new RemoveTeamAction());
 
         @Override
         public int id() {

--- a/src/main/java/net/minestom/server/network/packet/server/play/TrackedWaypointPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/TrackedWaypointPacket.java
@@ -65,7 +65,7 @@ public record TrackedWaypointPacket(
                 .unionType(Target::dataSerializer, Target::targetToType);
 
         record Empty() implements Target {
-            public static final NetworkBuffer.Type<Empty> NETWORK_TYPE = NetworkBufferTemplate.template(Empty::new);
+            public static final NetworkBuffer.Type<Empty> NETWORK_TYPE = NetworkBufferTemplate.template(new Empty());
         }
 
         record Vec3i(@NotNull Point point) implements Target {

--- a/src/main/java/net/minestom/server/recipe/display/SlotDisplay.java
+++ b/src/main/java/net/minestom/server/recipe/display/SlotDisplay.java
@@ -6,7 +6,6 @@ import net.minestom.server.item.Material;
 import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.registry.TagKey;
-import net.minestom.server.utils.Unit;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -22,8 +21,7 @@ public sealed interface SlotDisplay extends ComponentHolder<SlotDisplay> {
     final class Empty implements SlotDisplay {
         public static final Empty INSTANCE = new Empty();
 
-        public static final NetworkBuffer.Type<Empty> NETWORK_TYPE = NetworkBuffer.UNIT.transform(
-                buffer -> INSTANCE, empty -> Unit.INSTANCE);
+        public static final NetworkBuffer.Type<Empty> NETWORK_TYPE = NetworkBufferTemplate.template(INSTANCE);
 
         private Empty() {
         }
@@ -32,8 +30,7 @@ public sealed interface SlotDisplay extends ComponentHolder<SlotDisplay> {
     final class AnyFuel implements SlotDisplay {
         public static final AnyFuel INSTANCE = new AnyFuel();
 
-        public static final NetworkBuffer.Type<AnyFuel> NETWORK_TYPE = NetworkBuffer.UNIT.transform(
-                buffer -> INSTANCE, empty -> Unit.INSTANCE);
+        public static final NetworkBuffer.Type<AnyFuel> NETWORK_TYPE = NetworkBufferTemplate.template(INSTANCE);
 
         private AnyFuel() {
         }


### PR DESCRIPTION
Kept the supplier version as it could remain useful in some very niche situations (not in this repo I suppose) and to avoid a breaking change