### PR TITLE
Split block occlusion and collision shapes

### DIFF
--- a/src/main/java/net/minestom/server/collision/BlockCollision.java
+++ b/src/main/java/net/minestom/server/collision/BlockCollision.java
@@ -61,8 +61,8 @@ final class BlockCollision {
                                                Block.Getter getter, PhysicsResult lastPhysicsResult) {
         if (lastPhysicsResult != null && lastPhysicsResult.collisionShapes()[1] instanceof ShapeImpl shape) {
             var currentBlock = getter.getBlock(lastPhysicsResult.collisionShapePositions()[1], Block.Getter.Condition.TYPE);
-            var lastBlockBoxes = shape.collisionBoundingBoxes();
-            var currentBlockBoxes = ((ShapeImpl) currentBlock.registry().collisionShape()).collisionBoundingBoxes();
+            var lastBlockBoxes = shape.boundingBoxes();
+            var currentBlockBoxes = ((ShapeImpl) currentBlock.registry().collisionShape()).boundingBoxes();
 
             // Fast exit if entity hasn't moved
             if (lastPhysicsResult.collisionY()

--- a/src/main/java/net/minestom/server/collision/CollisionUtils.java
+++ b/src/main/java/net/minestom/server/collision/CollisionUtils.java
@@ -177,12 +177,22 @@ public final class CollisionUtils {
         return newPosition;
     }
 
-    public static Shape parseBlockShape(Map<Object, Object> internCache, String collision, String occlusion, boolean occludes, byte lightEmission) {
-        record ShapeEntry(String collision, String occlusion, boolean occludes, byte lightEmission) {} // Easy way to Hashcode
-        ShapeEntry entry = new ShapeEntry(collision, occlusion, occludes, lightEmission);
+    public static Shape parseCollisionShape(Map<Object, Object> internCache, String shape) {
+        record ShapeEntry(String shape) {} // Easy way to Hashcode
+        ShapeEntry entry = new ShapeEntry(shape);
         final Shape cachedShape = (Shape) internCache.get(entry);
         if (cachedShape != null) return cachedShape;
-        final Shape parsedShape = ShapeImpl.parseBlockFromRegistry(collision, occlusion, occludes, lightEmission);
+        final Shape parsedShape = ShapeImpl.parseShapeFromRegistry(shape, (byte) 0);
+        internCache.put(entry, parsedShape);
+        return (Shape) internCache.computeIfAbsent(parsedShape, k -> parsedShape);
+    }
+
+    public static Shape parseOcclusionShape(Map<Object, Object> internCache, String shape, boolean occludes, byte lightEmission) {
+        record ShapeEntry(String shape, boolean occludes, byte lightEmission) {} // Easy way to Hashcode
+        ShapeEntry entry = new ShapeEntry(shape, occludes, lightEmission);
+        final Shape cachedShape = (Shape) internCache.get(entry);
+        if (cachedShape != null) return cachedShape;
+        final Shape parsedShape = occludes ? ShapeImpl.parseShapeFromRegistry(shape, lightEmission) : ShapeImpl.emptyShape(lightEmission);
         internCache.put(entry, parsedShape);
         return (Shape) internCache.computeIfAbsent(parsedShape, k -> parsedShape);
     }

--- a/src/main/java/net/minestom/server/collision/CollisionUtils.java
+++ b/src/main/java/net/minestom/server/collision/CollisionUtils.java
@@ -178,12 +178,10 @@ public final class CollisionUtils {
     }
 
     public static Shape parseCollisionShape(Map<Object, Object> internCache, String shape) {
-        record ShapeEntry(String shape) {} // Easy way to Hashcode
-        ShapeEntry entry = new ShapeEntry(shape);
-        final Shape cachedShape = (Shape) internCache.get(entry);
+        final Shape cachedShape = (Shape) internCache.get(shape);
         if (cachedShape != null) return cachedShape;
         final Shape parsedShape = ShapeImpl.parseShapeFromRegistry(shape, (byte) 0);
-        internCache.put(entry, parsedShape);
+        internCache.put(shape, parsedShape);
         return (Shape) internCache.computeIfAbsent(parsedShape, k -> parsedShape);
     }
 

--- a/src/main/java/net/minestom/server/collision/ShapeImpl.java
+++ b/src/main/java/net/minestom/server/collision/ShapeImpl.java
@@ -126,7 +126,7 @@ public record ShapeImpl(ShapeData shapeData, OcclusionData occlusionData) implem
      *
      * @return the bounding boxes for this shape
      */
-    public @NotNull @Unmodifiable List<BoundingBox> collisionBoundingBoxes() {
+    public @NotNull @Unmodifiable List<BoundingBox> boundingBoxes() {
         return shapeData.boundingBoxes;
     }
 

--- a/src/main/java/net/minestom/server/instance/LightingChunk.java
+++ b/src/main/java/net/minestom/server/instance/LightingChunk.java
@@ -107,9 +107,9 @@ public class LightingChunk extends DynamicChunk {
         if (block == Block.AIR) return false;
         if (DIFFUSE_SKY_LIGHT.contains(block.key())) return true;
 
-        Shape shape = block.registry().collisionShape();
-        boolean occludesTop = Block.AIR.registry().collisionShape().isOccluded(shape, BlockFace.TOP);
-        boolean occludesBottom = Block.AIR.registry().collisionShape().isOccluded(shape, BlockFace.BOTTOM);
+        Shape shape = block.registry().occlusionShape();
+        boolean occludesTop = Block.AIR.registry().occlusionShape().isOccluded(shape, BlockFace.TOP);
+        boolean occludesBottom = Block.AIR.registry().occlusionShape().isOccluded(shape, BlockFace.BOTTOM);
 
         return occludesBottom || occludesTop;
     }

--- a/src/main/java/net/minestom/server/instance/light/BlockLight.java
+++ b/src/main/java/net/minestom/server/instance/light/BlockLight.java
@@ -99,13 +99,13 @@ final class BlockLight implements Light {
                     });
 
                     if (blockTo == null && blockFrom != null) {
-                        if (blockFrom.registry().collisionShape().isOccluded(Block.AIR.registry().collisionShape(), face.getOppositeFace()))
+                        if (blockFrom.registry().occlusionShape().isOccluded(Block.AIR.registry().occlusionShape(), face.getOppositeFace()))
                             continue;
                     } else if (blockTo != null && blockFrom == null) {
-                        if (Block.AIR.registry().collisionShape().isOccluded(blockTo.registry().collisionShape(), face))
+                        if (Block.AIR.registry().occlusionShape().isOccluded(blockTo.registry().occlusionShape(), face))
                             continue;
                     } else if (blockTo != null && blockFrom != null) {
-                        if (blockFrom.registry().collisionShape().isOccluded(blockTo.registry().collisionShape(), face.getOppositeFace()))
+                        if (blockFrom.registry().occlusionShape().isOccluded(blockTo.registry().occlusionShape(), face.getOppositeFace()))
                             continue;
                     }
 

--- a/src/main/java/net/minestom/server/instance/light/LightCompute.java
+++ b/src/main/java/net/minestom/server/instance/light/LightCompute.java
@@ -82,8 +82,8 @@ public final class LightCompute {
                     final Block currentBlock = Objects.requireNonNullElse(getBlock(blockPalette, x, y, z), Block.AIR);
                     final Block propagatedBlock = Objects.requireNonNullElse(getBlock(blockPalette, xO, yO, zO), Block.AIR);
 
-                    final Shape currentShape = currentBlock.registry().collisionShape();
-                    final Shape propagatedShape = propagatedBlock.registry().collisionShape();
+                    final Shape currentShape = currentBlock.registry().occlusionShape();
+                    final Shape propagatedShape = propagatedBlock.registry().occlusionShape();
 
                     final boolean airAir = currentBlock.isAir() && propagatedBlock.isAir();
                     if (!airAir && currentShape.isOccluded(propagatedShape, BlockFace.fromDirection(direction)))

--- a/src/main/java/net/minestom/server/instance/light/SkyLight.java
+++ b/src/main/java/net/minestom/server/instance/light/SkyLight.java
@@ -101,13 +101,13 @@ final class SkyLight implements Light {
                     });
 
                     if (blockTo == null && blockFrom != null) {
-                        if (blockFrom.registry().collisionShape().isOccluded(Block.AIR.registry().collisionShape(), face.getOppositeFace()))
+                        if (blockFrom.registry().occlusionShape().isOccluded(Block.AIR.registry().occlusionShape(), face.getOppositeFace()))
                             continue;
                     } else if (blockTo != null && blockFrom == null) {
-                        if (Block.AIR.registry().collisionShape().isOccluded(blockTo.registry().collisionShape(), face))
+                        if (Block.AIR.registry().occlusionShape().isOccluded(blockTo.registry().occlusionShape(), face))
                             continue;
                     } else if (blockTo != null && blockFrom != null) {
-                        if (blockFrom.registry().collisionShape().isOccluded(blockTo.registry().collisionShape(), face.getOppositeFace()))
+                        if (blockFrom.registry().occlusionShape().isOccluded(blockTo.registry().occlusionShape(), face.getOppositeFace()))
                             continue;
                     }
 

--- a/src/test/java/net/minestom/server/instance/light/BlockIsOccludedTest.java
+++ b/src/test/java/net/minestom/server/instance/light/BlockIsOccludedTest.java
@@ -13,8 +13,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class BlockIsOccludedTest {
     @Test
     public void blockAir() {
-        Shape airBlock = Block.AIR.registry().collisionShape();
-        
+        Shape airBlock = Block.AIR.registry().occlusionShape();
+
         for (BlockFace face : BlockFace.values()) {
             assertFalse(airBlock.isOccluded(airBlock, face));
         }
@@ -22,8 +22,8 @@ public class BlockIsOccludedTest {
 
     @Test
     public void blockLantern() {
-        Shape shape = Block.LANTERN.registry().collisionShape();
-        Shape airBlock = Block.AIR.registry().collisionShape();
+        Shape shape = Block.LANTERN.registry().occlusionShape();
+        Shape airBlock = Block.AIR.registry().occlusionShape();
 
         for (BlockFace face : BlockFace.values()) {
             assertFalse(shape.isOccluded(airBlock, face));
@@ -32,8 +32,8 @@ public class BlockIsOccludedTest {
 
     @Test
     public void blockSpruceLeaves() {
-        Shape shape = Block.SPRUCE_LEAVES.registry().collisionShape();
-        Shape airBlock = Block.AIR.registry().collisionShape();
+        Shape shape = Block.SPRUCE_LEAVES.registry().occlusionShape();
+        Shape airBlock = Block.AIR.registry().occlusionShape();
 
         for (BlockFace face : BlockFace.values()) {
             assertFalse(shape.isOccluded(airBlock, face));
@@ -42,8 +42,8 @@ public class BlockIsOccludedTest {
 
     @Test
     public void blockCauldron() {
-        Shape shape = Block.CAULDRON.registry().collisionShape();
-        Shape airBlock = Block.AIR.registry().collisionShape();
+        Shape shape = Block.CAULDRON.registry().occlusionShape();
+        Shape airBlock = Block.AIR.registry().occlusionShape();
 
         for (BlockFace face : BlockFace.values()) {
             assertFalse(shape.isOccluded(airBlock, face));
@@ -52,8 +52,8 @@ public class BlockIsOccludedTest {
 
     @Test
     public void blockSlabBottomAir() {
-        Shape shape = Block.SANDSTONE_SLAB.registry().collisionShape();
-        Shape airBlock = Block.AIR.registry().collisionShape();
+        Shape shape = Block.SANDSTONE_SLAB.registry().occlusionShape();
+        Shape airBlock = Block.AIR.registry().occlusionShape();
 
         assertTrue(shape.isOccluded(airBlock, BlockFace.BOTTOM));
 
@@ -66,8 +66,8 @@ public class BlockIsOccludedTest {
 
     @Test
     public void blockSlabTopEnchantingTable() {
-        Shape shape1 = Block.SANDSTONE_SLAB.withProperty("type", "top").registry().collisionShape();
-        Shape shape2 = Block.ENCHANTING_TABLE.registry().collisionShape();
+        Shape shape1 = Block.SANDSTONE_SLAB.withProperty("type", "top").registry().occlusionShape();
+        Shape shape2 = Block.ENCHANTING_TABLE.registry().occlusionShape();
 
         assertFalse(shape1.isOccluded(shape2, BlockFace.BOTTOM));
 
@@ -83,9 +83,9 @@ public class BlockIsOccludedTest {
         Shape shape = Block.SANDSTONE_STAIRS.withProperties(Map.of(
                 "facing", "west",
                 "half", "bottom",
-                "shape", "straight")).registry().collisionShape();
+                "shape", "straight")).registry().occlusionShape();
 
-        Shape airBlock = Block.AIR.registry().collisionShape();
+        Shape airBlock = Block.AIR.registry().occlusionShape();
 
         assertTrue(shape.isOccluded(airBlock, BlockFace.WEST));
         assertTrue(shape.isOccluded(airBlock, BlockFace.BOTTOM));
@@ -98,8 +98,8 @@ public class BlockIsOccludedTest {
 
     @Test
     public void blockSlabBottomStone() {
-        Shape shape = Block.SANDSTONE_SLAB.registry().collisionShape();
-        Shape stoneBlock = Block.STONE.registry().collisionShape();
+        Shape shape = Block.SANDSTONE_SLAB.registry().occlusionShape();
+        Shape stoneBlock = Block.STONE.registry().occlusionShape();
 
         assertTrue(shape.isOccluded(stoneBlock, BlockFace.BOTTOM));
         assertTrue(shape.isOccluded(stoneBlock, BlockFace.NORTH));
@@ -111,8 +111,8 @@ public class BlockIsOccludedTest {
 
     @Test
     public void blockStone() {
-        Shape shape = Block.STONE.registry().collisionShape();
-        Shape airBlock = Block.AIR.registry().collisionShape();
+        Shape shape = Block.STONE.registry().occlusionShape();
+        Shape airBlock = Block.AIR.registry().occlusionShape();
 
         for (BlockFace face : BlockFace.values()) {
             assertTrue(shape.isOccluded(airBlock, face));
@@ -121,8 +121,8 @@ public class BlockIsOccludedTest {
 
     @Test
     public void blockStair() {
-        Shape shape = Block.SANDSTONE_STAIRS.registry().collisionShape();
-        Shape airBlock = Block.AIR.registry().collisionShape();
+        Shape shape = Block.SANDSTONE_STAIRS.registry().occlusionShape();
+        Shape airBlock = Block.AIR.registry().occlusionShape();
 
         assertTrue(shape.isOccluded(airBlock, BlockFace.NORTH));
         assertTrue(shape.isOccluded(airBlock, BlockFace.BOTTOM));
@@ -135,8 +135,8 @@ public class BlockIsOccludedTest {
 
     @Test
     public void blockSlab() {
-        Shape shape = Block.SANDSTONE_SLAB.registry().collisionShape();
-        Shape airBlock = Block.AIR.registry().collisionShape();
+        Shape shape = Block.SANDSTONE_SLAB.registry().occlusionShape();
+        Shape airBlock = Block.AIR.registry().occlusionShape();
 
         assertTrue(shape.isOccluded(airBlock, BlockFace.BOTTOM));
 
@@ -149,8 +149,8 @@ public class BlockIsOccludedTest {
 
     @Test
     public void blockSlabBottomAndSlabTop() {
-        Shape shape1 = Block.SANDSTONE_SLAB.registry().collisionShape();
-        Shape shape2 = Block.SANDSTONE_SLAB.withProperty("type", "top").registry().collisionShape();
+        Shape shape1 = Block.SANDSTONE_SLAB.registry().occlusionShape();
+        Shape shape2 = Block.SANDSTONE_SLAB.withProperty("type", "top").registry().occlusionShape();
 
         assertFalse(shape1.isOccluded(shape2, BlockFace.TOP));
 
@@ -163,7 +163,7 @@ public class BlockIsOccludedTest {
 
     @Test
     public void blockSlabBottomAndSlabBottom() {
-        Shape shape = Block.SANDSTONE_SLAB.registry().collisionShape();
+        Shape shape = Block.SANDSTONE_SLAB.registry().occlusionShape();
 
         assertTrue(shape.isOccluded(shape, BlockFace.BOTTOM));
         assertTrue(shape.isOccluded(shape, BlockFace.TOP));
@@ -176,8 +176,8 @@ public class BlockIsOccludedTest {
 
     @Test
     public void blockStairAndSlabBottom() {
-        Shape shape1 = Block.STONE_STAIRS.registry().collisionShape();
-        Shape shape2 = Block.SANDSTONE_SLAB.registry().collisionShape();
+        Shape shape1 = Block.STONE_STAIRS.registry().occlusionShape();
+        Shape shape2 = Block.SANDSTONE_SLAB.registry().occlusionShape();
 
         assertTrue(shape1.isOccluded(shape2, BlockFace.BOTTOM));
         assertTrue(shape1.isOccluded(shape2, BlockFace.NORTH));
@@ -190,8 +190,8 @@ public class BlockIsOccludedTest {
 
     @Test
     public void blockStairAndSlabTop() {
-        Shape shape1 = Block.STONE_STAIRS.registry().collisionShape();
-        Shape shape2 = Block.SANDSTONE_SLAB.withProperty("type", "top").registry().collisionShape();
+        Shape shape1 = Block.STONE_STAIRS.registry().occlusionShape();
+        Shape shape2 = Block.SANDSTONE_SLAB.withProperty("type", "top").registry().occlusionShape();
 
         assertTrue(shape1.isOccluded(shape2, BlockFace.NORTH));
         assertTrue(shape1.isOccluded(shape2, BlockFace.BOTTOM));
@@ -200,5 +200,25 @@ public class BlockIsOccludedTest {
         assertTrue(shape1.isOccluded(shape2, BlockFace.SOUTH));
 
         assertFalse(shape1.isOccluded(shape2, BlockFace.TOP));
+    }
+
+    @Test
+    public void occlusionShapeLeaves() {
+        Shape shape = Block.OAK_LEAVES.registry().occlusionShape();
+        Shape airBlock = Block.AIR.registry().occlusionShape();
+
+        for (BlockFace face : BlockFace.values()) {
+            assertFalse(shape.isOccluded(airBlock, face));
+        }
+    }
+
+    @Test
+    public void collisionShapeLeaves() {
+        Shape shape = Block.OAK_LEAVES.registry().collisionShape();
+        Shape airBlock = Block.AIR.registry().collisionShape();
+
+        for (BlockFace face : BlockFace.values()) {
+            assertTrue(shape.isOccluded(airBlock, face));
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

This PR separates the occlusion and collision shapes of blocks. Previously, those were linked together in the `ShapeImpl` object.

For example, `ShapeImpl#isOccluded` would perform an occlusion check using the _occlusion shape_, but `ShapeImpl#relativeStart` (on the same shape) would return the relative start of the _collision shape_. Besides being very confusing, this made it impossible to perform occlusion checks on the _collision shape_ or get the relative start of the _occlusion shape_.
Especially the ability to do occlusion checks on the collision shape is very useful for reimplementing certain vanilla features (my current use case is fluids).

With this PR it is possible to do the following:
`block.registry().occlusionShape().relativeStart()`
`block.registry().collisionShape().isOccluded(...)`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

This is a breaking change, since existing uses of `shape.collisionShape().isOccluded()` will now no longer check occlusion for the _occlusion shape_, but for the _collision shape_.

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

This does slightly increase the memory usage of block shapes, since the `relativeStart`, `relativeEnd` and `lightEmission` fields will now be tracked for both shape types. However, with the added functionality I think it is worth it.

Also: previously, `ShapeImpl` had a `CollisionData` field and a `LightData` field, which were independent of each other. With this PR, it has a `ShapeData` and an `OcclusionData` field, but these are no longer independent, since the `OcclusionData` is made using the `ShapeData`. Would this matter? In my opinion it is cleaner this way, but we could also just add all the data fields to `ShapeImpl` directly.