### PR TITLE
Fix AnvilLoader not closing the region file if chunks weren't originally loaded by AnvilLoader

### DIFF
--- a/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
+++ b/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
@@ -321,21 +321,14 @@ public class AnvilLoader implements IChunkLoader {
         final int chunkZ = chunk.getChunkZ();
 
         // Find the region file or create an empty one if missing
+
+        final int regionX = CoordConversion.chunkToRegion(chunkX);
+        final int regionZ = CoordConversion.chunkToRegion(chunkZ);
+
         RegionFile mcaFile;
         fileCreationLock.lock();
         try {
             mcaFile = getMCAFile(chunkX, chunkZ);
-
-            final int regionX = CoordConversion.chunkToRegion(chunkX);
-            final int regionZ = CoordConversion.chunkToRegion(chunkZ);
-
-            this.perRegionLoadedChunksLock.lock();
-            try {
-                this.perRegionLoadedChunks.computeIfAbsent(new IntIntImmutablePair(regionX, regionZ), k -> new HashSet<>())
-                        .add(new IntIntImmutablePair(chunkX, chunkZ));
-            } finally {
-                this.perRegionLoadedChunksLock.unlock();
-            }
 
             if (mcaFile == null) {
                 final String regionFileName = RegionFile.getFileName(regionX, regionZ);
@@ -356,6 +349,14 @@ public class AnvilLoader implements IChunkLoader {
             }
         } finally {
             fileCreationLock.unlock();
+
+            this.perRegionLoadedChunksLock.lock();
+            try {
+                this.perRegionLoadedChunks.computeIfAbsent(new IntIntImmutablePair(regionX, regionZ), k -> new HashSet<>())
+                        .add(new IntIntImmutablePair(chunkX, chunkZ));
+            } finally {
+                this.perRegionLoadedChunksLock.unlock();
+            }
         }
 
         try {

--- a/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
+++ b/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
@@ -343,8 +343,8 @@ public class AnvilLoader implements IChunkLoader {
                     MinecraftServer.getExceptionManager().handleException(e);
                     return;
                 }
+                this.perRegionLoadedChunksLock.lock();
                 try {
-                    this.perRegionLoadedChunksLock.lock();
                     this.perRegionLoadedChunks.computeIfAbsent(new IntIntImmutablePair(regionX, regionZ), k -> new HashSet<>())
                             .add(new IntIntImmutablePair(chunkX, chunkZ));
                 } finally {

--- a/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
+++ b/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
@@ -343,6 +343,13 @@ public class AnvilLoader implements IChunkLoader {
                     MinecraftServer.getExceptionManager().handleException(e);
                     return;
                 }
+                try {
+                    this.perRegionLoadedChunksLock.lock();
+                    this.perRegionLoadedChunks.computeIfAbsent(new IntIntImmutablePair(regionX, regionZ), k -> new HashSet<>())
+                            .add(new IntIntImmutablePair(chunkX, chunkZ));
+                } finally {
+                    this.perRegionLoadedChunksLock.unlock();
+                }
             }
         } finally {
             fileCreationLock.unlock();

--- a/testing/src/main/java/net/minestom/testing/Env.java
+++ b/testing/src/main/java/net/minestom/testing/Env.java
@@ -57,6 +57,10 @@ public interface Env {
         return process().instance().createInstanceContainer();
     }
 
+    default @NotNull Instance createEmptyInstance(IChunkLoader chunkLoader) {
+        return process().instance().createInstanceContainer(chunkLoader);
+    }
+
     default void destroyInstance(Instance instance) {
         process().instance().unregisterInstance(instance);
     }


### PR DESCRIPTION
## Proposed changes

This fixes `AnvilLoader` not closing region files if chunks weren't originally loaded by `AnvilLoader`. This can happen when generating a new instance and then saving the chunks. Then if you unregister the instance or unload the chunks, the region files are not closed.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
