### PR TITLE
Fix PlayerConfigCustomClickEvent#getPlayer always returning null

### DIFF
--- a/src/main/java/net/minestom/server/event/player/PlayerConfigCustomClickEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerConfigCustomClickEvent.java
@@ -25,7 +25,7 @@ public class PlayerConfigCustomClickEvent implements PlayerEvent {
 
     @Override
     public @NotNull Player getPlayer() {
-        return null;
+        return this.player;
     }
 
     public @NotNull Key getKey() {


### PR DESCRIPTION
## Proposed changes

`PlayerConfigCustomClickEvent.getPlayer()` always returns `null` despite the player being stored in the event and the method being annotated as `@NotNull`.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments