### PR TITLE
fix two NPE's when for some reason palette values are null

### DIFF
--- a/src/main/java/net/minestom/server/instance/palette/PaletteImpl.java
+++ b/src/main/java/net/minestom/server/instance/palette/PaletteImpl.java
@@ -63,6 +63,7 @@ final class PaletteImpl implements Palette {
     public int get(int x, int y, int z) {
         validateCoord(dimension, x, y, z);
         if (bitsPerEntry == 0) return count;
+        if (values == null) return 0;
         final int value = read(dimension(), bitsPerEntry, values, x, y, z);
         return paletteIndexToValue(value);
     }
@@ -557,7 +558,11 @@ final class PaletteImpl implements Palette {
 
     @Override
     public int paletteIndexToValue(int value) {
-        return hasPalette() ? paletteToValueList.elements()[value] : value;
+        if (hasPalette() && paletteToValueList != null) {
+            return paletteToValueList.elements()[value];
+        } else {
+            return value;
+        }
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

not sure if its the best way to do it but sometimes the Palette's `values` array and also `paletteToValueList` are null,
which causes NPE
this fixes the exceptions by just checking if its null
`PaletteImpl#get` returns air if values are null now
`PaletteImpl#paletteIndexToValue` checks for `hasPalette()` AND if the array isn't null together now

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...