### PR TITLE
fix: anvil loader loading biomes to block palettes

### DIFF
--- a/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
+++ b/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
@@ -203,7 +203,7 @@ public class AnvilLoader implements IChunkLoader {
                 } else if (convertedBiomePalette.length > 1) {
                     final long[] packedIndices = biomesTag.getLongArray("data");
                     Check.stateCondition(packedIndices.length == 0, "Missing packed biomes data");
-                    section.blockPalette().load(convertedBiomePalette, packedIndices);
+                    section.biomePalette().load(convertedBiomePalette, packedIndices);
                 }
             }
 
@@ -251,9 +251,6 @@ public class AnvilLoader implements IChunkLoader {
                     }
                     block = block.withProperties(properties);
                 }
-                // Handler
-                final BlockHandler handler = MinecraftServer.getBlockManager().getHandler(block.name());
-                if (handler != null) block = block.withHandler(handler);
 
                 convertedPalette[i] = block.stateId();
             }


### PR DESCRIPTION
## Proposed changes

Anvil used to load biomes into block palettes, now it loads into the biome palette correctly. 
Block handlers also used to be loaded into blocks while loading the block palette of a section, which is unnecessary.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...