### PR TITLE
BlockVec canonical constructor should take ints

### DIFF
--- a/demo/src/main/java/net/minestom/demo/PlayerInit.java
+++ b/demo/src/main/java/net/minestom/demo/PlayerInit.java
@@ -1,7 +1,6 @@
 package net.minestom.demo;
 
 import net.kyori.adventure.key.Key;
-import net.kyori.adventure.nbt.*;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
@@ -12,7 +11,6 @@ import net.minestom.server.advancements.FrameType;
 import net.minestom.server.advancements.Notification;
 import net.minestom.server.adventure.MinestomAdventure;
 import net.minestom.server.adventure.audience.Audiences;
-import net.minestom.server.adventure.serializer.nbt.NbtComponentSerializer;
 import net.minestom.server.component.DataComponents;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
@@ -46,7 +44,6 @@ import net.minestom.server.network.packet.server.common.CustomReportDetailsPacke
 import net.minestom.server.network.packet.server.common.ServerLinksPacket;
 import net.minestom.server.network.packet.server.play.TrackedWaypointPacket;
 import net.minestom.server.sound.SoundEvent;
-import net.minestom.server.tag.Tag;
 import net.minestom.server.utils.Either;
 import net.minestom.server.utils.MathUtils;
 import net.minestom.server.utils.time.TimeUnit;
