### PR TITLE
UseItemListener call move with new rotation before PlayerUseItemEvent

### DIFF
--- a/src/main/java/net/minestom/server/listener/PlayerPositionListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerPositionListener.java
@@ -10,6 +10,7 @@ import net.minestom.server.instance.Instance;
 import net.minestom.server.network.packet.client.play.*;
 import net.minestom.server.network.packet.server.play.PlayerPositionAndLookPacket;
 import net.minestom.server.utils.chunk.ChunkUtils;
+import org.jetbrains.annotations.ApiStatus;
 
 public class PlayerPositionListener {
     private static final double MAX_COORDINATE = 30_000_000;
@@ -18,6 +19,14 @@ public class PlayerPositionListener {
     public static void playerPacketListener(ClientPlayerPositionStatusPacket packet, Player player) {
         // TODO: Should we expose horizontal collision here and the methods below?
         player.refreshOnGround(packet.onGround());
+    }
+
+    /**
+     * Exists to update yaw/pitch from UseItemListener
+     */
+    @ApiStatus.Internal
+    public static void playerRotation(Player player, float yaw, float pitch) {
+        processMovement(player, player.getPosition().withView(yaw, pitch), player.isOnGround());
     }
 
     public static void playerLookListener(ClientPlayerRotationPacket packet, Player player) {

--- a/src/main/java/net/minestom/server/listener/UseItemListener.java
+++ b/src/main/java/net/minestom/server/listener/UseItemListener.java
@@ -21,6 +21,8 @@ import net.minestom.server.network.packet.server.play.AcknowledgeBlockChangePack
 public class UseItemListener {
 
     public static void useItemListener(ClientUseItemPacket packet, Player player) {
+        PlayerPositionListener.playerRotation(player, packet.yaw(), packet.pitch());
+
         final PlayerHand hand = packet.hand();
         final ItemStack itemStack = player.getItemInHand(hand);
         final Material material = itemStack.material();

--- a/src/test/java/net/minestom/server/listener/TestUseItemListenerIntegration.java
+++ b/src/test/java/net/minestom/server/listener/TestUseItemListenerIntegration.java
@@ -98,4 +98,15 @@ public class TestUseItemListenerIntegration {
         assertEquals(boots, player.getItemInMainHand());
         assertEquals(oldBoots, player.getEquipment(EquipmentSlot.BOOTS));
     }
+
+    @Test
+    void testRotation(Env env) {
+        var instance = env.createFlatInstance();
+        var player = env.createPlayer(instance, new Pos(0, 41, 0));
+        player.refreshReceivedTeleportId(player.getLastSentTeleportId());
+
+        assertEquals(new Pos(0, 41, 0), player.getPosition());
+        UseItemListener.useItemListener(new ClientUseItemPacket(PlayerHand.MAIN, 42, 5f, 10f), player);
+        assertEquals(new Pos(0, 41, 0, 5f, 10f), player.getPosition());
+    }
 }


### PR DESCRIPTION
## Proposed changes

Use yaw+pitch from ClientUseItemPacket to update player position before calling PlayerUseItemEvent.

Currently if you use an item to shoot an projectile for example, the projectile shoots in the direction of the last movement packet, not the actually correct direction sent by the packet.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments