### PR TITLE
make DimensionType effects codec not optional

### DIFF
--- a/src/main/java/net/minestom/server/world/DimensionType.java
+++ b/src/main/java/net/minestom/server/world/DimensionType.java
@@ -37,7 +37,7 @@ public sealed interface DimensionType extends DimensionTypes permits DimensionTy
             "min_y", Codec.INT, DimensionType::minY,
             "height", Codec.INT, DimensionType::height,
             "infiniburn", Codec.STRING, DimensionType::infiniburn,
-            "effects", Codec.KEY.optional(OVERWORLD_EFFECTS), DimensionType::effects,
+            "effects", Codec.KEY, DimensionType::effects,
             "monster_spawn_block_light_limit", Codec.INT, DimensionType::monsterSpawnBlockLightLimit,
             "monster_spawn_light_level", Codec.INT.orElse(Codec.UNIT.transform(ignored -> 0, ignored -> Unit.INSTANCE)), DimensionType::monsterSpawnLightLevel,
             DimensionType::create);


### PR DESCRIPTION
## Proposed changes

DimensinonType effects are not supposed to be optional in the codec.
https://minecraft.wiki/w/Java_Edition_protocol/Registry_data#Dimension_Type
While the client seems to allow it, other software such as packetevents bricks:
```
java.lang.IllegalStateException: NBT effects does not exist
    at com.github.retrooper.packetevents.protocol.nbt.NBTCompound.getTagOrThrow(NBTCompound.java:63)
    at com.github.retrooper.packetevents.protocol.nbt.NBTCompound.getTagOfTypeOrThrow(NBTCompound.java:74)
    at com.github.retrooper.packetevents.protocol.nbt.NBTCompound.getStringTagValueOrThrow(NBTCompound.java:172)
    at com.github.retrooper.packetevents.protocol.world.dimension.DimensionType.decode(DimensionType.java:137)
    ...
```
As long as we only use the builtin DimensionTypes this is not an issue, but when defining a custom DimensionType with `OVERWORLD_EFFECTS` effects this breaks

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I like cats