### PR TITLE
Add transitive depdencies to modules, remove transitive fastutil

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     implementation(libs.minestomData)
 
     // Performance/data structures
-    api(libs.fastutil)
+    implementation(libs.fastutil)
     implementation(libs.bundles.flare)
     api(libs.gson)
     implementation(libs.jcTools)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,10 @@ dependencies {
     testImplementation(project(":testing"))
 }
 
+tasks.withType<JavaCompile> {
+    options.compilerArgs.add("-Xlint:-requires-transitive-automatic") // Adventure dependencies are automatic until 5.0.0, see https://github.com/KyoriPowered/adventure/issues/1287
+}
+
 // GraalVM Native Image configuration
 tasks.register<Test>("testWithAgent") {
     group = "verification"

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,19 +1,19 @@
 module net.minestom.server {
-    requires static org.jetbrains.annotations;  // TODO remove this when jspecify matures.
-    requires com.google.gson;
+    requires transitive static org.jetbrains.annotations;  // TODO remove this when jspecify matures.
+    requires transitive com.google.gson;
     requires it.unimi.dsi.fastutil;
     requires space.vectrix.flare.fastutil;
     requires jdk.unsupported; // Unsafe
-    requires net.kyori.adventure;
-    requires net.kyori.adventure.nbt;
-    requires net.kyori.adventure.key;
-    requires net.kyori.examination.api;
-    requires net.kyori.adventure.text.logger.slf4j;
-    requires net.kyori.adventure.text.serializer.legacy;
-    requires net.kyori.adventure.text.serializer.gson;
-    requires net.kyori.adventure.text.serializer.plain;
-    requires net.kyori.adventure.text.serializer.json;
-    requires net.kyori.adventure.text.serializer.ansi;
+    requires transitive net.kyori.adventure;
+    requires transitive net.kyori.adventure.nbt;
+    requires transitive net.kyori.adventure.key;
+    requires transitive net.kyori.examination.api;
+    requires transitive net.kyori.adventure.text.logger.slf4j;
+    requires transitive net.kyori.adventure.text.serializer.legacy;
+    requires transitive net.kyori.adventure.text.serializer.gson;
+    requires transitive net.kyori.adventure.text.serializer.plain;
+    requires transitive net.kyori.adventure.text.serializer.json;
+    requires transitive net.kyori.adventure.text.serializer.ansi;
     requires org.slf4j;
     requires org.jctools.core;
     requires jdk.jfr;

--- a/testing/src/main/java/module-info.java
+++ b/testing/src/main/java/module-info.java
@@ -1,9 +1,6 @@
 module net.minestom.testing {
-    requires static org.jetbrains.annotations; // TODO Remove when JSpecify is mature
     requires transitive net.minestom.server;
-    requires net.kyori.adventure;
-    requires net.kyori.adventure.nbt;
-    requires org.junit.jupiter.api;
+    requires org.junit.jupiter.api; // Users can bring their own version.
 
     exports net.minestom.testing;
     exports net.minestom.testing.util;


### PR DESCRIPTION
Currently Minestom does not export adventure transitively in module-info. This adds that and missing json and jetbrains annotations. This also removes the exporting of fastutil as its a implementation detail and doesnt have to be exposed to users.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Only breaking if people rely on us providing a transitive dependency for fastutil.