### PR TITLE
Fix entity line of sight detection

### DIFF
--- a/src/main/java/net/minestom/server/collision/CollisionUtils.java
+++ b/src/main/java/net/minestom/server/collision/CollisionUtils.java
@@ -134,16 +134,17 @@ public final class CollisionUtils {
      * @param start    start of the line of sight.
      * @param end      end of the line of sight.
      * @param shape    shape to check.
+     * @param shapePos position of the shape to check.
      * @return true is shape is reachable by the given line of sight; false otherwise.
      */
     public static boolean isLineOfSightReachingShape(Instance instance, @Nullable Chunk chunk,
                                                      Point start, Point end,
-                                                     Shape shape) {
+                                                     Shape shape, Point shapePos) {
         final PhysicsResult result = handlePhysics(instance, chunk,
                 BoundingBox.ZERO, start.asPos(), end.sub(start).asVec(),
                 null, false);
 
-        return shape.intersectBox(end.sub(result.newPosition()).sub(Vec.EPSILON), BoundingBox.ZERO);
+        return shape.intersectBox(shapePos.sub(result.newPosition()).sub(Vec.EPSILON), BoundingBox.ZERO);
     }
 
     public static PhysicsResult handlePhysics(Entity entity, Vec entityVelocity) {

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -1755,10 +1755,10 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         final Pos start = position.withY(position.y() + getEyeHeight());
         final Pos end = entity.position.withY(entity.position.y() + entity.getEyeHeight());
         final Vec direction = exactView ? position.direction() : end.sub(start).asVec().normalize();
-        if (!entity.boundingBox.boundingBoxRayIntersectionCheck(start.asVec(), direction, entity.getPosition())) {
+        if (!entity.boundingBox.boundingBoxRayIntersectionCheck(start.asVec(), direction, entity.position)) {
             return false;
         }
-        return CollisionUtils.isLineOfSightReachingShape(instance, currentChunk, start, end, entity.boundingBox);
+        return CollisionUtils.isLineOfSightReachingShape(instance, currentChunk, start, end, entity.boundingBox, entity.position);
     }
 
     /**
@@ -1786,10 +1786,10 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         final Pos start = position.withY(position.y() + getEyeHeight());
         final Vec startAsVec = start.asVec();
         final Predicate<Entity> finalPredicate = e -> e != this
-                && e.boundingBox.boundingBoxRayIntersectionCheck(startAsVec, position.direction(), e.getPosition())
+                && e.boundingBox.boundingBoxRayIntersectionCheck(startAsVec, position.direction(), e.position)
                 && predicate.test(e)
                 && CollisionUtils.isLineOfSightReachingShape(instance, currentChunk, start,
-                e.position.withY(e.position.y() + e.getEyeHeight()), e.boundingBox);
+                e.position.withY(e.position.y() + e.getEyeHeight()), e.boundingBox, e.position);
 
         Optional<Entity> nearby = instance.getNearbyEntities(position, range).stream()
                 .filter(finalPredicate)

--- a/src/test/java/net/minestom/server/entity/EntityLineOfSightIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/EntityLineOfSightIntegrationTest.java
@@ -144,6 +144,7 @@ public class EntityLineOfSightIntegrationTest {
         assertFalse(entity.hasLineOfSight(entity2, true));
         assertTrue(entity.hasLineOfSight(entity2, false));
     }
+
     @Test
     public void entityPhysicsCheckLineOfSightLargeBoundingBox(Env env) {
         var instance = env.createFlatInstance();
@@ -165,5 +166,28 @@ public class EntityLineOfSightIntegrationTest {
         assertEquals(entity2, entity.getLineOfSightEntity(20, (e) -> true));
         assertTrue(entity.hasLineOfSight(entity2, true));
         assertTrue(entity.hasLineOfSight(entity2, false));
+    }
+
+    @Test
+    public void entityPhysicsCheckLineOfSightDifferentTypes(Env env) {
+        var instance = env.createFlatInstance();
+
+        var entity = new Entity(EntityTypes.CHICKEN);
+        entity.setInstance(instance, new Pos(0, 42, 0)).join();
+        entity.setView(-90, 0);
+
+        var entity2 = new Entity(EntityTypes.ZOMBIE);
+        entity2.setInstance(instance, new Pos(10, 42, 0)).join();
+
+        assertEquals(entity2, entity.getLineOfSightEntity(20, (e) -> true));
+        assertTrue(entity.hasLineOfSight(entity2, true));
+
+        entity.teleport(new Pos(10, 42, 0)).join();
+        entity2.teleport(new Pos(0, 42, 0)).join();
+        entity2.setView(-90, 0);
+
+        assertNull(entity2.getLineOfSightEntity(20, (e) -> true));
+        assertFalse(entity2.hasLineOfSight(entity, true));
+        assertTrue(entity2.hasLineOfSight(entity, false));
     }
 }


### PR DESCRIPTION
## Proposed changes

Previously, the line of sight detection would not correctly take into account the position of the target bounding box, in some cases resulting in `Entity#hasLineOfSight` returning `false` when it should have been `true`.

This PR fixes the issue and adds a test which would have failed before the fix.

This would solve issue #1500, which I think was wrongly marked as not planned.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)