### PR TITLE
Point#sectionXYZ getters

### DIFF
--- a/src/main/java/net/minestom/server/coordinate/Point.java
+++ b/src/main/java/net/minestom/server/coordinate/Point.java
@@ -71,18 +71,37 @@ public sealed interface Point permits Vec, Pos, BlockVec {
     }
 
     @Contract(pure = true)
-    default int chunkX() {
+    default int sectionX() {
         return globalToChunk(x());
     }
 
     @Contract(pure = true)
-    default int section() {
+    default int sectionY() {
         return globalToChunk(y());
     }
 
     @Contract(pure = true)
-    default int chunkZ() {
+    default int sectionZ() {
         return globalToChunk(z());
+    }
+
+    @Contract(pure = true)
+    default int chunkX() {
+        return sectionX();
+    }
+
+    @Contract(pure = true)
+    default int chunkZ() {
+        return sectionZ();
+    }
+
+    /**
+     * @deprecated use {@link #sectionY()} instead.
+     */
+    @Deprecated
+    @Contract(pure = true)
+    default int section() {
+        return sectionY();
     }
 
     /**

--- a/src/main/java/net/minestom/server/instance/generator/GenerationUnit.java
+++ b/src/main/java/net/minestom/server/instance/generator/GenerationUnit.java
@@ -77,8 +77,8 @@ public interface GenerationUnit {
      */
     default @NotNull Set<Vec> sections() {
         final Point start = absoluteStart(), end = absoluteEnd();
-        final int minX = start.chunkX(), minY = start.section(), minZ = start.chunkZ();
-        final int maxX = end.chunkX(), maxY = end.section(), maxZ = end.chunkZ();
+        final int minX = start.sectionX(), minY = start.sectionY(), minZ = start.sectionZ();
+        final int maxX = end.sectionX(), maxY = end.sectionY(), maxZ = end.sectionZ();
         final int count = (maxX - minX) * (maxY - minY) * (maxZ - minZ);
         Vec[] sections = new Vec[count];
         int index = 0;

--- a/src/main/java/net/minestom/server/instance/generator/GeneratorImpl.java
+++ b/src/main/java/net/minestom/server/instance/generator/GeneratorImpl.java
@@ -63,9 +63,9 @@ public final class GeneratorImpl {
         for (int i = 0; i < sectionCount; i++) {
             GenSection section = areaSections[i];
             final Vec point = to3D(i, width, height, depth);
-            final int sectionX = (int) point.x() + start.chunkX();
-            final int sectionY = (int) point.y() + start.section();
-            final int sectionZ = (int) point.z() + start.chunkZ();
+            final int sectionX = (int) point.x() + start.sectionX();
+            final int sectionY = (int) point.y() + start.sectionY();
+            final int sectionZ = (int) point.z() + start.sectionZ();
             final GenerationUnit sectionUnit = section(biomeRegistry, section, sectionX, sectionY, sectionZ);
             sectionsArray[i] = sectionUnit;
         }
@@ -105,9 +105,9 @@ public final class GeneratorImpl {
         public void setBlock(int x, int y, int z, @NotNull Block block) {
             resize(x, y, z);
             GenerationUnit section = findAbsolute(sections, minSection, width, height, depth, x, y, z);
-            assert section.absoluteStart().chunkX() == globalToChunk(x) &&
-                    section.absoluteStart().section() == globalToChunk(y) &&
-                    section.absoluteStart().chunkZ() == globalToChunk(z) :
+            assert section.absoluteStart().sectionX() == globalToChunk(x) &&
+                    section.absoluteStart().sectionY() == globalToChunk(y) &&
+                    section.absoluteStart().sectionZ() == globalToChunk(z) :
                     "Invalid section " + section.absoluteStart() + " for " + x + ", " + y + ", " + z;
             section.modifier().setBlock(x, y, z, block);
         }
@@ -146,9 +146,9 @@ public final class GeneratorImpl {
                     newSections[index] = s;
                 }
                 // Fill new sections
-                final int startX = newMin.chunkX();
-                final int startY = newMin.section();
-                final int startZ = newMin.chunkZ();
+                final int startX = newMin.sectionX();
+                final int startY = newMin.sectionY();
+                final int startZ = newMin.sectionZ();
                 for (int i = 0; i < newSections.length; i++) {
                     if (newSections[i] == null) {
                         final Vec coordinates = to3D(i, newWidth, newHeight, newDepth);

--- a/src/test/java/net/minestom/server/instance/generator/GeneratorTest.java
+++ b/src/test/java/net/minestom/server/instance/generator/GeneratorTest.java
@@ -517,12 +517,12 @@ public class GeneratorTest {
         Point end = unit.absoluteEnd();
 
         // Calculate expected section bounds
-        int expectedMinX = start.chunkX();
-        int expectedMinY = start.section();
-        int expectedMinZ = start.chunkZ();
-        int expectedMaxX = end.chunkX();
-        int expectedMaxY = end.section();
-        int expectedMaxZ = end.chunkZ();
+        int expectedMinX = start.sectionX();
+        int expectedMinY = start.sectionY();
+        int expectedMinZ = start.sectionZ();
+        int expectedMaxX = end.sectionX();
+        int expectedMaxY = end.sectionY();
+        int expectedMaxZ = end.sectionZ();
 
         // Verify all sections are within the expected bounds
         for (Point section : sections) {


### PR DESCRIPTION
`section` has always been a confused name.

Kept `chunkXZ` as they provide a different intent.