### PR TITLE
NetworkBuffer Unions support subtypes of T

### DIFF
--- a/src/main/java/net/minestom/server/item/component/AttributeList.java
+++ b/src/main/java/net/minestom/server/item/component/AttributeList.java
@@ -106,9 +106,8 @@ public record AttributeList(@NotNull List<Modifier> modifiers) {
             public static final Codec<Type> CODEC = Codec.Enum(Type.class);
         }
 
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        private static NetworkBuffer.Type<Display> dataSerializer(@NotNull Type type) {
-            return (NetworkBuffer.Type) switch (type) {
+        private static NetworkBuffer.Type<? extends Display> dataSerializer(@NotNull Type type) {
+            return switch (type) {
                 case DEFAULT -> Default.NETWORK_TYPE;
                 case HIDDEN -> Hidden.NETWORK_TYPE;
                 case OVERRIDE -> Override.NETWORK_TYPE;

--- a/src/main/java/net/minestom/server/item/component/ConsumeEffect.java
+++ b/src/main/java/net/minestom/server/item/component/ConsumeEffect.java
@@ -85,9 +85,8 @@ public sealed interface ConsumeEffect {
                 PlaySound::new);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private static NetworkBuffer.Type<ConsumeEffect> networkType(@NotNull ConsumeEffectType type) {
-        return (NetworkBuffer.Type) switch (type) {
+    private static NetworkBuffer.Type<? extends ConsumeEffect> networkType(@NotNull ConsumeEffectType type) {
+        return switch (type) {
             case APPLY_EFFECTS -> ApplyEffects.NETWORK_TYPE;
             case REMOVE_EFFECTS -> RemoveEffects.NETWORK_TYPE;
             case CLEAR_ALL_EFFECTS -> ClearAllEffects.NETWORK_TYPE;

--- a/src/main/java/net/minestom/server/network/NetworkBuffer.java
+++ b/src/main/java/net/minestom/server/network/NetworkBuffer.java
@@ -218,7 +218,7 @@ public sealed interface NetworkBuffer permits NetworkBufferImpl {
             return new NetworkBufferTypeImpl.OptionalType<>(this);
         }
 
-        default <R> @NotNull Type<R> unionType(@NotNull Function<T, NetworkBuffer.Type<R>> serializers, @NotNull Function<R, T> keyFunc) {
+        default <R, TR extends R> @NotNull Type<R> unionType(@NotNull Function<T, NetworkBuffer.Type<TR>> serializers, @NotNull Function<R, ? extends T> keyFunc) {
             return new NetworkBufferTypeImpl.UnionType<>(this, keyFunc, serializers);
         }
 

--- a/src/main/java/net/minestom/server/network/packet/server/play/TrackedWaypointPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/TrackedWaypointPacket.java
@@ -93,9 +93,8 @@ public record TrackedWaypointPacket(
             public static final NetworkBuffer.Type<Type> NETWORK_TYPE = NetworkBuffer.Enum(Type.class);
         }
 
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        private static NetworkBuffer.Type<Target> dataSerializer(@NotNull Type type) {
-            return (NetworkBuffer.Type) switch (type) {
+        private static NetworkBuffer.Type<? extends Target> dataSerializer(@NotNull Type type) {
+            return switch (type) {
                 case EMPTY -> Empty.NETWORK_TYPE;
                 case VEC3I -> Vec3i.NETWORK_TYPE;
                 case CHUNK -> Chunk.NETWORK_TYPE;

--- a/src/main/java/net/minestom/server/recipe/display/RecipeDisplay.java
+++ b/src/main/java/net/minestom/server/recipe/display/RecipeDisplay.java
@@ -182,9 +182,8 @@ public sealed interface RecipeDisplay extends ComponentHolder<RecipeDisplay> {
         }
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private static NetworkBuffer.Type<RecipeDisplay> dataSerializer(@NotNull RecipeDisplayType type) {
-        return (NetworkBuffer.Type) switch (type) {
+    private static NetworkBuffer.Type<? extends RecipeDisplay> dataSerializer(@NotNull RecipeDisplayType type) {
+        return switch (type) {
             case CRAFTING_SHAPELESS -> CraftingShapeless.NETWORK_TYPE;
             case CRAFTING_SHAPED -> CraftingShaped.NETWORK_TYPE;
             case FURNACE -> Furnace.NETWORK_TYPE;

--- a/src/main/java/net/minestom/server/recipe/display/SlotDisplay.java
+++ b/src/main/java/net/minestom/server/recipe/display/SlotDisplay.java
@@ -146,9 +146,8 @@ public sealed interface SlotDisplay extends ComponentHolder<SlotDisplay> {
         return this;
     }
 
-    private static NetworkBuffer.Type<SlotDisplay> dataSerializer(@NotNull SlotDisplayType type) {
-        //noinspection unchecked
-        return (NetworkBuffer.Type<SlotDisplay>) switch (type) {
+    private static NetworkBuffer.Type<? extends SlotDisplay> dataSerializer(@NotNull SlotDisplayType type) {
+        return switch (type) {
             case EMPTY -> Empty.NETWORK_TYPE;
             case ANY_FUEL -> AnyFuel.NETWORK_TYPE;
             case ITEM -> Item.NETWORK_TYPE;


### PR DESCRIPTION
## Proposed changes
After codec unions were fixed, these were kind of left out; we should update them to support implementing interfaces too. We may be creating debt by not doing proper definitions with ? extends T passed back; but this does look nicer and does enough to check during compile time.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)