@@ -59,8 +56,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class PlayerInit {
 
@@ -242,7 +237,7 @@ public class PlayerInit {
                 if (block.getProperty("part") == null || block.getProperty("facing") == null) return;
                 var isHead = "head".equals(block.getProperty("part"));
                 var facing = BlockFace.valueOf(block.getProperty("facing").toUpperCase());
-                var other = (isHead ? pos.add(facing.getOppositeFace().toDirection().vec().asPosition()) : pos.add(facing.toDirection().vec().asPosition()));
+                var other = (isHead ? pos.add(facing.getOppositeFace().toDirection().vec().asPos()) : pos.add(facing.toDirection().vec().asPos()));
                 var otherBlock = instance.getBlock(other);
                 if (otherBlock.id() == block.id()) {
                     instance.setBlock(other, Block.AIR);
@@ -257,7 +252,7 @@ public class PlayerInit {
                     if (block.getProperty("part") == null || block.getProperty("facing") == null) return;
                     var isHead = "head".equals(block.getProperty("part"));
                     var facing = BlockFace.valueOf(block.getProperty("facing").toUpperCase());
-                    var other = (isHead ? pos.add(facing.getOppositeFace().toDirection().vec().asPosition()) : pos.add(facing.toDirection().vec().asPosition()));
+                    var other = (isHead ? pos.add(facing.getOppositeFace().toDirection().vec().asPos()) : pos.add(facing.toDirection().vec().asPos()));
                     var otherBlock = instance.getBlock(other);
                     if (otherBlock.id() == block.id()) {
                         player.setVelocity(Vec.ZERO);

--- a/src/main/java/net/minestom/server/collision/BlockCollision.java
+++ b/src/main/java/net/minestom/server/collision/BlockCollision.java
@@ -203,7 +203,7 @@ final class BlockCollision {
         BlockIterator iterator = new BlockIterator();
         // When large moves are done we need to ray-cast to find all blocks that could intersect with the movement
         for (Vec point : allFaces) {
-            iterator.reset(Vec.fromPoint(point.add(entityPosition)), velocity, 0, velocity.length(), false);
+            iterator.reset(point.add(entityPosition), velocity, 0, velocity.length(), false);
             int timer = -1;
 
             while (iterator.hasNext() && timer != 0) {

--- a/src/main/java/net/minestom/server/collision/BoundingBox.java
+++ b/src/main/java/net/minestom/server/collision/BoundingBox.java
@@ -22,7 +22,7 @@ public record BoundingBox(Vec relativeStart, Vec relativeEnd) implements Shape {
     final static BoundingBox ZERO = new BoundingBox(Vec.ZERO, Vec.ZERO);
 
     public BoundingBox(double width, double height, double depth, Point offset) {
-        this(Vec.fromPoint(offset), new Vec(width, height, depth).add(offset));
+        this(offset.asVec(), new Vec(width, height, depth).add(offset));
     }
 
     public BoundingBox(double width, double height, double depth) {
@@ -299,7 +299,7 @@ public record BoundingBox(Vec relativeStart, Vec relativeEnd) implements Shape {
     }
 
     public static @NotNull BoundingBox fromPoints(@NotNull Point a, @NotNull Point b) {
-        Vec aVec = Vec.fromPoint(a);
+        Vec aVec = a.asVec();
         Vec min = aVec.min(b);
         Vec max = aVec.max(b);
         Vec dimensions = max.sub(min);

--- a/src/main/java/net/minestom/server/collision/CollisionUtils.java
+++ b/src/main/java/net/minestom/server/collision/CollisionUtils.java
@@ -141,8 +141,7 @@ public final class CollisionUtils {
                                                      @NotNull Point start, @NotNull Point end,
                                                      @NotNull Shape shape) {
         final PhysicsResult result = handlePhysics(instance, chunk,
-                BoundingBox.ZERO,
-                Pos.fromPoint(start), Vec.fromPoint(end.sub(start)),
+                BoundingBox.ZERO, start.asPosition(), end.sub(start).asVec(),
                 null, false);
 
         return shape.intersectBox(end.sub(result.newPosition()).sub(Vec.EPSILON), BoundingBox.ZERO);
@@ -178,7 +177,8 @@ public final class CollisionUtils {
     }
 
     public static Shape parseBlockShape(Map<Object, Object> internCache, String collision, String occlusion, boolean occludes, byte lightEmission) {
-        record ShapeEntry(String collision, String occlusion, boolean occludes, byte lightEmission) {} // Easy way to Hashcode
+        record ShapeEntry(String collision, String occlusion, boolean occludes, byte lightEmission) {
+        } // Easy way to Hashcode
         ShapeEntry entry = new ShapeEntry(collision, occlusion, occludes, lightEmission);
         final Shape cachedShape = (Shape) internCache.get(entry);
         if (cachedShape != null) return cachedShape;

--- a/src/main/java/net/minestom/server/collision/CollisionUtils.java
+++ b/src/main/java/net/minestom/server/collision/CollisionUtils.java
@@ -141,7 +141,7 @@ public final class CollisionUtils {
                                                      @NotNull Point start, @NotNull Point end,
                                                      @NotNull Shape shape) {
         final PhysicsResult result = handlePhysics(instance, chunk,
-                BoundingBox.ZERO, start.asPosition(), end.sub(start).asVec(),
+                BoundingBox.ZERO, start.asPos(), end.sub(start).asVec(),
                 null, false);
 
         return shape.intersectBox(end.sub(result.newPosition()).sub(Vec.EPSILON), BoundingBox.ZERO);

--- a/src/main/java/net/minestom/server/collision/EntityCollision.java
+++ b/src/main/java/net/minestom/server/collision/EntityCollision.java
@@ -28,7 +28,7 @@ final class EntityCollision {
 
             // Overlapping with entity, math can't be done we return the entity
             if (e.getBoundingBox().intersectBox(e.getPosition().sub(point), boundingBox)) {
-                var p = point.asPosition();
+                var p = point.asPos();
                 result.add(new EntityCollisionResult(p, e, Vec.ZERO, 0));
                 continue;
             }
@@ -37,7 +37,7 @@ final class EntityCollision {
             boolean intersected = e.getBoundingBox().intersectBoxSwept(point, entityVelocity, e.getPosition(), boundingBox, sweepResult);
 
             if (intersected && sweepResult.res < 1) {
-                var p = point.asPosition().add(entityVelocity.mul(sweepResult.res));
+                var p = point.asPos().add(entityVelocity.mul(sweepResult.res));
                 Vec direction = new Vec(sweepResult.collidedPositionX, sweepResult.collidedPositionY, sweepResult.collidedPositionZ);
                 result.add(new EntityCollisionResult(p, e, direction, sweepResult.res));
             }

--- a/src/main/java/net/minestom/server/collision/EntityCollision.java
+++ b/src/main/java/net/minestom/server/collision/EntityCollision.java
@@ -1,7 +1,6 @@
 package net.minestom.server.collision;
 
 import net.minestom.server.coordinate.Point;
-import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.instance.Instance;
@@ -18,7 +17,7 @@ final class EntityCollision {
 
         List<EntityCollisionResult> result = new ArrayList<>();
 
-        var maxDistance = Math.pow(boundingBox.height() * boundingBox.height() + boundingBox.depth()/2 * boundingBox.depth()/2 + boundingBox.width()/2 * boundingBox.width()/2, 1/3.0);
+        var maxDistance = Math.pow(boundingBox.height() * boundingBox.height() + boundingBox.depth() / 2 * boundingBox.depth() / 2 + boundingBox.width() / 2 * boundingBox.width() / 2, 1 / 3.0);
         double projectileDistance = entityVelocity.length();
 
         for (Entity e : instance.getNearbyEntities(point, extendRadius + maxDistance + projectileDistance)) {
@@ -29,7 +28,7 @@ final class EntityCollision {
 
             // Overlapping with entity, math can't be done we return the entity
             if (e.getBoundingBox().intersectBox(e.getPosition().sub(point), boundingBox)) {
-                var p = Pos.fromPoint(point);
+                var p = point.asPosition();
                 result.add(new EntityCollisionResult(p, e, Vec.ZERO, 0));
                 continue;
             }
@@ -38,7 +37,7 @@ final class EntityCollision {
             boolean intersected = e.getBoundingBox().intersectBoxSwept(point, entityVelocity, e.getPosition(), boundingBox, sweepResult);
 
             if (intersected && sweepResult.res < 1) {
-                var p = Pos.fromPoint(point).add(entityVelocity.mul(sweepResult.res));
+                var p = point.asPosition().add(entityVelocity.mul(sweepResult.res));
                 Vec direction = new Vec(sweepResult.collidedPositionX, sweepResult.collidedPositionY, sweepResult.collidedPositionZ);
                 result.add(new EntityCollisionResult(p, e, direction, sweepResult.res));
             }

--- a/src/main/java/net/minestom/server/coordinate/BlockVec.java
+++ b/src/main/java/net/minestom/server/coordinate/BlockVec.java
@@ -101,7 +101,7 @@ public record BlockVec(int blockX, int blockY, int blockZ) implements Point {
 
     @Contract(pure = true)
     public @NotNull BlockVec add(@NotNull BlockVec blockVec) {
-        return new BlockVec(blockX + blockVec.x(), blockY + blockVec.y(), blockZ + blockVec.z());
+        return new BlockVec(blockX + blockVec.blockX, blockY + blockVec.blockY, blockZ + blockVec.blockZ);
     }
 
     @Override
@@ -131,7 +131,7 @@ public record BlockVec(int blockX, int blockY, int blockZ) implements Point {
 
     @Contract(pure = true)
     public @NotNull BlockVec sub(@NotNull BlockVec blockVec) {
-        return new BlockVec(blockX - blockVec.x(), blockY - blockVec.y(), blockZ - blockVec.z());
+        return new BlockVec(blockX - blockVec.blockX, blockY - blockVec.blockY, blockZ - blockVec.blockZ);
     }
 
     @Override
@@ -154,6 +154,11 @@ public record BlockVec(int blockX, int blockY, int blockZ) implements Point {
         return mul(point.x(), point.y(), point.z());
     }
 
+    @Contract(pure = true)
+    public @NotNull BlockVec mul(@NotNull BlockVec blockVec) {
+        return new BlockVec(blockX * blockVec.blockX, blockY * blockVec.blockY, blockZ * blockVec.blockZ);
+    }
+
     @Override
     public @NotNull Point mul(double value) {
         return mul(value, value, value);
@@ -167,6 +172,11 @@ public record BlockVec(int blockX, int blockY, int blockZ) implements Point {
     @Override
     public @NotNull Point div(@NotNull Point point) {
         return div(point.x(), point.y(), point.z());
+    }
+
+    @Contract(pure = true)
+    public @NotNull BlockVec div(@NotNull BlockVec blockVec) {
+        return new BlockVec(blockX / blockVec.blockX, blockY / blockVec.blockY, blockZ / blockVec.blockZ);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/coordinate/BlockVec.java
+++ b/src/main/java/net/minestom/server/coordinate/BlockVec.java
@@ -208,9 +208,4 @@ public record BlockVec(int blockX, int blockY, int blockZ) implements Point {
             case EAST -> add(1, 0, 0);
         };
     }
-
-    @Contract(pure = true)
-    public @NotNull Vec asVec() {
-        return new Vec(blockX, blockY, blockZ);
-    }
 }

--- a/src/main/java/net/minestom/server/coordinate/BlockVec.java
+++ b/src/main/java/net/minestom/server/coordinate/BlockVec.java
@@ -16,12 +16,24 @@ import static net.minestom.server.coordinate.CoordConversion.globalToBlock;
  * callers continually having to convert.
  */
 public record BlockVec(int blockX, int blockY, int blockZ) implements Point {
+    public static final BlockVec ZERO = new BlockVec(0);
+    public static final BlockVec ONE = new BlockVec(1);
+    public static final BlockVec SECTION = new BlockVec(16);
+
     public BlockVec(double x, double y, double z) {
         this(globalToBlock(x), globalToBlock(y), globalToBlock(z));
     }
 
     public BlockVec(@NotNull Point point) {
         this(point.blockX(), point.blockY(), point.blockZ());
+    }
+
+    public BlockVec(int value) {
+        this(value, value, value);
+    }
+
+    public BlockVec(double value) {
+        this(value, value, value);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/coordinate/BlockVec.java
+++ b/src/main/java/net/minestom/server/coordinate/BlockVec.java
@@ -21,7 +21,7 @@ public record BlockVec(int blockX, int blockY, int blockZ) implements Point {
     }
 
     public BlockVec(@NotNull Point point) {
-        this(point.x(), point.y(), point.z());
+        this(point.blockX(), point.blockY(), point.blockZ());
     }
 
     @Override

--- a/src/main/java/net/minestom/server/coordinate/BlockVec.java
+++ b/src/main/java/net/minestom/server/coordinate/BlockVec.java
@@ -6,6 +6,8 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.function.DoubleUnaryOperator;
 
+import static net.minestom.server.coordinate.CoordConversion.globalToBlock;
+
 /**
  * Represents an immutable block position.
  * <p>
@@ -13,15 +15,9 @@ import java.util.function.DoubleUnaryOperator;
  * it's usually better to accept a Point rather than a BlockVec to avoid
  * callers continually having to convert.
  */
-public record BlockVec(double x, double y, double z) implements Point {
-    public BlockVec {
-        x = Math.floor(x);
-        y = Math.floor(y);
-        z = Math.floor(z);
-    }
-
-    public BlockVec(int x, int y, int z) {
-        this((double) x, (double) y, (double) z);
+public record BlockVec(int blockX, int blockY, int blockZ) implements Point {
+    public BlockVec(double x, double y, double z) {
+        this(globalToBlock(x), globalToBlock(y), globalToBlock(z));
     }
 
     public BlockVec(@NotNull Point point) {
@@ -29,83 +25,83 @@ public record BlockVec(double x, double y, double z) implements Point {
     }
 
     @Override
-    public int blockX() {
-        return (int) x;
+    public double x() {
+        return blockX;
     }
 
     @Override
-    public int blockY() {
-        return (int) y;
+    public double y() {
+        return blockY;
     }
 
     @Override
-    public int blockZ() {
-        return (int) z;
+    public double z() {
+        return blockZ;
     }
 
     @Override
     public @NotNull Point withX(@NotNull DoubleUnaryOperator operator) {
-        return new Vec(operator.applyAsDouble(x), y, z);
+        return new Vec(operator.applyAsDouble(blockX), blockY, blockZ);
     }
 
     @Override
     public @NotNull Point withX(double x) {
-        return new Vec(x, y, z);
+        return new Vec(x, blockY, blockZ);
     }
 
     @Contract(pure = true)
     public @NotNull BlockVec withBlockX(int x) {
-        return new BlockVec(x, y, z);
+        return new BlockVec(x, blockY, blockZ);
     }
 
     @Override
     public @NotNull Point withY(@NotNull DoubleUnaryOperator operator) {
-        return new Vec(x, operator.applyAsDouble(y), z);
+        return new Vec(blockX, operator.applyAsDouble(blockY), blockZ);
     }
 
     @Override
     public @NotNull Point withY(double y) {
-        return new Vec(x, y, z);
+        return new Vec(blockX, y, blockZ);
     }
 
     @Contract(pure = true)
     public @NotNull BlockVec withBlockY(int y) {
-        return new BlockVec(x, y, z);
+        return new BlockVec(blockX, y, blockZ);
     }
 
     @Override
     public @NotNull Point withZ(@NotNull DoubleUnaryOperator operator) {
-        return new Vec(x, y, operator.applyAsDouble(z));
+        return new Vec(blockX, blockY, operator.applyAsDouble(blockZ));
     }
 
     @Override
     public @NotNull Point withZ(double z) {
-        return new Vec(x, y, z);
+        return new Vec(blockX, blockY, z);
     }
 
     @Contract(pure = true)
     public @NotNull BlockVec withBlockZ(int z) {
-        return new BlockVec(x, y, z);
+        return new BlockVec(blockX, blockY, z);
     }
 
     @Override
     public @NotNull Point add(double x, double y, double z) {
-        return new Vec(this.x + x, this.y + y, this.z + z);
+        return new Vec(blockX + x, blockY + y, blockZ + z);
     }
 
     @Contract(pure = true)
     public @NotNull BlockVec add(int x, int y, int z) {
-        return new BlockVec(this.x + x, this.y + y, this.z + z);
+        return new BlockVec(blockX + x, blockY + y, blockZ + z);
     }
 
     @Override
     public @NotNull Point add(@NotNull Point point) {
-        return new Vec(this.x + point.x(), this.y + point.y(), this.z + point.z());
+        return new Vec(blockX + point.x(), blockY + point.y(), blockZ + point.z());
     }
 
     @Contract(pure = true)
     public @NotNull BlockVec add(@NotNull BlockVec blockVec) {
-        return new BlockVec(this.x + blockVec.x(), this.y + blockVec.y(), this.z + blockVec.z());
+        return new BlockVec(blockX + blockVec.x(), blockY + blockVec.y(), blockZ + blockVec.z());
     }
 
     @Override
@@ -115,17 +111,17 @@ public record BlockVec(double x, double y, double z) implements Point {
 
     @Contract(pure = true)
     public @NotNull BlockVec add(int value) {
-        return new BlockVec(x + value, y + value, z + value);
+        return new BlockVec(blockX + value, blockY + value, blockZ + value);
     }
 
     @Override
     public @NotNull Point sub(double x, double y, double z) {
-        return new Vec(this.x - x, this.y - y, this.z - z);
+        return new Vec(blockX - x, blockY - y, blockZ - z);
     }
 
     @Contract(pure = true)
     public @NotNull BlockVec sub(int x, int y, int z) {
-        return new BlockVec(this.x - x, this.y - y, this.z - z);
+        return new BlockVec(blockX - x, blockY - y, blockZ - z);
     }
 
     @Override
@@ -135,7 +131,7 @@ public record BlockVec(double x, double y, double z) implements Point {
 
     @Contract(pure = true)
     public @NotNull BlockVec sub(@NotNull BlockVec blockVec) {
-        return new BlockVec(this.x - blockVec.x(), this.y - blockVec.y(), this.z - blockVec.z());
+        return new BlockVec(blockX - blockVec.x(), blockY - blockVec.y(), blockZ - blockVec.z());
     }
 
     @Override
@@ -145,12 +141,12 @@ public record BlockVec(double x, double y, double z) implements Point {
 
     @Contract(pure = true)
     public @NotNull BlockVec sub(int value) {
-        return new BlockVec(x - value, y - value, z - value);
+        return new BlockVec(blockX - value, blockY - value, blockZ - value);
     }
 
     @Override
     public @NotNull Point mul(double x, double y, double z) {
-        return new Vec(this.x * x, this.y * y, this.z * z);
+        return new Vec(blockX * x, blockY * y, blockZ * z);
     }
 
     @Override
@@ -165,7 +161,7 @@ public record BlockVec(double x, double y, double z) implements Point {
 
     @Override
     public @NotNull Point div(double x, double y, double z) {
-        return new Vec(this.x / x, this.y / y, this.z / z);
+        return new Vec(blockX / x, blockY / y, blockZ / z);
     }
 
     @Override
@@ -193,6 +189,6 @@ public record BlockVec(double x, double y, double z) implements Point {
 
     @Contract(pure = true)
     public @NotNull Vec asVec() {
-        return new Vec(x, y, z);
+        return new Vec(blockX, blockY, blockZ);
     }
 }

--- a/src/main/java/net/minestom/server/coordinate/Point.java
+++ b/src/main/java/net/minestom/server/coordinate/Point.java
@@ -297,4 +297,31 @@ public sealed interface Point permits Vec, Pos, BlockVec {
     default boolean sameBlock(@NotNull Point point) {
         return sameBlock(point.blockX(), point.blockY(), point.blockZ());
     }
+
+    @Contract(pure = true)
+    default @NotNull Pos asPosition() {
+        return switch (this) {
+            case Pos pos -> pos;
+            case Vec vec -> new Pos(vec.x(), vec.y(), vec.z());
+            case BlockVec blockVec -> new Pos(blockVec.blockX(), blockVec.blockY(), blockVec.blockZ());
+        };
+    }
+
+    @Contract(pure = true)
+    default @NotNull Vec asVec() {
+        return switch (this) {
+            case Vec vec -> vec;
+            case Pos pos -> new Vec(pos.x(), pos.y(), pos.z());
+            case BlockVec blockVec -> new Vec(blockVec.blockX(), blockVec.blockY(), blockVec.blockZ());
+        };
+    }
+
+    @Contract(pure = true)
+    default @NotNull BlockVec asBlockVec() {
+        return switch (this) {
+            case BlockVec blockVec -> blockVec;
+            case Pos pos -> new BlockVec(pos.blockX(), pos.blockY(), pos.blockZ());
+            case Vec vec -> new BlockVec(vec.blockX(), vec.blockY(), vec.blockZ());
+        };
+    }
 }

--- a/src/main/java/net/minestom/server/coordinate/Point.java
+++ b/src/main/java/net/minestom/server/coordinate/Point.java
@@ -299,7 +299,7 @@ public sealed interface Point permits Vec, Pos, BlockVec {
     }
 
     @Contract(pure = true)
-    default @NotNull Pos asPosition() {
+    default @NotNull Pos asPos() {
         return switch (this) {
             case Pos pos -> pos;
             case Vec vec -> new Pos(vec.x(), vec.y(), vec.z());

--- a/src/main/java/net/minestom/server/coordinate/Point.java
+++ b/src/main/java/net/minestom/server/coordinate/Point.java
@@ -239,12 +239,13 @@ public sealed interface Point permits Vec, Pos, BlockVec {
 
     /**
      * Checks it two points have similar (x/y/z) coordinates within a given epsilon.
-     * @param x the x coordinate to compare
-     * @param y the y coordinate to compare
-     * @param z the z coordinate to compare
+     *
+     * @param x       the x coordinate to compare
+     * @param y       the y coordinate to compare
+     * @param z       the z coordinate to compare
      * @param epsilon the maximum difference allowed between the two points (exclusive)
-     * @throws IllegalArgumentException if epsilon is less than or equal to 0
      * @return true if the two positions are similar within the epsilon
+     * @throws IllegalArgumentException if epsilon is less than or equal to 0
      */
     default boolean samePoint(double x, double y, double z, double epsilon) {
         Check.argCondition(epsilon <= 0, "Epsilon must be greater than 0 but found {0}", epsilon);
@@ -253,10 +254,11 @@ public sealed interface Point permits Vec, Pos, BlockVec {
 
     /**
      * Checks it two points have similar (x/y/z) coordinates within a given epsilon.
-     * @param point the point to compare
+     *
+     * @param point   the point to compare
      * @param epsilon the maximum difference allowed between the two points (exclusive)
-     * @throws IllegalArgumentException if epsilon is less than or equal to 0
      * @return true if the two positions are similar within the epsilon
+     * @throws IllegalArgumentException if epsilon is less than or equal to 0
      */
     default boolean samePoint(@NotNull Point point, double epsilon) {
         return samePoint(point.x(), point.y(), point.z(), epsilon);

--- a/src/main/java/net/minestom/server/coordinate/Pos.java
+++ b/src/main/java/net/minestom/server/coordinate/Pos.java
@@ -283,11 +283,6 @@ public record Pos(double x, double y, double z, float yaw, float pitch) implemen
         return (Pos) Point.super.relative(face);
     }
 
-    @Contract(pure = true)
-    public @NotNull Vec asVec() {
-        return new Vec(x, y, z);
-    }
-
     @FunctionalInterface
     public interface Operator {
         @NotNull Pos apply(double x, double y, double z, float yaw, float pitch);

--- a/src/main/java/net/minestom/server/coordinate/Pos.java
+++ b/src/main/java/net/minestom/server/coordinate/Pos.java
@@ -39,6 +39,7 @@ public record Pos(double x, double y, double z, float yaw, float pitch) implemen
      *
      * @param point the point to convert
      * @return the converted position
+     * @deprecated use {@link Point#asPosition()} instead
      */
     public static @NotNull Pos fromPoint(@NotNull Point point) {
         if (point instanceof Pos pos) return pos;
@@ -117,7 +118,7 @@ public record Pos(double x, double y, double z, float yaw, float pitch) implemen
     @Contract(pure = true)
     public @NotNull Pos withLookAt(@NotNull Point point) {
         if (samePoint(point)) return this;
-        final Vec delta = Vec.fromPoint(point.sub(this)).normalize();
+        final Vec delta = point.sub(this).asVec().normalize();
         return withView(PositionUtils.getLookYaw(delta.x(), delta.z()),
                 PositionUtils.getLookPitch(delta.x(), delta.y(), delta.z()));
     }

--- a/src/main/java/net/minestom/server/coordinate/Pos.java
+++ b/src/main/java/net/minestom/server/coordinate/Pos.java
@@ -41,6 +41,7 @@ public record Pos(double x, double y, double z, float yaw, float pitch) implemen
      * @return the converted position
      * @deprecated use {@link Point#asPos()} instead
      */
+    @Deprecated
     public static @NotNull Pos fromPoint(@NotNull Point point) {
         if (point instanceof Pos pos) return pos;
         return new Pos(point.x(), point.y(), point.z());

--- a/src/main/java/net/minestom/server/coordinate/Pos.java
+++ b/src/main/java/net/minestom/server/coordinate/Pos.java
@@ -39,7 +39,7 @@ public record Pos(double x, double y, double z, float yaw, float pitch) implemen
      *
      * @param point the point to convert
      * @return the converted position
-     * @deprecated use {@link Point#asPosition()} instead
+     * @deprecated use {@link Point#asPos()} instead
      */
     public static @NotNull Pos fromPoint(@NotNull Point point) {
         if (point instanceof Pos pos) return pos;

--- a/src/main/java/net/minestom/server/coordinate/Vec.java
+++ b/src/main/java/net/minestom/server/coordinate/Vec.java
@@ -202,11 +202,6 @@ public record Vec(double x, double y, double z) implements Point {
         return new Vec(Math.max(x, value), Math.max(y, value), Math.max(z, value));
     }
 
-    @Contract(pure = true)
-    public @NotNull Pos asPosition() {
-        return new Pos(x, y, z);
-    }
-
     /**
      * Gets the magnitude of the vector squared.
      *

--- a/src/main/java/net/minestom/server/coordinate/Vec.java
+++ b/src/main/java/net/minestom/server/coordinate/Vec.java
@@ -204,6 +204,15 @@ public record Vec(double x, double y, double z) implements Point {
     }
 
     /**
+     * @deprecated use {@link Point#asPos()} instead.
+     */
+    @Deprecated
+    @Contract(pure = true)
+    public @NotNull Pos asPosition() {
+        return new Pos(x, y, z);
+    }
+
+    /**
      * Gets the magnitude of the vector squared.
      *
      * @return the magnitude

--- a/src/main/java/net/minestom/server/coordinate/Vec.java
+++ b/src/main/java/net/minestom/server/coordinate/Vec.java
@@ -44,6 +44,7 @@ public record Vec(double x, double y, double z) implements Point {
      *
      * @param point the point to convert
      * @return the converted vector
+     * @deprecated use {@link Point#asVec()} instead
      */
     public static @NotNull Vec fromPoint(@NotNull Point point) {
         if (point instanceof Vec vec) return vec;

--- a/src/main/java/net/minestom/server/coordinate/Vec.java
+++ b/src/main/java/net/minestom/server/coordinate/Vec.java
@@ -46,6 +46,7 @@ public record Vec(double x, double y, double z) implements Point {
      * @return the converted vector
      * @deprecated use {@link Point#asVec()} instead
      */
+    @Deprecated
     public static @NotNull Vec fromPoint(@NotNull Point point) {
         if (point instanceof Vec vec) return vec;
         return new Vec(point.x(), point.y(), point.z());

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -860,7 +860,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     }
 
     public CompletableFuture<Void> setInstance(@NotNull Instance instance, @NotNull Point spawnPosition) {
-        return setInstance(instance, spawnPosition.asPosition());
+        return setInstance(instance, spawnPosition.asPos());
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -860,7 +860,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     }
 
     public CompletableFuture<Void> setInstance(@NotNull Instance instance, @NotNull Point spawnPosition) {
-        return setInstance(instance, Pos.fromPoint(spawnPosition));
+        return setInstance(instance, spawnPosition.asPosition());
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/EntityProjectile.java
+++ b/src/main/java/net/minestom/server/entity/EntityProjectile.java
@@ -141,7 +141,7 @@ public class EntityProjectile extends Entity {
         final double part = bb.width() / 2;
         final Vec dir = posNow.sub(pos).asVec();
         final int parts = (int) Math.ceil(dir.length() / part);
-        final Pos direction = dir.normalize().mul(part).asPosition();
+        final Pos direction = dir.normalize().mul(part).asPos();
         final long aliveTicks = getAliveTicks();
         Block block = null;
         Point blockPos = null;

--- a/src/main/java/net/minestom/server/entity/metadata/display/AbstractDisplayMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/display/AbstractDisplayMeta.java
@@ -46,28 +46,28 @@ public class AbstractDisplayMeta extends EntityMeta {
     }
 
     public @NotNull Vec getScale() {
-        return Vec.fromPoint(metadata.get(MetadataDef.Display.SCALE));
+        return metadata.get(MetadataDef.Display.SCALE).asVec();
     }
 
     public void setScale(@NotNull Vec value) {
         metadata.set(MetadataDef.Display.SCALE, value);
     }
 
-    public float @NotNull[] getLeftRotation() {
+    public float @NotNull [] getLeftRotation() {
         //todo replace with actual quaternion type
         return metadata.get(MetadataDef.Display.ROTATION_LEFT);
     }
 
-    public void setLeftRotation(float @NotNull[] value) {
+    public void setLeftRotation(float @NotNull [] value) {
         metadata.set(MetadataDef.Display.ROTATION_LEFT, value);
     }
 
-    public float @NotNull[] getRightRotation() {
+    public float @NotNull [] getRightRotation() {
         //todo replace with actual quaternion type
         return metadata.get(MetadataDef.Display.ROTATION_RIGHT);
     }
 
-    public void setRightRotation(float @NotNull[] value) {
+    public void setRightRotation(float @NotNull [] value) {
         metadata.set(MetadataDef.Display.ROTATION_RIGHT, value);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/ArmorStandMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/ArmorStandMeta.java
@@ -46,7 +46,7 @@ public class ArmorStandMeta extends LivingEntityMeta {
 
     @NotNull
     public Vec getHeadRotation() {
-        return Vec.fromPoint(metadata.get(MetadataDef.ArmorStand.HEAD_ROTATION));
+        return metadata.get(MetadataDef.ArmorStand.HEAD_ROTATION).asVec();
     }
 
     public void setHeadRotation(@NotNull Vec value) {
@@ -55,7 +55,7 @@ public class ArmorStandMeta extends LivingEntityMeta {
 
     @NotNull
     public Vec getBodyRotation() {
-        return Vec.fromPoint(metadata.get(MetadataDef.ArmorStand.BODY_ROTATION));
+        return metadata.get(MetadataDef.ArmorStand.BODY_ROTATION).asVec();
     }
 
     public void setBodyRotation(@NotNull Vec value) {
@@ -64,7 +64,7 @@ public class ArmorStandMeta extends LivingEntityMeta {
 
     @NotNull
     public Vec getLeftArmRotation() {
-        return Vec.fromPoint(metadata.get(MetadataDef.ArmorStand.LEFT_ARM_ROTATION));
+        return metadata.get(MetadataDef.ArmorStand.LEFT_ARM_ROTATION).asVec();
     }
 
     public void setLeftArmRotation(@NotNull Vec value) {
@@ -73,7 +73,7 @@ public class ArmorStandMeta extends LivingEntityMeta {
 
     @NotNull
     public Vec getRightArmRotation() {
-        return Vec.fromPoint(metadata.get(MetadataDef.ArmorStand.RIGHT_ARM_ROTATION));
+        return metadata.get(MetadataDef.ArmorStand.RIGHT_ARM_ROTATION).asVec();
     }
 
     public void setRightArmRotation(@NotNull Vec value) {
@@ -82,7 +82,7 @@ public class ArmorStandMeta extends LivingEntityMeta {
 
     @NotNull
     public Vec getLeftLegRotation() {
-        return Vec.fromPoint(metadata.get(MetadataDef.ArmorStand.LEFT_LEG_ROTATION));
+        return metadata.get(MetadataDef.ArmorStand.LEFT_LEG_ROTATION).asVec();
     }
 
     public void setLeftLegRotation(@NotNull Vec value) {
@@ -91,7 +91,7 @@ public class ArmorStandMeta extends LivingEntityMeta {
 
     @NotNull
     public Vec getRightLegRotation() {
-        return Vec.fromPoint(metadata.get(MetadataDef.ArmorStand.RIGHT_LEG_ROTATION));
+        return metadata.get(MetadataDef.ArmorStand.RIGHT_LEG_ROTATION).asVec();
     }
 
     public void setRightLegRotation(@NotNull Vec value) {

--- a/src/main/java/net/minestom/server/entity/pathfinding/Navigator.java
+++ b/src/main/java/net/minestom/server/entity/pathfinding/Navigator.java
@@ -164,7 +164,7 @@ public final class Navigator {
 
             computingPath = PathGenerator.generate(entity.getInstance(),
                     entity.getPosition(),
-                    Pos.fromPoint(goalPosition),
+                    goalPosition.asPosition(),
                     minimumDistance, path.maxDistance(),
                     path.pathVariance(), entity.getBoundingBox(), this.entity.isOnGround(), nodeGenerator, null);
 

--- a/src/main/java/net/minestom/server/entity/pathfinding/Navigator.java
+++ b/src/main/java/net/minestom/server/entity/pathfinding/Navigator.java
@@ -164,7 +164,7 @@ public final class Navigator {
 
             computingPath = PathGenerator.generate(entity.getInstance(),
                     entity.getPosition(),
-                    goalPosition.asPosition(),
+                    goalPosition.asPos(),
                     minimumDistance, path.maxDistance(),
                     path.pathVariance(), entity.getBoundingBox(), this.entity.isOnGround(), nodeGenerator, null);
 

--- a/src/main/java/net/minestom/server/entity/pathfinding/PathGenerator.java
+++ b/src/main/java/net/minestom/server/entity/pathfinding/PathGenerator.java
@@ -25,7 +25,7 @@ public final class PathGenerator {
 
         final Point target = (generator.hasGravitySnap())
                 ? orgTarget.withY(generator.gravitySnap(getter, orgTarget.x(), orgTarget.y(), orgTarget.z(), boundingBox, 100).orElse(orgTarget.y()))
-                : Pos.fromPoint(orgTarget);
+                : orgTarget.asPosition();
 
         PPath path = new PPath(maxDistance, pathVariance, onComplete);
         computePath(getter, start, target, closeDistance, maxDistance, pathVariance, boundingBox, path, generator);

--- a/src/main/java/net/minestom/server/entity/pathfinding/PathGenerator.java
+++ b/src/main/java/net/minestom/server/entity/pathfinding/PathGenerator.java
@@ -25,7 +25,7 @@ public final class PathGenerator {
 
         final Point target = (generator.hasGravitySnap())
                 ? orgTarget.withY(generator.gravitySnap(getter, orgTarget.x(), orgTarget.y(), orgTarget.z(), boundingBox, 100).orElse(orgTarget.y()))
-                : orgTarget.asPosition();
+                : orgTarget.asPos();
 
         PPath path = new PPath(maxDistance, pathVariance, onComplete);
         computePath(getter, start, target, closeDistance, maxDistance, pathVariance, boundingBox, path, generator);

--- a/src/main/java/net/minestom/server/entity/pathfinding/followers/FlyingNodeFollower.java
+++ b/src/main/java/net/minestom/server/entity/pathfinding/followers/FlyingNodeFollower.java
@@ -54,7 +54,7 @@ public class FlyingNodeFollower implements NodeFollower {
         }
 
         final var physicsResult = CollisionUtils.handlePhysics(entity, new Vec(speedX, speedY, speedZ));
-        this.entity.refreshPosition(Pos.fromPoint(physicsResult.newPosition()).withView(yaw, pitch));
+        this.entity.refreshPosition(physicsResult.newPosition().asPosition().withView(yaw, pitch));
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/pathfinding/followers/FlyingNodeFollower.java
+++ b/src/main/java/net/minestom/server/entity/pathfinding/followers/FlyingNodeFollower.java
@@ -54,7 +54,7 @@ public class FlyingNodeFollower implements NodeFollower {
         }
 
         final var physicsResult = CollisionUtils.handlePhysics(entity, new Vec(speedX, speedY, speedZ));
-        this.entity.refreshPosition(physicsResult.newPosition().asPosition().withView(yaw, pitch));
+        this.entity.refreshPosition(physicsResult.newPosition().asPos().withView(yaw, pitch));
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/pathfinding/followers/GroundNodeFollower.java
+++ b/src/main/java/net/minestom/server/entity/pathfinding/followers/GroundNodeFollower.java
@@ -49,7 +49,7 @@ public class GroundNodeFollower implements NodeFollower {
         final float pitch = PositionUtils.getLookPitch(dxLook, dyLook, dzLook);
 
         final var physicsResult = CollisionUtils.handlePhysics(entity, new Vec(speedX, 0, speedZ));
-        this.entity.refreshPosition(Pos.fromPoint(physicsResult.newPosition()).withView(yaw, pitch));
+        this.entity.refreshPosition(physicsResult.newPosition().asPosition().withView(yaw, pitch));
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/pathfinding/followers/GroundNodeFollower.java
+++ b/src/main/java/net/minestom/server/entity/pathfinding/followers/GroundNodeFollower.java
@@ -49,7 +49,7 @@ public class GroundNodeFollower implements NodeFollower {
         final float pitch = PositionUtils.getLookPitch(dxLook, dyLook, dzLook);
 
         final var physicsResult = CollisionUtils.handlePhysics(entity, new Vec(speedX, 0, speedZ));
-        this.entity.refreshPosition(physicsResult.newPosition().asPosition().withView(yaw, pitch));
+        this.entity.refreshPosition(physicsResult.newPosition().asPos().withView(yaw, pitch));
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/pathfinding/followers/WaterNodeFollower.java
+++ b/src/main/java/net/minestom/server/entity/pathfinding/followers/WaterNodeFollower.java
@@ -61,7 +61,7 @@ public class WaterNodeFollower implements NodeFollower {
         }
 
         final var physicsResult = CollisionUtils.handlePhysics(entity, new Vec(speedX, speedY, speedZ));
-        this.entity.refreshPosition(Pos.fromPoint(physicsResult.newPosition()).withView(yaw, pitch));
+        this.entity.refreshPosition(physicsResult.newPosition().asPosition().withView(yaw, pitch));
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/pathfinding/followers/WaterNodeFollower.java
+++ b/src/main/java/net/minestom/server/entity/pathfinding/followers/WaterNodeFollower.java
@@ -61,7 +61,7 @@ public class WaterNodeFollower implements NodeFollower {
         }
 
         final var physicsResult = CollisionUtils.handlePhysics(entity, new Vec(speedX, speedY, speedZ));
-        this.entity.refreshPosition(physicsResult.newPosition().asPosition().withView(yaw, pitch));
+        this.entity.refreshPosition(physicsResult.newPosition().asPos().withView(yaw, pitch));
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/pathfinding/generators/NodeGenerator.java
+++ b/src/main/java/net/minestom/server/entity/pathfinding/generators/NodeGenerator.java
@@ -61,7 +61,7 @@ public interface NodeGenerator {
 
         if (getter.getBlock(end) != Block.AIR) return false;
         PhysicsResult res = CollisionUtils.handlePhysics(getter, boundingBox,
-                Pos.fromPoint(start), Vec.fromPoint(diff), null, false);
+                start.asPosition(), diff.asVec(), null, false);
         return !res.collisionZ() && !res.collisionY() && !res.collisionX();
     }
 

--- a/src/main/java/net/minestom/server/entity/pathfinding/generators/NodeGenerator.java
+++ b/src/main/java/net/minestom/server/entity/pathfinding/generators/NodeGenerator.java
@@ -4,8 +4,6 @@ import net.minestom.server.collision.BoundingBox;
 import net.minestom.server.collision.CollisionUtils;
 import net.minestom.server.collision.PhysicsResult;
 import net.minestom.server.coordinate.Point;
-import net.minestom.server.coordinate.Pos;
-import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.pathfinding.PNode;
 import net.minestom.server.instance.block.Block;
 import org.jetbrains.annotations.NotNull;
@@ -61,7 +59,7 @@ public interface NodeGenerator {
 
         if (getter.getBlock(end) != Block.AIR) return false;
         PhysicsResult res = CollisionUtils.handlePhysics(getter, boundingBox,
-                start.asPosition(), diff.asVec(), null, false);
+                start.asPos(), diff.asVec(), null, false);
         return !res.collisionZ() && !res.collisionY() && !res.collisionX();
     }
 

--- a/src/main/java/net/minestom/server/entity/pathfinding/generators/PreciseGroundNodeGenerator.java
+++ b/src/main/java/net/minestom/server/entity/pathfinding/generators/PreciseGroundNodeGenerator.java
@@ -139,7 +139,7 @@ public class PreciseGroundNodeGenerator implements NodeGenerator {
         final Point end = endOrg.add(0, Vec.EPSILON, 0);
         final Point start = startOrg.add(0, Vec.EPSILON, 0);
         final Point diff = end.sub(start);
-        PhysicsResult res = CollisionUtils.handlePhysics(getter, boundingBox, start.asPosition(), diff.asVec(), null, false);
+        PhysicsResult res = CollisionUtils.handlePhysics(getter, boundingBox, start.asPos(), diff.asVec(), null, false);
         return !res.collisionZ() && !res.collisionY() && !res.collisionX();
     }
 }

--- a/src/main/java/net/minestom/server/entity/pathfinding/generators/PreciseGroundNodeGenerator.java
+++ b/src/main/java/net/minestom/server/entity/pathfinding/generators/PreciseGroundNodeGenerator.java
@@ -139,7 +139,7 @@ public class PreciseGroundNodeGenerator implements NodeGenerator {
         final Point end = endOrg.add(0, Vec.EPSILON, 0);
         final Point start = startOrg.add(0, Vec.EPSILON, 0);
         final Point diff = end.sub(start);
-        PhysicsResult res = CollisionUtils.handlePhysics(getter, boundingBox, Pos.fromPoint(start), Vec.fromPoint(diff), null, false);
+        PhysicsResult res = CollisionUtils.handlePhysics(getter, boundingBox, start.asPosition(), diff.asVec(), null, false);
         return !res.collisionZ() && !res.collisionY() && !res.collisionX();
     }
 }

--- a/src/test/java/net/minestom/server/collision/EntityProjectileCollisionIntegrationTest.java
+++ b/src/test/java/net/minestom/server/collision/EntityProjectileCollisionIntegrationTest.java
@@ -1,10 +1,7 @@
 package net.minestom.server.collision;
 
 import net.minestom.server.MinecraftServer;
-import net.minestom.server.instance.WorldBorder;
 import net.minestom.server.ServerFlag;
-import net.minestom.testing.Env;
-import net.minestom.testing.EnvTest;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
@@ -17,8 +14,11 @@ import net.minestom.server.event.entity.projectile.ProjectileCollideWithBlockEve
 import net.minestom.server.event.entity.projectile.ProjectileCollideWithEntityEvent;
 import net.minestom.server.event.entity.projectile.ProjectileUncollideEvent;
 import net.minestom.server.instance.Instance;
+import net.minestom.server.instance.WorldBorder;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.utils.time.TimeUnit;
+import net.minestom.testing.Env;
+import net.minestom.testing.EnvTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicReference;
@@ -94,7 +94,7 @@ public class EntityProjectileCollisionIntegrationTest {
         projectile.setInstance(instance, shooter.getPosition().withY(y -> y + shooter.getEyeHeight())).join();
 
         final LivingEntity target = new LivingEntity(EntityType.RABBIT);
-        target.setInstance(instance, Pos.fromPoint(targetPosition)).join();
+        target.setInstance(instance, targetPosition.asPosition()).join();
         projectile.shoot(targetPosition, 1, 0);
 
         final var eventRef = new AtomicReference<ProjectileCollideWithEntityEvent>();

--- a/src/test/java/net/minestom/server/collision/EntityProjectileCollisionIntegrationTest.java
+++ b/src/test/java/net/minestom/server/collision/EntityProjectileCollisionIntegrationTest.java
@@ -94,7 +94,7 @@ public class EntityProjectileCollisionIntegrationTest {
         projectile.setInstance(instance, shooter.getPosition().withY(y -> y + shooter.getEyeHeight())).join();
 
         final LivingEntity target = new LivingEntity(EntityType.RABBIT);
-        target.setInstance(instance, targetPosition.asPosition()).join();
+        target.setInstance(instance, targetPosition.asPos()).join();
         projectile.shoot(targetPosition, 1, 0);
 
         final var eventRef = new AtomicReference<ProjectileCollideWithEntityEvent>();

--- a/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
@@ -195,7 +195,7 @@ public class PlayerMovementIntegrationTest {
         assertEquals(new Pos(0, 40, 0), p1.getPosition());
         collector.assertSingle(packet -> {
             assertEquals(0, packet.flags());
-            assertEquals(new Vec(0, 40, 0), Vec.fromPoint(packet.position()));
+            assertEquals(new Vec(0, 40, 0), packet.position().asVec());
             // Must reset velocity or the player will keep moving and create a loop of teleport cancel teleport.
             assertEquals(Vec.ZERO, packet.delta());
         });


### PR DESCRIPTION
Current implementation forces 3 flooring calls and require casting to retrieve block coordinates. Overhead should be moved to the case where doubles are explicitly provided.

This should be non-breaking in regard to `Point` but may still affect hash code and perhaps reflection.

I doubt it, but probably require review to ensure I didn't fail my Replace All.

edit: ended up deprecating static converters as well in favor of default Point methods