### PR TITLE
Add Adventure Key support for resource location argument

### DIFF
--- a/demo/src/main/java/net/minestom/demo/commands/CookieCommand.java
+++ b/demo/src/main/java/net/minestom/demo/commands/CookieCommand.java
@@ -1,5 +1,6 @@
 package net.minestom.demo.commands;
 
+import net.kyori.adventure.key.Key;
 import net.minestom.server.command.CommandSender;
 import net.minestom.server.command.builder.Command;
 import net.minestom.server.command.builder.CommandContext;
@@ -16,7 +17,7 @@ public class CookieCommand extends Command {
     }
 
     public static class Store extends Command {
-        private final Argument<String> keyArg = ArgumentType.ResourceLocation("key");
+        private final Argument<Key> keyArg = ArgumentType.ResourceLocation("key");
         private final Argument<String[]> valueArg = ArgumentType.StringArray("value");
 
         public Store() {
@@ -28,7 +29,7 @@ public class CookieCommand extends Command {
         private void store(CommandSender sender, CommandContext context) {
             if (!(sender instanceof Player player)) return;
 
-            String key = context.get(keyArg);
+            String key = context.get(keyArg).asString();
             byte[] value = String.join(" ", context.get(valueArg)).getBytes();
 
             player.getPlayerConnection().storeCookie(key, value);
@@ -37,7 +38,7 @@ public class CookieCommand extends Command {
     }
 
     public static class Fetch extends Command {
-        private final Argument<String> keyArg = ArgumentType.ResourceLocation("key");
+        private final Argument<Key> keyArg = ArgumentType.ResourceLocation("key");
 
         public Fetch() {
             super("fetch");
@@ -48,7 +49,7 @@ public class CookieCommand extends Command {
         private void fetch(CommandSender sender, CommandContext context) {
             if (!(sender instanceof Player player)) return;
 
-            String key = context.get(keyArg);
+            String key = context.get(keyArg).asString();
 
             player.getPlayerConnection().fetchCookie(key).thenAccept(value -> {
                 if (value == null) {

--- a/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentResourceLocation.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentResourceLocation.java
@@ -1,25 +1,26 @@
 package net.minestom.server.command.builder.arguments.minecraft;
 
+import net.kyori.adventure.key.KeyPattern;
 import net.minestom.server.command.ArgumentParserType;
 import net.minestom.server.command.CommandSender;
 import net.minestom.server.command.builder.arguments.Argument;
 import net.minestom.server.command.builder.exception.ArgumentSyntaxException;
-import net.minestom.server.utils.StringUtils;
+import net.kyori.adventure.key.Key;
 
-public class ArgumentResourceLocation extends Argument<String> {
+public class ArgumentResourceLocation extends Argument<Key> {
 
-    public static final int SPACE_ERROR = 1;
+    public static final int PARSE_ERROR = 1;
 
     public ArgumentResourceLocation(String id) {
         super(id);
     }
 
     @Override
-    public String parse(CommandSender sender, String input) throws ArgumentSyntaxException {
-        if (input.contains(StringUtils.SPACE))
-            throw new ArgumentSyntaxException("Resource location cannot contain space character", input, SPACE_ERROR);
+    public Key parse(CommandSender sender, @KeyPattern String input) throws ArgumentSyntaxException {
+        if (!Key.parseable(input))
+            throw new ArgumentSyntaxException("Invalid resource location", input, PARSE_ERROR);
 
-        return input;
+        return Key.key(input);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentResourceLocation.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentResourceLocation.java
@@ -7,6 +7,12 @@ import net.minestom.server.command.builder.arguments.Argument;
 import net.minestom.server.command.builder.exception.ArgumentSyntaxException;
 import net.kyori.adventure.key.Key;
 
+/**
+ * Represents a resource location (namespaced identifier) value.
+ * <p>
+ *     Example: {@code minecraft:air}
+ * </p>
+ */
 public class ArgumentResourceLocation extends Argument<Key> {
 
     public static final int PARSE_ERROR = 1;

--- a/src/test/java/net/minestom/server/command/ArgumentTypeTest.java
+++ b/src/test/java/net/minestom/server/command/ArgumentTypeTest.java
@@ -1,5 +1,6 @@
 package net.minestom.server.command;
 
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.CompoundBinaryTag;
 import net.kyori.adventure.nbt.IntArrayBinaryTag;
 import net.kyori.adventure.nbt.IntBinaryTag;
@@ -210,9 +211,14 @@ public class ArgumentTypeTest {
     @Test
     public void testArgumentResourceLocation() {
         var arg = ArgumentType.ResourceLocation("resource_location");
-        assertArg(arg, "minecraft:resource_location_example", "minecraft:resource_location_example");
+
+        assertArg(arg, Key.key("foo:bar"), "foo:bar");
+        assertArg(arg, Key.key("minecraft:air"), "air");
+        assertArg(arg, Key.key("minecraft:foo/bar"), "foo/bar");
+
         assertInvalidArg(arg, "minecraft:invalid resource location");
-        //assertInvalidArg(arg, "minecraft:");
+        assertInvalidArg(arg, "!");
+        assertInvalidArg(arg, "a/b:empty");
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

This pull request modifies the `ArgumentResourceLocation` class to:

- Support the `Key` type from Adventure library
- Properly validate resource location values to ensure client input is not malformed

Prior to this commit, the resource location argument implementation merely checks if there are any space characters in the input, and returns a `String`. The consequence of this behaviour is that API consumers must validate and parse the resulting value, making the `resource_location` argument type not any more useful than `string` in its intended use case.

Note that a `KeyPattern` annotation was added to the `input` parameter of the `parse` method in order to suppress an IDE warning. I am happy to remove that annotation if it is considered in appropriate.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
