### PR TITLE
Fix block break speed being incorrect for instant break blocks and zero mining speed

### DIFF
--- a/src/main/java/net/minestom/server/utils/block/BlockBreakCalculation.java
+++ b/src/main/java/net/minestom/server/utils/block/BlockBreakCalculation.java
@@ -89,8 +89,6 @@ public class BlockBreakCalculation {
             speedMultiplier /= 5;
         }
 
-        double damage = speedMultiplier / blockHardness;
-
         // if speed multiplier is 0, the block is unbreakable
         if (speedMultiplier == 0) {
             return UNBREAKABLE;
@@ -101,6 +99,7 @@ public class BlockBreakCalculation {
             return 0;
         }
 
+        double damage = speedMultiplier / blockHardness;
         if (isBestTool) {
             damage /= 30;
         } else {

--- a/src/main/java/net/minestom/server/utils/block/BlockBreakCalculation.java
+++ b/src/main/java/net/minestom/server/utils/block/BlockBreakCalculation.java
@@ -91,6 +91,16 @@ public class BlockBreakCalculation {
 
         double damage = speedMultiplier / blockHardness;
 
+        // if speed multiplier is 0, the block is unbreakable
+        if (speedMultiplier == 0) {
+            return UNBREAKABLE;
+        }
+
+        // prevent division by zero
+        if (blockHardness == 0) {
+            return 0;
+        }
+
         if (isBestTool) {
             damage /= 30;
         } else {

--- a/src/test/java/net/minestom/server/utils/block/BlockBreakCalculationTest.java
+++ b/src/test/java/net/minestom/server/utils/block/BlockBreakCalculationTest.java
@@ -58,6 +58,13 @@ public class BlockBreakCalculationTest {
         assertEquals(BlockBreakCalculation.UNBREAKABLE, breakTicks(Block.BEDROCK, player));
     }
 
+    @Test
+    public void testZeroHardnessBlock() {
+        assertEquals(0, breakTicks(Block.SCAFFOLDING, player));
+        player.getAttribute(Attribute.BLOCK_BREAK_SPEED).setBaseValue(0);
+        assertEquals(BlockBreakCalculation.UNBREAKABLE, breakTicks(Block.SCAFFOLDING, player));
+    }
+
     @BeforeEach
     void setupPlayer(Env env) {
         final var instance = env.createFlatInstance();


### PR DESCRIPTION
## Proposed changes

This fixes the issue with breaking a block that has zero hardness still instamines it even if the player has zero mining speed.
This fixes #2851.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments
I'm not sure if there is a better way to do this, but this should work. It just adds a check for block hardness being zero and the player's mining speed being zero.