### PR TITLE
fix: incorrect minecart meta

### DIFF
--- a/demo/src/main/java/net/minestom/demo/Main.java
+++ b/demo/src/main/java/net/minestom/demo/Main.java
@@ -90,6 +90,7 @@ public class Main {
         commandManager.register(new AttributeCommand());
         commandManager.register(new PrimedTNTCommand());
         commandManager.register(new SleepCommand());
+        commandManager.register(new MinecartCommand());
 
         commandManager.setUnknownCommandCallback((sender, command) -> sender.sendMessage(Component.text("Unknown command", NamedTextColor.RED)));
 

--- a/demo/src/main/java/net/minestom/demo/commands/MinecartCommand.java
+++ b/demo/src/main/java/net/minestom/demo/commands/MinecartCommand.java
@@ -1,0 +1,56 @@
+package net.minestom.demo.commands;
+
+import net.minestom.server.command.CommandSender;
+import net.minestom.server.command.builder.Command;
+import net.minestom.server.command.builder.CommandContext;
+import net.minestom.server.command.builder.arguments.Argument;
+import net.minestom.server.command.builder.arguments.ArgumentType;
+import net.minestom.server.command.builder.condition.Conditions;
+import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.EntityType;
+import net.minestom.server.entity.Player;
+import net.minestom.server.entity.metadata.minecart.AbstractMinecartMeta;
+import net.minestom.server.instance.block.Block;
+
+public class MinecartCommand extends Command {
+
+    private final Argument<Type> type = ArgumentType.Enum("type", Type.class);
+    private final Argument<Block> block = ArgumentType.BlockState("block").setDefaultValue(Block.AIR);
+    private final Argument<Integer> offset = ArgumentType.Integer("offset").setDefaultValue(6);
+
+    public MinecartCommand() {
+        super("minecart");
+
+        setCondition(Conditions::playerOnly);
+        addSyntax(this::execute, type, block, offset);
+    }
+
+    private void execute(CommandSender sender, CommandContext context) {
+        var player = (Player) sender;
+
+        var minecart = new Entity(switch (context.get(type)) {
+            case NORMAL -> EntityType.MINECART;
+            case CHEST -> EntityType.CHEST_MINECART;
+            case FURNACE -> EntityType.FURNACE_MINECART;
+            case TNT -> EntityType.TNT_MINECART;
+            case HOPPER -> EntityType.HOPPER_MINECART;
+            case SPAWNER -> EntityType.SPAWNER_MINECART;
+            case COMMAND_BLOCK -> EntityType.COMMAND_BLOCK_MINECART;
+        });
+        var meta = (AbstractMinecartMeta) minecart.getEntityMeta();
+        meta.setCustomBlockState(context.get(block).stateId());
+        meta.setCustomBlockYPosition(context.get(offset));
+
+        minecart.setInstance(player.getInstance(), player.getPosition().withView(0f, 0f));
+    }
+
+    private enum Type {
+        NORMAL,
+        CHEST,
+        FURNACE,
+        TNT,
+        HOPPER,
+        SPAWNER,
+        COMMAND_BLOCK,
+    }
+}

--- a/src/main/java/net/minestom/server/entity/MetadataDef.java
+++ b/src/main/java/net/minestom/server/entity/MetadataDef.java
@@ -154,9 +154,8 @@ public sealed class MetadataDef {
     }
 
     public static sealed class AbstractMinecart extends AbstractVehicle {
-        public static final Entry<Integer> CUSTOM_BLOCK_ID_AND_DAMAGE = index(0, Metadata::VarInt, 0);
+        public static final Entry<@Nullable Integer> CUSTOM_BLOCK_STATE = index(0, Metadata::OptBlockState, null);
         public static final Entry<Integer> CUSTOM_BLOCK_Y_POSITION = index(1, Metadata::VarInt, 6);
-        public static final Entry<Boolean> SHOW_CUSTOM_BLOCK = index(2, Metadata::Boolean, false);
     }
 
     public static final class MinecartFurnace extends AbstractMinecart {

--- a/src/main/java/net/minestom/server/entity/MetadataDef.java
+++ b/src/main/java/net/minestom/server/entity/MetadataDef.java
@@ -163,7 +163,7 @@ public sealed class MetadataDef {
     }
 
     public static final class MinecartCommandBlock extends AbstractMinecart {
-        public static final Entry<String> COMMAND = index(0, Metadata::String, "false");
+        public static final Entry<String> COMMAND = index(0, Metadata::String, "");
         public static final Entry<Component> LAST_OUTPUT = index(1, Metadata::Chat, Component.empty());
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/AbstractMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/AbstractMinecartMeta.java
@@ -4,19 +4,18 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.AbstractVehicleMeta;
-import net.minestom.server.entity.metadata.ObjectDataProvider;
 
-public abstract class AbstractMinecartMeta extends AbstractVehicleMeta implements ObjectDataProvider {
+public abstract class AbstractMinecartMeta extends AbstractVehicleMeta {
     protected AbstractMinecartMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 
-    public int getCustomBlockIdAndDamage() {
-        return metadata.get(MetadataDef.AbstractMinecart.CUSTOM_BLOCK_ID_AND_DAMAGE);
+    public int getCustomBlockState() {
+        return metadata.get(MetadataDef.AbstractMinecart.CUSTOM_BLOCK_STATE);
     }
 
-    public void setCustomBlockIdAndDamage(int value) {
-        metadata.set(MetadataDef.AbstractMinecart.CUSTOM_BLOCK_ID_AND_DAMAGE, value);
+    public void setCustomBlockState(int value) {
+        metadata.set(MetadataDef.AbstractMinecart.CUSTOM_BLOCK_STATE, value);
     }
 
     // in 16th of a block
@@ -26,19 +25,6 @@ public abstract class AbstractMinecartMeta extends AbstractVehicleMeta implement
 
     public void setCustomBlockYPosition(int value) {
         metadata.set(MetadataDef.AbstractMinecart.CUSTOM_BLOCK_Y_POSITION, value);
-    }
-
-    public boolean getShowCustomBlock() {
-        return metadata.get(MetadataDef.AbstractMinecart.SHOW_CUSTOM_BLOCK);
-    }
-
-    public void setShowCustomBlock(boolean show) {
-        metadata.set(MetadataDef.AbstractMinecart.SHOW_CUSTOM_BLOCK, show);
-    }
-
-    @Override
-    public boolean requiresVelocityPacketAtSpawn() {
-        return true;
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/ChestMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/ChestMinecartMeta.java
@@ -8,9 +8,4 @@ public class ChestMinecartMeta extends AbstractMinecartContainerMeta {
         super(entity, metadata);
     }
 
-    @Override
-    public int getObjectData() {
-        return 1;
-    }
-
 }

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/CommandBlockMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/CommandBlockMinecartMeta.java
@@ -25,9 +25,4 @@ public class CommandBlockMinecartMeta extends AbstractMinecartMeta {
     public void setLastOutput(Component value) {
         metadata.set(MetadataDef.MinecartCommandBlock.LAST_OUTPUT, value);
     }
-
-    @Override
-    public int getObjectData() {
-        return 6;
-    }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/FurnaceMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/FurnaceMinecartMeta.java
@@ -17,9 +17,4 @@ public class FurnaceMinecartMeta extends AbstractMinecartMeta {
         metadata.set(MetadataDef.MinecartFurnace.HAS_FUEL, value);
     }
 
-    @Override
-    public int getObjectData() {
-        return 2;
-    }
-
 }

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/HopperMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/HopperMinecartMeta.java
@@ -8,9 +8,4 @@ public class HopperMinecartMeta extends AbstractMinecartContainerMeta {
         super(entity, metadata);
     }
 
-    @Override
-    public int getObjectData() {
-        return 5;
-    }
-
 }

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/MinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/MinecartMeta.java
@@ -8,9 +8,4 @@ public class MinecartMeta extends AbstractMinecartMeta {
         super(entity, metadata);
     }
 
-    @Override
-    public int getObjectData() {
-        return 0;
-    }
-
 }

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/SpawnerMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/SpawnerMinecartMeta.java
@@ -8,9 +8,4 @@ public class SpawnerMinecartMeta extends AbstractMinecartMeta {
         super(entity, metadata);
     }
 
-    @Override
-    public int getObjectData() {
-        return 4;
-    }
-
 }

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/TntMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/TntMinecartMeta.java
@@ -8,9 +8,4 @@ public class TntMinecartMeta extends AbstractMinecartMeta {
         super(entity, metadata);
     }
 
-    @Override
-    public int getObjectData() {
-        return 3;
-    }
-
 }


### PR DESCRIPTION
## Proposed changes

Fixes missed changes to the Minecart metadata. Changes the minecart block state field from varint to its actual optional blockstate, removes show custom block field, and fixes the default value of command block minecart input field from "false" to its actual default of "". This also removes the ObjectData from the minecart as it does not use ObjectData in vanilla.

Sources:
 - https://minecraft.wiki/w/Java_Edition_protocol/Entity_metadata#Abstract_Minecart
 - https://minecraft.wiki/w/Java_Edition_protocol/Object_data

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
