### PR TITLE
Update the section API

### DIFF
--- a/src/main/java/net/minestom/server/instance/DynamicChunk.java
+++ b/src/main/java/net/minestom/server/instance/DynamicChunk.java
@@ -159,9 +159,9 @@ public class DynamicChunk extends Chunk {
 
     @Override
     public void tick(long time) {
-        int i = 0;
-        for (Section section : sections) {
-            final int sectionY = i++ + minSection;
+        for (int i = 0; i < sections.size(); i++) {
+            Section section = sections.get(i);
+            final int sectionY = i + minSection;
             SectionImpl impl = (SectionImpl) section;
             var tickableMap = impl.tickableMap();
             if (tickableMap.isEmpty()) continue;

--- a/src/main/java/net/minestom/server/instance/DynamicChunk.java
+++ b/src/main/java/net/minestom/server/instance/DynamicChunk.java
@@ -87,6 +87,7 @@ public class DynamicChunk extends Chunk {
         Section section = getSectionAt(y);
         final int localX = globalToSectionRelative(x), localY = globalToSectionRelative(y), localZ = globalToSectionRelative(z);
 
+        section.blockPalette().set(localX, localY, localZ, block.stateId());
         Block lastCachedBlock = section.cacheBlock(localX, localY, localZ, block);
         BlockHandler handler = block.handler();
 

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -294,8 +294,7 @@ public abstract class Instance implements Block.Getter, Block.Setter,
         final Chunk chunk = getChunk(sectionX, sectionZ);
         if (chunk != null) {
             Section section = chunk.getSection(sectionY);
-            section.skyLight().invalidate();
-            section.blockLight().invalidate();
+            section.invalidate();
             chunk.invalidate();
             EventDispatcher.call(new InstanceSectionInvalidateEvent(this, sectionX, sectionY, sectionZ));
         }

--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -475,13 +475,15 @@ public class InstanceContainer extends Instance {
         if (cache.isEmpty()) return;
         final int height = section.start().blockY();
         Section sec = chunk.getSectionAt(height);
-        Int2ObjectMaps.fastForEach(cache, blockEntry -> {
-            final int index = blockEntry.getIntKey();
-            final Block block = blockEntry.getValue();
-            final int localX = sectionBlockIndexGetX(index), localY = sectionBlockIndexGetY(index), localZ = sectionBlockIndexGetZ(index);
-            sec.blockPalette().set(localX, localY, localZ, block.stateId());
-            sec.cacheBlock(localX, localY, localZ, block);
-        });
+        synchronized (chunk) {
+            Int2ObjectMaps.fastForEach(cache, blockEntry -> {
+                final int index = blockEntry.getIntKey();
+                final Block block = blockEntry.getValue();
+                final int localX = sectionBlockIndexGetX(index), localY = sectionBlockIndexGetY(index), localZ = sectionBlockIndexGetZ(index);
+                sec.blockPalette().set(localX, localY, localZ, block.stateId());
+                sec.cacheBlock(localX, localY, localZ, block);
+            });
+        }
     }
 
     @Override

--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -474,19 +474,13 @@ public class InstanceContainer extends Instance {
         var cache = section.genSection().specials();
         if (cache.isEmpty()) return;
         final int height = section.start().blockY();
-        final int sectionY = globalToChunk(height);
-        SectionImpl sec = (SectionImpl) chunk.getSection(sectionY);
+        Section sec = chunk.getSectionAt(height);
         Int2ObjectMaps.fastForEach(cache, blockEntry -> {
             final int index = blockEntry.getIntKey();
             final Block block = blockEntry.getValue();
             final int localX = sectionBlockIndexGetX(index), localY = sectionBlockIndexGetY(index), localZ = sectionBlockIndexGetZ(index);
             sec.blockPalette().set(localX, localY, localZ, block.stateId());
-            if (block.hasNbt() || block.handler() != null || block.registry().isBlockEntity()) {
-                sec.entries().put(index, block);
-                if (block.handler() != null && block.handler().isTickable()) {
-                    sec.tickableMap().put(index, block);
-                }
-            }
+            sec.cacheBlock(localX, localY, localZ, block);
         });
     }
 

--- a/src/main/java/net/minestom/server/instance/LightingChunk.java
+++ b/src/main/java/net/minestom/server/instance/LightingChunk.java
@@ -134,8 +134,7 @@ public class LightingChunk extends DynamicChunk {
                 for (int k = -1; k <= 1; k++) {
                     if (k + coordinate < neighborChunk.getMinSection() || k + coordinate >= neighborChunk.getMaxSection())
                         continue;
-                    neighborChunk.getSection(k + coordinate).blockLight().invalidate();
-                    neighborChunk.getSection(k + coordinate).skyLight().invalidate();
+                    neighborChunk.getSection(k + coordinate).invalidate();
                 }
             }
         }
@@ -187,8 +186,7 @@ public class LightingChunk extends DynamicChunk {
         super.onGenerate();
 
         for (int section = minSection; section < maxSection; section++) {
-            getSection(section).blockLight().invalidate();
-            getSection(section).skyLight().invalidate();
+            getSection(section).invalidate();
         }
 
         invalidate();
@@ -204,8 +202,7 @@ public class LightingChunk extends DynamicChunk {
                         light.invalidate();
 
                         for (int section = minSection; section < maxSection; section++) {
-                            light.getSection(section).blockLight().invalidate();
-                            light.getSection(section).skyLight().invalidate();
+                            light.getSection(section).invalidate();
                         }
                     }
                 }
@@ -443,8 +440,7 @@ public class LightingChunk extends DynamicChunk {
                 if (!(chunk instanceof LightingChunk lighting)) continue;
                 for (int sectionIndex = chunk.minSection; sectionIndex < chunk.maxSection; sectionIndex++) {
                     Section section = chunk.getSection(sectionIndex);
-                    section.blockLight().invalidate();
-                    section.skyLight().invalidate();
+                    section.invalidate();
                     sections.add(new Vec(chunk.getChunkX(), sectionIndex, chunk.getChunkZ()));
                 }
                 lighting.invalidate();
@@ -565,9 +561,7 @@ public class LightingChunk extends DynamicChunk {
     @Override
     public Chunk copy(Instance instance, int chunkX, int chunkZ) {
         var sections = this.sections.stream().map(Section::clone).toList();
-        LightingChunk lightingChunk = new LightingChunk(instance, chunkX, chunkZ, sections);
-        lightingChunk.entries.putAll(entries);
-        return lightingChunk;
+        return new LightingChunk(instance, chunkX, chunkZ, sections);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/instance/Section.java
+++ b/src/main/java/net/minestom/server/instance/Section.java
@@ -6,6 +6,7 @@ import net.minestom.server.instance.light.Light;
 import net.minestom.server.instance.palette.Palette;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 public sealed interface Section extends Cloneable permits SectionImpl {
@@ -36,7 +37,7 @@ public sealed interface Section extends Cloneable permits SectionImpl {
 
     Light blockLight();
 
-    Int2ObjectOpenHashMap<@Nullable Block> entries();
+    Map<Integer, @Nullable Block> entries();
 
     @Nullable Block cacheBlock(int x, int y, int z, Block block);
 

--- a/src/main/java/net/minestom/server/instance/Section.java
+++ b/src/main/java/net/minestom/server/instance/Section.java
@@ -36,7 +36,7 @@ public sealed interface Section extends Cloneable permits SectionImpl {
 
     Light blockLight();
 
-    Int2ObjectOpenHashMap<Block> entries();
+    Int2ObjectOpenHashMap<@Nullable Block> entries();
 
     @Nullable Block cacheBlock(int x, int y, int z, Block block);
 

--- a/src/main/java/net/minestom/server/instance/Section.java
+++ b/src/main/java/net/minestom/server/instance/Section.java
@@ -1,66 +1,60 @@
 package net.minestom.server.instance;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.light.Light;
 import net.minestom.server.instance.palette.Palette;
+import org.jetbrains.annotations.Nullable;
 
-public final class Section {
-    private final Palette blockPalette;
-    private final Palette biomePalette;
-    private final Light skyLight;
-    private final Light blockLight;
+import java.util.concurrent.atomic.AtomicLong;
 
-    private Section(Palette blockPalette, Palette biomePalette, Light skyLight, Light blockLight) {
-        this.blockPalette = blockPalette;
-        this.biomePalette = biomePalette;
-        this.skyLight = skyLight;
-        this.blockLight = blockLight;
+public sealed interface Section extends Cloneable permits SectionImpl {
+    static Section section(Palette blockPalette, Palette biomePalette, Light skyLight, Light blockLight) {
+        return new SectionImpl(
+                blockPalette, biomePalette,
+                skyLight, blockLight,
+                new Int2ObjectOpenHashMap<>(), new Int2ObjectOpenHashMap<>(),
+                new AtomicLong(1)
+        );
     }
 
-    private Section(Palette blockPalette, Palette biomePalette) {
-        this(blockPalette, biomePalette, Light.sky(), Light.block());
+    static Section section(Palette blockPalette, Palette biomePalette) {
+        return section(blockPalette, biomePalette, Light.sky(), Light.block());
     }
 
-    public Section() {
-        this(Palette.blocks(), Palette.biomes());
+    static Section section() {
+        return section(Palette.blocks(), Palette.biomes());
     }
 
-    public Palette blockPalette() {
-        return blockPalette;
-    }
+    Palette blockPalette();
 
-    public Palette biomePalette() {
-        return biomePalette;
-    }
+    Palette biomePalette();
 
-    public void clear() {
-        this.blockPalette.fill(0);
-        this.biomePalette.fill(0);
-    }
+    void clear();
 
-    @Override
-    public Section clone() {
+    Light skyLight();
+
+    Light blockLight();
+
+    Int2ObjectOpenHashMap<Block> entries();
+
+    @Nullable Block cacheBlock(int x, int y, int z, Block block);
+
+    void invalidate();
+
+    @SuppressWarnings("MethodDoesntCallSuperMethod")
+    default Section clone() {
+        SectionImpl impl = (SectionImpl) this;
         final Light skyLight = Light.sky();
         final Light blockLight = Light.block();
-
-        skyLight.set(this.skyLight.array());
-        blockLight.set(this.blockLight.array());
-
-        return new Section(this.blockPalette.clone(), this.biomePalette.clone(), skyLight, blockLight);
-    }
-
-    public void setSkyLight(byte[] copyArray) {
-        this.skyLight.set(copyArray);
-    }
-
-    public void setBlockLight(byte[] copyArray) {
-        this.blockLight.set(copyArray);
-    }
-
-    public Light skyLight() {
-        return skyLight;
-    }
-
-    public Light blockLight() {
-        return blockLight;
+        skyLight.set(impl.skyLight().array());
+        blockLight.set(impl.blockLight().array());
+        return new SectionImpl(
+                impl.blockPalette().clone(), impl.biomePalette().clone(),
+                skyLight, blockLight,
+                new Int2ObjectOpenHashMap<>(impl.entries()),
+                new Int2ObjectOpenHashMap<>(impl.tickableMap()),
+                new AtomicLong()
+        );
     }
 }

--- a/src/main/java/net/minestom/server/instance/SectionImpl.java
+++ b/src/main/java/net/minestom/server/instance/SectionImpl.java
@@ -19,6 +19,7 @@ record SectionImpl(
         Int2ObjectOpenHashMap<Block> tickableMap,
         AtomicLong version
 ) implements Section {
+    @Override
     public void clear() {
         this.blockPalette.fill(0);
         this.biomePalette.fill(0);

--- a/src/main/java/net/minestom/server/instance/SectionImpl.java
+++ b/src/main/java/net/minestom/server/instance/SectionImpl.java
@@ -1,0 +1,62 @@
+package net.minestom.server.instance;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import net.minestom.server.instance.block.Block;
+import net.minestom.server.instance.block.BlockHandler;
+import net.minestom.server.instance.light.Light;
+import net.minestom.server.instance.palette.Palette;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static net.minestom.server.coordinate.CoordConversion.sectionBlockIndex;
+
+record SectionImpl(
+        Palette blockPalette, Palette biomePalette,
+        Light skyLight, Light blockLight,
+        // Key = CoordConversion#sectionBlockIndex
+        Int2ObjectOpenHashMap<@Nullable Block> entries,
+        Int2ObjectOpenHashMap<Block> tickableMap,
+        AtomicLong version
+) implements Section {
+    public void clear() {
+        this.blockPalette.fill(0);
+        this.biomePalette.fill(0);
+        this.entries.clear();
+        this.tickableMap.clear();
+    }
+
+    @Override
+    public @Nullable Block cacheBlock(int x, int y, int z, Block block) {
+        final int index = sectionBlockIndex(x, y, z);
+        // Handler
+        final BlockHandler handler = block.handler();
+        final Block lastCachedBlock;
+        if (handler != null || block.hasNbt() || block.registry().isBlockEntity()) {
+            lastCachedBlock = entries().put(index, block);
+        } else {
+            lastCachedBlock = entries().remove(index);
+        }
+        // Block tick
+        if (handler != null && handler.isTickable()) {
+            tickableMap().put(index, block);
+        } else {
+            tickableMap().remove(index);
+        }
+        // Palette
+        blockPalette().set(x, y, z, block.stateId());
+        return lastCachedBlock;
+    }
+
+    @Override
+    public void invalidate() {
+        this.version.incrementAndGet();
+        this.skyLight.invalidate();
+        this.blockLight.invalidate();
+    }
+
+    @Override
+    public Section clone() {
+        return Section.super.clone();
+    }
+}

--- a/src/main/java/net/minestom/server/instance/SectionImpl.java
+++ b/src/main/java/net/minestom/server/instance/SectionImpl.java
@@ -43,8 +43,6 @@ record SectionImpl(
         } else {
             tickableMap().remove(index);
         }
-        // Palette
-        blockPalette().set(x, y, z, block.stateId());
         return lastCachedBlock;
     }
 

--- a/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
+++ b/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
@@ -298,7 +298,7 @@ public class AnvilLoader implements IChunkLoader {
 
             // Place block
             final Block finalBlock = !trimmedTag.isEmpty() ? block.withNbt(trimmedTag) : block;
-            loadedChunk.setBlock(x, y, z, finalBlock);
+            section.cacheBlock(localX, localY, localZ, finalBlock);
         }
     }
 
@@ -413,7 +413,7 @@ public class AnvilLoader implements IChunkLoader {
                     blockPaletteEntries.add(blockState);
                 } else {
                     section.blockPalette().getAll((x, y, z, value) -> {
-                        Block block = chunk.getBlock(x, globalSectionY + y, z, Block.Getter.Condition.CACHED);
+                        Block block = section.entries().get(sectionBlockIndex(x, y, z));
                         if (block == null) block = Block.fromStateId(value);
                         assert block != null;
                         final CompoundBinaryTag blockState = blockStateNbt(block);

--- a/src/main/java/net/minestom/server/instance/generator/GeneratorImpl.java
+++ b/src/main/java/net/minestom/server/instance/generator/GeneratorImpl.java
@@ -275,7 +275,7 @@ public final class GeneratorImpl {
                 for (int x = 0; x < 16; x++) {
                     for (int y = 0; y < 16; y++) {
                         for (int z = 0; z < 16; z++) {
-                            this.genSection.specials.put(chunkBlockIndex(x, y, z), block);
+                            this.genSection.specials.put(sectionBlockIndex(x, y, z), block);
                         }
                     }
                 }
@@ -303,9 +303,9 @@ public final class GeneratorImpl {
 
         private void handleCache(int x, int y, int z, Block block) {
             if (requireCache(block)) {
-                this.genSection.specials.put(chunkBlockIndex(x, y, z), block);
+                this.genSection.specials.put(sectionBlockIndex(x, y, z), block);
             } else if (!genSection.specials.isEmpty()) {
-                this.genSection.specials.remove(chunkBlockIndex(x, y, z));
+                this.genSection.specials.remove(sectionBlockIndex(x, y, z));
             }
         }
 

--- a/src/test/java/net/minestom/server/instance/block/handler/BlockHandlerIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/block/handler/BlockHandlerIntegrationTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static net.minestom.testing.TestUtils.assertPoint;
 import static org.junit.jupiter.api.Assertions.*;
 
 @EnvTest
@@ -70,7 +71,7 @@ class BlockHandlerIntegrationTest {
             @Override
             public boolean onInteract(Interaction interaction) {
                 interacted.set(true);
-                assertEquals(blockPosition, interaction.getBlockPosition());
+                assertPoint(blockPosition, interaction.getBlockPosition());
                 return false;
             }
 
@@ -81,7 +82,7 @@ class BlockHandlerIntegrationTest {
         };
 
         instance.setBlock(blockPosition, Block.STONE.withHandler(handler));
-        var player = env.createPlayer(instance, blockPosition.asPosition());
+        var player = env.createPlayer(instance, blockPosition.asPos());
         player.addPacketToQueue(new ClientPlayerBlockPlacementPacket(PlayerHand.MAIN, blockPosition, BlockFace.TOP, 0, 0, 0, false, false, 1));
         player.interpretPacketQueue(); // Use packets
 
@@ -98,7 +99,7 @@ class BlockHandlerIntegrationTest {
             @Override
             public void tick(Tick tick) {
                 ticked.set(true);
-                assertEquals(tick.getBlockPosition(), blockPosition.asVec());
+                assertPoint(blockPosition.asVec(), tick.getBlockPosition());
             }
 
             @Override
@@ -131,7 +132,7 @@ class BlockHandlerIntegrationTest {
             @Override
             public void tick(Tick tick) {
                 ticked.set(true);
-                assertEquals(tick.getBlockPosition(), blockPosition.asVec());
+                assertPoint(blockPosition.asVec(), tick.getBlockPosition());
             }
 
             @Override


### PR DESCRIPTION
Move `Block` storage (block entities, handler, NBT) to `Section` which could later be used to speedup stateful block check, and handle world state versioning.

The only breaking change is the new `Section` factory methods, and its change from a class to interface (ABI)