### PR TITLE
Fix: Use instance view distance for join handshake

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -1578,7 +1578,6 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
         if (isInPlayState) playerMeta.setNotifyAboutChanges(true);
 
         final byte previousViewDistance = previous.viewDistance();
-        final byte newViewDistance = settings.viewDistance();
         // Check to see if we're in an instance first, as this method is called when first logging in since the client sends the Settings packet during configuration
         if (instance != null) {
             final int previousEffectiveViewDistance = computeEffectiveViewDistance(previousViewDistance, instance);


### PR DESCRIPTION
## Proposed changes

- Joining an instance with a small view distance (e.g. 2) still advertised the global default of 8 in the initial JoinGamePacket, so vanilla clients spun up a 19×19 area (361 chunks). The server-side count exposed via Instance#getChunks().size() showed the same overshoot until the client later sent its settings packet, which contradicted the configured radius and inflated memory usage under load.
- The login handshake now uses the instance’s configured view distance (clamped to Mojang’s 2–32 bounds) when building JoinGamePacket, so the very first tick matches the world configuration.
- When a player moves to an instance with a different radius, we immediately push UpdateViewDistancePacket and UpdateSimulationDistancePacket so the client adjusts fog and simulation limits without waiting for another settings exchange.
- With these changes the chunk count retrieved from Instance#getChunks().size() stays at the expected (viewDistance + 1)^2 (e.g. 49 for view distance 2) from the moment the player spawns.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING.md (CONTRIBUTING.md)
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added necessary documentation (if appropriate)~~

## Further comments

Scope is limited to server→client view-distance negotiation; generation and persistence code paths remain unchanged. Verified manually by joining an instance set to view distance 2 and observing that the handshake and Instance#getChunks().size() both report the expected 49 chunks immediately, then switching to a larger-radius instance and seeing view distance packets update the client on the fly.

### Before
(client view distance 12; effective view distance 8; instance view distance 2)
<img width="854" height="479" alt="image" src="https://github.com/user-attachments/assets/1e12a482-e3a6-4a29-a155-fdf5746c484f" />

### After
(client view distance 12; effective view distance 8; instance view distance 2)
<img width="852" height="479" alt="image" src="https://github.com/user-attachments/assets/951c391f-498d-46ca-b356-616c8908261e" />
