### PR TITLE
Use the BlocksAttacks component in UseItemListener

### DIFF
--- a/src/main/java/net/minestom/server/item/component/BlocksAttacks.java
+++ b/src/main/java/net/minestom/server/item/component/BlocksAttacks.java
@@ -28,8 +28,8 @@ public record BlocksAttacks(
             DamageReduction.NETWORK_TYPE.list(Short.MAX_VALUE), BlocksAttacks::damageReductions,
             ItemDamageFunction.NETWORK_TYPE, BlocksAttacks::itemDamage,
             TagKey.networkType(Registries::damageType).optional(), BlocksAttacks::bypassedBy,
-            SoundEvent.NETWORK_TYPE, BlocksAttacks::blockSound,
-            SoundEvent.NETWORK_TYPE, BlocksAttacks::disableSound,
+            SoundEvent.NETWORK_TYPE.optional(), BlocksAttacks::blockSound,
+            SoundEvent.NETWORK_TYPE.optional(), BlocksAttacks::disableSound,
             BlocksAttacks::new);
     public static final Codec<BlocksAttacks> NBT_TYPE = StructCodec.struct(
             "block_delay_seconds", Codec.FLOAT.optional(0f), BlocksAttacks::blockDelaySeconds,

--- a/src/main/java/net/minestom/server/listener/UseItemListener.java
+++ b/src/main/java/net/minestom/server/listener/UseItemListener.java
@@ -11,6 +11,7 @@ import net.minestom.server.inventory.PlayerInventory;
 import net.minestom.server.item.ItemAnimation;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
+import net.minestom.server.item.component.BlocksAttacks;
 import net.minestom.server.item.component.Consumable;
 import net.minestom.server.item.component.Equippable;
 import net.minestom.server.item.component.InstrumentComponent;
@@ -25,6 +26,7 @@ public class UseItemListener {
         final ItemStack itemStack = player.getItemInHand(hand);
         final Material material = itemStack.material();
         final Consumable consumable = itemStack.get(DataComponents.CONSUMABLE);
+        final BlocksAttacks blocksAttacks = itemStack.get(DataComponents.BLOCKS_ATTACKS);
 
         // The following item animations and use item times come from vanilla.
         // These items do not yet use components, but hopefully they will in the future
@@ -39,7 +41,7 @@ public class UseItemListener {
             // client they can hold it forever
             useItemTime = 7200;
             useAnimation = ItemAnimation.CROSSBOW;
-        } else if (material == Material.SHIELD) {
+        } else if (blocksAttacks != null) {
             useItemTime = 72000;
             useAnimation = ItemAnimation.BLOCK;
         } else if (material == Material.TRIDENT) {

--- a/src/main/java/net/minestom/server/listener/UseItemListener.java
+++ b/src/main/java/net/minestom/server/listener/UseItemListener.java
@@ -11,7 +11,6 @@ import net.minestom.server.inventory.PlayerInventory;
 import net.minestom.server.item.ItemAnimation;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
-import net.minestom.server.item.component.BlocksAttacks;
 import net.minestom.server.item.component.Consumable;
 import net.minestom.server.item.component.Equippable;
 import net.minestom.server.item.component.InstrumentComponent;
@@ -26,7 +25,6 @@ public class UseItemListener {
         final ItemStack itemStack = player.getItemInHand(hand);
         final Material material = itemStack.material();
         final Consumable consumable = itemStack.get(DataComponents.CONSUMABLE);
-        final BlocksAttacks blocksAttacks = itemStack.get(DataComponents.BLOCKS_ATTACKS);
 
         // The following item animations and use item times come from vanilla.
         // These items do not yet use components, but hopefully they will in the future
@@ -41,7 +39,7 @@ public class UseItemListener {
             // client they can hold it forever
             useItemTime = 7200;
             useAnimation = ItemAnimation.CROSSBOW;
-        } else if (blocksAttacks != null) {
+        } else if (itemStack.has(DataComponents.BLOCKS_ATTACKS)) {
             useItemTime = 72000;
             useAnimation = ItemAnimation.BLOCK;
         } else if (material == Material.TRIDENT) {

--- a/src/test/java/net/minestom/server/item/component/BlocksAttacksTest.java
+++ b/src/test/java/net/minestom/server/item/component/BlocksAttacksTest.java
@@ -1,0 +1,52 @@
+package net.minestom.server.item.component;
+
+import net.minestom.server.component.DataComponents;
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.PlayerHand;
+import net.minestom.server.instance.block.BlockFace;
+import net.minestom.server.item.ItemStack;
+import net.minestom.server.item.Material;
+import net.minestom.server.network.packet.client.play.ClientPlayerDiggingPacket;
+import net.minestom.server.network.packet.client.play.ClientUseItemPacket;
+import net.minestom.testing.Env;
+import net.minestom.testing.EnvTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnvTest
+public class BlocksAttacksTest {
+
+    @Test
+    public void test(Env env) {
+        var instance = env.createFlatInstance();
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0, 42, 0));
+
+        player.setItemInMainHand(ItemStack.of(Material.SHIELD));
+
+        player.addPacketToQueue(new ClientUseItemPacket(PlayerHand.MAIN, 0, 0f, 0f));
+        player.interpretPacketQueue();
+
+        assertTrue(player.isUsingItem());
+        assertTrue(player.getPlayerMeta().isHandActive());
+
+        player.addPacketToQueue(new ClientPlayerDiggingPacket(ClientPlayerDiggingPacket.Status.UPDATE_ITEM_STATE, player.getPosition(), BlockFace.NORTH, 1));
+        player.interpretPacketQueue();
+
+        assertFalse(player.isUsingItem());
+        assertFalse(player.getPlayerMeta().isHandActive());
+
+        player.setItemInMainHand(ItemStack.of(Material.DIAMOND_SWORD).with(DataComponents.BLOCKS_ATTACKS,
+                new BlocksAttacks(1f, 1f, List.of(), BlocksAttacks.ItemDamageFunction.DEFAULT, null, null, null)));
+
+        player.addPacketToQueue(new ClientUseItemPacket(PlayerHand.MAIN, 0, 0f, 0f));
+        player.interpretPacketQueue();
+
+        assertTrue(player.isUsingItem());
+        assertTrue(player.getPlayerMeta().isHandActive());
+    }
+}


### PR DESCRIPTION
## Proposed changes

The blocking animation does not properly show on other clients if you aren't using a shield, due to only checking for the shield material rather than the component.

Additionally also fixes a minor bug in the BlocksAttacks component where the Sound Events in the network serializer were not marked as optional.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

~~Will do some quick testing to ensure this is the proper fix and will update this text once this is done~~
Completed some testing, before the change another client would not see the blocking animation if the item was not a shield, but still had the blocks attacks component