### PR TITLE
Add support for entity head rotation

### DIFF
--- a/src/main/java/net/minestom/server/coordinate/Pos.java
+++ b/src/main/java/net/minestom/server/coordinate/Pos.java
@@ -296,7 +296,7 @@ public record Pos(double x, double y, double z, float yaw, float pitch) implemen
      * @param yaw The possible "wrong" yaw
      * @return a fixed yaw
      */
-    private static float fixYaw(float yaw) {
+    public static float fixYaw(float yaw) {
         yaw = yaw % 360;
         if (yaw < -180.0F) {
             yaw += 360.0F;

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -2263,7 +2263,7 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
         if (hasPassenger()) {
             connection.sendPacket(getPassengersPacket());
         }
-        connection.sendPacket(new EntityHeadLookPacket(getEntityId(), position.yaw()));
+        connection.sendPacket(new EntityHeadLookPacket(getEntityId(), headRotation));
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

This pull request adds support for the `EntityHeadLookPacket`. Previously, it was tied to the yaw value, but it is now possible for an entity to have a different head rotation than yaw. This is needed to correctly mimic some mob behavior in vanilla.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

The change is non breaking: `Entity#refreshPosition` should function exactly the same as before, assuming no custom head rotations have been done.

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

# Further comments

Currently, doing `entity.refreshPosition(somePos)` (with `ignoreView = false`) will reset the head rotation to the yaw of `somePos`. While this does in most cases make sense, it could be a source of confusion. A solution would be to add a `headRotation` field to `refreshPosition`, but I felt this was cleaner.