### PR TITLE
Ensure nullability constraints at runtime for Codecs

### DIFF
--- a/src/main/java/net/minestom/server/MinecraftServer.java
+++ b/src/main/java/net/minestom/server/MinecraftServer.java
@@ -70,7 +70,7 @@ public final class MinecraftServer implements MinecraftConstants {
     public static final int TICK_MS = 1000 / TICK_PER_SECOND;
 
     // In-Game Manager
-    private static volatile ServerProcess serverProcess;
+    private static volatile @UnknownNullability ServerProcess serverProcess;
 
     private static int compressionThreshold = 256;
     private static String brandName = "Minestom";

--- a/src/main/java/net/minestom/server/codec/Codec.java
+++ b/src/main/java/net/minestom/server/codec/Codec.java
@@ -144,6 +144,7 @@ public interface Codec<T extends @UnknownNullability Object> extends Encoder<T>,
      */
     @Contract(pure = true)
     static <E extends Enum<E>> Codec<E> Enum(Class<E> enumClass) {
+        Objects.requireNonNull(enumClass, "Enum class cannot be null");
         return STRING.transform(
                 value -> Enum.valueOf(enumClass, value.toUpperCase(Locale.ROOT)),
                 value -> value.name().toLowerCase(Locale.ROOT));
@@ -193,6 +194,7 @@ public interface Codec<T extends @UnknownNullability Object> extends Encoder<T>,
             Function<T, StructCodec<? extends T>> serializerGetter,
             String key
     ) {
+        Objects.requireNonNull(registry, "registry");
         return Codec.RegistryTaggedUnion((ignored) -> registry, serializerGetter, key);
     }
 

--- a/src/main/java/net/minestom/server/codec/CodecImpl.java
+++ b/src/main/java/net/minestom/server/codec/CodecImpl.java
@@ -24,10 +24,9 @@ import java.util.function.Supplier;
 final class CodecImpl {
 
     record RawValueImpl<D>(Transcoder<D> coder, D value) implements Codec.RawValue {
-
         RawValueImpl {
-            Objects.requireNonNull(coder);
-            Objects.requireNonNull(value);
+            Objects.requireNonNull(coder, "coder");
+            Objects.requireNonNull(value, "value");
         }
 
         @Override
@@ -59,6 +58,11 @@ final class CodecImpl {
     }
 
     record PrimitiveImpl<T>(PrimitiveEncoder<T> encoder, Decoder<T> decoder) implements Codec<T> {
+        PrimitiveImpl {
+            Objects.requireNonNull(encoder, "encoder");
+            Objects.requireNonNull(decoder, "decoder");
+        }
+
         @Override
         public <D> Result<T> decode(Transcoder<D> coder, D value) {
             return decoder.decode(coder, value);
@@ -72,6 +76,10 @@ final class CodecImpl {
     }
 
     record OptionalImpl<T>(Codec<T> inner, @Nullable T defaultValue) implements Codec<T> {
+        OptionalImpl {
+            Objects.requireNonNull(inner, "inner");
+        }
+
         @Override
         public <D> Result<T> decode(Transcoder<D> coder, D value) {
             return new Result.Ok<>(inner.decode(coder, value).orElse(defaultValue));
@@ -87,6 +95,12 @@ final class CodecImpl {
 
     record TransformImpl<T, S>(Codec<T> inner, ThrowingFunction<T, S> to,
                                ThrowingFunction<@Nullable S, T> from) implements Codec<S> {
+        TransformImpl {
+            Objects.requireNonNull(inner, "inner");
+            Objects.requireNonNull(to, "to");
+            Objects.requireNonNull(from, "from");
+        }
+
         @Override
         public <D> Result<S> decode(Transcoder<D> coder, D value) {
             try {
@@ -111,6 +125,10 @@ final class CodecImpl {
     }
 
     record ListImpl<T>(Codec<T> inner, int maxSize) implements Codec<List<T>> {
+        ListImpl {
+            Objects.requireNonNull(inner, "inner");
+        }
+
         @Override
         public <D> Result<List<T>> decode(Transcoder<D> coder, D value) {
             final Result<List<D>> listResult = coder.getList(value);
@@ -147,6 +165,10 @@ final class CodecImpl {
     }
 
     record SetImpl<T>(Codec<T> inner, int maxSize) implements Codec<Set<T>> {
+        SetImpl {
+            Objects.requireNonNull(inner, "inner");
+        }
+
         @Override
         public <D> Result<Set<T>> decode(Transcoder<D> coder, D value) {
             final Result<List<D>> listResult = coder.getList(value);
@@ -183,6 +205,11 @@ final class CodecImpl {
 
     record MapImpl<K, V>(Codec<K> keyCodec, Codec<V> valueCodec,
                          int maxSize) implements Codec<Map<K, V>> {
+        MapImpl {
+            Objects.requireNonNull(keyCodec, "keyCodec");
+            Objects.requireNonNull(valueCodec, "valueCodec");
+        }
+
         @Override
         public <D> Result<Map<K, V>> decode(Transcoder<D> coder, D value) {
             final Result<MapLike<D>> mapResult = coder.getMap(value);
@@ -232,6 +259,11 @@ final class CodecImpl {
     record UnionImpl<T, R>(String keyField, Codec<T> keyCodec,
                            Function<T, @Nullable StructCodec<? extends R>> serializers,
                            Function<R, ? extends T> keyFunc) implements StructCodec<R> {
+        UnionImpl {
+            Objects.requireNonNull(serializers, "serializers");
+            Objects.requireNonNull(keyField, "keyField");
+            Objects.requireNonNull(keyFunc, "keyFunc");
+        }
 
         @SuppressWarnings("unchecked")
         @Override
@@ -267,6 +299,12 @@ final class CodecImpl {
             Function<T, StructCodec<? extends T>> valueToCodec,
             String key
     ) implements StructCodec<T> {
+        RegistryTaggedUnionImpl {
+            Objects.requireNonNull(registrySelector, "registrySelector");
+            Objects.requireNonNull(valueToCodec, "valueToCodec");
+            Objects.requireNonNull(key, "key");
+        }
+
         @Override
         public <D> Result<T> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
             if (!(coder instanceof RegistryTranscoder<D> context))
@@ -304,7 +342,8 @@ final class CodecImpl {
         final Codec<T> delegate;
 
         public RecursiveImpl(Function<Codec<T>, Codec<T>> self) {
-            this.delegate = self.apply(this);
+            Objects.requireNonNull(self, "self");
+            this.delegate = Objects.requireNonNull(self.apply(this), "delegate");
         }
 
         @Override
@@ -323,7 +362,7 @@ final class CodecImpl {
         private @Nullable Codec<T> delegate;
 
         ForwardRefImpl(Supplier<Codec<T>> delegateFunc) {
-            this.delegateFunc = delegateFunc;
+            this.delegateFunc = Objects.requireNonNull(delegateFunc, "delegateFunc");
         }
 
         private Codec<T> delegate() {
@@ -343,6 +382,11 @@ final class CodecImpl {
     }
 
     record OrElseImpl<T>(Codec<T> primary, Codec<T> secondary) implements Codec<T> {
+        OrElseImpl {
+            Objects.requireNonNull(primary, "primary");
+            Objects.requireNonNull(secondary, "secondary");
+        }
+
         @Override
         public <D> Result<T> decode(Transcoder<D> coder, D value) {
             final Result<T> primaryResult = primary.decode(coder, value);
@@ -397,6 +441,11 @@ final class CodecImpl {
     }
 
     record EitherImpl<L, R>(Codec<L> leftCodec, Codec<R> rightCodec) implements Codec<Either<L, R>> {
+        EitherImpl {
+            Objects.requireNonNull(leftCodec, "leftCodec");
+            Objects.requireNonNull(rightCodec, "rightCodec");
+        }
+        
         @Override
         public <D> Result<Either<L, R>> decode(Transcoder<D> coder, D value) {
             final Result<L> leftResult = leftCodec.decode(coder, value);

--- a/src/main/java/net/minestom/server/codec/Result.java
+++ b/src/main/java/net/minestom/server/codec/Result.java
@@ -35,7 +35,7 @@ public sealed interface Result<T extends @UnknownNullability Object> {
      */
     record Error<T>(String message) implements Result<T> {
         public Error {
-            message = Objects.requireNonNull(message, "Message cannot be null");
+            Objects.requireNonNull(message, "Message cannot be null");
         }
     }
 
@@ -100,7 +100,7 @@ public sealed interface Result<T extends @UnknownNullability Object> {
      * @throws IllegalStateException if this instance of {@link Error}
      */
     @Contract(pure = true)
-    default @UnknownNullability T orElseThrow() {
+    default T orElseThrow() {
         return switch (this) {
             case Ok<T>(T value) -> value;
             case Error<?>(String errorMessage) -> throw new IllegalArgumentException(errorMessage);
@@ -115,7 +115,7 @@ public sealed interface Result<T extends @UnknownNullability Object> {
      * @throws IllegalStateException if this instance of {@link Error}
      */
     @Contract(pure = true)
-    default @UnknownNullability T orElseThrow(String message) {
+    default T orElseThrow(String message) {
         return switch (this) {
             case Ok<T>(T value) -> value;
             case Error<?>(String errorMessage) -> throw new IllegalArgumentException(

--- a/src/main/java/net/minestom/server/codec/StructCodec.java
+++ b/src/main/java/net/minestom/server/codec/StructCodec.java
@@ -139,7 +139,7 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new struct codec for value
      */
     static <R> StructCodec<R> struct(R value) {
-        final Result<R> ok = new Result.Ok<>(value);
+        final Result<R> ok = new Result.Ok<>(Objects.requireNonNull(value, "value"));
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -161,6 +161,7 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new struct codec for value
      */
     static <R> StructCodec<R> struct(Supplier<R> ctor) {
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -189,6 +190,10 @@ public interface StructCodec<R> extends Codec<R> {
             String name1, Codec<P1> codec1, Function<R, P1> getter1,
             F1<P1, R> ctor
     ) {
+        Objects.requireNonNull(name1, "name1");
+        Objects.requireNonNull(codec1, "codec1");
+        Objects.requireNonNull(getter1, "getter1");
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -227,6 +232,13 @@ public interface StructCodec<R> extends Codec<R> {
             String name2, Codec<P2> codec2, Function<R, P2> getter2,
             F2<P1, P2, R> ctor
     ) {
+        Objects.requireNonNull(name1, "name1");
+        Objects.requireNonNull(codec1, "codec1");
+        Objects.requireNonNull(getter1, "getter1");
+        Objects.requireNonNull(name2, "name2");
+        Objects.requireNonNull(codec2, "codec2");
+        Objects.requireNonNull(getter2, "getter2");
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -275,6 +287,16 @@ public interface StructCodec<R> extends Codec<R> {
             String name3, Codec<P3> codec3, Function<R, P3> getter3,
             F3<P1, P2, P3, R> ctor
     ) {
+        Objects.requireNonNull(name1, "name1");
+        Objects.requireNonNull(codec1, "codec1");
+        Objects.requireNonNull(getter1, "getter1");
+        Objects.requireNonNull(name2, "name2");
+        Objects.requireNonNull(codec2, "codec2");
+        Objects.requireNonNull(getter2, "getter2");
+        Objects.requireNonNull(name3, "name3");
+        Objects.requireNonNull(codec3, "codec3");
+        Objects.requireNonNull(getter3, "getter3");
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -333,6 +355,19 @@ public interface StructCodec<R> extends Codec<R> {
             String name4, Codec<P4> codec4, Function<R, P4> getter4,
             F4<P1, P2, P3, P4, R> ctor
     ) {
+        Objects.requireNonNull(name1, "name1");
+        Objects.requireNonNull(codec1, "codec1");
+        Objects.requireNonNull(getter1, "getter1");
+        Objects.requireNonNull(name2, "name2");
+        Objects.requireNonNull(codec2, "codec2");
+        Objects.requireNonNull(getter2, "getter2");
+        Objects.requireNonNull(name3, "name3");
+        Objects.requireNonNull(codec3, "codec3");
+        Objects.requireNonNull(getter3, "getter3");
+        Objects.requireNonNull(name4, "name4");
+        Objects.requireNonNull(codec4, "codec4");
+        Objects.requireNonNull(getter4, "getter4");
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -401,6 +436,22 @@ public interface StructCodec<R> extends Codec<R> {
             String name5, Codec<P5> codec5, Function<R, P5> getter5,
             F5<P1, P2, P3, P4, P5, R> ctor
     ) {
+        Objects.requireNonNull(name1, "name1");
+        Objects.requireNonNull(codec1, "codec1");
+        Objects.requireNonNull(getter1, "getter1");
+        Objects.requireNonNull(name2, "name2");
+        Objects.requireNonNull(codec2, "codec2");
+        Objects.requireNonNull(getter2, "getter2");
+        Objects.requireNonNull(name3, "name3");
+        Objects.requireNonNull(codec3, "codec3");
+        Objects.requireNonNull(getter3, "getter3");
+        Objects.requireNonNull(name4, "name4");
+        Objects.requireNonNull(codec4, "codec4");
+        Objects.requireNonNull(getter4, "getter4");
+        Objects.requireNonNull(name5, "name5");
+        Objects.requireNonNull(codec5, "codec5");
+        Objects.requireNonNull(getter5, "getter5");
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -479,6 +530,25 @@ public interface StructCodec<R> extends Codec<R> {
             String name6, Codec<P6> codec6, Function<R, P6> getter6,
             F6<P1, P2, P3, P4, P5, P6, R> ctor
     ) {
+        Objects.requireNonNull(name1, "name1");
+        Objects.requireNonNull(codec1, "codec1");
+        Objects.requireNonNull(getter1, "getter1");
+        Objects.requireNonNull(name2, "name2");
+        Objects.requireNonNull(codec2, "codec2");
+        Objects.requireNonNull(getter2, "getter2");
+        Objects.requireNonNull(name3, "name3");
+        Objects.requireNonNull(codec3, "codec3");
+        Objects.requireNonNull(getter3, "getter3");
+        Objects.requireNonNull(name4, "name4");
+        Objects.requireNonNull(codec4, "codec4");
+        Objects.requireNonNull(getter4, "getter4");
+        Objects.requireNonNull(name5, "name5");
+        Objects.requireNonNull(codec5, "codec5");
+        Objects.requireNonNull(getter5, "getter5");
+        Objects.requireNonNull(name6, "name6");
+        Objects.requireNonNull(codec6, "codec6");
+        Objects.requireNonNull(getter6, "getter6");
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -567,6 +637,28 @@ public interface StructCodec<R> extends Codec<R> {
             String name7, Codec<P7> codec7, Function<R, P7> getter7,
             F7<P1, P2, P3, P4, P5, P6, P7, R> ctor
     ) {
+        Objects.requireNonNull(name1, "name1");
+        Objects.requireNonNull(codec1, "codec1");
+        Objects.requireNonNull(getter1, "getter1");
+        Objects.requireNonNull(name2, "name2");
+        Objects.requireNonNull(codec2, "codec2");
+        Objects.requireNonNull(getter2, "getter2");
+        Objects.requireNonNull(name3, "name3");
+        Objects.requireNonNull(codec3, "codec3");
+        Objects.requireNonNull(getter3, "getter3");
+        Objects.requireNonNull(name4, "name4");
+        Objects.requireNonNull(codec4, "codec4");
+        Objects.requireNonNull(getter4, "getter4");
+        Objects.requireNonNull(name5, "name5");
+        Objects.requireNonNull(codec5, "codec5");
+        Objects.requireNonNull(getter5, "getter5");
+        Objects.requireNonNull(name6, "name6");
+        Objects.requireNonNull(codec6, "codec6");
+        Objects.requireNonNull(getter6, "getter6");
+        Objects.requireNonNull(name7, "name7");
+        Objects.requireNonNull(codec7, "codec7");
+        Objects.requireNonNull(getter7, "getter7");
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -666,6 +758,31 @@ public interface StructCodec<R> extends Codec<R> {
             String name8, Codec<P8> codec8, Function<R, P8> getter8,
             F8<P1, P2, P3, P4, P5, P6, P7, P8, R> ctor
     ) {
+        Objects.requireNonNull(name1, "name1");
+        Objects.requireNonNull(codec1, "codec1");
+        Objects.requireNonNull(getter1, "getter1");
+        Objects.requireNonNull(name2, "name2");
+        Objects.requireNonNull(codec2, "codec2");
+        Objects.requireNonNull(getter2, "getter2");
+        Objects.requireNonNull(name3, "name3");
+        Objects.requireNonNull(codec3, "codec3");
+        Objects.requireNonNull(getter3, "getter3");
+        Objects.requireNonNull(name4, "name4");
+        Objects.requireNonNull(codec4, "codec4");
+        Objects.requireNonNull(getter4, "getter4");
+        Objects.requireNonNull(name5, "name5");
+        Objects.requireNonNull(codec5, "codec5");
+        Objects.requireNonNull(getter5, "getter5");
+        Objects.requireNonNull(name6, "name6");
+        Objects.requireNonNull(codec6, "codec6");
+        Objects.requireNonNull(getter6, "getter6");
+        Objects.requireNonNull(name7, "name7");
+        Objects.requireNonNull(codec7, "codec7");
+        Objects.requireNonNull(getter7, "getter7");
+        Objects.requireNonNull(name8, "name8");
+        Objects.requireNonNull(codec8, "codec8");
+        Objects.requireNonNull(getter8, "getter8");
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -774,6 +891,34 @@ public interface StructCodec<R> extends Codec<R> {
             String name9, Codec<P9> codec9, Function<R, P9> getter9,
             F9<P1, P2, P3, P4, P5, P6, P7, P8, P9, R> ctor
     ) {
+        Objects.requireNonNull(name1, "name1");
+        Objects.requireNonNull(codec1, "codec1");
+        Objects.requireNonNull(getter1, "getter1");
+        Objects.requireNonNull(name2, "name2");
+        Objects.requireNonNull(codec2, "codec2");
+        Objects.requireNonNull(getter2, "getter2");
+        Objects.requireNonNull(name3, "name3");
+        Objects.requireNonNull(codec3, "codec3");
+        Objects.requireNonNull(getter3, "getter3");
+        Objects.requireNonNull(name4, "name4");
+        Objects.requireNonNull(codec4, "codec4");
+        Objects.requireNonNull(getter4, "getter4");
+        Objects.requireNonNull(name5, "name5");
+        Objects.requireNonNull(codec5, "codec5");
+        Objects.requireNonNull(getter5, "getter5");
+        Objects.requireNonNull(name6, "name6");
+        Objects.requireNonNull(codec6, "codec6");
+        Objects.requireNonNull(getter6, "getter6");
+        Objects.requireNonNull(name7, "name7");
+        Objects.requireNonNull(codec7, "codec7");
+        Objects.requireNonNull(getter7, "getter7");
+        Objects.requireNonNull(name8, "name8");
+        Objects.requireNonNull(codec8, "codec8");
+        Objects.requireNonNull(getter8, "getter8");
+        Objects.requireNonNull(name9, "name9");
+        Objects.requireNonNull(codec9, "codec9");
+        Objects.requireNonNull(getter9, "getter9");
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -892,6 +1037,37 @@ public interface StructCodec<R> extends Codec<R> {
             String name10, Codec<P10> codec10, Function<R, P10> getter10,
             F10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R> ctor
     ) {
+        Objects.requireNonNull(name1, "name1");
+        Objects.requireNonNull(codec1, "codec1");
+        Objects.requireNonNull(getter1, "getter1");
+        Objects.requireNonNull(name2, "name2");
+        Objects.requireNonNull(codec2, "codec2");
+        Objects.requireNonNull(getter2, "getter2");
+        Objects.requireNonNull(name3, "name3");
+        Objects.requireNonNull(codec3, "codec3");
+        Objects.requireNonNull(getter3, "getter3");
+        Objects.requireNonNull(name4, "name4");
+        Objects.requireNonNull(codec4, "codec4");
+        Objects.requireNonNull(getter4, "getter4");
+        Objects.requireNonNull(name5, "name5");
+        Objects.requireNonNull(codec5, "codec5");
+        Objects.requireNonNull(getter5, "getter5");
+        Objects.requireNonNull(name6, "name6");
+        Objects.requireNonNull(codec6, "codec6");
+        Objects.requireNonNull(getter6, "getter6");
+        Objects.requireNonNull(name7, "name7");
+        Objects.requireNonNull(codec7, "codec7");
+        Objects.requireNonNull(getter7, "getter7");
+        Objects.requireNonNull(name8, "name8");
+        Objects.requireNonNull(codec8, "codec8");
+        Objects.requireNonNull(getter8, "getter8");
+        Objects.requireNonNull(name9, "name9");
+        Objects.requireNonNull(codec9, "codec9");
+        Objects.requireNonNull(getter9, "getter9");
+        Objects.requireNonNull(name10, "name10");
+        Objects.requireNonNull(codec10, "codec10");
+        Objects.requireNonNull(getter10, "getter10");
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -1020,6 +1196,40 @@ public interface StructCodec<R> extends Codec<R> {
             String name11, Codec<P11> codec11, Function<R, P11> getter11,
             F11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, R> ctor
     ) {
+        Objects.requireNonNull(name1, "name1");
+        Objects.requireNonNull(codec1, "codec1");
+        Objects.requireNonNull(getter1, "getter1");
+        Objects.requireNonNull(name2, "name2");
+        Objects.requireNonNull(codec2, "codec2");
+        Objects.requireNonNull(getter2, "getter2");
+        Objects.requireNonNull(name3, "name3");
+        Objects.requireNonNull(codec3, "codec3");
+        Objects.requireNonNull(getter3, "getter3");
+        Objects.requireNonNull(name4, "name4");
+        Objects.requireNonNull(codec4, "codec4");
+        Objects.requireNonNull(getter4, "getter4");
+        Objects.requireNonNull(name5, "name5");
+        Objects.requireNonNull(codec5, "codec5");
+        Objects.requireNonNull(getter5, "getter5");
+        Objects.requireNonNull(name6, "name6");
+        Objects.requireNonNull(codec6, "codec6");
+        Objects.requireNonNull(getter6, "getter6");
+        Objects.requireNonNull(name7, "name7");
+        Objects.requireNonNull(codec7, "codec7");
+        Objects.requireNonNull(getter7, "getter7");
+        Objects.requireNonNull(name8, "name8");
+        Objects.requireNonNull(codec8, "codec8");
+        Objects.requireNonNull(getter8, "getter8");
+        Objects.requireNonNull(name9, "name9");
+        Objects.requireNonNull(codec9, "codec9");
+        Objects.requireNonNull(getter9, "getter9");
+        Objects.requireNonNull(name10, "name10");
+        Objects.requireNonNull(codec10, "codec10");
+        Objects.requireNonNull(getter10, "getter10");
+        Objects.requireNonNull(name11, "name11");
+        Objects.requireNonNull(codec11, "codec11");
+        Objects.requireNonNull(getter11, "getter11");
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -1159,6 +1369,43 @@ public interface StructCodec<R> extends Codec<R> {
             String name12, Codec<P12> codec12, Function<R, P12> getter12,
             F12<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R> ctor
     ) {
+        Objects.requireNonNull(name1, "name1");
+        Objects.requireNonNull(codec1, "codec1");
+        Objects.requireNonNull(getter1, "getter1");
+        Objects.requireNonNull(name2, "name2");
+        Objects.requireNonNull(codec2, "codec2");
+        Objects.requireNonNull(getter2, "getter2");
+        Objects.requireNonNull(name3, "name3");
+        Objects.requireNonNull(codec3, "codec3");
+        Objects.requireNonNull(getter3, "getter3");
+        Objects.requireNonNull(name4, "name4");
+        Objects.requireNonNull(codec4, "codec4");
+        Objects.requireNonNull(getter4, "getter4");
+        Objects.requireNonNull(name5, "name5");
+        Objects.requireNonNull(codec5, "codec5");
+        Objects.requireNonNull(getter5, "getter5");
+        Objects.requireNonNull(name6, "name6");
+        Objects.requireNonNull(codec6, "codec6");
+        Objects.requireNonNull(getter6, "getter6");
+        Objects.requireNonNull(name7, "name7");
+        Objects.requireNonNull(codec7, "codec7");
+        Objects.requireNonNull(getter7, "getter7");
+        Objects.requireNonNull(name8, "name8");
+        Objects.requireNonNull(codec8, "codec8");
+        Objects.requireNonNull(getter8, "getter8");
+        Objects.requireNonNull(name9, "name9");
+        Objects.requireNonNull(codec9, "codec9");
+        Objects.requireNonNull(getter9, "getter9");
+        Objects.requireNonNull(name10, "name10");
+        Objects.requireNonNull(codec10, "codec10");
+        Objects.requireNonNull(getter10, "getter10");
+        Objects.requireNonNull(name11, "name11");
+        Objects.requireNonNull(codec11, "codec11");
+        Objects.requireNonNull(getter11, "getter11");
+        Objects.requireNonNull(name12, "name12");
+        Objects.requireNonNull(codec12, "codec12");
+        Objects.requireNonNull(getter12, "getter12");
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -1307,6 +1554,46 @@ public interface StructCodec<R> extends Codec<R> {
             String name13, Codec<P13> codec13, Function<R, P13> getter13,
             F13<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, R> ctor
     ) {
+        Objects.requireNonNull(name1, "name1");
+        Objects.requireNonNull(codec1, "codec1");
+        Objects.requireNonNull(getter1, "getter1");
+        Objects.requireNonNull(name2, "name2");
+        Objects.requireNonNull(codec2, "codec2");
+        Objects.requireNonNull(getter2, "getter2");
+        Objects.requireNonNull(name3, "name3");
+        Objects.requireNonNull(codec3, "codec3");
+        Objects.requireNonNull(getter3, "getter3");
+        Objects.requireNonNull(name4, "name4");
+        Objects.requireNonNull(codec4, "codec4");
+        Objects.requireNonNull(getter4, "getter4");
+        Objects.requireNonNull(name5, "name5");
+        Objects.requireNonNull(codec5, "codec5");
+        Objects.requireNonNull(getter5, "getter5");
+        Objects.requireNonNull(name6, "name6");
+        Objects.requireNonNull(codec6, "codec6");
+        Objects.requireNonNull(getter6, "getter6");
+        Objects.requireNonNull(name7, "name7");
+        Objects.requireNonNull(codec7, "codec7");
+        Objects.requireNonNull(getter7, "getter7");
+        Objects.requireNonNull(name8, "name8");
+        Objects.requireNonNull(codec8, "codec8");
+        Objects.requireNonNull(getter8, "getter8");
+        Objects.requireNonNull(name9, "name9");
+        Objects.requireNonNull(codec9, "codec9");
+        Objects.requireNonNull(getter9, "getter9");
+        Objects.requireNonNull(name10, "name10");
+        Objects.requireNonNull(codec10, "codec10");
+        Objects.requireNonNull(getter10, "getter10");
+        Objects.requireNonNull(name11, "name11");
+        Objects.requireNonNull(codec11, "codec11");
+        Objects.requireNonNull(getter11, "getter11");
+        Objects.requireNonNull(name12, "name12");
+        Objects.requireNonNull(codec12, "codec12");
+        Objects.requireNonNull(getter12, "getter12");
+        Objects.requireNonNull(name13, "name13");
+        Objects.requireNonNull(codec13, "codec13");
+        Objects.requireNonNull(getter13, "getter13");
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -1465,6 +1752,49 @@ public interface StructCodec<R> extends Codec<R> {
             String name14, Codec<P14> codec14, Function<R, P14> getter14,
             F14<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, R> ctor
     ) {
+        Objects.requireNonNull(name1, "name1");
+        Objects.requireNonNull(codec1, "codec1");
+        Objects.requireNonNull(getter1, "getter1");
+        Objects.requireNonNull(name2, "name2");
+        Objects.requireNonNull(codec2, "codec2");
+        Objects.requireNonNull(getter2, "getter2");
+        Objects.requireNonNull(name3, "name3");
+        Objects.requireNonNull(codec3, "codec3");
+        Objects.requireNonNull(getter3, "getter3");
+        Objects.requireNonNull(name4, "name4");
+        Objects.requireNonNull(codec4, "codec4");
+        Objects.requireNonNull(getter4, "getter4");
+        Objects.requireNonNull(name5, "name5");
+        Objects.requireNonNull(codec5, "codec5");
+        Objects.requireNonNull(getter5, "getter5");
+        Objects.requireNonNull(name6, "name6");
+        Objects.requireNonNull(codec6, "codec6");
+        Objects.requireNonNull(getter6, "getter6");
+        Objects.requireNonNull(name7, "name7");
+        Objects.requireNonNull(codec7, "codec7");
+        Objects.requireNonNull(getter7, "getter7");
+        Objects.requireNonNull(name8, "name8");
+        Objects.requireNonNull(codec8, "codec8");
+        Objects.requireNonNull(getter8, "getter8");
+        Objects.requireNonNull(name9, "name9");
+        Objects.requireNonNull(codec9, "codec9");
+        Objects.requireNonNull(getter9, "getter9");
+        Objects.requireNonNull(name10, "name10");
+        Objects.requireNonNull(codec10, "codec10");
+        Objects.requireNonNull(getter10, "getter10");
+        Objects.requireNonNull(name11, "name11");
+        Objects.requireNonNull(codec11, "codec11");
+        Objects.requireNonNull(getter11, "getter11");
+        Objects.requireNonNull(name12, "name12");
+        Objects.requireNonNull(codec12, "codec12");
+        Objects.requireNonNull(getter12, "getter12");
+        Objects.requireNonNull(name13, "name13");
+        Objects.requireNonNull(codec13, "codec13");
+        Objects.requireNonNull(getter13, "getter13");
+        Objects.requireNonNull(name14, "name14");
+        Objects.requireNonNull(codec14, "codec14");
+        Objects.requireNonNull(getter14, "getter14");
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -1633,6 +1963,52 @@ public interface StructCodec<R> extends Codec<R> {
             String name15, Codec<P15> codec15, Function<R, P15> getter15,
             F15<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, R> ctor
     ) {
+        Objects.requireNonNull(name1, "name1");
+        Objects.requireNonNull(codec1, "codec1");
+        Objects.requireNonNull(getter1, "getter1");
+        Objects.requireNonNull(name2, "name2");
+        Objects.requireNonNull(codec2, "codec2");
+        Objects.requireNonNull(getter2, "getter2");
+        Objects.requireNonNull(name3, "name3");
+        Objects.requireNonNull(codec3, "codec3");
+        Objects.requireNonNull(getter3, "getter3");
+        Objects.requireNonNull(name4, "name4");
+        Objects.requireNonNull(codec4, "codec4");
+        Objects.requireNonNull(getter4, "getter4");
+        Objects.requireNonNull(name5, "name5");
+        Objects.requireNonNull(codec5, "codec5");
+        Objects.requireNonNull(getter5, "getter5");
+        Objects.requireNonNull(name6, "name6");
+        Objects.requireNonNull(codec6, "codec6");
+        Objects.requireNonNull(getter6, "getter6");
+        Objects.requireNonNull(name7, "name7");
+        Objects.requireNonNull(codec7, "codec7");
+        Objects.requireNonNull(getter7, "getter7");
+        Objects.requireNonNull(name8, "name8");
+        Objects.requireNonNull(codec8, "codec8");
+        Objects.requireNonNull(getter8, "getter8");
+        Objects.requireNonNull(name9, "name9");
+        Objects.requireNonNull(codec9, "codec9");
+        Objects.requireNonNull(getter9, "getter9");
+        Objects.requireNonNull(name10, "name10");
+        Objects.requireNonNull(codec10, "codec10");
+        Objects.requireNonNull(getter10, "getter10");
+        Objects.requireNonNull(name11, "name11");
+        Objects.requireNonNull(codec11, "codec11");
+        Objects.requireNonNull(getter11, "getter11");
+        Objects.requireNonNull(name12, "name12");
+        Objects.requireNonNull(codec12, "codec12");
+        Objects.requireNonNull(getter12, "getter12");
+        Objects.requireNonNull(name13, "name13");
+        Objects.requireNonNull(codec13, "codec13");
+        Objects.requireNonNull(getter13, "getter13");
+        Objects.requireNonNull(name14, "name14");
+        Objects.requireNonNull(codec14, "codec14");
+        Objects.requireNonNull(getter14, "getter14");
+        Objects.requireNonNull(name15, "name15");
+        Objects.requireNonNull(codec15, "codec15");
+        Objects.requireNonNull(getter15, "getter15");
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -1811,6 +2187,55 @@ public interface StructCodec<R> extends Codec<R> {
             String name16, Codec<P16> codec16, Function<R, P16> getter16,
             F16<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, R> ctor
     ) {
+        Objects.requireNonNull(name1, "name1");
+        Objects.requireNonNull(codec1, "codec1");
+        Objects.requireNonNull(getter1, "getter1");
+        Objects.requireNonNull(name2, "name2");
+        Objects.requireNonNull(codec2, "codec2");
+        Objects.requireNonNull(getter2, "getter2");
+        Objects.requireNonNull(name3, "name3");
+        Objects.requireNonNull(codec3, "codec3");
+        Objects.requireNonNull(getter3, "getter3");
+        Objects.requireNonNull(name4, "name4");
+        Objects.requireNonNull(codec4, "codec4");
+        Objects.requireNonNull(getter4, "getter4");
+        Objects.requireNonNull(name5, "name5");
+        Objects.requireNonNull(codec5, "codec5");
+        Objects.requireNonNull(getter5, "getter5");
+        Objects.requireNonNull(name6, "name6");
+        Objects.requireNonNull(codec6, "codec6");
+        Objects.requireNonNull(getter6, "getter6");
+        Objects.requireNonNull(name7, "name7");
+        Objects.requireNonNull(codec7, "codec7");
+        Objects.requireNonNull(getter7, "getter7");
+        Objects.requireNonNull(name8, "name8");
+        Objects.requireNonNull(codec8, "codec8");
+        Objects.requireNonNull(getter8, "getter8");
+        Objects.requireNonNull(name9, "name9");
+        Objects.requireNonNull(codec9, "codec9");
+        Objects.requireNonNull(getter9, "getter9");
+        Objects.requireNonNull(name10, "name10");
+        Objects.requireNonNull(codec10, "codec10");
+        Objects.requireNonNull(getter10, "getter10");
+        Objects.requireNonNull(name11, "name11");
+        Objects.requireNonNull(codec11, "codec11");
+        Objects.requireNonNull(getter11, "getter11");
+        Objects.requireNonNull(name12, "name12");
+        Objects.requireNonNull(codec12, "codec12");
+        Objects.requireNonNull(getter12, "getter12");
+        Objects.requireNonNull(name13, "name13");
+        Objects.requireNonNull(codec13, "codec13");
+        Objects.requireNonNull(getter13, "getter13");
+        Objects.requireNonNull(name14, "name14");
+        Objects.requireNonNull(codec14, "codec14");
+        Objects.requireNonNull(getter14, "getter14");
+        Objects.requireNonNull(name15, "name15");
+        Objects.requireNonNull(codec15, "codec15");
+        Objects.requireNonNull(getter15, "getter15");
+        Objects.requireNonNull(name16, "name16");
+        Objects.requireNonNull(codec16, "codec16");
+        Objects.requireNonNull(getter16, "getter16");
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -1999,6 +2424,58 @@ public interface StructCodec<R> extends Codec<R> {
             String name17, Codec<P17> codec17, Function<R, P17> getter17,
             F17<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, R> ctor
     ) {
+        Objects.requireNonNull(name1, "name1");
+        Objects.requireNonNull(codec1, "codec1");
+        Objects.requireNonNull(getter1, "getter1");
+        Objects.requireNonNull(name2, "name2");
+        Objects.requireNonNull(codec2, "codec2");
+        Objects.requireNonNull(getter2, "getter2");
+        Objects.requireNonNull(name3, "name3");
+        Objects.requireNonNull(codec3, "codec3");
+        Objects.requireNonNull(getter3, "getter3");
+        Objects.requireNonNull(name4, "name4");
+        Objects.requireNonNull(codec4, "codec4");
+        Objects.requireNonNull(getter4, "getter4");
+        Objects.requireNonNull(name5, "name5");
+        Objects.requireNonNull(codec5, "codec5");
+        Objects.requireNonNull(getter5, "getter5");
+        Objects.requireNonNull(name6, "name6");
+        Objects.requireNonNull(codec6, "codec6");
+        Objects.requireNonNull(getter6, "getter6");
+        Objects.requireNonNull(name7, "name7");
+        Objects.requireNonNull(codec7, "codec7");
+        Objects.requireNonNull(getter7, "getter7");
+        Objects.requireNonNull(name8, "name8");
+        Objects.requireNonNull(codec8, "codec8");
+        Objects.requireNonNull(getter8, "getter8");
+        Objects.requireNonNull(name9, "name9");
+        Objects.requireNonNull(codec9, "codec9");
+        Objects.requireNonNull(getter9, "getter9");
+        Objects.requireNonNull(name10, "name10");
+        Objects.requireNonNull(codec10, "codec10");
+        Objects.requireNonNull(getter10, "getter10");
+        Objects.requireNonNull(name11, "name11");
+        Objects.requireNonNull(codec11, "codec11");
+        Objects.requireNonNull(getter11, "getter11");
+        Objects.requireNonNull(name12, "name12");
+        Objects.requireNonNull(codec12, "codec12");
+        Objects.requireNonNull(getter12, "getter12");
+        Objects.requireNonNull(name13, "name13");
+        Objects.requireNonNull(codec13, "codec13");
+        Objects.requireNonNull(getter13, "getter13");
+        Objects.requireNonNull(name14, "name14");
+        Objects.requireNonNull(codec14, "codec14");
+        Objects.requireNonNull(getter14, "getter14");
+        Objects.requireNonNull(name15, "name15");
+        Objects.requireNonNull(codec15, "codec15");
+        Objects.requireNonNull(getter15, "getter15");
+        Objects.requireNonNull(name16, "name16");
+        Objects.requireNonNull(codec16, "codec16");
+        Objects.requireNonNull(getter16, "getter16");
+        Objects.requireNonNull(name17, "name17");
+        Objects.requireNonNull(codec17, "codec17");
+        Objects.requireNonNull(getter17, "getter17");
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -2197,6 +2674,61 @@ public interface StructCodec<R> extends Codec<R> {
             String name18, Codec<P18> codec18, Function<R, P18> getter18,
             F18<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, R> ctor
     ) {
+        Objects.requireNonNull(name1, "name1");
+        Objects.requireNonNull(codec1, "codec1");
+        Objects.requireNonNull(getter1, "getter1");
+        Objects.requireNonNull(name2, "name2");
+        Objects.requireNonNull(codec2, "codec2");
+        Objects.requireNonNull(getter2, "getter2");
+        Objects.requireNonNull(name3, "name3");
+        Objects.requireNonNull(codec3, "codec3");
+        Objects.requireNonNull(getter3, "getter3");
+        Objects.requireNonNull(name4, "name4");
+        Objects.requireNonNull(codec4, "codec4");
+        Objects.requireNonNull(getter4, "getter4");
+        Objects.requireNonNull(name5, "name5");
+        Objects.requireNonNull(codec5, "codec5");
+        Objects.requireNonNull(getter5, "getter5");
+        Objects.requireNonNull(name6, "name6");
+        Objects.requireNonNull(codec6, "codec6");
+        Objects.requireNonNull(getter6, "getter6");
+        Objects.requireNonNull(name7, "name7");
+        Objects.requireNonNull(codec7, "codec7");
+        Objects.requireNonNull(getter7, "getter7");
+        Objects.requireNonNull(name8, "name8");
+        Objects.requireNonNull(codec8, "codec8");
+        Objects.requireNonNull(getter8, "getter8");
+        Objects.requireNonNull(name9, "name9");
+        Objects.requireNonNull(codec9, "codec9");
+        Objects.requireNonNull(getter9, "getter9");
+        Objects.requireNonNull(name10, "name10");
+        Objects.requireNonNull(codec10, "codec10");
+        Objects.requireNonNull(getter10, "getter10");
+        Objects.requireNonNull(name11, "name11");
+        Objects.requireNonNull(codec11, "codec11");
+        Objects.requireNonNull(getter11, "getter11");
+        Objects.requireNonNull(name12, "name12");
+        Objects.requireNonNull(codec12, "codec12");
+        Objects.requireNonNull(getter12, "getter12");
+        Objects.requireNonNull(name13, "name13");
+        Objects.requireNonNull(codec13, "codec13");
+        Objects.requireNonNull(getter13, "getter13");
+        Objects.requireNonNull(name14, "name14");
+        Objects.requireNonNull(codec14, "codec14");
+        Objects.requireNonNull(getter14, "getter14");
+        Objects.requireNonNull(name15, "name15");
+        Objects.requireNonNull(codec15, "codec15");
+        Objects.requireNonNull(getter15, "getter15");
+        Objects.requireNonNull(name16, "name16");
+        Objects.requireNonNull(codec16, "codec16");
+        Objects.requireNonNull(getter16, "getter16");
+        Objects.requireNonNull(name17, "name17");
+        Objects.requireNonNull(codec17, "codec17");
+        Objects.requireNonNull(getter17, "getter17");
+        Objects.requireNonNull(name18, "name18");
+        Objects.requireNonNull(codec18, "codec18");
+        Objects.requireNonNull(getter18, "getter18");
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -2405,6 +2937,64 @@ public interface StructCodec<R> extends Codec<R> {
             String name19, Codec<P19> codec19, Function<R, P19> getter19,
             F19<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, R> ctor
     ) {
+        Objects.requireNonNull(name1, "name1");
+        Objects.requireNonNull(codec1, "codec1");
+        Objects.requireNonNull(getter1, "getter1");
+        Objects.requireNonNull(name2, "name2");
+        Objects.requireNonNull(codec2, "codec2");
+        Objects.requireNonNull(getter2, "getter2");
+        Objects.requireNonNull(name3, "name3");
+        Objects.requireNonNull(codec3, "codec3");
+        Objects.requireNonNull(getter3, "getter3");
+        Objects.requireNonNull(name4, "name4");
+        Objects.requireNonNull(codec4, "codec4");
+        Objects.requireNonNull(getter4, "getter4");
+        Objects.requireNonNull(name5, "name5");
+        Objects.requireNonNull(codec5, "codec5");
+        Objects.requireNonNull(getter5, "getter5");
+        Objects.requireNonNull(name6, "name6");
+        Objects.requireNonNull(codec6, "codec6");
+        Objects.requireNonNull(getter6, "getter6");
+        Objects.requireNonNull(name7, "name7");
+        Objects.requireNonNull(codec7, "codec7");
+        Objects.requireNonNull(getter7, "getter7");
+        Objects.requireNonNull(name8, "name8");
+        Objects.requireNonNull(codec8, "codec8");
+        Objects.requireNonNull(getter8, "getter8");
+        Objects.requireNonNull(name9, "name9");
+        Objects.requireNonNull(codec9, "codec9");
+        Objects.requireNonNull(getter9, "getter9");
+        Objects.requireNonNull(name10, "name10");
+        Objects.requireNonNull(codec10, "codec10");
+        Objects.requireNonNull(getter10, "getter10");
+        Objects.requireNonNull(name11, "name11");
+        Objects.requireNonNull(codec11, "codec11");
+        Objects.requireNonNull(getter11, "getter11");
+        Objects.requireNonNull(name12, "name12");
+        Objects.requireNonNull(codec12, "codec12");
+        Objects.requireNonNull(getter12, "getter12");
+        Objects.requireNonNull(name13, "name13");
+        Objects.requireNonNull(codec13, "codec13");
+        Objects.requireNonNull(getter13, "getter13");
+        Objects.requireNonNull(name14, "name14");
+        Objects.requireNonNull(codec14, "codec14");
+        Objects.requireNonNull(getter14, "getter14");
+        Objects.requireNonNull(name15, "name15");
+        Objects.requireNonNull(codec15, "codec15");
+        Objects.requireNonNull(getter15, "getter15");
+        Objects.requireNonNull(name16, "name16");
+        Objects.requireNonNull(codec16, "codec16");
+        Objects.requireNonNull(getter16, "getter16");
+        Objects.requireNonNull(name17, "name17");
+        Objects.requireNonNull(codec17, "codec17");
+        Objects.requireNonNull(getter17, "getter17");
+        Objects.requireNonNull(name18, "name18");
+        Objects.requireNonNull(codec18, "codec18");
+        Objects.requireNonNull(getter18, "getter18");
+        Objects.requireNonNull(name19, "name19");
+        Objects.requireNonNull(codec19, "codec19");
+        Objects.requireNonNull(getter19, "getter19");
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {
@@ -2623,6 +3213,67 @@ public interface StructCodec<R> extends Codec<R> {
             String name20, Codec<P20> codec20, Function<R, P20> getter20,
             F20<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, R> ctor
     ) {
+        Objects.requireNonNull(name1, "name1");
+        Objects.requireNonNull(codec1, "codec1");
+        Objects.requireNonNull(getter1, "getter1");
+        Objects.requireNonNull(name2, "name2");
+        Objects.requireNonNull(codec2, "codec2");
+        Objects.requireNonNull(getter2, "getter2");
+        Objects.requireNonNull(name3, "name3");
+        Objects.requireNonNull(codec3, "codec3");
+        Objects.requireNonNull(getter3, "getter3");
+        Objects.requireNonNull(name4, "name4");
+        Objects.requireNonNull(codec4, "codec4");
+        Objects.requireNonNull(getter4, "getter4");
+        Objects.requireNonNull(name5, "name5");
+        Objects.requireNonNull(codec5, "codec5");
+        Objects.requireNonNull(getter5, "getter5");
+        Objects.requireNonNull(name6, "name6");
+        Objects.requireNonNull(codec6, "codec6");
+        Objects.requireNonNull(getter6, "getter6");
+        Objects.requireNonNull(name7, "name7");
+        Objects.requireNonNull(codec7, "codec7");
+        Objects.requireNonNull(getter7, "getter7");
+        Objects.requireNonNull(name8, "name8");
+        Objects.requireNonNull(codec8, "codec8");
+        Objects.requireNonNull(getter8, "getter8");
+        Objects.requireNonNull(name9, "name9");
+        Objects.requireNonNull(codec9, "codec9");
+        Objects.requireNonNull(getter9, "getter9");
+        Objects.requireNonNull(name10, "name10");
+        Objects.requireNonNull(codec10, "codec10");
+        Objects.requireNonNull(getter10, "getter10");
+        Objects.requireNonNull(name11, "name11");
+        Objects.requireNonNull(codec11, "codec11");
+        Objects.requireNonNull(getter11, "getter11");
+        Objects.requireNonNull(name12, "name12");
+        Objects.requireNonNull(codec12, "codec12");
+        Objects.requireNonNull(getter12, "getter12");
+        Objects.requireNonNull(name13, "name13");
+        Objects.requireNonNull(codec13, "codec13");
+        Objects.requireNonNull(getter13, "getter13");
+        Objects.requireNonNull(name14, "name14");
+        Objects.requireNonNull(codec14, "codec14");
+        Objects.requireNonNull(getter14, "getter14");
+        Objects.requireNonNull(name15, "name15");
+        Objects.requireNonNull(codec15, "codec15");
+        Objects.requireNonNull(getter15, "getter15");
+        Objects.requireNonNull(name16, "name16");
+        Objects.requireNonNull(codec16, "codec16");
+        Objects.requireNonNull(getter16, "getter16");
+        Objects.requireNonNull(name17, "name17");
+        Objects.requireNonNull(codec17, "codec17");
+        Objects.requireNonNull(getter17, "getter17");
+        Objects.requireNonNull(name18, "name18");
+        Objects.requireNonNull(codec18, "codec18");
+        Objects.requireNonNull(getter18, "getter18");
+        Objects.requireNonNull(name19, "name19");
+        Objects.requireNonNull(codec19, "codec19");
+        Objects.requireNonNull(getter19, "getter19");
+        Objects.requireNonNull(name20, "name20");
+        Objects.requireNonNull(codec20, "codec20");
+        Objects.requireNonNull(getter20, "getter20");
+        Objects.requireNonNull(ctor, "ctor");
         return new StructCodec<>() {
             @Override
             public <D> Result<R> decodeFromMap(Transcoder<D> coder, MapLike<D> map) {

--- a/src/main/java/net/minestom/server/codec/TranscoderProxy.java
+++ b/src/main/java/net/minestom/server/codec/TranscoderProxy.java
@@ -18,12 +18,16 @@ public interface TranscoderProxy<D> extends Transcoder<D> {
      * @param transcoder The transcoder (possibly proxy) to extract
      * @return The delegate transcoder
      */
-    static Transcoder<?> extractDelegate(Transcoder<?> transcoder) {
-        if (transcoder instanceof TranscoderProxy<?> proxy)
+    static <D> Transcoder<D> extractDelegate(Transcoder<D> transcoder) {
+        if (transcoder instanceof TranscoderProxy<D> proxy)
             return extractDelegate(proxy.delegate());
         return transcoder;
     }
 
+    /**
+     * The delegate to use; This should be considered immutable during its lifetime.
+     * @return the {@link Transcoder} delegated for {@link TranscoderProxy}
+     */
     Transcoder<D> delegate();
 
     @Override

--- a/src/main/java/net/minestom/server/dialog/Dialog.java
+++ b/src/main/java/net/minestom/server/dialog/Dialog.java
@@ -108,7 +108,7 @@ public sealed interface Dialog extends Holder.Direct<Dialog>, DialogLike {
     ) implements Dialog {
         public static final StructCodec<DialogList> CODEC = StructCodec.struct(
                 StructCodec.INLINE, DialogMetadata.CODEC, DialogList::metadata,
-                "dialogs", HolderSet.codec(Registries::dialog, Dialog.REGISTRY_CODEC), DialogList::dialogs,
+                "dialogs", HolderSet.codec(Registries::dialog, Codec.ForwardRef(() -> Dialog.REGISTRY_CODEC)), DialogList::dialogs,
                 "exit_action", DialogActionButton.CODEC.optional(), DialogList::exitAction,
                 "columns", Codec.INT.optional(2), DialogList::columns,
                 "button_width", Codec.INT.optional(150), DialogList::buttonWidth,

--- a/src/main/java/net/minestom/server/dialog/DialogAction.java
+++ b/src/main/java/net/minestom/server/dialog/DialogAction.java
@@ -68,7 +68,7 @@ public sealed interface DialogAction {
 
     record ShowDialog(Holder<Dialog> dialog) implements DialogAction {
         public static final StructCodec<ShowDialog> CODEC = StructCodec.struct(
-                "dialog", Holder.codec(Registries::dialog, Dialog.REGISTRY_CODEC), ShowDialog::dialog,
+                "dialog", Holder.codec(Registries::dialog, Codec.ForwardRef(() -> Dialog.REGISTRY_CODEC)), ShowDialog::dialog,
                 ShowDialog::new);
 
         @Override

--- a/src/main/java/net/minestom/server/registry/RegistryCodecs.java
+++ b/src/main/java/net/minestom/server/registry/RegistryCodecs.java
@@ -12,10 +12,15 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.Objects;
 
 final class RegistryCodecs {
 
     record RegistryKeyImpl<T>(Registries.Selector<T> selector) implements Codec<RegistryKey<T>> {
+        RegistryKeyImpl {
+            Objects.requireNonNull(selector, "selector");
+        }
+
         @Override
         public <D> Result<RegistryKey<T>> decode(Transcoder<D> coder, D value) {
             if (!(coder instanceof RegistryTranscoder<D> context))
@@ -42,6 +47,11 @@ final class RegistryCodecs {
             Registries.Selector<T> selector,
             Codec<T> registryCodec
     ) implements Codec<Holder<T>> {
+        HolderCodec {
+            Objects.requireNonNull(selector, "selector");
+            Objects.requireNonNull(registryCodec, "registryCodec");
+        }
+
         @Override
         public <D> Result<Holder<T>> decode(Transcoder<D> coder, D value) {
             if (!(coder instanceof RegistryTranscoder<D> context))
@@ -72,6 +82,10 @@ final class RegistryCodecs {
     }
 
     record TagKeyImpl<T>(Registries.Selector<T> selector, boolean hash) implements Codec<TagKey<T>> {
+        TagKeyImpl {
+            Objects.requireNonNull(selector, "selector");
+        }
+
         @Override
         public <D> Result<TagKey<T>> decode(Transcoder<D> coder, D value) {
             if (!(coder instanceof RegistryTranscoder<D> context))
@@ -102,6 +116,9 @@ final class RegistryCodecs {
 
     record RegistryTagImpl<T>(Registries.Selector<T> selector) implements Codec<RegistryTag<T>> {
         // Per vanilla, this codec supports registryless context, in which case it can only decode direct tags.
+        RegistryTagImpl {
+            Objects.requireNonNull(selector, "selector");
+        }
 
         @Override
         public <D> Result<RegistryTag<T>> decode(Transcoder<D> coder, D value) {
@@ -160,6 +177,10 @@ final class RegistryCodecs {
             Codec<RegistryTag<T>> tagCodec,
             Codec<T> directCodec
     ) implements Codec<HolderSet<T>> {
+        HolderSetImpl {
+            Objects.requireNonNull(tagCodec, "tagCodec");
+            Objects.requireNonNull(directCodec, "directCodec");
+        }
         @Override
         public <D> Result<HolderSet<T>> decode(Transcoder<D> coder, D value) {
             // First try to decode as a tag


### PR DESCRIPTION
Should make known any initialization issues; also fixes #2893 
Also adds type and docs to TranscoderProxy & fixes MinecraftServer#process nullability being dumb. (Immutable server processes will ensure its never null at runtime during the first call).

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)