### PR TITLE
Fix nullability documentation of Codec

### DIFF
--- a/src/main/java/net/minestom/server/codec/Codec.java
+++ b/src/main/java/net/minestom/server/codec/Codec.java
@@ -129,7 +129,7 @@ public interface Codec<T extends @UnknownNullability Object> extends Encoder<T>,
     }
 
     @Contract(pure = true)
-    static <L, R> Codec<Either<L, R>> Either(Codec<L> leftCodec, Codec<R> rightCodec) {
+    static <L, R> Codec<@UnknownNullability Either<L, R>> Either(Codec<L> leftCodec, Codec<R> rightCodec) {
         return new CodecImpl.EitherImpl<>(leftCodec, rightCodec);
     }
 

--- a/src/main/java/net/minestom/server/codec/Codec.java
+++ b/src/main/java/net/minestom/server/codec/Codec.java
@@ -41,7 +41,7 @@ public interface Codec<T extends @UnknownNullability Object> extends Encoder<T>,
         <D> Result<D> convertTo(Transcoder<D> coder);
     }
 
-    Codec<RawValue> RAW_VALUE = new CodecImpl.RawValueCodecImpl();
+    Codec<@UnknownNullability RawValue> RAW_VALUE = new CodecImpl.RawValueCodecImpl();
 
     Codec<Unit> UNIT = StructCodec.struct(Unit.INSTANCE);
 

--- a/src/main/java/net/minestom/server/codec/Decoder.java
+++ b/src/main/java/net/minestom/server/codec/Decoder.java
@@ -1,9 +1,10 @@
 package net.minestom.server.codec;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.UnknownNullability;
 
 @ApiStatus.Experimental
