### PR TITLE
Implement ANSI Component Serializer for Logging

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ adventure-nbt = { group = "net.kyori", name = "adventure-nbt", version.ref = "ad
 adventure-serializer-gson = { group = "net.kyori", name = "adventure-text-serializer-gson", version.ref = "adventure" }
 adventure-serializer-legacy = { group = "net.kyori", name = "adventure-text-serializer-legacy", version.ref = "adventure" }
 adventure-serializer-plain = { group = "net.kyori", name = "adventure-text-serializer-plain", version.ref = "adventure" }
+adventure-serializer-ansi = { group = "net.kyori", name = "adventure-text-serializer-ansi", version.ref = "adventure" }
 adventure-text-logger-slf4j = { group = "net.kyori", name = "adventure-text-logger-slf4j", version.ref = "adventure" }
 
 # Miscellaneous
@@ -75,7 +76,7 @@ logback-classic = { group = "ch.qos.logback", name = "logback-classic", version.
 [bundles]
 
 flare = ["flare", "flare-fastutil"]
-adventure = ["adventure-api", "adventure-nbt", "adventure-serializer-gson", "adventure-serializer-legacy", "adventure-serializer-plain", "adventure-text-logger-slf4j"]
+adventure = ["adventure-api", "adventure-nbt", "adventure-serializer-gson", "adventure-serializer-legacy", "adventure-serializer-plain", "adventure-serializer-ansi", "adventure-text-logger-slf4j"]
 junit = ["junit-api", "junit-engine", "junit-params", "junit-suite-api", "junit-suite-engine"]
 logback = ["logback-core", "logback-classic"]
 

--- a/src/main/java/net/minestom/server/adventure/provider/MinestomComponentLoggerProvider.java
+++ b/src/main/java/net/minestom/server/adventure/provider/MinestomComponentLoggerProvider.java
@@ -2,17 +2,13 @@ package net.minestom.server.adventure.provider;
 
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
 import net.kyori.adventure.text.logger.slf4j.ComponentLoggerProvider;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.serializer.ansi.ANSIComponentSerializer;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("UnstableApiUsage") // we are permitted to provide this
 public class MinestomComponentLoggerProvider implements ComponentLoggerProvider {
-    private static final LegacyComponentSerializer SERIALIZER = LegacyComponentSerializer.builder()
-            .character(LegacyComponentSerializer.SECTION_CHAR)
-            .flattener(MinestomFlattenerProvider.INSTANCE)
-            .hexColors()
-            .build();
+    private static final ANSIComponentSerializer SERIALIZER = ANSIComponentSerializer.ansi();
 
     @Override
     public @NotNull ComponentLogger logger(@NotNull LoggerHelper helper, @NotNull String name) {


### PR DESCRIPTION
## Proposed changes
Replaces the `LegacyComponentSerializer` with the `ANSIComponentSerializer` in the `MinestomComponentLoggerProvider` to provide colored console output instead of legacy color codes.

The `MinestomComponentLoggerProvider` was first introduced in d7e958fa07820882150567416f76b759a1dace6d in combination with `TerminalColorConverter` which converted the legacy color codes into ANSI manually.
`TerminalColorConverted` was removed in 909cc992eb5c44a5e9ec06e5459865d69d9e963e. Therefore, I think the ANSI (or plain text) serializer should be used instead of legacy codes.

(I am not sure whether this is considered a bugfix, new feature or breaking change)

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)