### PR TITLE
Fix AnvilLoader incorrectly saving filled palettes

### DIFF
--- a/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
+++ b/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
@@ -450,7 +450,7 @@ public class AnvilLoader implements IChunkLoader {
                     biomePalette.add(biomeName);
                 } else {
                     section.biomePalette().getAll((x, y, z, value) -> {
-                        int biomeIndex = (x / 4) + (y / 4) * 4 * 4 + (z / 4) * 4;
+                        int biomeIndex = x + y * 4 * 4 + z * 4;
                         final RegistryKey<Biome> biomeKey = MinecraftServer.getBiomeRegistry().getKey(value);
                         assert biomeKey != null;
                         final BinaryTag biomeName = StringBinaryTag.stringBinaryTag(biomeKey.key().asString());

--- a/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
+++ b/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
@@ -17,6 +17,7 @@ import net.minestom.server.instance.block.BlockHandler;
 import net.minestom.server.instance.palette.Palettes;
 import net.minestom.server.registry.DynamicRegistry;
 import net.minestom.server.registry.RegistryKey;
+import net.minestom.server.utils.MathUtils;
 import net.minestom.server.utils.validate.Check;
 import net.minestom.server.world.biome.Biome;
 import org.jetbrains.annotations.Nullable;
@@ -406,7 +407,10 @@ public class AnvilLoader implements IChunkLoader {
                 final int globalSectionY = sectionY * 16;
                 // Retrieve block data
                 if (section.blockPalette().singleValue() != -1) {
-                    blockPaletteIndices.add(section.blockPalette().singleValue());
+                    final Block block = Block.fromStateId(section.blockPalette().singleValue());
+                    assert block != null;
+                    final CompoundBinaryTag blockState = blockStateNbt(block);
+                    blockPaletteEntries.add(blockState);
                 } else {
                     section.blockPalette().getAll((x, y, z, value) -> {
                         Block block = chunk.getBlock(x, globalSectionY + y, z, Block.Getter.Condition.CACHED);
@@ -439,7 +443,11 @@ public class AnvilLoader implements IChunkLoader {
                 }
                 // Retrieve biome data
                 if (section.biomePalette().singleValue() != -1) {
-                    blockPaletteIndices.add(section.biomePalette().singleValue());
+                    final RegistryKey<Biome> biomeKey = MinecraftServer.getBiomeRegistry()
+                            .getKey(section.biomePalette().singleValue());
+                    assert biomeKey != null;
+                    final BinaryTag biomeName = StringBinaryTag.stringBinaryTag(biomeKey.key().asString());
+                    biomePalette.add(biomeName);
                 } else {
                     section.biomePalette().getAll((x, y, z, value) -> {
                         int biomeIndex = (x / 4) + (y / 4) * 4 * 4 + (z / 4) * 4;
@@ -460,7 +468,7 @@ public class AnvilLoader implements IChunkLoader {
                 blockStates.put("palette", ListBinaryTag.listBinaryTag(BinaryTagTypes.COMPOUND, blockPaletteEntries));
                 if (blockPaletteEntries.size() > 1) {
                     // If there is only one entry we do not need to write the packed indices
-                    final int bitsPerEntry = (int) Math.max(4, Math.ceil(Math.log(blockPaletteEntries.size()) / Math.log(2)));
+                    final int bitsPerEntry = Math.max(4, MathUtils.bitsToRepresent(blockPaletteEntries.size() - 1));
                     blockStates.putLongArray("data", Palettes.pack(blockIndices, bitsPerEntry));
                 }
                 sectionData.put("block_states", blockStates.build());
@@ -469,7 +477,7 @@ public class AnvilLoader implements IChunkLoader {
                 biomes.put("palette", ListBinaryTag.listBinaryTag(BinaryTagTypes.STRING, biomePalette));
                 if (biomePalette.size() > 1) {
                     // If there is only one entry we do not need to write the packed indices
-                    final int bitsPerEntry = (int) Math.max(1, Math.ceil(Math.log(biomePalette.size()) / Math.log(2)));
+                    final int bitsPerEntry = MathUtils.bitsToRepresent(biomePalette.size() - 1);
                     biomes.putLongArray("data", Palettes.pack(biomeIndices, bitsPerEntry));
                 }
                 sectionData.put("biomes", biomes.build());


### PR DESCRIPTION
## Proposed changes

This PR fixes a bug in `AnvilLoader#saveSectionData` that would lead to a palette saving an empty palette to file if the palette had a single value. It also replaces the old bitsPerEntry calculation with a more idiomatic approach.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...