### PR TITLE
Hide the unbreakable and weapon attributes on items

### DIFF
--- a/src/main/java/net/minestom/server/item/ItemStackImpl.java
+++ b/src/main/java/net/minestom/server/item/ItemStackImpl.java
@@ -208,7 +208,8 @@ record ItemStackImpl(Material material, int amount, DataComponentMap components)
                     DataComponents.CONTAINER, DataComponents.CONTAINER_LOOT, DataComponents.FIREWORK_EXPLOSION,
                     DataComponents.FIREWORKS, DataComponents.INSTRUMENT, DataComponents.MAP_ID,
                     DataComponents.PAINTING_VARIANT, DataComponents.POT_DECORATIONS, DataComponents.POTION_CONTENTS,
-                    DataComponents.TROPICAL_FISH_PATTERN, DataComponents.WRITTEN_BOOK_CONTENT
+                    DataComponents.TROPICAL_FISH_PATTERN, DataComponents.WRITTEN_BOOK_CONTENT,
+                    DataComponents.UNBREAKABLE, DataComponents.ATTRIBUTE_MODIFIERS
             )));
         }
 


### PR DESCRIPTION
## Proposed changes


This PR adds the Unbreakable and Attribute Modifiers components to the list of hidden components in the `ItemBuilder#hideExtraTooltip()` implementation. It brings the method more in line with the rest of the behavior, by hiding the rest of the "extra tooltip" components. I didn't bother opening an issue because it would take just add to the pile of issues, when I could just fix it.

The builders for these items only differed by the inclusion of the two components in the TooltipDisplay object supplied to the `TOOLTIP_DISPLAY` data component 
Before:
<img width="416" height="243" alt="image" src="https://github.com/user-attachments/assets/2c53a475-e654-44d3-84d4-3888ef8b2f4e" />

After:
<img width="413" height="150" alt="image" src="https://github.com/user-attachments/assets/caf24b51-75bf-4ec3-b70e-1cfd80ed87ad" />


## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Its a pretty simple change, so I don't believe much discussion is necessary.