### PR TITLE
Air amount click increase

### DIFF
--- a/src/main/java/net/minestom/server/item/ItemStack.java
+++ b/src/main/java/net/minestom/server/item/ItemStack.java
@@ -82,7 +82,7 @@ public sealed interface ItemStack extends TagReadable, DataComponent.Holder, Hov
     /**
      * Constant AIR item. Should be used instead of 'null'.
      */
-    @NotNull ItemStack AIR = ItemStack.of(Material.AIR);
+    @NotNull ItemStack AIR = new ItemStackImpl(Material.AIR, 0, DataComponentMap.EMPTY);
 
     @Contract(value = "_ -> new", pure = true)
     static @NotNull Builder builder(@NotNull Material material) {

--- a/src/main/java/net/minestom/server/item/ItemStackImpl.java
+++ b/src/main/java/net/minestom/server/item/ItemStackImpl.java
@@ -48,7 +48,7 @@ record ItemStackImpl(Material material, int amount, DataComponentMap components)
     }
 
     static ItemStack create(Material material, int amount, DataComponentMap components) {
-        if (amount <= 0) return AIR;
+        if (amount <= 0 || material == Material.AIR) return AIR;
         return new ItemStackImpl(material, amount, components);
     }
 


### PR DESCRIPTION
## Proposed changes

This fixes #2838. It makes the `AIR` `ItemStack` have a size of 0 instead of 1, which prevents bugs such as the one in the linked issue. This makes sense because an `AIR` `ItemStack` in the inventory represents an empty item, so it really should not have a size. This is a potential breaking change if for some reason somebody is using the `amount` on an `Air` `ItemStack`.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