-public interface Decoder<T> {
+public interface Decoder<T extends @UnknownNullability Object> {
 
     static <T> Decoder<T> unit(T value) {
         return new Decoder<>() {

--- a/src/main/java/net/minestom/server/codec/Encoder.java
+++ b/src/main/java/net/minestom/server/codec/Encoder.java
@@ -2,9 +2,10 @@ package net.minestom.server.codec;
 
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
 
 @ApiStatus.Experimental
-public interface Encoder<T> {
+public interface Encoder<T extends @UnknownNullability Object> {
 
     static <T> Encoder<T> empty() {
         return new Encoder<>() {

--- a/src/main/java/net/minestom/server/codec/Result.java
+++ b/src/main/java/net/minestom/server/codec/Result.java
@@ -1,53 +1,61 @@
 package net.minestom.server.codec;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
 
 import java.util.function.Function;
 
 @ApiStatus.Experimental
-public sealed interface Result<T> {
+public sealed interface Result<T extends @UnknownNullability Object> {
 
-    record Ok<T>(T value) implements Result<T> {
+    record Ok<T extends @UnknownNullability Object>(T value) implements Result<T> {
     }
 
     record Error<T>(String message) implements Result<T> {
     }
 
+    @Contract(pure = true)
     default <S> Result<S> map(Function<T, Result<S>> mapper) {
         return this instanceof Ok<T>(T value) ? mapper.apply(value) : cast();
     }
 
+    @Contract(pure = true)
     default <S> Result<S> mapResult(Function<T, S> mapper) {
         return this instanceof Ok<T>(T value) ? new Ok<>(mapper.apply(value)) : cast();
     }
-
+    @Contract(pure = true)
     default Result<T> mapError(Function<String, String> mapper) {
-        return this instanceof Error<T>(String message) ? new Error<>(mapper.apply(message)) : this;
+        return this instanceof Error<?>(String message) ? new Error<>(mapper.apply(message)) : this;
     }
 
-    default T orElse(T other) {
+    @Contract(pure = true)
+    default @UnknownNullability T orElse(@Nullable T other) {
         return this instanceof Ok<T>(T value)
                 ? value : other;
     }
 
+    @Contract(pure = true)
     default T orElseThrow() {
         return orElseThrow(null);
     }
 
+    @Contract(pure = true)
     default T orElseThrow(@Nullable String message) {
         return switch (this) {
             case Ok<T>(T value) -> value;
-            case Error<T>(String errorMessage) -> throw new IllegalArgumentException(
+            case Error<?>(String errorMessage) -> throw new IllegalArgumentException(
                     message != null ? String.format("%s: %s", message, errorMessage) : errorMessage
             );
         };
     }
 
+    @Contract(pure = true)
+    @SuppressWarnings("unchecked")
     default <S> Result<S> cast() {
-        if (!(this instanceof Result.Error<T>))
+        if (!(this instanceof Result.Error<?>))
             throw new ClassCastException("Cannot cast a Result.Ok to a Result.Error");
-        //noinspection unchecked
         return (Result.Error<S>) this;
     }
 

--- a/src/main/java/net/minestom/server/codec/StructCodec.java
+++ b/src/main/java/net/minestom/server/codec/StructCodec.java
@@ -4,6 +4,7 @@ import net.minestom.server.codec.Transcoder.MapBuilder;
 import net.minestom.server.codec.Transcoder.MapLike;
 import net.minestom.server.network.NetworkBufferTemplate.*;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
 
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -83,7 +84,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    static <R, P1> StructCodec<R> struct(
+    static <R, P1 extends @UnknownNullability Object> StructCodec<R> struct(
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             F1<P1, R> ctor
     ) {
@@ -105,7 +106,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    static <R, P1, P2> StructCodec<R> struct(
+    static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object> StructCodec<R> struct(
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             String name2, Codec<P2> codec2, Function<R, P2> getter2,
             F2<P1, P2, R> ctor
@@ -133,7 +134,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    static <R, P1, P2, P3> StructCodec<R> struct(
+    static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object> StructCodec<R> struct(
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             String name2, Codec<P2> codec2, Function<R, P2> getter2,
             String name3, Codec<P3> codec3, Function<R, P3> getter3,
@@ -167,7 +168,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    static <R, P1, P2, P3, P4> StructCodec<R> struct(
+    static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object> StructCodec<R> struct(
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             String name2, Codec<P2> codec2, Function<R, P2> getter2,
             String name3, Codec<P3> codec3, Function<R, P3> getter3,
@@ -207,7 +208,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    static <R, P1, P2, P3, P4, P5> StructCodec<R> struct(
+    static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object> StructCodec<R> struct(
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             String name2, Codec<P2> codec2, Function<R, P2> getter2,
             String name3, Codec<P3> codec3, Function<R, P3> getter3,
@@ -253,7 +254,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    static <R, P1, P2, P3, P4, P5, P6> StructCodec<R> struct(
+    static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object> StructCodec<R> struct(
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             String name2, Codec<P2> codec2, Function<R, P2> getter2,
             String name3, Codec<P3> codec3, Function<R, P3> getter3,
@@ -305,7 +306,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    static <R, P1, P2, P3, P4, P5, P6, P7> StructCodec<R> struct(
+    static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object> StructCodec<R> struct(
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             String name2, Codec<P2> codec2, Function<R, P2> getter2,
             String name3, Codec<P3> codec3, Function<R, P3> getter3,
@@ -363,7 +364,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    static <R, P1, P2, P3, P4, P5, P6, P7, P8> StructCodec<R> struct(
+    static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object> StructCodec<R> struct(
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             String name2, Codec<P2> codec2, Function<R, P2> getter2,
             String name3, Codec<P3> codec3, Function<R, P3> getter3,
@@ -427,7 +428,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    static <R, P1, P2, P3, P4, P5, P6, P7, P8, P9> StructCodec<R> struct(
+    static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object> StructCodec<R> struct(
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             String name2, Codec<P2> codec2, Function<R, P2> getter2,
             String name3, Codec<P3> codec3, Function<R, P3> getter3,
@@ -497,7 +498,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    static <R, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> StructCodec<R> struct(
+    static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object> StructCodec<R> struct(
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             String name2, Codec<P2> codec2, Function<R, P2> getter2,
             String name3, Codec<P3> codec3, Function<R, P3> getter3,
@@ -573,7 +574,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    static <R, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> StructCodec<R> struct(
+    static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object> StructCodec<R> struct(
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             String name2, Codec<P2> codec2, Function<R, P2> getter2,
             String name3, Codec<P3> codec3, Function<R, P3> getter3,
@@ -655,7 +656,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    static <R, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12> StructCodec<R> struct(
+    static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object> StructCodec<R> struct(
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             String name2, Codec<P2> codec2, Function<R, P2> getter2,
             String name3, Codec<P3> codec3, Function<R, P3> getter3,
@@ -743,7 +744,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    static <R, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13> StructCodec<R> struct(
+    static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object> StructCodec<R> struct(
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             String name2, Codec<P2> codec2, Function<R, P2> getter2,
             String name3, Codec<P3> codec3, Function<R, P3> getter3,
@@ -837,7 +838,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    static <R, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14> StructCodec<R> struct(
+    static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object> StructCodec<R> struct(
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             String name2, Codec<P2> codec2, Function<R, P2> getter2,
             String name3, Codec<P3> codec3, Function<R, P3> getter3,
@@ -937,7 +938,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    static <R, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15> StructCodec<R> struct(
+    static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object> StructCodec<R> struct(
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             String name2, Codec<P2> codec2, Function<R, P2> getter2,
             String name3, Codec<P3> codec3, Function<R, P3> getter3,
@@ -1043,7 +1044,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    static <R, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16> StructCodec<R> struct(
+    static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object> StructCodec<R> struct(
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             String name2, Codec<P2> codec2, Function<R, P2> getter2,
             String name3, Codec<P3> codec3, Function<R, P3> getter3,
@@ -1155,7 +1156,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    static <R, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17> StructCodec<R> struct(
+    static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object> StructCodec<R> struct(
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             String name2, Codec<P2> codec2, Function<R, P2> getter2,
             String name3, Codec<P3> codec3, Function<R, P3> getter3,
@@ -1273,7 +1274,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    static <R, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18> StructCodec<R> struct(
+    static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, P18 extends @UnknownNullability Object> StructCodec<R> struct(
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             String name2, Codec<P2> codec2, Function<R, P2> getter2,
             String name3, Codec<P3> codec3, Function<R, P3> getter3,
@@ -1397,7 +1398,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    static <R, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19> StructCodec<R> struct(
+    static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, P18 extends @UnknownNullability Object, P19 extends @UnknownNullability Object> StructCodec<R> struct(
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             String name2, Codec<P2> codec2, Function<R, P2> getter2,
             String name3, Codec<P3> codec3, Function<R, P3> getter3,
@@ -1527,7 +1528,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    static <R, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20> StructCodec<R> struct(
+    static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, P18 extends @UnknownNullability Object, P19 extends @UnknownNullability Object, P20 extends @UnknownNullability Object> StructCodec<R> struct(
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             String name2, Codec<P2> codec2, Function<R, P2> getter2,
             String name3, Codec<P3> codec3, Function<R, P3> getter3,
@@ -1663,7 +1664,7 @@ public interface StructCodec<R> extends Codec<R> {
         };
     }
 
-    private static <D, T> Result<T> get(Transcoder<D> coder, Codec<T> codec, String key, MapLike<D> map) {
+    private static <D, T> Result<@Nullable T> get(Transcoder<D> coder, Codec<T> codec, String key, MapLike<D> map) {
         if (INLINE.equals(key)) {
             final Codec<T> decodeCodec = codec instanceof CodecImpl.OptionalImpl<T>(
                     Codec<T> inner, T ignored

--- a/src/main/java/net/minestom/server/codec/TranscoderNbtImpl.java
+++ b/src/main/java/net/minestom/server/codec/TranscoderNbtImpl.java
@@ -7,8 +7,6 @@ import java.util.*;
 final class TranscoderNbtImpl implements Transcoder<BinaryTag> {
     static final TranscoderNbtImpl INSTANCE = new TranscoderNbtImpl();
 
-    private static final Set<String> WRAPPED_ELEMENT_KEYS = Set.of("");
-
     @Override
     public BinaryTag createNull() {
         return EndBinaryTag.endBinaryTag();

--- a/src/main/java/net/minestom/server/network/NetworkBufferTemplate.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferTemplate.java
@@ -1,108 +1,109 @@
 package net.minestom.server.network;
 
 import net.minestom.server.network.NetworkBuffer.Type;
+import org.jetbrains.annotations.UnknownNullability;
 
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 public final class NetworkBufferTemplate {
     @FunctionalInterface
-    public interface F1<P1, R> {
+    public interface F1<P1 extends @UnknownNullability Object, R> {
         R apply(P1 p1);
     }
 
     @FunctionalInterface
-    public interface F2<P1, P2, R> {
+    public interface F2<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, R> {
         R apply(P1 p1, P2 p2);
     }
 
     @FunctionalInterface
-    public interface F3<P1, P2, P3, R> {
+    public interface F3<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, R> {
         R apply(P1 p1, P2 p2, P3 p3);
     }
 
     @FunctionalInterface
-    public interface F4<P1, P2, P3, P4, R> {
+    public interface F4<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, R> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4);
     }
 
     @FunctionalInterface
-    public interface F5<P1, P2, P3, P4, P5, R> {
+    public interface F5<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, R> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5);
     }
 
     @FunctionalInterface
-    public interface F6<P1, P2, P3, P4, P5, P6, R> {
+    public interface F6<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, R> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6);
     }
 
     @FunctionalInterface
-    public interface F7<P1, P2, P3, P4, P5, P6, P7, R> {
+    public interface F7<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, R> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7);
     }
 
     @FunctionalInterface
-    public interface F8<P1, P2, P3, P4, P5, P6, P7, P8, R> {
+    public interface F8<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, R> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8);
     }
 
     @FunctionalInterface
-    public interface F9<P1, P2, P3, P4, P5, P6, P7, P8, P9, R> {
+    public interface F9<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, R> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9);
     }
 
     @FunctionalInterface
-    public interface F10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R> {
+    public interface F10<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, R> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10);
     }
 
     @FunctionalInterface
-    public interface F11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, R> {
+    public interface F11<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, R> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11);
     }
 
     @FunctionalInterface
-    public interface F12<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R> {
+    public interface F12<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, R> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12);
     }
 
     @FunctionalInterface
-    public interface F13<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, R> {
+    public interface F13<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, R> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13);
     }
 
     @FunctionalInterface
-    public interface F14<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, R> {
+    public interface F14<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, R> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14);
     }
 
     @FunctionalInterface
-    public interface F15<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, R> {
+    public interface F15<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, R> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15);
     }
 
     @FunctionalInterface
-    public interface F16<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, R> {
+    public interface F16<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, R> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16);
     }
 
     @FunctionalInterface
-    public interface F17<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, R> {
+    public interface F17<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, R> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17);
     }
 
     @FunctionalInterface
-    public interface F18<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, R> {
+    public interface F18<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, P18 extends @UnknownNullability Object, R> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17, P18 p18);
     }
 
     @FunctionalInterface
-    public interface F19<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, R> {
+    public interface F19<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, P18 extends @UnknownNullability Object, P19 extends @UnknownNullability Object, R> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17, P18 p18, P19 p19);
     }
 
     @FunctionalInterface
-    public interface F20<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, R> {
+    public interface F20<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, P18 extends @UnknownNullability Object, P19 extends @UnknownNullability Object, P20 extends @UnknownNullability Object, R> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17, P18 p18, P19 p19, P20 p20);
     }
 

--- a/src/main/java/net/minestom/server/utils/ThrowingFunction.java
+++ b/src/main/java/net/minestom/server/utils/ThrowingFunction.java
@@ -1,7 +1,9 @@
 package net.minestom.server.utils;
 
+import org.jetbrains.annotations.UnknownNullability;
+
 @FunctionalInterface
-public interface ThrowingFunction<I, O> {
+public interface ThrowingFunction<I extends @UnknownNullability Object, O extends @UnknownNullability Object> {
     O apply(I i) throws Exception;
 
     static <T> ThrowingFunction<T, T> identity() {


### PR DESCRIPTION
## Proposed changes

Fixes nullability warnings across Minestom with codecs.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments
Cleanup some other warnings in the codec package
Cleanup union's with revised version
Changed how optional defaultValue cannot be null as optional exists and we can gaurrentee its nullable.
Yes I know the extends Object, looks bad but thats how the spec is works (jspecify does this too)
Maybe result should not allow nullable values and instead always be an null error then a Result#orNull?