### PR TITLE
Compare material prototype BLOCK_STATE instead of empty

### DIFF
--- a/src/main/java/net/minestom/server/item/component/ItemBlockState.java
+++ b/src/main/java/net/minestom/server/item/component/ItemBlockState.java
@@ -19,6 +19,10 @@ public record ItemBlockState(Map<String, String> properties) {
         properties = Map.copyOf(properties);
     }
 
+    public ItemBlockState(String key, String value) {
+        this(Map.of(key, value));
+    }
+
     public ItemBlockState with(String key, String value) {
         Map<String, String> newProperties = new HashMap<>(properties);
         newProperties.put(key, value);

--- a/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
+++ b/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
@@ -159,7 +159,7 @@ public class BlockPlacementListener {
         // BlockPlaceEvent check
         PlayerBlockPlaceEvent playerBlockPlaceEvent = new PlayerBlockPlaceEvent(player, placedBlock, blockFace, new BlockVec(placementPosition), cursorPosition, packet.hand());
         playerBlockPlaceEvent.consumeBlock(player.getGameMode() != GameMode.CREATIVE);
-        playerBlockPlaceEvent.setDoBlockUpdates(blockState.equals(ItemBlockState.EMPTY));
+        playerBlockPlaceEvent.setDoBlockUpdates(blockState.equals(useMaterial.prototype().get(DataComponents.BLOCK_STATE, ItemBlockState.EMPTY)));
         EventDispatcher.call(playerBlockPlaceEvent);
         if (playerBlockPlaceEvent.isCancelled()) {
             refresh(player, chunk);

--- a/src/test/java/net/minestom/server/instance/BlockPlaceIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/BlockPlaceIntegrationTest.java
@@ -1,19 +1,22 @@
 package net.minestom.server.instance;
 
+import net.minestom.server.component.DataComponents;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.PlayerHand;
+import net.minestom.server.event.EventFilter;
+import net.minestom.server.event.player.PlayerBlockPlaceEvent;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
+import net.minestom.server.item.component.ItemBlockState;
 import net.minestom.server.listener.BlockPlacementListener;
 import net.minestom.server.network.packet.client.play.ClientPlayerBlockPlacementPacket;
 import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 @EnvTest
 public class BlockPlaceIntegrationTest {
@@ -58,4 +61,39 @@ public class BlockPlaceIntegrationTest {
         var placedBlock = instance.getBlock(3, -64, 0);
         assertEquals(Block.STONE, placedBlock);
     }
+
+    @Test
+    void testPlaceNoUpdateWithItemBlockStateComponent(Env env) {
+        Instance instance = env.createFlatInstance();
+        var player = env.createPlayer(instance, new Pos(0, -64, 0));
+        player.setItemInHand(PlayerHand.MAIN, ItemStack.of(Material.STONE_STAIRS, 5)
+                .with(DataComponents.BLOCK_STATE, new ItemBlockState("facing", "west")));
+
+        var placeCollector = env.trackEvent(PlayerBlockPlaceEvent.class, EventFilter.PLAYER, player);
+
+        var placePacket = new ClientPlayerBlockPlacementPacket(PlayerHand.MAIN, new Pos(3, -64, 0), BlockFace.TOP, 0.5f, 0.5f, 0.5f, false, false, 1);
+        BlockPlacementListener.listener(placePacket, player);
+
+        // Should default to no updates because of the BLOCK_STATE component
+        placeCollector.assertSingle(event -> assertFalse(event.shouldDoBlockUpdates()));
+    }
+
+    @Test
+    void testPlaceNoUpdateBlockStateComponentBeeHiveRegression(Env env) {
+        // We originally compared to an empty block state but some blocks (like bee hive)
+        // have a default value, so we only should trigger no updates if the block state is
+        // different from the default.
+        Instance instance = env.createFlatInstance();
+        var player = env.createPlayer(instance, new Pos(0, -64, 0));
+        player.setItemInHand(PlayerHand.MAIN, ItemStack.of(Material.BEEHIVE, 5));
+
+        var placeCollector = env.trackEvent(PlayerBlockPlaceEvent.class, EventFilter.PLAYER, player);
+
+        var placePacket = new ClientPlayerBlockPlacementPacket(PlayerHand.MAIN, new Pos(3, -64, 0), BlockFace.TOP, 0.5f, 0.5f, 0.5f, false, false, 1);
+        BlockPlacementListener.listener(placePacket, player);
+
+        // Should have updates because we only have the default BLOCK_STATE value
+        placeCollector.assertSingle(event -> assertTrue(event.shouldDoBlockUpdates()));
+    }
+
 }


### PR DESCRIPTION
## Proposed changes

Some materials have a default block state component, we shouldn't default to disabling updates when placing a block with the default. Previously we compared to empty, now we account for the default.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)