### PR TITLE
Fix command condition bypass bug

### DIFF
--- a/src/main/java/net/minestom/server/command/GraphImpl.java
+++ b/src/main/java/net/minestom/server/command/GraphImpl.java
@@ -121,7 +121,13 @@ record GraphImpl(NodeImpl root) implements Graph {
             for (var syntax : command.getSyntaxes()) {
                 if (syntax.getArguments().length == 0) {
                     executor = syntax.getExecutor();
-                    condition = syntax.getCommandCondition();
+                    CommandCondition syntaxCondition = syntax.getCommandCondition();
+                    if (syntaxCondition != null && defaultCondition != null) {
+                        condition = (sender, commandString) ->
+                            defaultCondition.canUse(sender, commandString) && syntaxCondition.canUse(sender, commandString);
+                    } else if (syntaxCondition != null) {
+                        condition = syntaxCondition;
+                    }
                     break;
                 }
             }

--- a/src/main/java/net/minestom/server/command/builder/Command.java
+++ b/src/main/java/net/minestom/server/command/builder/Command.java
@@ -38,7 +38,7 @@ import java.util.stream.Stream;
  * you can set it using {@link #setDefaultExecutor(CommandExecutor)}.
  * <p>
  * Before any syntax to be successfully executed the {@link CommandSender} needs to validated
- * the {@link CommandCondition} sets with {@link #setCondition(CommandCondition)} (ignored if null).
+ * the {@link CommandCondition} sets with {@link #setCondition(CommandCondition...)} (ignored if null).
  * <p>
  * Some {@link Argument} could also require additional condition (eg: a number which need to be between 2 values),
  * in this case, if the whole syntax is correct but not the argument condition,

--- a/src/main/java/net/minestom/server/command/builder/Command.java
+++ b/src/main/java/net/minestom/server/command/builder/Command.java
@@ -223,7 +223,6 @@ public class Command {
         return addConditionalSyntax(null, executor, args);
     }
 
-
     /**
      * Creates a syntax from a formatted string.
      * <p>

--- a/src/main/java/net/minestom/server/command/builder/Command.java
+++ b/src/main/java/net/minestom/server/command/builder/Command.java
@@ -106,7 +106,7 @@ public class Command {
      * @see #getCondition()
      */
     public void setCondition(CommandCondition... conditions) {
-        if (conditions.length == 0) {
+        if (conditions == null || conditions.length == 0) {
             this.condition = null;
         } else if (conditions.length == 1) {
             this.condition = conditions[0];
@@ -123,7 +123,7 @@ public class Command {
      */
     @SafeVarargs
     public final void setCondition(Predicate<CommandSender>... predicates) {
-        if (predicates.length == 0) {
+        if (predicates == null || predicates.length == 0) {
             this.condition = null;
         } else if (predicates.length == 1) {
             final Predicate<CommandSender> predicate = predicates[0];

--- a/src/main/java/net/minestom/server/command/builder/Command.java
+++ b/src/main/java/net/minestom/server/command/builder/Command.java
@@ -220,7 +220,7 @@ public class Command {
      * @see #addConditionalSyntax(CommandCondition, CommandExecutor, Argument[])
      */
     public Collection<CommandSyntax> addSyntax(CommandExecutor executor, Argument<?>... args) {
-        return addConditionalSyntax((CommandCondition) null, executor, args);
+        return addConditionalSyntax(null, executor, args);
     }
 
 

--- a/src/main/java/net/minestom/server/command/builder/Command.java
+++ b/src/main/java/net/minestom/server/command/builder/Command.java
@@ -8,11 +8,8 @@ import net.minestom.server.command.builder.arguments.ArgumentLiteral;
 import net.minestom.server.command.builder.arguments.ArgumentType;
 import net.minestom.server.command.builder.arguments.ArgumentWord;
 import net.minestom.server.command.builder.condition.CommandCondition;
-import net.minestom.server.command.builder.condition.Conditions;
 import net.minestom.server.utils.StringUtils;
-import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
 import org.slf4j.Logger;
@@ -39,7 +36,7 @@ import java.util.stream.Stream;
  * you can set it using {@link #setDefaultExecutor(CommandExecutor)}.
  * <p>
  * Before any syntax to be successfully executed the {@link CommandSender} needs to validated
- * the {@link CommandCondition} sets with {@link #setCondition(CommandCondition...)} (ignored if null).
+ * the {@link CommandCondition} sets with {@link #setCondition(CommandCondition)} (ignored if null).
  * <p>
  * Some {@link Argument} could also require additional condition (eg: a number which need to be between 2 values),
  * in this case, if the whole syntax is correct but not the argument condition,
@@ -101,23 +98,13 @@ public class Command {
     }
 
     /**
-     * Sets the {@link CommandCondition}s required to execute the command.
+     * Sets the {@link CommandCondition}.
      *
-     * @param condition the condition that must pass
-     * @param conditions the rest of the conditions that must pass
+     * @param commandCondition the new command condition, null to do not call anything
      * @see #getCondition()
      */
-    public void setCondition(@Nullable CommandCondition condition, CommandCondition... conditions) {
-        Check.argCondition(condition == null && conditions.length > 0, "the first argument must not be null if you are passing in multiple conditions");
-
-        if (condition == null) {
-            this.condition = null;
-        } else {
-            var finalConditions = new CommandCondition[conditions.length + 1];
-            finalConditions[0] = condition;
-            System.arraycopy(conditions, 0, finalConditions, 1, conditions.length);
-            this.condition = Conditions.all(finalConditions);
-        }
+    public void setCondition(@Nullable CommandCondition commandCondition) {
+        this.condition = commandCondition;
     }
 
     /**

--- a/src/main/java/net/minestom/server/command/builder/Command.java
+++ b/src/main/java/net/minestom/server/command/builder/Command.java
@@ -21,7 +21,6 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -105,35 +104,12 @@ public class Command {
      * @param conditions the conditions that must all pass
      * @see #getCondition()
      */
-    public void setCondition(CommandCondition... conditions) {
+    public void setCondition(@Nullable CommandCondition... conditions) {
         if (conditions == null || conditions.length == 0) {
             this.condition = null;
         } else if (conditions.length == 1) {
             this.condition = conditions[0];
         } else {
-            this.condition = Conditions.all(conditions);
-        }
-    }
-
-    /**
-     * Sets the {@link CommandCondition} using predicates.
-     *
-     * @param predicates the predicates that must all pass
-     * @see #setCondition(CommandCondition...)
-     */
-    @SafeVarargs
-    public final void setCondition(Predicate<CommandSender>... predicates) {
-        if (predicates == null || predicates.length == 0) {
-            this.condition = null;
-        } else if (predicates.length == 1) {
-            final Predicate<CommandSender> predicate = predicates[0];
-            this.condition = (sender, commandString) -> predicate.test(sender);
-        } else {
-            CommandCondition[] conditions = new CommandCondition[predicates.length];
-            for (int i = 0; i < predicates.length; i++) {
-                final Predicate<CommandSender> predicate = predicates[i];
-                conditions[i] = (sender, commandString) -> predicate.test(sender);
-            }
             this.condition = Conditions.all(conditions);
         }
     }
@@ -247,19 +223,6 @@ public class Command {
         return addConditionalSyntax((CommandCondition) null, executor, args);
     }
 
-    /**
-     * Adds a new syntax with a sender predicate condition.
-     *
-     * @param senderPredicate the predicate to test the sender
-     * @param executor the executor to call when the syntax is successfully received
-     * @param args all the arguments of the syntax
-     * @return the created {@link CommandSyntax syntaxes}
-     * @see #addConditionalSyntax(CommandCondition, CommandExecutor, Argument[])
-     */
-    public Collection<CommandSyntax> addConditionalSyntax(@Nullable Predicate<CommandSender> senderPredicate, CommandExecutor executor, Argument<?>... args) {
-        CommandCondition condition = senderPredicate == null ? null : (sender, commandString) -> senderPredicate.test(sender);
-        return addConditionalSyntax(condition, executor, args);
-    }
 
     /**
      * Creates a syntax from a formatted string.

--- a/src/main/java/net/minestom/server/command/builder/Command.java
+++ b/src/main/java/net/minestom/server/command/builder/Command.java
@@ -104,7 +104,7 @@ public class Command {
      * @param conditions the conditions that must all pass
      * @see #getCondition()
      */
-    public void setCondition(@Nullable CommandCondition... conditions) {
+    public void setCondition(CommandCondition @Nullable... conditions) {
         if (conditions == null || conditions.length == 0) {
             this.condition = null;
         } else if (conditions.length == 1) {

--- a/src/main/java/net/minestom/server/command/builder/Command.java
+++ b/src/main/java/net/minestom/server/command/builder/Command.java
@@ -10,7 +10,9 @@ import net.minestom.server.command.builder.arguments.ArgumentWord;
 import net.minestom.server.command.builder.condition.CommandCondition;
 import net.minestom.server.command.builder.condition.Conditions;
 import net.minestom.server.utils.StringUtils;
+import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
 import org.slf4j.Logger;
@@ -99,18 +101,22 @@ public class Command {
     }
 
     /**
-     * Sets the {@link CommandCondition}.
+     * Sets the {@link CommandCondition}s required to execute the command.
      *
-     * @param conditions the conditions that must all pass
+     * @param condition the condition that must pass
+     * @param conditions the rest of the conditions that must pass
      * @see #getCondition()
      */
-    public void setCondition(CommandCondition @Nullable... conditions) {
-        if (conditions == null || conditions.length == 0) {
+    public void setCondition(@Nullable CommandCondition condition, CommandCondition... conditions) {
+        Check.argCondition(condition == null && conditions.length > 0, "the first argument must not be null if you are passing in multiple conditions");
+
+        if (condition == null) {
             this.condition = null;
-        } else if (conditions.length == 1) {
-            this.condition = conditions[0];
         } else {
-            this.condition = Conditions.all(conditions);
+            var finalConditions = new CommandCondition[conditions.length + 1];
+            finalConditions[0] = condition;
+            System.arraycopy(conditions, 0, finalConditions, 1, conditions.length);
+            this.condition = Conditions.all(finalConditions);
         }
     }
 

--- a/src/main/java/net/minestom/server/command/builder/condition/Conditions.java
+++ b/src/main/java/net/minestom/server/command/builder/condition/Conditions.java
@@ -3,6 +3,8 @@ package net.minestom.server.command.builder.condition;
 import net.minestom.server.command.CommandSender;
 import net.minestom.server.command.ConsoleSender;
 import net.minestom.server.entity.Player;
+import net.minestom.server.utils.validate.Check;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Common command conditions
@@ -11,7 +13,11 @@ public class Conditions {
     /**
      * Will only execute if all command conditions succeed.
      */
-    public static CommandCondition all(CommandCondition... conditions) {
+    public static CommandCondition all(@NotNull CommandCondition @NotNull... conditions) {
+        Check.notNull(conditions, "conditions cannot be null");
+        for (CommandCondition condition : conditions) {
+            Check.notNull(condition, "condition cannot be null");
+        }
         return (sender, commandString) -> {
             for (CommandCondition condition : conditions) {
                 if (!condition.canUse(sender, commandString)) {
@@ -26,7 +32,11 @@ public class Conditions {
     /**
      * Will execute if one or more command conditions succeed.
      */
-    public static CommandCondition any(CommandCondition... conditions) {
+    public static CommandCondition any(@NotNull CommandCondition @NotNull... conditions) {
+        Check.notNull(conditions, "conditions cannot be null");
+        for (CommandCondition condition : conditions) {
+            Check.notNull(condition, "condition cannot be null");
+        }
         return (sender, commandString) -> {
             for (CommandCondition condition : conditions) {
                 if (condition.canUse(sender, commandString)) {
@@ -55,7 +65,8 @@ public class Conditions {
     /**
      * Inverts the result of the given condition.
      */
-    public static CommandCondition not(CommandCondition condition) {
+    public static CommandCondition not(@NotNull CommandCondition condition) {
+        Check.notNull(condition, "condition cannot be null");
         return (sender, commandString) -> !condition.canUse(sender, commandString);
     }
 }

--- a/src/main/java/net/minestom/server/command/builder/condition/Conditions.java
+++ b/src/main/java/net/minestom/server/command/builder/condition/Conditions.java
@@ -4,7 +4,6 @@ import net.minestom.server.command.CommandSender;
 import net.minestom.server.command.ConsoleSender;
 import net.minestom.server.entity.Player;
 import net.minestom.server.utils.validate.Check;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Common command conditions
@@ -13,7 +12,7 @@ public class Conditions {
     /**
      * Will only execute if all command conditions succeed.
      */
-    public static CommandCondition all(@NotNull CommandCondition @NotNull... conditions) {
+    public static CommandCondition all(CommandCondition... conditions) {
         Check.notNull(conditions, "conditions cannot be null");
         for (CommandCondition condition : conditions) {
             Check.notNull(condition, "condition cannot be null");
@@ -32,7 +31,7 @@ public class Conditions {
     /**
      * Will execute if one or more command conditions succeed.
      */
-    public static CommandCondition any(@NotNull CommandCondition @NotNull... conditions) {
+    public static CommandCondition any(CommandCondition... conditions) {
         Check.notNull(conditions, "conditions cannot be null");
         for (CommandCondition condition : conditions) {
             Check.notNull(condition, "condition cannot be null");
@@ -65,7 +64,7 @@ public class Conditions {
     /**
      * Inverts the result of the given condition.
      */
-    public static CommandCondition not(@NotNull CommandCondition condition) {
+    public static CommandCondition not(CommandCondition condition) {
         Check.notNull(condition, "condition cannot be null");
         return (sender, commandString) -> !condition.canUse(sender, commandString);
     }

--- a/src/main/java/net/minestom/server/command/builder/condition/Conditions.java
+++ b/src/main/java/net/minestom/server/command/builder/condition/Conditions.java
@@ -51,4 +51,11 @@ public class Conditions {
     public static boolean consoleOnly(CommandSender sender, String commandString) {
         return sender instanceof ConsoleSender;
     }
+
+    /**
+     * Inverts the result of the given condition.
+     */
+    public static CommandCondition not(CommandCondition condition) {
+        return (sender, commandString) -> !condition.canUse(sender, commandString);
+    }
 }

--- a/src/test/java/net/minestom/server/command/CommandConditionTest.java
+++ b/src/test/java/net/minestom/server/command/CommandConditionTest.java
@@ -7,7 +7,10 @@ import net.minestom.server.tag.TagHandler;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static net.minestom.server.command.builder.arguments.ArgumentType.Integer;
+import static net.minestom.server.command.builder.arguments.ArgumentType.Literal;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class CommandConditionTest {
@@ -170,6 +173,296 @@ public class CommandConditionTest {
         called.set(false);
         dispatcher.execute(sender3, "test");
         assertFalse(called.get(), "sender3 should be blocked by command condition");
+    }
+
+    @Test
+    public void multipleZeroArgSyntaxesWithConditions() {
+        var dispatcher = new CommandDispatcher();
+        var sender1 = new Sender();
+        var sender2 = new Sender();
+        var sender3 = new Sender();
+
+        AtomicInteger executionCount = new AtomicInteger(0);
+
+        var command = new Command("multi");
+        command.setCondition((sender, commandString) -> sender == sender1 || sender == sender2);
+
+        // First zero-arg syntax with additional condition
+        command.addConditionalSyntax((sender, commandString) -> sender == sender1,
+                (sender, context) -> executionCount.incrementAndGet());
+
+        dispatcher.register(command);
+
+        // sender1 should work (passes both conditions)
+        dispatcher.execute(sender1, "multi");
+        assertEquals(1, executionCount.get(), "sender1 should execute successfully");
+
+        // sender2 should be blocked by syntax condition
+        executionCount.set(0);
+        dispatcher.execute(sender2, "multi");
+        assertEquals(0, executionCount.get(), "sender2 should be blocked by syntax condition");
+
+        // sender3 should be blocked by command condition
+        dispatcher.execute(sender3, "multi");
+        assertEquals(0, executionCount.get(), "sender3 should be blocked by command condition");
+    }
+
+    @Test
+    public void defaultExecutorWithConditionAndSyntaxes() {
+        var dispatcher = new CommandDispatcher();
+        var adminSender = new Sender();
+        var normalSender = new Sender();
+
+        AtomicBoolean defaultCalled = new AtomicBoolean(false);
+        AtomicBoolean syntaxCalled = new AtomicBoolean(false);
+
+        var command = new Command("cmd");
+        command.setCondition((sender, commandString) -> sender == adminSender);
+        command.setDefaultExecutor((sender, context) -> defaultCalled.set(true));
+        command.addSyntax((sender, context) -> syntaxCalled.set(true), Integer("value"));
+
+        dispatcher.register(command);
+
+        // Admin executing without args should trigger default executor
+        dispatcher.execute(adminSender, "cmd");
+        assertTrue(defaultCalled.get(), "Admin should execute default executor");
+        assertFalse(syntaxCalled.get());
+
+        // Normal user should be blocked even from default executor
+        defaultCalled.set(false);
+        dispatcher.execute(normalSender, "cmd");
+        assertFalse(defaultCalled.get(), "Normal user should be blocked from default executor");
+        assertFalse(syntaxCalled.get());
+
+        // Admin with valid syntax
+        dispatcher.execute(adminSender, "cmd 42");
+        assertTrue(syntaxCalled.get(), "Admin should execute syntax");
+
+        // Normal user should be blocked from syntax too
+        syntaxCalled.set(false);
+        dispatcher.execute(normalSender, "cmd 42");
+        assertFalse(syntaxCalled.get(), "Normal user should be blocked from syntax");
+    }
+
+    @Test
+    public void deeplyNestedSubcommandConditions() {
+        var dispatcher = new CommandDispatcher();
+        var adminSender = new Sender();
+        var normalSender = new Sender();
+
+        AtomicBoolean called = new AtomicBoolean(false);
+
+        var rootCmd = new Command("root");
+        rootCmd.setCondition((sender, commandString) -> sender == adminSender);
+
+        var level1 = new Command("level1");
+        var level2 = new Command("level2");
+        var level3 = new Command("level3");
+        level3.setDefaultExecutor((sender, context) -> called.set(true));
+
+        level2.addSubcommand(level3);
+        level1.addSubcommand(level2);
+        rootCmd.addSubcommand(level1);
+
+        dispatcher.register(rootCmd);
+
+        // Admin should be able to execute deeply nested command
+        dispatcher.execute(adminSender, "root level1 level2 level3");
+        assertTrue(called.get(), "Admin should execute deeply nested command");
+
+        // Normal user should be blocked at root level
+        called.set(false);
+        dispatcher.execute(normalSender, "root level1 level2 level3");
+        assertFalse(called.get(), "Normal user should be blocked by root condition");
+    }
+
+    @Test
+    public void syntaxConditionOnlyNoCommandCondition() {
+        var dispatcher = new CommandDispatcher();
+        var sender1 = new Sender();
+        var sender2 = new Sender();
+
+        AtomicBoolean called = new AtomicBoolean(false);
+
+        var command = new Command("test");
+        // No command condition set
+        command.addConditionalSyntax((sender, commandString) -> sender == sender1,
+                (sender, context) -> called.set(true));
+
+        dispatcher.register(command);
+
+        // sender1 should execute (passes syntax condition)
+        dispatcher.execute(sender1, "test");
+        assertTrue(called.get(), "sender1 should execute with syntax condition");
+
+        // sender2 should be blocked (fails syntax condition)
+        called.set(false);
+        dispatcher.execute(sender2, "test");
+        assertFalse(called.get(), "sender2 should be blocked by syntax condition");
+    }
+
+    @Test
+    public void mixedSyntaxConditions() {
+        var dispatcher = new CommandDispatcher();
+        var sender1 = new Sender();
+        var sender2 = new Sender();
+        var sender3 = new Sender();
+
+        AtomicInteger whichSyntax = new AtomicInteger(0);
+
+        var command = new Command("mixed");
+        command.setCondition((sender, commandString) -> sender == sender1 || sender == sender2);
+
+        // Syntax 1: zero-arg, no additional condition (should use command condition only)
+        command.addSyntax((sender, context) -> whichSyntax.set(1));
+
+        // Syntax 2: with arg and additional condition
+        command.addConditionalSyntax((sender, commandString) -> sender == sender1,
+                (sender, context) -> whichSyntax.set(2), Literal("special"));
+
+        dispatcher.register(command);
+
+        // sender1 can execute both syntaxes
+        dispatcher.execute(sender1, "mixed");
+        assertEquals(1, whichSyntax.get(), "sender1 should execute syntax 1");
+
+        whichSyntax.set(0);
+        dispatcher.execute(sender1, "mixed special");
+        assertEquals(2, whichSyntax.get(), "sender1 should execute syntax 2");
+
+        // sender2 can execute syntax 1 but not syntax 2
+        whichSyntax.set(0);
+        dispatcher.execute(sender2, "mixed");
+        assertEquals(1, whichSyntax.get(), "sender2 should execute syntax 1");
+
+        whichSyntax.set(0);
+        dispatcher.execute(sender2, "mixed special");
+        assertEquals(0, whichSyntax.get(), "sender2 should be blocked from syntax 2");
+
+        // sender3 should be blocked from everything
+        dispatcher.execute(sender3, "mixed");
+        assertEquals(0, whichSyntax.get(), "sender3 should be blocked by command condition");
+
+        dispatcher.execute(sender3, "mixed special");
+        assertEquals(0, whichSyntax.get(), "sender3 should be blocked by command condition");
+    }
+
+    @Test
+    public void subcommandWithOwnConditionRequiresBoth() {
+        var dispatcher = new CommandDispatcher();
+        var sender1 = new Sender();
+        var sender2 = new Sender();
+        var sender3 = new Sender();
+
+        AtomicBoolean called = new AtomicBoolean(false);
+
+        var parent = new Command("parent");
+        parent.setCondition((sender, commandString) -> sender == sender1 || sender == sender2);
+
+        var child = new Command("child");
+        child.setCondition((sender, commandString) -> sender == sender1 || sender == sender3);
+        child.setDefaultExecutor((sender, context) -> called.set(true));
+
+        parent.addSubcommand(child);
+        dispatcher.register(parent);
+
+        // sender1 passes both conditions
+        dispatcher.execute(sender1, "parent child");
+        assertTrue(called.get(), "sender1 should pass both conditions");
+
+        // sender2 passes parent but not child
+        called.set(false);
+        dispatcher.execute(sender2, "parent child");
+        assertFalse(called.get(), "sender2 should be blocked by child condition");
+
+        // sender3 passes child but not parent
+        dispatcher.execute(sender3, "parent child");
+        assertFalse(called.get(), "sender3 should be blocked by parent condition");
+    }
+
+    @Test
+    public void zeroArgSyntaxAndDefaultExecutorWithCondition() {
+        var dispatcher = new CommandDispatcher();
+        var adminSender = new Sender();
+        var normalSender = new Sender();
+
+        AtomicBoolean defaultCalled = new AtomicBoolean(false);
+        AtomicBoolean syntaxCalled = new AtomicBoolean(false);
+
+        var command = new Command("cmd");
+        command.setCondition((sender, commandString) -> sender == adminSender);
+        command.setDefaultExecutor((sender, context) -> defaultCalled.set(true));
+        command.addSyntax((sender, context) -> syntaxCalled.set(true)); // zero-arg syntax
+
+        dispatcher.register(command);
+
+        // Admin should execute the syntax (syntax takes precedence over default executor)
+        dispatcher.execute(adminSender, "cmd");
+        assertTrue(syntaxCalled.get(), "Admin should execute zero-arg syntax");
+        assertFalse(defaultCalled.get(), "Default executor should not be called when syntax matches");
+
+        // Normal user should be blocked
+        syntaxCalled.set(false);
+        dispatcher.execute(normalSender, "cmd");
+        assertFalse(syntaxCalled.get(), "Normal user should be blocked from syntax");
+        assertFalse(defaultCalled.get(), "Normal user should be blocked from default executor");
+    }
+
+    @Test
+    public void testGraphZeroArgCondition() {
+        var adminSender = new Sender();
+        var normalSender = new Sender();
+
+        var command = new Command("admin");
+        command.setCondition((sender, commandString) -> sender == adminSender);
+        command.addSyntax((sender, context) -> {});
+
+        Graph graph = Graph.fromCommand(command);
+        Graph.Node root = graph.root();
+
+        assertNotNull(root.execution(), "Root node should have execution");
+        assertNotNull(root.execution().condition(), "Root node should preserve command condition");
+        assertFalse(root.execution().test(normalSender), "Normal sender should fail condition check");
+        assertTrue(root.execution().test(adminSender), "Admin sender should pass condition check");
+    }
+
+    @Test
+    public void graphPreservesConditionsForSyntaxWithArguments() {
+        var adminSender = new Sender();
+
+        var command = new Command("admin");
+        command.setCondition((sender, commandString) -> sender == adminSender);
+        command.addSyntax((sender, context) -> {}, Integer("value"));
+
+        Graph graph = Graph.fromCommand(command);
+        Graph.Node root = graph.root();
+
+        assertNotNull(root.execution(), "Root should have execution");
+        assertNotNull(root.execution().condition(), "Root should have command condition");
+
+        // Check that the argument node also has condition info propagated
+        assertEquals(1, root.next().size(), "Should have one child for the Integer argument");
+        Graph.Node argNode = root.next().getFirst();
+        assertNotNull(argNode.execution(), "Argument node should have execution");
+    }
+
+    @Test
+    public void graphComparisonDetectsConditionDifferences() {
+        var adminSender = new Sender();
+
+        var command1 = new Command("test");
+        command1.setCondition((sender, commandString) -> sender == adminSender);
+        command1.addSyntax((sender, context) -> {});
+
+        var command2 = new Command("test");
+        // No condition
+        command2.addSyntax((sender, context) -> {});
+
+        Graph graph1 = Graph.fromCommand(command1);
+        Graph graph2 = Graph.fromCommand(command2);
+
+        assertFalse(graph1.compare(graph2, Graph.Comparator.TREE),
+                "Graphs with different conditions should not be equal");
     }
 
     private static final class Sender implements CommandSender {


### PR DESCRIPTION
In `GraphImpl.java`, when a command had a condition and you added a zero-argument syntax without its own condition, the syntax's null condition would overwrite the command's condition. This let anyone bypass permission checks and run admin-only commands.

I also added some utilities like `setCondition(Predicate<CommandSender>...)`, changed `setCondition(CommandCondition)` to varargs, and `Conditions#not(CommandCondition)`.