### PR TITLE
Instance#generateChunk

### DIFF
--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -378,6 +378,19 @@ public abstract class Instance implements Block.Getter, Block.Setter,
     public abstract void setGenerator(@Nullable Generator generator);
 
     /**
+     * Runs the provided {@link Generator} to generate a chunk at the given position.
+     * <p>
+     * Loads the chunk if not already loaded.
+     *
+     * @param chunkX    the chunk X
+     * @param chunkZ    the chunk Z
+     * @param generator the generator to use
+     * @return a future called once the generation is complete
+     */
+    @ApiStatus.Experimental
+    public abstract CompletableFuture<Void> generateChunk(int chunkX, int chunkZ, Generator generator);
+
+    /**
      * Gets all the instance's loaded chunks.
      *
      * @return an unmodifiable containing all the instance chunks
@@ -886,6 +899,7 @@ public abstract class Instance implements Block.Getter, Block.Setter,
 
     /**
      * Gets the chunk view distance of this instance, which defaults to {@link ServerFlag#CHUNK_VIEW_DISTANCE}.
+     *
      * @return The chunk view distance of this instance
      */
     public int viewDistance() {
@@ -894,6 +908,7 @@ public abstract class Instance implements Block.Getter, Block.Setter,
 
     /**
      * Sets the chunk view distance of this instance
+     *
      * @param newViewDistance the new view distance
      */
     public void viewDistance(int newViewDistance) {

--- a/src/main/java/net/minestom/server/instance/SharedInstance.java
+++ b/src/main/java/net/minestom/server/instance/SharedInstance.java
@@ -7,6 +7,7 @@ import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.instance.block.BlockHandler;
 import net.minestom.server.instance.generator.Generator;
 import net.minestom.server.utils.chunk.ChunkSupplier;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
@@ -93,6 +94,12 @@ public class SharedInstance extends Instance {
     @Override
     public void setGenerator(@Nullable Generator generator) {
         instanceContainer.setGenerator(generator);
+    }
+
+    @ApiStatus.Experimental
+    @Override
+    public CompletableFuture<Void> generateChunk(int chunkX, int chunkZ, Generator generator) {
+        return instanceContainer.generateChunk(chunkX, chunkZ, generator);
     }
 
     @Override

--- a/src/test/java/net/minestom/server/instance/GeneratorIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/GeneratorIntegrationTest.java
@@ -2,6 +2,7 @@ package net.minestom.server.instance;
 
 import net.kyori.adventure.nbt.CompoundBinaryTag;
 import net.minestom.server.instance.block.Block;
+import net.minestom.server.instance.generator.Generator;
 import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
 import org.junit.jupiter.api.Test;
@@ -10,8 +11,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.*;
 
 @EnvTest
 public class GeneratorIntegrationTest {
@@ -96,5 +96,24 @@ public class GeneratorIntegrationTest {
         for (int y = 0; y < 40; y++) {
             assertEquals(y == 39 ? Block.STONE : Block.GRASS_BLOCK, instance.getBlock(0, y, 0), "y=" + y);
         }
+    }
+
+    @Test
+    public void explicitChunkGenerate(Env env) {
+        var instance = env.createEmptyInstance();
+        Generator generator = unit -> unit.modifier().fill(Block.GRASS_BLOCK);
+        instance.generateChunk(0, 0, generator).join();
+        assertNotNull(instance.getChunk(0, 0));
+        assertEquals(Block.GRASS_BLOCK, instance.getBlock(0, 0, 0));
+    }
+
+    @Test
+    public void explicitChunkGenerateOverride(Env env) {
+        var instance = env.createEmptyInstance();
+        instance.setGenerator(unit -> unit.modifier().fill(Block.STONE));
+        Generator generator = unit -> unit.modifier().fill(Block.GRASS_BLOCK);
+        instance.generateChunk(0, 0, generator).join();
+        assertNotNull(instance.getChunk(0, 0));
+        assertEquals(Block.GRASS_BLOCK, instance.getBlock(0, 0, 0));
     }
 }


### PR DESCRIPTION
Add a method to run/apply a generator on an already generated chunk (load it first if necessary).

Useful for example if you wish to reload the world with a new generator.

Perhaps the method should be renamed. Keeping in mind that a section version could be added later on.