### PR TITLE
Palette optimization

### DIFF
--- a/src/main/java/net/minestom/server/instance/DynamicChunk.java
+++ b/src/main/java/net/minestom/server/instance/DynamicChunk.java
@@ -259,7 +259,7 @@ public class DynamicChunk extends Chunk {
         synchronized (this) {
             heightmaps = getHeightmaps();
 
-            NetworkBuffer.Type<Palette> biomeSerializer = Palette.biomeSerializer(MinecraftServer.getBiomeRegistry().size());
+            NetworkBuffer.Type<Palette> biomeSerializer = Palette.biomeSerializer();
             data = NetworkBuffer.makeArray(networkBuffer -> {
                 for (Section section : sections) {
                     networkBuffer.write(SHORT, (short) section.blockPalette().count());

--- a/src/main/java/net/minestom/server/instance/heightmap/Heightmap.java
+++ b/src/main/java/net/minestom/server/instance/heightmap/Heightmap.java
@@ -72,7 +72,7 @@ public abstract class Heightmap {
             }
 
             final Palette blockPalette = chunk.getSection(sectionY).blockPalette();
-            final int localHeight = blockPalette.height(localX, localZ, (px, py, pz, value) -> {
+            final int localHeight = blockPalette.height(localX, localZ, (value) -> {
                 if (value == 0) return false;
                 final Block block = Block.fromStateId(value);
                 return block != null && checkBlock(block);

--- a/src/main/java/net/minestom/server/instance/palette/Palette.java
+++ b/src/main/java/net/minestom/server/instance/palette/Palette.java
@@ -19,8 +19,8 @@ import static net.minestom.server.network.NetworkBuffer.*;
  * No arrays allocated, value stored in count field.
  * <br>
  * Indirect Mode {@code (bitsPerEntry <= maxBitsPerEntry)}: Uses palette compression.
- * Values array stores palette indices, paletteToValueList and valueToPaletteMap
- * provide bidirectional mapping between indices and block values.
+ * Values array stores palette indices, paletteIndexMap
+ * provides bidirectional mapping between indices and block values.
  * <br>
  * Direct Mode {@code (bitsPerEntry > maxBitsPerEntry)}: Stores block values directly.
  * No palette structures, values array contains actual block values using directBits.
@@ -81,8 +81,21 @@ public sealed interface Palette permits PaletteImpl {
 
     void fill(int value);
 
+    /**
+     * Efficiently fills a cuboid from {@code (x0, y0, z0)} to {@code (x1, y1, z1)} (inclusive).
+     * <p>
+     * If any part of the cuboid lies outside the bounds of palette,
+     * those out-of-bounds positions are ignored.
+     * <p>
+     * Coordinate order does not matter.
+     *
+     * @param value The value to fill with
+     */
     void fill(int x0, int y0, int z0, int x1, int y1, int z1, int value);
 
+    /**
+     * Efficiently offsets all values in the palette by the given offset.
+     */
     void offset(int offset);
 
     /**
@@ -135,6 +148,15 @@ public sealed interface Palette permits PaletteImpl {
      */
     boolean any(int value);
 
+    /**
+     * Gets the highest y position where predicate returns true, or -1 if none matched.
+     * <p>
+     * It is assumed that the predicate result is independent of passed coordinates.
+     *
+     * @param x the x coordinate to check at
+     * @param z the z coordinate to check at
+     * @return the highest y position where predicate returns true, or -1 if none matched.
+     */
     int height(int x, int z, EntryPredicate predicate);
 
     /**

--- a/src/main/java/net/minestom/server/instance/palette/Palette.java
+++ b/src/main/java/net/minestom/server/instance/palette/Palette.java
@@ -66,25 +66,21 @@ public sealed interface Palette permits PaletteImpl {
 
     void getAllPresent(EntryConsumer consumer);
 
-    int height(int x, int z, EntryPredicate predicate);
-
     void set(int x, int y, int z, int value);
+
+    void setAll(EntrySupplier supplier);
+
+    void replace(int oldValue, int newValue);
+
+    void replace(int x, int y, int z, IntUnaryOperator operator);
+
+    void replaceAll(EntryFunction function);
 
     void fill(int value);
 
     void fill(int x0, int y0, int z0, int x1, int y1, int z1, int value);
 
-    void load(int[] palette, long[] values);
-
     void offset(int offset);
-
-    void replace(int oldValue, int newValue);
-
-    void setAll(EntrySupplier supplier);
-
-    void replace(int x, int y, int z, IntUnaryOperator operator);
-
-    void replaceAll(EntryFunction function);
 
     /**
      * Efficiently copies values from another palette with the given offset.
@@ -109,8 +105,10 @@ public sealed interface Palette permits PaletteImpl {
      */
     void copyFrom(Palette source);
 
+    void load(int[] palette, long[] values);
+
     /**
-     * Returns the number of entries in this palette.
+     * @return the number of entries that are not equal to 0 in this palette.
      */
     int count();
 
@@ -133,6 +131,8 @@ public sealed interface Palette permits PaletteImpl {
      * @return true if the palette contains the value, false otherwise
      */
     boolean any(int value);
+
+    int height(int x, int z, EntryPredicate predicate);
 
     /**
      * Returns the number of bits used per entry.

--- a/src/main/java/net/minestom/server/instance/palette/Palette.java
+++ b/src/main/java/net/minestom/server/instance/palette/Palette.java
@@ -239,6 +239,7 @@ public sealed interface Palette permits PaletteImpl {
                 if (directBits != value.directBits && value.isDirect()) {
                     value.values = Palettes.remap(dimension, value.directBits, directBits, value.values, Int2IntFunction.identity());
                     value.directBits = (byte) directBits;
+                    value.bitsPerEntry = value.directBits;
                 }
                 final byte bitsPerEntry = value.bitsPerEntry;
                 buffer.write(BYTE, bitsPerEntry);

--- a/src/main/java/net/minestom/server/instance/palette/Palette.java
+++ b/src/main/java/net/minestom/server/instance/palette/Palette.java
@@ -304,13 +304,17 @@ public sealed interface Palette permits PaletteImpl {
                 buffer.write(BYTE, bitsPerEntry);
                 if (bitsPerEntry == 0) {
                     buffer.write(VAR_INT, value.count);
+                } else if (value.isDirect()) {
+                    if (value.bitsPerEntry != directBits) {
+                        value.writeValuesResized(buffer, directBits);
+                    } else {
+                        for (final long l : value.values) buffer.write(LONG, l);
+                    }
                 } else {
-                    if (!value.isDirect()) {
-                        final int paletteSize = value.paletteIndexMap.size();
-                        buffer.write(VAR_INT, paletteSize);
-                        for (int index = 0; index < paletteSize; index++) {
-                            buffer.write(VAR_INT, value.paletteIndexMap.indexToValue(index));
-                        }
+                    final int paletteSize = value.paletteIndexMap.size();
+                    buffer.write(VAR_INT, paletteSize);
+                    for (int index = 0; index < paletteSize; index++) {
+                        buffer.write(VAR_INT, value.paletteIndexMap.indexToValue(index));
                     }
                     for (final long l : value.values) buffer.write(LONG, l);
                 }

--- a/src/main/java/net/minestom/server/instance/palette/PaletteImpl.java
+++ b/src/main/java/net/minestom/server/instance/palette/PaletteImpl.java
@@ -251,19 +251,21 @@ final class PaletteImpl implements Palette {
                 int blockIndex = index / valuesPerLong;
                 int bitIndex = (index % valuesPerLong) * bitsPerEntry;
                 long block = values[blockIndex];
-                for (int x = minZ; x <= maxZ; x++) {
-                    if (((block >>> bitIndex) & mask) == airPaletteIndex) countDelta++;
-                    block = (block & ~(((long) mask) << bitIndex)) | (((long) paletteIndex) << bitIndex);
-
-                    bitIndex += bitsPerEntry;
+                for (int x = minX; x <= maxX; x++) {
                     if (bitIndex >= maxBitIndex) {
                         values[blockIndex] = block;
                         bitIndex = 0;
                         blockIndex++;
                         block = values[blockIndex];
                     }
+
+                    if (((block >>> bitIndex) & mask) == airPaletteIndex) countDelta++;
+                    block = (block & ~(((long) mask) << bitIndex)) | (((long) paletteIndex) << bitIndex);
+
+                    bitIndex += bitsPerEntry;
                     index++;
                 }
+                values[blockIndex] = block;
                 index += finalXTravel;
             }
             index += finalZTravel;

--- a/src/main/java/net/minestom/server/instance/palette/PaletteImpl.java
+++ b/src/main/java/net/minestom/server/instance/palette/PaletteImpl.java
@@ -147,7 +147,7 @@ final class PaletteImpl implements Palette {
                 newIndex = paletteIndexMap.UNSAFE_getIndex(newPos);
             }
             final AtomicInteger count = new AtomicInteger();
-            Palettes.remap(dimension, bitsPerEntry, bitsPerEntry, values, v -> {
+            this.values = Palettes.remap(dimension, bitsPerEntry, bitsPerEntry, values, v -> {
                if (v == oldIndex) {
                    count.setPlain(count.getPlain() + 1);
                    return newIndex;
@@ -741,6 +741,7 @@ final class PaletteImpl implements Palette {
         final byte newDirectBits = (byte) MathUtils.bitsToRepresent(value);
         if (allowResize && isDirect()) {
             this.values = Palettes.remap(dimension, directBits, newDirectBits, values, Int2IntFunction.identity());
+            this.bitsPerEntry = newDirectBits;
         }
         this.directBits = newDirectBits;
     }

--- a/src/main/java/net/minestom/server/instance/palette/PaletteIndexMap.java
+++ b/src/main/java/net/minestom/server/instance/palette/PaletteIndexMap.java
@@ -67,6 +67,13 @@ final class PaletteIndexMap implements Cloneable {
         return -1;
     }
 
+    int valueToIndexCapped(final int value, final int maxSize) {
+        final int pos = find(value);
+        if (pos >= 0) return index[pos];
+        if (size >= maxSize) return -1;
+        return UNSAFE_insert(~pos, value);
+    }
+
     int indexToValue(final int index) {
         return indexToValue[index];
     }

--- a/src/main/java/net/minestom/server/instance/palette/PaletteIndexMap.java
+++ b/src/main/java/net/minestom/server/instance/palette/PaletteIndexMap.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2002-2024 Sebastiano Vigna
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.minestom.server.instance.palette;
+
+import it.unimi.dsi.fastutil.HashCommon;
+import net.minestom.server.utils.MathUtils;
+
+/**
+ * A performant implementation for transforming values into palette indices.
+ * Derived from {@link it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap} and modified to suit our specific needs.
+ */
+@SuppressWarnings({"StatementWithEmptyBody", "UnusedReturnValue"})
+final class PaletteIndexMap implements Cloneable {
+    private int[] value;
+    private int[] index;
+    private int[] indexToValue;
+
+    private int mask;
+    private boolean containsNullKey;
+    private int n;
+    private int maxFill;
+    private int size;
+
+    /**
+     * Assumes bitsPerEntry > 0
+     */
+    PaletteIndexMap(byte bitsPerEntry) {
+        n = 2 << bitsPerEntry;
+        mask = n - 1;
+        maxFill = n - (n >> 2);
+        value = new int[n + 1];
+        index = new int[n + 1];
+        indexToValue = new int[1 << bitsPerEntry];
+    }
+
+    PaletteIndexMap(int[] palette, int paletteLength) {
+        if (paletteLength > palette.length)
+            throw new IllegalArgumentException("Palette length greater than palette array length");
+
+        this(paletteLength > 1 ? (byte) MathUtils.bitsToRepresent(paletteLength) : 1);
+        for (int i = 0; i < paletteLength; i++) {
+            final int value = palette[i];
+            final int pos = find(value);
+            if (pos >= 0) throw new IllegalArgumentException("Palette entries must be unique");
+            UNSAFE_insert(~pos, value);
+        }
+    }
+
+    PaletteIndexMap(int[] palette) {
+        this(palette, palette.length);
+    }
+
+    int find(final int value) {
+        if (value == 0) return containsNullKey ? n : ~n;
+        int curr;
+        final int[] key = this.value;
+        int pos;
+        // The starting point.
+        if ((curr = key[pos = (HashCommon.mix((value))) & mask]) == 0) return ~pos;
+        if (value == curr) return pos;
+        // There's always an unused entry.
+        while (true) {
+            if ((curr = key[pos = (pos + 1) & mask]) == 0) return ~pos;
+            if (value == curr) return pos;
+        }
+    }
+
+    int UNSAFE_insert(final int pos, final int value) {
+        final int nextIndex = size;
+        if (pos == n) containsNullKey = true;
+        this.value[pos] = value;
+        this.index[pos] = nextIndex;
+        if (indexToValue.length == nextIndex) {
+            final int[] newIndexToValue = new int[indexToValue.length << 1];
+            System.arraycopy(indexToValue, 0, newIndexToValue, 0, indexToValue.length);
+            indexToValue = newIndexToValue;
+        }
+        indexToValue[nextIndex] = value;
+        if (++size > maxFill) rehash(n << 1);
+        return nextIndex;
+    }
+
+    int UNSAFE_getIndex(final int pos) {
+        return index[pos];
+    }
+
+    int valueToIndex(final int value) {
+        final int pos = find(value);
+        if (pos >= 0) return index[pos];
+        return UNSAFE_insert(~pos, value);
+    }
+
+    int valueToIndexOrDefault(final int value) {
+        final int pos = find(value);
+        if (pos >= 0) return index[pos];
+        return -1;
+    }
+
+    int indexToValue(final int index) {
+        return indexToValue[index];
+    }
+
+    int[] indexToValueArray() {
+        return indexToValue;
+    }
+
+    /**
+     * Tries to replace the index for oldValue with newValue,
+     * which succeeds if only oldValue is part of the palette.
+     * <br>
+     * The map is modified if and only if oldValue is in the palette and newValue isn't.
+     * In which case oldValue will stop pointing to its old index and newValue will point to it instead.
+     *
+     * @return -1 if this doesn't contain oldValue,
+     * otherwise returns the old index of oldValue in the lower 32 bits of the result
+     * and the index of newValue in the higher 32 bits.
+     */
+    long tryReplace(final int oldValue, final int newValue) {
+        final int oldPos = find(oldValue);
+        if (oldPos < 0) return -1;
+        final int oldIndex = index[oldPos];
+        int newPos = find(newValue);
+        if (newPos >= 0) return (((long) index[newPos]) << 32) | oldIndex;
+        shiftKeys(oldPos);
+        // May have changed since we called shiftKeys
+        newPos = find(newValue);
+        value[newPos] = newValue;
+        index[newPos] = oldIndex;
+        indexToValue[oldIndex] = newValue;
+        return (((long) oldIndex) << 32) | oldIndex;
+    }
+
+    public int size() {
+        return size;
+    }
+
+    public boolean isEmpty() {
+        return size == 0;
+    }
+
+    private void rehash(final int newN) {
+        final int[] key = this.value;
+        final int[] value = this.index;
+        final int mask = newN - 1;
+        final int[] newKey = new int[newN + 1];
+        final int[] newValue = new int[newN + 1];
+        int i = n, pos;
+        for (int j = realSize(); j-- != 0;) {
+            while (key[--i] == 0);
+            if (!((newKey[pos = (HashCommon.mix((key[i]))) & mask]) == 0))
+                while (!((newKey[pos = (pos + 1) & mask]) == 0));
+            newKey[pos] = key[i];
+            newValue[pos] = value[i];
+        }
+        newValue[newN] = value[n];
+        n = newN;
+        this.mask = mask;
+        maxFill = n - (n >> 2);
+        this.value = newKey;
+        this.index = newValue;
+    }
+
+    private void shiftKeys(int pos) {
+        // Shift entries with the same hash.
+        int last, slot;
+        int curr;
+        final int[] value = this.value;
+        final int[] index = this.index;
+        while (true) {
+            pos = ((last = pos) + 1) & mask;
+            while (true) {
+                if ((curr = value[pos]) == 0) {
+                    value[last] = (0);
+                    return;
+                }
+                slot = (HashCommon.mix(curr)) & mask;
+                if (last <= pos ? last >= slot || slot > pos : last >= slot && slot > pos) break;
+                pos = (pos + 1) & mask;
+            }
+            value[last] = curr;
+            index[last] = index[pos];
+        }
+    }
+
+    private int realSize() {
+        return containsNullKey ? size - 1 : size;
+    }
+
+    @Override
+    public PaletteIndexMap clone() {
+        PaletteIndexMap c;
+        try {
+            c = (PaletteIndexMap) super.clone();
+        } catch (CloneNotSupportedException cantHappen) {
+            throw new InternalError();
+        }
+        c.containsNullKey = containsNullKey;
+        c.value = value.clone();
+        c.index = index.clone();
+        c.indexToValue = indexToValue.clone();
+        return c;
+    }
+}

--- a/src/main/java/net/minestom/server/instance/palette/PaletteIndexMap.java
+++ b/src/main/java/net/minestom/server/instance/palette/PaletteIndexMap.java
@@ -47,7 +47,7 @@ final class PaletteIndexMap implements Cloneable {
     }
 
     PaletteIndexMap(int[] palette) {
-        this(palette.length > 1 ? (byte) MathUtils.bitsToRepresent(palette.length) : 1);
+        this(palette.length > 1 ? (byte) MathUtils.bitsToRepresent(palette.length - 1) : 1);
         for (final int value : palette) {
             final int pos = find(value);
             if (pos >= 0) throw new IllegalArgumentException("Palette entries must be unique");

--- a/src/main/java/net/minestom/server/instance/palette/PaletteIndexMap.java
+++ b/src/main/java/net/minestom/server/instance/palette/PaletteIndexMap.java
@@ -87,10 +87,6 @@ final class PaletteIndexMap implements Cloneable {
         return size;
     }
 
-    public boolean isEmpty() {
-        return size == 0;
-    }
-
     int find(final int value) {
         if (value == 0) return containsNullKey ? n : ~n;
         int curr;

--- a/src/main/java/net/minestom/server/instance/palette/PaletteIndexMap.java
+++ b/src/main/java/net/minestom/server/instance/palette/PaletteIndexMap.java
@@ -46,21 +46,13 @@ final class PaletteIndexMap implements Cloneable {
         indexToValue = new int[1 << bitsPerEntry];
     }
 
-    PaletteIndexMap(int[] palette, int paletteLength) {
-        if (paletteLength > palette.length)
-            throw new IllegalArgumentException("Palette length greater than palette array length");
-
-        this(paletteLength > 1 ? (byte) MathUtils.bitsToRepresent(paletteLength) : 1);
-        for (int i = 0; i < paletteLength; i++) {
-            final int value = palette[i];
+    PaletteIndexMap(int[] palette) {
+        this(palette.length > 1 ? (byte) MathUtils.bitsToRepresent(palette.length) : 1);
+        for (final int value : palette) {
             final int pos = find(value);
             if (pos >= 0) throw new IllegalArgumentException("Palette entries must be unique");
             UNSAFE_insert(~pos, value);
         }
-    }
-
-    PaletteIndexMap(int[] palette) {
-        this(palette, palette.length);
     }
 
     int valueToIndex(final int value) {

--- a/src/main/java/net/minestom/server/instance/palette/PaletteIndexMap.java
+++ b/src/main/java/net/minestom/server/instance/palette/PaletteIndexMap.java
@@ -22,7 +22,7 @@ import net.minestom.server.utils.MathUtils;
  * A performant implementation for transforming values into palette indices.
  * Derived from {@link it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap} and modified to suit our specific needs.
  */
-@SuppressWarnings({"StatementWithEmptyBody", "UnusedReturnValue"})
+@SuppressWarnings("UnusedReturnValue")
 final class PaletteIndexMap implements Cloneable {
     private int[] value;
     private int[] index;
@@ -169,9 +169,11 @@ final class PaletteIndexMap implements Cloneable {
         final int[] newValue = new int[newN + 1];
         int i = n, pos;
         for (int j = realSize(); j-- != 0;) {
+            //noinspection StatementWithEmptyBody
             while (key[--i] == 0);
-            if (!((newKey[pos = (HashCommon.mix((key[i]))) & mask]) == 0))
-                while (!((newKey[pos = (pos + 1) & mask]) == 0));
+            if ((newKey[pos = (HashCommon.mix(key[i])) & mask]) != 0)
+                //noinspection StatementWithEmptyBody
+                while ((newKey[pos = (pos + 1) & mask]) != 0);
             newKey[pos] = key[i];
             newValue[pos] = value[i];
         }
@@ -189,13 +191,17 @@ final class PaletteIndexMap implements Cloneable {
 
     @Override
     public PaletteIndexMap clone() {
-        PaletteIndexMap c;
+        final PaletteIndexMap c;
         try {
             c = (PaletteIndexMap) super.clone();
-        } catch (CloneNotSupportedException cantHappen) {
+        } catch (CloneNotSupportedException _) {
             throw new InternalError();
         }
+        c.mask = mask;
         c.containsNullKey = containsNullKey;
+        c.n = n;
+        c.maxFill = maxFill;
+        c.size = size;
         c.value = value.clone();
         c.index = index.clone();
         c.indexToValue = indexToValue.clone();

--- a/src/main/java/net/minestom/server/instance/palette/PaletteIndexMap.java
+++ b/src/main/java/net/minestom/server/instance/palette/PaletteIndexMap.java
@@ -83,8 +83,17 @@ final class PaletteIndexMap implements Cloneable {
         return indexToValue;
     }
 
-    public int size() {
+    int size() {
         return size;
+    }
+
+    int maxValue() {
+        int result = 0;
+        for (int index = 0; index < size; index++) {
+            final int value = indexToValue[index];
+            if (value > result) result = value;
+        }
+        return result;
     }
 
     int find(final int value) {

--- a/src/main/java/net/minestom/server/instance/palette/PaletteIndexMap.java
+++ b/src/main/java/net/minestom/server/instance/palette/PaletteIndexMap.java
@@ -113,6 +113,7 @@ final class PaletteIndexMap implements Cloneable {
         return indexToValue[index];
     }
 
+    /// Should not be modified
     int[] indexToValueArray() {
         return indexToValue;
     }

--- a/src/main/java/net/minestom/server/instance/palette/PaletteIndexMap.java
+++ b/src/main/java/net/minestom/server/instance/palette/PaletteIndexMap.java
@@ -87,15 +87,6 @@ final class PaletteIndexMap implements Cloneable {
         return size;
     }
 
-    int maxValue() {
-        int result = 0;
-        for (int index = 0; index < size; index++) {
-            final int value = indexToValue[index];
-            if (value > result) result = value;
-        }
-        return result;
-    }
-
     int find(final int value) {
         if (value == 0) return containsNullKey ? n : ~n;
         int curr;

--- a/src/main/java/net/minestom/server/instance/palette/Palettes.java
+++ b/src/main/java/net/minestom/server/instance/palette/Palettes.java
@@ -1,6 +1,7 @@
 package net.minestom.server.instance.palette;
 
 import it.unimi.dsi.fastutil.ints.Int2IntFunction;
+import net.minestom.server.utils.MathUtils;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Arrays;
@@ -44,6 +45,10 @@ public final class Palettes {
         final int elementCount = dimension * dimension * dimension;
         final int valuesPerLong = 64 / bitsPerEntry;
         return (elementCount + valuesPerLong - 1) / valuesPerLong;
+    }
+
+    public static int directBitsPerEntry(int maxValue, int maxBitsPerEntry, int directBits) {
+        return Math.clamp(64 / (64 / MathUtils.bitsToRepresent(maxValue)), maxBitsPerEntry + 1, directBits);
     }
 
     public static int read(int dimension, int bitsPerEntry, long[] values,
@@ -131,6 +136,26 @@ public final class Palettes {
             final int end = Math.min(valuesPerLong, size - idx);
             for (int j = 0; j < end; j++, idx++) {
                 if (((int) (block & mask)) == paletteIndex) result++;
+                block >>>= bitsPerEntry;
+            }
+        }
+        return result;
+    }
+
+    public static int singleValue(int dimension, int bitsPerEntry, long[] values) {
+        int result = -1;
+        final int size = dimension * dimension * dimension;
+        final int valuesPerLong = 64 / bitsPerEntry;
+        final int mask = (1 << bitsPerEntry) - 1;
+        for (int i = 0, idx = 0; i < values.length; i++) {
+            long block = values[i];
+            final int end = Math.min(valuesPerLong, size - idx);
+            for (int j = 0; j < end; j++, idx++) {
+                if (result < 0) {
+                    result = (int) (block & mask);
+                } else if (result != (block & mask)) {
+                    return -1;
+                }
                 block >>>= bitsPerEntry;
             }
         }

--- a/src/main/java/net/minestom/server/instance/palette/Palettes.java
+++ b/src/main/java/net/minestom/server/instance/palette/Palettes.java
@@ -2,9 +2,11 @@ package net.minestom.server.instance.palette;
 
 import it.unimi.dsi.fastutil.ints.Int2IntFunction;
 import net.minestom.server.utils.MathUtils;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Arrays;
 
+@ApiStatus.Internal
 public final class Palettes {
     private Palettes() {
     }
@@ -94,6 +96,20 @@ public final class Palettes {
     public static int sectionIndex(int dimension, int x, int y, int z) {
         final int dimensionBitCount = MathUtils.bitsToRepresent(dimension - 1);
         return y << (dimensionBitCount << 1) | z << dimensionBitCount | x;
+    }
+
+    // Validation
+
+    public static void validateCoord(int dimension, int x, int y, int z) {
+        if (x < 0 || y < 0 || z < 0)
+            throw new IllegalArgumentException("Coordinates must be non-negative");
+        if (x >= dimension || y >= dimension || z >= dimension)
+            throw new IllegalArgumentException("Coordinates must be less than the dimension size, got " + x + ", " + y + ", " + z + " for dimension " + dimension);
+    }
+
+    public static void validateDimension(int dimension) {
+        if (dimension <= 1 || (dimension & dimension - 1) != 0)
+            throw new IllegalArgumentException("Dimension must be a positive power of 2, got " + dimension);
     }
 
     // Optimized operations

--- a/src/main/java/net/minestom/server/instance/palette/Palettes.java
+++ b/src/main/java/net/minestom/server/instance/palette/Palettes.java
@@ -107,7 +107,13 @@ public final class Palettes {
 
     public static long[] remap(int dimension, int oldBitsPerEntry, int newBitsPerEntry,
                                long[] values, Int2IntFunction function) {
-        final long[] result = new long[arrayLength(dimension, newBitsPerEntry)];
+        return remap(dimension, oldBitsPerEntry, newBitsPerEntry, values, false, function);
+    }
+
+    public static long[] remap(int dimension, int oldBitsPerEntry, int newBitsPerEntry,
+                               long[] values, boolean forceRealloc, Int2IntFunction function) {
+        final long[] result = forceRealloc || oldBitsPerEntry != newBitsPerEntry ?
+                new long[arrayLength(dimension, newBitsPerEntry)] : values;
         final int magicMask = (1 << oldBitsPerEntry) - 1;
         final int oldValuesPerLong = 64 / oldBitsPerEntry;
         final int newValuesPerLong = 64 / newBitsPerEntry;

--- a/src/main/java/net/minestom/server/instance/palette/Palettes.java
+++ b/src/main/java/net/minestom/server/instance/palette/Palettes.java
@@ -1,7 +1,6 @@
 package net.minestom.server.instance.palette;
 
 import it.unimi.dsi.fastutil.ints.Int2IntFunction;
-import net.minestom.server.utils.MathUtils;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.Arrays;
@@ -79,8 +78,16 @@ public final class Palettes {
     }
 
     public static int sectionIndex(int dimension, int x, int y, int z) {
-        final int dimensionBitCount = MathUtils.bitsToRepresent(dimension - 1);
+        final int dimensionBitCount = dimensionBits(dimension);
         return y << (dimensionBitCount << 1) | z << dimensionBitCount | x;
+    }
+
+    public static int paletteBits(int paletteSize) {
+        return Integer.SIZE - Integer.numberOfLeadingZeros(paletteSize - 1);
+    }
+
+    public static int dimensionBits(int dimension) {
+        return Integer.numberOfTrailingZeros(dimension); // Always a power of 2
     }
 
     // Validation
@@ -90,6 +97,13 @@ public final class Palettes {
             throw new IllegalArgumentException("Coordinates must be non-negative");
         if (x >= dimension || y >= dimension || z >= dimension)
             throw new IllegalArgumentException("Coordinates must be less than the dimension size, got " + x + ", " + y + ", " + z + " for dimension " + dimension);
+    }
+
+    public static void validateValue(int value, int directBits) {
+        if (value < 0)
+            throw new IllegalArgumentException("Palette values must be non-negative");
+        if (value >= (1 << directBits))
+            throw new IllegalArgumentException("Palette values must fit in the direct bits size");
     }
 
     public static void validateDimension(int dimension) {
@@ -174,7 +188,7 @@ public final class Palettes {
         }
 
         final int dimensionMinus = dimension - 1;
-        final int dimensionBits = MathUtils.bitsToRepresent(dimension - 1);
+        final int dimensionBits = dimensionBits(dimension);
         final int finalXTravel = dimensionMinus - maxX;
         final int initialZTravel = minZ << dimensionBits;
         final int finalZTravel = (dimensionMinus - maxZ) << dimensionBits;

--- a/src/main/java/net/minestom/server/instance/palette/Palettes.java
+++ b/src/main/java/net/minestom/server/instance/palette/Palettes.java
@@ -105,6 +105,23 @@ public final class Palettes {
                     consumer.accept(x, y, z, value);
     }
 
+    public static int count(int dimension, int bitsPerEntry, long[] values, int paletteIndex) {
+        if (paletteIndex < 0) return 0;
+        int result = 0;
+        final int size = dimension * dimension * dimension;
+        final int valuesPerLong = 64 / bitsPerEntry;
+        final int mask = (1 << bitsPerEntry) - 1;
+        for (int i = 0, idx = 0; i < values.length; i++) {
+            long block = values[i];
+            int end = Math.min(valuesPerLong, size - idx);
+            for (int j = 0; j < end; j++, idx++) {
+                if (((int) (block & mask)) == paletteIndex) result++;
+                block >>>= bitsPerEntry;
+            }
+        }
+        return result;
+    }
+
     public static long[] remap(int dimension, int oldBitsPerEntry, int newBitsPerEntry,
                                long[] values, Int2IntFunction function) {
         return remap(dimension, oldBitsPerEntry, newBitsPerEntry, values, false, function);

--- a/src/main/java/net/minestom/server/instance/palette/Palettes.java
+++ b/src/main/java/net/minestom/server/instance/palette/Palettes.java
@@ -82,17 +82,6 @@ public final class Palettes {
         Arrays.fill(values, block);
     }
 
-    public static int count(int bitsPerEntry, long[] values) {
-        final int valuesPerLong = 64 / bitsPerEntry;
-        int count = 0;
-        for (long block : values) {
-            for (int i = 0; i < valuesPerLong; i++) {
-                count += (int) ((block >>> i * bitsPerEntry) & ((1 << bitsPerEntry) - 1));
-            }
-        }
-        return count;
-    }
-
     public static int sectionIndex(int dimension, int x, int y, int z) {
         final int dimensionBitCount = MathUtils.bitsToRepresent(dimension - 1);
         return y << (dimensionBitCount << 1) | z << dimensionBitCount | x;

--- a/src/test/java/net/minestom/server/instance/anvil/AnvilLoaderIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/anvil/AnvilLoaderIntegrationTest.java
@@ -207,7 +207,7 @@ public class AnvilLoaderIntegrationTest {
             Section originalSection = originalChunk.getSection(section);
             Section reloadedSection = reloadedChunk.getSection(section);
 
-            NetworkBuffer.Type<Palette> biomeSerializer = Palette.biomeSerializer(MinecraftServer.getBiomeRegistry().size());
+            NetworkBuffer.Type<Palette> biomeSerializer = Palette.biomeSerializer();
             // easiest equality check to write is a memory compare on written output
             var original = NetworkBuffer.makeArray(buffer -> {
                 buffer.write(SHORT, (short) originalSection.blockPalette().count());

--- a/src/test/java/net/minestom/server/instance/palette/PaletteCloneTest.java
+++ b/src/test/java/net/minestom/server/instance/palette/PaletteCloneTest.java
@@ -225,35 +225,6 @@ public class PaletteCloneTest {
     }
 
     @Test
-    public void cloneWithOffset() {
-        var palettes = testPalettes();
-        for (Palette original : palettes) {
-            // Set pattern and apply offset
-            original.setAll((x, y, z) -> x + y + z + 100);
-            original.offset(50);
-
-            Palette cloned = original.clone();
-
-            assertTrue(original.compare(cloned));
-
-            // Verify offset was preserved in clone
-            cloned.getAll((x, y, z, value) -> {
-                int expected = x + y + z + 100 + 50;
-                assertEquals(expected, value);
-            });
-
-            // Apply different offset to original
-            original.offset(-25);
-
-            // Verify clone is unaffected
-            cloned.getAll((x, y, z, value) -> {
-                int expected = x + y + z + 100 + 50;
-                assertEquals(expected, value);
-            });
-        }
-    }
-
-    @Test
     public void cloneWithReplace() {
         var palettes = testPalettes();
         for (Palette original : palettes) {
@@ -363,8 +334,8 @@ public class PaletteCloneTest {
             assertTrue(original.compare(cloned));
 
             // Verify independence
-            original.set(0, 0, 0, 999);
-            assertNotEquals(999, cloned.get(0, 0, 0));
+            original.set(0, 0, 0, 101);
+            assertNotEquals(101, cloned.get(0, 0, 0));
         }
     }
 

--- a/src/test/java/net/minestom/server/instance/palette/PaletteCopyTest.java
+++ b/src/test/java/net/minestom/server/instance/palette/PaletteCopyTest.java
@@ -438,4 +438,145 @@ public class PaletteCopyTest {
             assertTrue(target.compare(backup));
         }
     }
+
+    @Nested
+    @DisplayName("Offset Copy Operations")
+    class OffsetCopyOperations {
+        @Test
+        @DisplayName("Copy with positive offset")
+        void CopyWithPositiveOffset() {
+            Palette source = Palette.blocks();
+            Palette target = Palette.blocks();
+
+            source.fill(10);
+
+            target.copyFrom(source, 2, 4, 8);
+            assertEquals((16 - 2) * (16 - 4) * (16 - 8), target.count());
+
+            for (int x = 0; x < 16; x++) {
+                for (int y = 0; y < 16; y++) {
+                    for (int z = 0; z < 16; z++) {
+                        if (x < 2 || y < 4 || z < 8) {
+                            assertEquals(0, target.get(x, y, z));
+                        } else {
+                            assertEquals(10, target.get(x, y, z));
+                        }
+                    }
+                }
+            }
+        }
+
+        @Test
+        @DisplayName("Copy Multi with positive offset")
+        void copyMultiWithPositiveOffset() {
+            Palette source = Palette.blocks();
+            Palette target = Palette.blocks();
+
+            source.fill(10);
+            source.set(0, 0, 0, 11);
+            source.set(5, 5, 5, 12);
+            source.set(2, 4, 8, 13);
+
+            target.copyFrom(source, 8, 4, 2);
+            assertEquals((16 - 8) * (16 - 4) * (16 - 2), target.count());
+
+            for (int x = 0; x < 16; x++) {
+                for (int y = 0; y < 16; y++) {
+                    for (int z = 0; z < 16; z++) {
+                        if (x < 8 || y < 4 || z < 2) {
+                            assertEquals(0, target.get(x, y, z));
+                        } else if (x == 8 && y == 4 && z == 2) {
+                            assertEquals(11, target.get(x, y, z));
+                        } else if (x == (8 + 5) && y == (4 + 5) && z == (2 + 5)) {
+                            assertEquals(12, target.get(x, y, z));
+                        } else if (x == (8 + 2) && y == (4 + 4) && z == (2 + 8)) {
+                            assertEquals(13, target.get(x, y, z));
+                        } else {
+                            assertEquals(10, target.get(x, y, z));
+                        }
+                    }
+                }
+            }
+        }
+
+        @Test
+        @DisplayName("Copy with negative offset")
+        void copyWithNegativeOffset() {
+            Palette source = Palette.blocks();
+            Palette target = Palette.blocks();
+
+            source.fill(10);
+
+            target.copyFrom(source, -2, -4, -8);
+            assertEquals((16 - 2) * (16 - 4) * (16 - 8), target.count());
+
+            for (int x = 0; x < 16; x++) {
+                for (int y = 0; y < 16; y++) {
+                    for (int z = 0; z < 16; z++) {
+                        if (x >= 16 - 2 || y >= 16 - 4 || z >= 16 - 8) {
+                            assertEquals(0, target.get(x, y, z));
+                        } else {
+                            assertEquals(10, target.get(x, y, z));
+                        }
+                    }
+                }
+            }
+        }
+
+        @Test
+        @DisplayName("Copy Multi with negative offset")
+        void copyMultiWithNegativeOffset() {
+            Palette source = Palette.blocks();
+            Palette target = Palette.blocks();
+
+            source.fill(10);
+            source.set(15, 15, 15, 11);
+            source.set(10, 10, 10, 12);
+            source.set(11, 12, 13, 13);
+
+            target.copyFrom(source, -8, -4, -2);
+            assertEquals((16 - 8) * (16 - 4) * (16 - 2), target.count());
+
+            for (int x = 0; x < 16; x++) {
+                for (int y = 0; y < 16; y++) {
+                    for (int z = 0; z < 16; z++) {
+                        if (x >= 16 - 8 || y >= 16 - 4 || z >= 16 - 2) {
+                            assertEquals(0, target.get(x, y, z));
+                        } else if (x == (15 - 8) && y == (15 - 4) && z == (15 - 2)) {
+                            assertEquals(11, target.get(x, y, z));
+                        } else if (x == (10 - 8) && y == (10 - 4) && z == (10 - 2)) {
+                            assertEquals(12, target.get(x, y, z));
+                        } else if (x == (11 - 8) && y == (12 - 4) && z == (13 - 2)) {
+                            assertEquals(13, target.get(x, y, z));
+                        } else {
+                            assertEquals(10, target.get(x, y, z));
+                        }
+                    }
+                }
+            }
+        }
+
+        @Test
+        @DisplayName("Copy out of bounds")
+        void copyOutOfBounds() {
+            Palette source = Palette.blocks();
+            Palette target = Palette.blocks();
+            Palette backup = target.clone();
+
+            source.fill(16);
+            source.set(0, 0, 0, 8);
+            source.set(4, 4, 4, 9);
+            source.set(8, 8, 8, 10);
+            source.set(15, 15, 15, 11);
+
+            target.copyFrom(source, 20, 0, 0);
+            assertTrue(target.compare(backup));
+
+            target.copyFrom(source, 0, 16, 0);
+            assertTrue(target.compare(backup));
+
+            target.copyFrom(source, 0, 0, -16);
+            assertTrue(target.compare(backup));
+        }
+    }
 }

--- a/src/test/java/net/minestom/server/instance/palette/PaletteCopyTest.java
+++ b/src/test/java/net/minestom/server/instance/palette/PaletteCopyTest.java
@@ -202,23 +202,6 @@ public class PaletteCopyTest {
             assertEquals(0, target.bitsPerEntry());
             assertTrue(target.compare(source));
         }
-
-        @Test
-        @DisplayName("Copy high value entries")
-        void copyHighValueEntries() {
-            Palette source = Palette.blocks();
-            Palette target = Palette.blocks();
-
-            int highValue = 1_000_000;
-            source.set(0, 0, 0, highValue);
-            source.set(15, 15, 15, highValue + 1);
-
-            target.copyFrom(source);
-
-            assertTrue(target.compare(source));
-            assertEquals(highValue, target.get(0, 0, 0));
-            assertEquals(highValue + 1, target.get(15, 15, 15));
-        }
     }
 
     @Nested

--- a/src/test/java/net/minestom/server/instance/palette/PaletteCopyTest.java
+++ b/src/test/java/net/minestom/server/instance/palette/PaletteCopyTest.java
@@ -526,8 +526,8 @@ public class PaletteCopyTest {
         @Test
         @DisplayName("Copy Multi with negative offset")
         void copyMultiWithNegativeOffset() {
-            Palette source = Palette.blocks();
-            Palette target = Palette.blocks();
+            final Palette source = Palette.blocks();
+            final Palette target = Palette.blocks();
 
             source.fill(10);
             source.set(15, 15, 15, 11);
@@ -557,26 +557,19 @@ public class PaletteCopyTest {
         }
 
         @Test
-        @DisplayName("Copy out of bounds")
-        void copyOutOfBounds() {
-            Palette source = Palette.blocks();
-            Palette target = Palette.blocks();
-            Palette backup = target.clone();
+        @DisplayName("Copy out of bounds throws")
+        void copyOutOfBoundsThrows() {
+            final Palette source = Palette.blocks();
+            final Palette target = Palette.blocks();
 
             source.fill(16);
             source.set(0, 0, 0, 8);
             source.set(4, 4, 4, 9);
             source.set(8, 8, 8, 10);
             source.set(15, 15, 15, 11);
-
-            target.copyFrom(source, 20, 0, 0);
-            assertTrue(target.compare(backup));
-
-            target.copyFrom(source, 0, 16, 0);
-            assertTrue(target.compare(backup));
-
-            target.copyFrom(source, 0, 0, -16);
-            assertTrue(target.compare(backup));
+            assertThrows(IllegalArgumentException.class, () -> target.copyFrom(source, 20, 0, 0));
+            assertThrows(IllegalArgumentException.class, () -> target.copyFrom(source, 0, 16, 0));
+            assertThrows(IllegalArgumentException.class, () -> target.copyFrom(source, 0, 0, -16));
         }
     }
 }

--- a/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
+++ b/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
@@ -1106,10 +1106,12 @@ public class PaletteTest {
 
     @Test
     public void fillHighValue() {
-        final Palette palette = Palette.blocks();
+        final PaletteImpl palette = (PaletteImpl) Palette.blocks();
 
         palette.fill(1 << 20);
         palette.set(0, 0, 0, 10);
+
+        palette.makeDirect();
 
         assertEquals(10, palette.get(0, 0, 0));
         assertEquals(1 << 20, palette.get(1, 1, 1));

--- a/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
+++ b/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
@@ -1022,61 +1022,28 @@ public class PaletteTest {
     }
 
     @Test
-    public void partialFillClipsOutOfBounds() {
-        for (Palette palette : testPalettes()) {
-            final int dimension = palette.dimension();
-            final int dimensionMinus = dimension - 1;
+    public void partialFillThrowsOutOfBounds() {
+        final Palette palette = Palette.blocks();
+        assertThrows(Exception.class, () -> palette.fill(-1, 0, 0, 0, 0, 0, 10));
+        assertThrows(Exception.class, () -> palette.fill(0, 0, 0, 16, 0, 0, 11));
+        assertThrows(Exception.class, () -> palette.fill(0, 0, 0, 100, 0, 0, 12));
+    }
 
-            palette.fill(1, 1, 1, 100, 100, 100, 10);
-            assertEquals(dimensionMinus * dimensionMinus * dimensionMinus, palette.count());
-
-            for (int x = 0; x < dimension; x++) {
-                for (int y = 0; y < dimension; y++) {
-                    for (int z = 0; z < dimension; z++) {
-                        if (x == 0 || y == 0 || z == 0) {
-                            assertEquals(0, palette.get(x, y, z));
-                        } else {
-                            assertEquals(10, palette.get(x, y, z));
-                        }
-                    }
-                }
-            }
-        }
+    @Test
+    public void partialFillThrowsUnordered() {
+        final Palette palette = Palette.blocks();
+        assertThrows(Exception.class, () -> palette.fill(10, 0, 0, 0, 10, 10, 1));
+        assertDoesNotThrow(() -> palette.fill(0, 2, 4, 0, 2, 4, 2));
     }
 
     @Test
     public void partialFillDoesTotalFill() {
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             final int dimension = palette.dimension();
             final int dimensionMinus = dimension - 1;
 
             palette.fill(0, 0, 0, dimensionMinus, dimensionMinus, dimensionMinus, 10);
             assertEquals(10, palette.singleValue());
-
-            palette.fill(-100, -100, -100, 100, 100, 100, 11);
-            assertEquals(11, palette.singleValue());
-        }
-    }
-
-    @Test
-    public void partialFillOrdersCoordinates() {
-        for (Palette palette : testPalettes()) {
-            final int dimension = palette.dimension();
-
-            palette.fill(1, 1, 1, 0, 0, 0, 10);
-            assertEquals(2 * 2 * 2, palette.count());
-
-            for (int x = 0; x < dimension; x++) {
-                for (int y = 0; y < dimension; y++) {
-                    for (int z = 0; z < dimension; z++) {
-                        if (x > 1 || y > 1 || z > 1) {
-                            assertEquals(0, palette.get(x, y, z));
-                        } else {
-                            assertEquals(10, palette.get(x, y, z));
-                        }
-                    }
-                }
-            }
         }
     }
 

--- a/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
+++ b/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
@@ -691,7 +691,7 @@ public class PaletteTest {
         assertEquals(15, palette.bitsPerEntry());
 
         // Should not have a palette anymore (direct mode)
-        assertNull(((PaletteImpl) palette).paletteToValueList);
+        assertNull(((PaletteImpl) palette).paletteIndexMap);
     }
 
     @Test
@@ -717,15 +717,15 @@ public class PaletteTest {
         assertEquals(3, palette.bitsPerEntry());
 
         // Should have palette
-        assertNotNull(((PaletteImpl) palette).paletteToValueList);
+        assertNotNull(((PaletteImpl) palette).paletteIndexMap);
 
         // Verify palette contents
-        assertEquals(5, ((PaletteImpl) palette).paletteToValueList.size());
-        assertEquals(0, ((PaletteImpl) palette).paletteToValueList.getInt(0));
-        assertEquals(10, ((PaletteImpl) palette).paletteToValueList.getInt(1));
-        assertEquals(20, ((PaletteImpl) palette).paletteToValueList.getInt(2));
-        assertEquals(30, ((PaletteImpl) palette).paletteToValueList.getInt(3));
-        assertEquals(40, ((PaletteImpl) palette).paletteToValueList.getInt(4));
+        assertEquals(5,  ((PaletteImpl) palette).paletteIndexMap.size());
+        assertEquals(0,  ((PaletteImpl) palette).paletteIndexMap.valueToIndexOrDefault(0));
+        assertEquals(10, ((PaletteImpl) palette).paletteIndexMap.valueToIndexOrDefault(1));
+        assertEquals(20, ((PaletteImpl) palette).paletteIndexMap.valueToIndexOrDefault(2));
+        assertEquals(30, ((PaletteImpl) palette).paletteIndexMap.valueToIndexOrDefault(3));
+        assertEquals(40, ((PaletteImpl) palette).paletteIndexMap.valueToIndexOrDefault(4));
     }
 
     @Test
@@ -742,8 +742,8 @@ public class PaletteTest {
         assertEquals(3, palette.bitsPerEntry());
 
         // Should have palette
-        assertNotNull(((PaletteImpl) palette).paletteToValueList);
-        assertEquals(8, ((PaletteImpl) palette).paletteToValueList.size());
+        assertNotNull(((PaletteImpl) palette).paletteIndexMap);
+        assertEquals(8, ((PaletteImpl) palette).paletteIndexMap.size());
     }
 
     @Test
@@ -763,8 +763,8 @@ public class PaletteTest {
         assertEquals(4, palette.bitsPerEntry());
 
         // Should still have palette (not direct)
-        assertNotNull(((PaletteImpl) palette).paletteToValueList);
-        assertEquals(16, ((PaletteImpl) palette).paletteToValueList.size());
+        assertNotNull(((PaletteImpl) palette).paletteIndexMap);
+        assertEquals(16, ((PaletteImpl) palette).paletteIndexMap.size());
     }
 
     @Test
@@ -781,9 +781,9 @@ public class PaletteTest {
         assertEquals(1, palette.bitsPerEntry());
 
         // Should have palette with single entry
-        assertNotNull(((PaletteImpl) palette).paletteToValueList);
-        assertEquals(1, ((PaletteImpl) palette).paletteToValueList.size());
-        assertEquals(0, ((PaletteImpl) palette).paletteToValueList.getInt(0));
+        assertNotNull(((PaletteImpl) palette).paletteIndexMap);
+        assertEquals(1, ((PaletteImpl) palette).paletteIndexMap.size());
+        assertEquals(0, ((PaletteImpl) palette).paletteIndexMap.valueToIndexOrDefault(0));
     }
 
     @Test
@@ -846,8 +846,8 @@ public class PaletteTest {
 
         // Should not have indirect palette structures (direct mode)
         PaletteImpl impl = (PaletteImpl) palette;
-        assertNull(impl.paletteToValueList,
-                "Direct palette should not have paletteToValueList");
+        assertNull(impl.paletteIndexMap,
+                "Direct palette should not have paletteIndexMap");
 
         // Verify we can still read some values correctly
         // In direct mode, palette indices become the actual values

--- a/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
+++ b/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
@@ -1078,7 +1078,61 @@ public class PaletteTest {
                 }
             }
         }
+    }
 
+    @Test
+    public void bulkPlacementHighValue() {
+        int value = 1 << 16;
+        for (Palette palette : testPalettes()) {
+            final int dimension = palette.dimension();
+
+            for (int x = 0, idx = 0; x < dimension; x++) {
+                for (int y = 0; y < dimension; y++) {
+                    for (int z = 0; z < dimension; z++, idx++) {
+                        palette.set(x, y, z, value + idx);
+                    }
+                }
+            }
+
+            for (int x = 0, idx = 0; x < dimension; x++) {
+                for (int y = 0; y < dimension; y++) {
+                    for (int z = 0; z < dimension; z++, idx++) {
+                        assertEquals(value + idx, palette.get(x, y, z));
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void fillHighValue() {
+        final Palette palette = Palette.blocks();
+
+        palette.fill(1 << 20);
+        palette.set(0, 0, 0, 10);
+
+        assertEquals(10, palette.get(0, 0, 0));
+        assertEquals(1 << 20, palette.get(1, 1, 1));
+    }
+
+    @Test
+    public void setAllHighValue() {
+        final Palette palette = Palette.blocks();
+        final int value = 1 << 16;
+        final AtomicInteger index = new AtomicInteger();
+        palette.setAll((_, _, _) -> {
+            final int idx = index.getPlain();
+            index.setPlain(idx + 1);
+            return value + idx;
+        });
+
+        for (int y = 0, idx = 0; y < 16; y++) {
+            for (int z = 0; z < 16; z++) {
+                for (int x = 0; x < 16; x++, idx++) {
+                    assertEquals(value + idx, palette.get(x, y, z));
+                }
+            }
+        }
     }
 
     private static List<Palette> testPalettes() {

--- a/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
+++ b/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
@@ -721,11 +721,11 @@ public class PaletteTest {
 
         // Verify palette contents
         assertEquals(5,  ((PaletteImpl) palette).paletteIndexMap.size());
-        assertEquals(0,  ((PaletteImpl) palette).paletteIndexMap.valueToIndexOrDefault(0));
-        assertEquals(10, ((PaletteImpl) palette).paletteIndexMap.valueToIndexOrDefault(1));
-        assertEquals(20, ((PaletteImpl) palette).paletteIndexMap.valueToIndexOrDefault(2));
-        assertEquals(30, ((PaletteImpl) palette).paletteIndexMap.valueToIndexOrDefault(3));
-        assertEquals(40, ((PaletteImpl) palette).paletteIndexMap.valueToIndexOrDefault(4));
+        assertEquals(0,  ((PaletteImpl) palette).paletteIndexMap.indexToValue(0));
+        assertEquals(10, ((PaletteImpl) palette).paletteIndexMap.indexToValue(1));
+        assertEquals(20, ((PaletteImpl) palette).paletteIndexMap.indexToValue(2));
+        assertEquals(30, ((PaletteImpl) palette).paletteIndexMap.indexToValue(3));
+        assertEquals(40, ((PaletteImpl) palette).paletteIndexMap.indexToValue(4));
     }
 
     @Test

--- a/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
+++ b/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
@@ -1105,6 +1105,19 @@ public class PaletteTest {
     }
 
     @Test
+    public void directPlacementHighValue() {
+        final PaletteImpl palette = (PaletteImpl) Palette.blocks();
+
+        palette.makeDirect();
+        assertEquals(Palette.BLOCK_PALETTE_DIRECT_BITS, palette.bitsPerEntry());
+
+        palette.set(0, 0, 0, 1 << 20);
+        assertEquals(21, palette.bitsPerEntry()); // 1 << 20 needs 21 bits to represent
+
+        assertEquals(1 << 20, palette.get(0, 0, 0));
+    }
+
+    @Test
     public void fillHighValue() {
         final PaletteImpl palette = (PaletteImpl) Palette.blocks();
 

--- a/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
+++ b/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
@@ -17,14 +17,14 @@ public class PaletteTest {
 
     @Test
     public void singlePlacement() {
-        var palette = Palette.blocks();
+        final var palette = Palette.blocks();
         palette.set(0, 0, 1, 1);
         assertEquals(1, palette.get(0, 0, 1));
     }
 
     @Test
     public void placement() {
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             assertEquals(0, palette.get(0, 0, 0), "Default value should be 0");
             assertEquals(0, palette.count());
             palette.set(0, 0, 0, 64);
@@ -55,17 +55,8 @@ public class PaletteTest {
     }
 
     @Test
-    public void placementHighValue() {
-        final int value = 250_000;
-        for (Palette palette : testPalettes()) {
-            palette.set(0, 0, 1, value);
-            assertEquals(value, palette.get(0, 0, 1));
-        }
-    }
-
-    @Test
     public void negPlacement() {
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             assertThrows(IllegalArgumentException.class, () -> palette.set(-1, 0, 0, 64));
             assertThrows(IllegalArgumentException.class, () -> palette.set(0, -1, 0, 64));
             assertThrows(IllegalArgumentException.class, () -> palette.set(0, 0, -1, 64));
@@ -78,7 +69,7 @@ public class PaletteTest {
 
     @Test
     public void resize() {
-        Palette palette = Palette.sized(16, 1, 5, 15, 2);
+        final Palette palette = Palette.sized(16, 1, 5, 15, 2);
         palette.set(0, 0, 0, 1);
         assertEquals(2, palette.bitsPerEntry());
         palette.set(0, 0, 1, 2);
@@ -96,7 +87,7 @@ public class PaletteTest {
 
     @Test
     public void fill() {
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             assertEquals(0, palette.count());
             palette.set(0, 0, 0, 5);
             assertEquals(1, palette.count());
@@ -125,96 +116,8 @@ public class PaletteTest {
     }
 
     @Test
-    public void offset() {
-        for (Palette palette : testPalettes()) {
-            palette.fill(0);
-            palette.offset(1);
-            for (int x = 0; x < palette.dimension(); x++) {
-                for (int y = 0; y < palette.dimension(); y++) {
-                    for (int z = 0; z < palette.dimension(); z++) {
-                        assertEquals(1, palette.get(x, y, z));
-                    }
-                }
-            }
-
-            palette.fill(1);
-            palette.set(0, 0, 1, 2);
-            palette.offset(-1);
-            for (int x = 0; x < palette.dimension(); x++) {
-                for (int y = 0; y < palette.dimension(); y++) {
-                    for (int z = 0; z < palette.dimension(); z++) {
-                        if (x == 0 && y == 0 && z == 1) {
-                            assertEquals(1, palette.get(x, y, z));
-                        } else {
-                            assertEquals(0, palette.get(x, y, z));
-                        }
-                    }
-                }
-            }
-        }
-        for (Palette palette : testPalettes()) {
-            palette.setAll((x, y, z) -> x + y + z + 100);
-            palette.offset(50);
-            palette.getAll((x, y, z, value) -> {
-                int expected = x + y + z + 100 + 50;
-                assertEquals(expected, value);
-            });
-        }
-
-        for (Palette palette : testPalettes()) {
-            palette.set(0, 0, 1, 1);
-            palette.set(0, 1, 0, 2);
-            palette.set(1, 0, 0, 3);
-            palette.offset(50);
-            palette.getAll((x, y, z, value) -> {
-                if (x == 0 && y == 0 && z == 1) {
-                    assertEquals(51, value);
-                } else if (x == 0 && y == 1 && z == 0) {
-                    assertEquals(52, value);
-                } else if (x == 1 && y == 0 && z == 0) {
-                    assertEquals(53, value);
-                } else {
-                    assertEquals(50, value);
-                }
-            });
-        }
-    }
-
-    @Test
-    public void offsetCount() {
-        for (Palette palette : testPalettes()) {
-            assertEquals(0, palette.count());
-            palette.fill(0);
-            assertEquals(0, palette.count());
-            palette.offset(1);
-            assertEquals(palette.maxSize(), palette.count());
-            palette.offset(-1);
-            assertEquals(0, palette.count());
-        }
-        for (Palette palette : testPalettes()) {
-            palette.fill(1);
-            assertEquals(palette.maxSize(), palette.count());
-            palette.set(0, 0, 1, 2);
-            palette.set(0, 1, 0, 3);
-            palette.set(1, 0, 0, 4);
-            palette.offset(-1);
-            assertEquals(3, palette.count());
-            palette.offset(1);
-            assertEquals(palette.maxSize(), palette.count());
-        }
-        for (Palette palette : testPalettes()) {
-            palette.setAll((x, y, z) -> x + y + z + 100);
-            assertEquals(palette.maxSize(), palette.count());
-            palette.offset(50);
-            assertEquals(palette.maxSize(), palette.count());
-            palette.offset(-50);
-            assertEquals(palette.maxSize(), palette.count());
-        }
-    }
-
-    @Test
     public void replace() {
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             palette.fill(0);
             palette.replace(0, 1);
             for (int x = 0; x < palette.dimension(); x++) {
@@ -241,7 +144,7 @@ public class PaletteTest {
             }
         }
 
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             palette.set(0, 0, 1, 1);
             palette.set(0, 1, 0, 2);
             palette.set(1, 0, 0, 3);
@@ -262,14 +165,14 @@ public class PaletteTest {
 
     @Test
     public void replaceCount() {
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             palette.fill(0);
             palette.replace(0, 1);
             assertEquals(palette.maxSize(), palette.count());
             palette.replace(1, 0);
             assertEquals(0, palette.count());
         }
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             palette.set(0, 0, 1, 1);
             palette.set(1, 1, 1, 1);
             palette.set(0, 1, 0, 2);
@@ -278,7 +181,7 @@ public class PaletteTest {
             palette.replace(1, 0);
             assertEquals(2, palette.count());
         }
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             palette.setAll((x, y, z) -> x + y + z + 100);
             assertEquals(palette.maxSize(), palette.count());
             palette.replace(100, 0);
@@ -288,18 +191,18 @@ public class PaletteTest {
 
     @Test
     public void countValue() {
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             assertEquals(palette.maxSize(), palette.count(0));
             assertEquals(0, palette.count(1));
         }
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             palette.fill(0);
             assertEquals(palette.maxSize(), palette.count(0));
             palette.replace(0, 1);
             assertEquals(0, palette.count(0));
             assertEquals(palette.maxSize(), palette.count(1));
         }
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             palette.set(0, 0, 1, 1);
             palette.set(1, 1, 1, 1);
             palette.set(0, 1, 0, 2);
@@ -310,7 +213,7 @@ public class PaletteTest {
             assertEquals(1, palette.count(3));
             assertEquals(0, palette.count(4));
         }
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             palette.setAll((x, y, z) -> x + y + z + 100);
             assertEquals(0, palette.count(0));
             assertEquals(1, palette.count(100));
@@ -319,7 +222,7 @@ public class PaletteTest {
 
     @Test
     public void anyValue() {
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             // Initially all zero
             assertFalse(palette.any(1));
             assertTrue(palette.any(0));
@@ -338,7 +241,7 @@ public class PaletteTest {
             assertFalse(palette.any(1));
             assertTrue(palette.any(2));
         }
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             palette.fill(5);
             assertTrue(palette.any(5));
             assertFalse(palette.any(0));
@@ -346,7 +249,7 @@ public class PaletteTest {
             assertFalse(palette.any(5));
             assertTrue(palette.any(0));
         }
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             palette.setAll((x, y, z) -> (x + y + z) % 3);
             assertTrue(palette.any(0));
             assertTrue(palette.any(1));
@@ -357,21 +260,13 @@ public class PaletteTest {
 
     @Test
     public void countValueEdgeCases() {
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             // All zero
             assertEquals(palette.maxSize(), palette.count(0));
             assertEquals(0, palette.count(-1));
             assertEquals(0, palette.count(Integer.MAX_VALUE));
-            // Fill with negative value
-            palette.fill(-7);
-            assertEquals(palette.maxSize(), palette.count(-7));
-            assertEquals(0, palette.count(0));
-            // Fill with max int
-            palette.fill(Integer.MAX_VALUE);
-            assertEquals(palette.maxSize(), palette.count(Integer.MAX_VALUE));
-            assertEquals(0, palette.count(0));
         }
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             palette.setAll((x, y, z) -> (x == 0 && y == 0 && z == 0) ? 42 : 0);
             assertEquals(1, palette.count(42));
             assertEquals(palette.maxSize() - 1, palette.count(0));
@@ -380,7 +275,7 @@ public class PaletteTest {
 
     @Test
     public void bulk() {
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             final int dimension = palette.dimension();
             // Place
             for (int x = 0; x < dimension; x++) {
@@ -404,7 +299,7 @@ public class PaletteTest {
 
     @Test
     public void bulkAll() {
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             // Fill all entries
             palette.setAll((x, y, z) -> x + y + z + 1);
             palette.getAll((x, y, z, value) -> assertEquals(x + y + z + 1, value,
@@ -418,7 +313,7 @@ public class PaletteTest {
             palette.getAll((x, y, z, value) -> assertEquals(x + y + z + 2, value));
         }
 
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             palette.setAll((x, y, z) -> x + y + z + 100);
             assertEquals(100, palette.get(0, 0, 0));
             palette.getAll((x, y, z, value) -> assertEquals(x + y + z + 100, value,
@@ -428,17 +323,17 @@ public class PaletteTest {
 
     @Test
     public void bulkAllOrder() {
-        for (Palette palette : testPalettes()) {
-            AtomicInteger count = new AtomicInteger();
+        for (final Palette palette : testPalettes()) {
+            final AtomicInteger count = new AtomicInteger();
 
             // Ensure that the lambda is called for every entry
             // even if the array is initialized
-            palette.getAll((x, y, z, value) -> count.incrementAndGet());
+            palette.getAll((_, _, _, _) -> count.incrementAndGet());
             assertEquals(count.get(), palette.maxSize());
 
             // Fill all entries
             count.set(0);
-            Set<Point> points = new HashSet<>();
+            final Set<Point> points = new HashSet<>();
             palette.setAll((x, y, z) -> {
                 assertTrue(points.add(new Vec(x, y, z)), "Duplicate point: " + x + ", " + y + ", " + z + ", dimension " + palette.dimension());
                 return count.incrementAndGet();
@@ -447,38 +342,38 @@ public class PaletteTest {
             assertEquals(palette.count(), count.get());
 
             count.set(0);
-            palette.getAll((x, y, z, value) -> assertEquals(count.incrementAndGet(), value));
+            palette.getAll((_, _, _, value) -> assertEquals(count.incrementAndGet(), value));
             assertEquals(count.get(), palette.count());
 
             // Replacing
             count.set(0);
-            palette.replaceAll((x, y, z, value) -> {
+            palette.replaceAll((_, _, _, value) -> {
                 assertEquals(count.incrementAndGet(), value);
                 return count.get();
             });
             assertEquals(count.get(), palette.count());
 
             count.set(0);
-            palette.getAll((x, y, z, value) -> assertEquals(count.incrementAndGet(), value));
+            palette.getAll((_, _, _, value) -> assertEquals(count.incrementAndGet(), value));
         }
     }
 
     @Test
     public void setAllConstant() {
-        for (Palette palette : testPalettes()) {
-            palette.setAll((x, y, z) -> 1);
-            palette.getAll((x, y, z, value) -> assertEquals(1, value));
+        for (final Palette palette : testPalettes()) {
+            palette.setAll((_, _, _) -> 1);
+            palette.getAll((_, _, _, value) -> assertEquals(1, value));
         }
     }
 
     @Test
     public void setAllBig() {
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             palette.setAll((x, y, z) -> x + y + z + 100);
             assertEquals(palette.maxSize(), palette.count());
             assertEquals(100, palette.get(0, 0, 0));
             palette.getAll((x, y, z, value) -> {
-                int expected = x + y + z + 100;
+                final int expected = x + y + z + 100;
                 assertEquals(expected, value);
             });
         }
@@ -486,15 +381,15 @@ public class PaletteTest {
 
     @Test
     public void getAllEmpty() {
-        for (Palette palette : testPalettes()) {
-            palette.getAll((x, y, z, value) -> assertEquals(0, value));
+        for (final Palette palette : testPalettes()) {
+            palette.getAll((_, _, _, value) -> assertEquals(0, value));
         }
     }
 
     @Test
     public void getAllPresent() {
-        for (Palette palette : testPalettes()) {
-            palette.getAllPresent((x, y, z, value) -> fail("The palette should be empty"));
+        for (final Palette palette : testPalettes()) {
+            palette.getAllPresent((_, _, _, _) -> fail("The palette should be empty"));
             palette.set(0, 0, 1, 1);
             palette.getAllPresent((x, y, z, value) -> {
                 assertEquals(0, x);
@@ -507,7 +402,7 @@ public class PaletteTest {
 
     @Test
     public void replaceAll() {
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             palette.setAll((x, y, z) -> x + y + z + 1);
             palette.replaceAll((x, y, z, value) -> {
                 assertEquals(x + y + z + 1, value);
@@ -516,28 +411,28 @@ public class PaletteTest {
             palette.getAll((x, y, z, value) -> assertEquals(x + y + z + 2, value));
         }
 
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             palette.fill(0);
-            palette.replaceAll((x, y, z, value) -> {
+            palette.replaceAll((_, _, _, value) -> {
                 assertEquals(0, value);
                 return value + 1;
             });
-            palette.getAll((x, y, z, value) -> assertEquals(1, value));
+            palette.getAll((_, _, _, value) -> assertEquals(1, value));
         }
 
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             palette.fill(1);
-            palette.replaceAll((x, y, z, value) -> {
+            palette.replaceAll((_, _, _, value) -> {
                 assertEquals(1, value);
                 return value + 1;
             });
-            palette.getAll((x, y, z, value) -> assertEquals(2, value));
+            palette.getAll((_, _, _, value) -> assertEquals(2, value));
         }
     }
 
     @Test
     public void replaceUnary() {
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             palette.set(0, 0, 0, 1);
             palette.replace(0, 0, 0, operand -> {
                 assertEquals(1, operand);
@@ -549,7 +444,7 @@ public class PaletteTest {
 
     @Test
     public void replaceLoop() {
-        var palette = Palette.sized(2, 1, 8, 15, 4);
+        final var palette = Palette.sized(2, 1, 8, 15, 4);
         palette.setAll((x, y, z) -> x + y + z);
         final int dimension = palette.dimension();
         for (int x = 0; x < dimension; x++) {
@@ -575,84 +470,84 @@ public class PaletteTest {
 
     @Test
     public void serializationBlockEmpty() {
-        NetworkBuffer buffer = NetworkBuffer.resizableBuffer();
-        Palette palette = Palette.blocks();
+        final NetworkBuffer buffer = NetworkBuffer.resizableBuffer();
+        final Palette palette = Palette.blocks();
         buffer.write(Palette.BLOCK_SERIALIZER, palette);
 
-        Palette deserialized = buffer.read(Palette.BLOCK_SERIALIZER);
+        final Palette deserialized = buffer.read(Palette.BLOCK_SERIALIZER);
         assertTrue(palette.compare(deserialized));
     }
 
     @Test
     public void serializationBlockPalette() {
-        NetworkBuffer buffer = NetworkBuffer.resizableBuffer();
-        Palette palette = Palette.blocks();
+        final NetworkBuffer buffer = NetworkBuffer.resizableBuffer();
+        final Palette palette = Palette.blocks();
         palette.set(0, 0, 0, 1);
         palette.set(1, 0, 0, 2);
         buffer.write(Palette.BLOCK_SERIALIZER, palette);
 
-        Palette deserialized = buffer.read(Palette.BLOCK_SERIALIZER);
+        final Palette deserialized = buffer.read(Palette.BLOCK_SERIALIZER);
         assertTrue(palette.compare(deserialized));
     }
 
     @Test
     public void serializationBlockDirect() {
-        NetworkBuffer buffer = NetworkBuffer.resizableBuffer();
-        Random random = new Random(12345);
-        Palette palette = Palette.blocks();
-        palette.setAll((x, y, z) -> random.nextInt(2048));
+        final NetworkBuffer buffer = NetworkBuffer.resizableBuffer();
+        final Random random = new Random(12345);
+        final Palette palette = Palette.blocks();
+        palette.setAll((_, _, _) -> random.nextInt(2048));
 
         buffer.write(Palette.BLOCK_SERIALIZER, palette);
 
-        Palette deserialized = buffer.read(Palette.BLOCK_SERIALIZER);
+        final Palette deserialized = buffer.read(Palette.BLOCK_SERIALIZER);
         assertTrue(palette.compare(deserialized));
     }
 
     @Test
     public void serializationBiomeEmpty() {
-        final var serializer = Palette.biomeSerializer(128);
-        NetworkBuffer buffer = NetworkBuffer.resizableBuffer();
-        Palette palette = Palette.biomes();
+        final var serializer = Palette.biomeSerializer();
+        final NetworkBuffer buffer = NetworkBuffer.resizableBuffer();
+        final Palette palette = Palette.biomes();
         buffer.write(serializer, palette);
 
-        Palette deserialized = buffer.read(serializer);
+        final Palette deserialized = buffer.read(serializer);
         assertTrue(palette.compare(deserialized));
     }
 
     @Test
     public void serializationBiomePalette() {
-        final var serializer = Palette.biomeSerializer(128);
-        NetworkBuffer buffer = NetworkBuffer.resizableBuffer();
-        Palette palette = Palette.biomes();
+        final var serializer = Palette.biomeSerializer();
+        final NetworkBuffer buffer = NetworkBuffer.resizableBuffer();
+        final Palette palette = Palette.biomes();
         palette.set(0, 0, 0, 1);
         palette.set(1, 0, 0, 2);
         buffer.write(serializer, palette);
 
-        Palette deserialized = buffer.read(serializer);
+        final Palette deserialized = buffer.read(serializer);
         assertTrue(palette.compare(deserialized));
     }
 
     @Test
     public void serializationBiomeDirect() {
-        final var serializer = Palette.biomeSerializer(128);
-        NetworkBuffer buffer = NetworkBuffer.resizableBuffer();
-        Palette palette = Palette.biomes();
-        Random random = new Random(12345);
-        palette.setAll((_, _, _) -> random.nextInt(2048));
+        final var serializer = Palette.biomeSerializer();
+        final NetworkBuffer buffer = NetworkBuffer.resizableBuffer();
+        final Palette palette = Palette.biomes();
+        final Random random = new Random(12345);
+        palette.setAll((_, _, _) -> random.nextInt(128));
 
         buffer.write(serializer, palette);
 
-        Palette deserialized = buffer.read(serializer);
+        final Palette deserialized = buffer.read(serializer);
         assertTrue(palette.compare(deserialized));
     }
 
     @Test
     public void loadBelowMinBitsPerEntry() {
         // Test loading with bpe below minBitsPerEntry - should resize to minBitsPerEntry
-        Palette palette = Palette.sized(4, 4, 8, 15, 4); // min=4, max=8, direct=15
+        final Palette palette = Palette.sized(4, 4, 8, 15, 4); // min=4, max=8, direct=15
 
-        int[] paletteData = {0, 1, 2, 3}; // 4 values need 2 bits, but min is 4
-        long[] values = new long[]{0x3210L}; // packed with 2 bits per entry
+        final int[] paletteData = {0, 1, 2, 3}; // 4 values need 2 bits, but min is 4
+        final long[] values = new long[]{0x3210L}; // packed with 2 bits per entry
 
         palette.load(paletteData, values);
 
@@ -669,19 +564,19 @@ public class PaletteTest {
     @Test
     public void loadAboveMaxBitsPerEntry() {
         // Test loading with bpe above maxBitsPerEntry - should become direct palette
-        Palette palette = Palette.sized(4, 1, 3, 15, 1); // min=1, max=3, direct=15
+        final Palette palette = Palette.sized(4, 1, 3, 15, 1); // min=1, max=3, direct=15
 
         // Create palette that would need more than 3 bits (max) - 16 values need 4 bits
-        int[] paletteData = new int[16];
+        final int[] paletteData = new int[16];
         for (int i = 0; i < 16; i++) {
             paletteData[i] = i + 100; // arbitrary values
         }
 
         // Create values array with 4 bits per entry
-        long[] values = new long[4]; // 64 entries, 4 bits each = 16 longs per entry, 4 longs total
+        final long[] values = new long[4]; // 64 entries, 4 bits each = 16 longs per entry, 4 longs total
         for (int i = 0; i < 64; i++) {
-            int longIndex = i / 16;
-            int bitIndex = (i % 16) * 4;
+            final int longIndex = i / 16;
+            final int bitIndex = (i % 16) * 4;
             values[longIndex] |= ((long) (i % 16)) << bitIndex;
         }
 
@@ -697,15 +592,15 @@ public class PaletteTest {
     @Test
     public void loadWithinRange() {
         // Test loading with bpe within min-max range - should use calculated bpe
-        Palette palette = Palette.sized(4, 2, 6, 15, 2); // min=2, max=6, direct=15
+        final Palette palette = Palette.sized(4, 2, 6, 15, 2); // min=2, max=6, direct=15
 
-        int[] paletteData = {0, 10, 20, 30, 40}; // 5 values need 3 bits
-        long[] values = new long[12]; // 64 entries, 3 bits each
+        final int[] paletteData = {0, 10, 20, 30, 40}; // 5 values need 3 bits
+        final long[] values = new long[12]; // 64 entries, 3 bits each
 
         // Fill with some test pattern
         for (int i = 0; i < 64; i++) {
-            int longIndex = i / 21; // 21 values per long with 3 bits each (63 bits used)
-            int bitIndex = (i % 21) * 3;
+            final int longIndex = i / 21; // 21 values per long with 3 bits each (63 bits used)
+            final int bitIndex = (i % 21) * 3;
             values[longIndex] |= ((long) (i % 5)) << bitIndex;
         }
 
@@ -729,10 +624,10 @@ public class PaletteTest {
     @Test
     public void loadExactlyMinBitsPerEntry() {
         // Test loading where calculated bpe equals minBitsPerEntry
-        Palette palette = Palette.sized(4, 3, 8, 15, 3); // min=3, max=8, direct=15
+        final Palette palette = Palette.sized(4, 3, 8, 15, 3); // min=3, max=8, direct=15
 
-        int[] paletteData = {0, 1, 2, 3, 4, 5, 6, 7}; // 8 values need exactly 3 bits
-        long[] values = new long[12]; // 64 entries, 3 bits each
+        final int[] paletteData = {0, 1, 2, 3, 4, 5, 6, 7}; // 8 values need exactly 3 bits
+        final long[] values = new long[12]; // 64 entries, 3 bits each
 
         palette.load(paletteData, values);
 
@@ -747,13 +642,13 @@ public class PaletteTest {
     @Test
     public void loadExactlyMaxBitsPerEntry() {
         // Test loading where calculated bpe equals maxBitsPerEntry
-        Palette palette = Palette.sized(4, 2, 4, 15, 2); // min=2, max=4, direct=15
+        final Palette palette = Palette.sized(4, 2, 4, 15, 2); // min=2, max=4, direct=15
 
-        int[] paletteData = new int[16]; // 16 values need exactly 4 bits
+        final int[] paletteData = new int[16]; // 16 values need exactly 4 bits
         for (int i = 0; i < 16; i++) {
             paletteData[i] = i * 10;
         }
-        long[] values = new long[16]; // 64 entries, 4 bits each
+        final long[] values = new long[16]; // 64 entries, 4 bits each
 
         palette.load(paletteData, values);
 
@@ -768,10 +663,10 @@ public class PaletteTest {
     @Test
     public void loadEmptyPalette() {
         // Test loading with empty palette
-        Palette palette = Palette.sized(4, 1, 8, 15, 1);
+        final Palette palette = Palette.sized(4, 1, 8, 15, 1);
 
-        int[] paletteData = {0}; // Single value palette
-        long[] values = new long[4]; // All zeros
+        final int[] paletteData = {0}; // Single value palette
+        final long[] values = new long[4]; // All zeros
 
         palette.load(paletteData, values);
 
@@ -787,10 +682,10 @@ public class PaletteTest {
     @Test
     public void loadValuesCloned() {
         // Test that values array is properly cloned
-        Palette palette = Palette.sized(4, 2, 6, 15, 2);
+        final Palette palette = Palette.sized(4, 2, 6, 15, 2);
 
-        int[] paletteData = {0, 1, 2};
-        long[] originalValues = {0x123456789ABCDEFL, 0xFEDCBA9876543210L};
+        final int[] paletteData = {0, 1, 2};
+        final long[] originalValues = {0x123456789ABCDEFL, 0xFEDCBA9876543210L};
 
         palette.load(paletteData, originalValues);
 
@@ -799,7 +694,7 @@ public class PaletteTest {
         originalValues[1] = 0L;
 
         // Palette should still have the original values
-        long[] paletteValues = palette.indexedValues();
+        final long[] paletteValues = palette.indexedValues();
         assertNotNull(paletteValues);
         assertEquals(0x123456789ABCDEFL, paletteValues[0]);
         assertEquals(0xFEDCBA9876543210L, paletteValues[1]);
@@ -808,31 +703,31 @@ public class PaletteTest {
     @Test
     public void loadThousandsOfIndicesBecomesDirectPalette() {
         // Test loading with thousands of indices to ensure it becomes a direct palette
-        Palette palette = Palette.blocks(); // min=4, max=8, direct=15
+        final Palette palette = Palette.blocks(); // min=4, max=8, direct=15
 
         // Create palette with thousands of unique values (way more than max palette size of 2^8=256)
         final int uniqueValueCount = 5000;
-        int[] paletteData = new int[uniqueValueCount];
+        final int[] paletteData = new int[uniqueValueCount];
         for (int i = 0; i < uniqueValueCount; i++) {
             paletteData[i] = i + 1000; // Use offset to avoid zero values
         }
 
         // Calculate bits needed: log2(5000) ≈ 13 bits, which exceeds maxBitsPerEntry (8)
         // This should force direct palette mode
-        int calculatedBits = 13; // Math.ceil(Math.log(uniqueValueCount) / Math.log(2))
+        final int calculatedBits = 13; // Math.ceil(Math.log(uniqueValueCount) / Math.log(2))
 
         // Create values array for 4096 entries (16x16x16) with calculated bits per entry
         final int totalEntries = 16 * 16 * 16; // 4096 entries
         final int valuesPerLong = 64 / calculatedBits;
         final int valuesArrayLength = (totalEntries + valuesPerLong - 1) / valuesPerLong;
-        long[] values = new long[valuesArrayLength];
+        final long[] values = new long[valuesArrayLength];
 
         // Fill with pattern using modulo to cycle through available palette indices
         final long mask = (1L << calculatedBits) - 1;
         for (int i = 0; i < totalEntries; i++) {
-            int paletteIndex = i % uniqueValueCount;
-            int longIndex = i / valuesPerLong;
-            int bitIndex = (i % valuesPerLong) * calculatedBits;
+            final int paletteIndex = i % uniqueValueCount;
+            final int longIndex = i / valuesPerLong;
+            final int bitIndex = (i % valuesPerLong) * calculatedBits;
             values[longIndex] |= ((long) paletteIndex & mask) << bitIndex;
         }
 
@@ -843,13 +738,13 @@ public class PaletteTest {
                 "Palette should use direct bits when loaded with thousands of indices");
 
         // Should not have indirect palette structures (direct mode)
-        PaletteImpl impl = (PaletteImpl) palette;
+        final PaletteImpl impl = (PaletteImpl) palette;
         assertNull(impl.paletteIndexMap,
                 "Direct palette should not have paletteIndexMap");
 
         // Verify we can still read some values correctly
         // In direct mode, palette indices become the actual values
-        int firstValue = palette.get(0, 0, 0);
+        final int firstValue = palette.get(0, 0, 0);
         assertTrue(firstValue >= 1000 && firstValue < 1000 + uniqueValueCount,
                 "Value should be within expected range for direct palette: " + firstValue);
 
@@ -860,50 +755,50 @@ public class PaletteTest {
 
     @Test
     public void height() {
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             final int dimension = palette.dimension();
 
             // Test with empty palette - predicate that always returns true should find the
             // top
-            assertEquals(dimension - 1, palette.height(0, 0, (x, y, z, value) -> true));
+            assertEquals(dimension - 1, palette.height(0, 0, (_) -> true));
             // Predicate that always returns false should return -1
-            assertEquals(-1, palette.height(0, 0, (x, y, z, value) -> false));
+            assertEquals(-1, palette.height(0, 0, (_) -> false));
 
             // Set a block at the top
             palette.set(0, dimension - 1, 0, 1);
-            assertEquals(dimension - 1, palette.height(0, 0, (x, y, z, value) -> value != 0));
+            assertEquals(dimension - 1, palette.height(0, 0, (value) -> value != 0));
 
             // Set a block in the middle
             if (dimension > 1) {
                 palette.set(1, dimension / 2, 1, 2);
-                assertEquals(dimension / 2, palette.height(1, 1, (x, y, z, value) -> value != 0));
+                assertEquals(dimension / 2, palette.height(1, 1, (value) -> value != 0));
             }
 
             // Set blocks at multiple heights - should return the highest one
             if (dimension > 2) {
                 palette.set(2, 1, 2, 3);
                 palette.set(2, dimension - 2, 2, 4);
-                assertEquals(dimension - 2, palette.height(2, 2, (x, y, z, value) -> value != 0));
+                assertEquals(dimension - 2, palette.height(2, 2, (value) -> value != 0));
             }
 
             // Test with predicate that matches air (value 0)
             palette.fill(5); // Fill with non-zero value
-            int testX = Math.min(1, dimension - 1);
-            int testZ = Math.min(1, dimension - 1);
+            final int testX = Math.min(1, dimension - 1);
+            final int testZ = Math.min(1, dimension - 1);
             palette.set(testX, dimension / 2, testZ, 0); // Set one block to air
-            assertEquals(dimension / 2, palette.height(testX, testZ, (x, y, z, value) -> value == 0));
+            assertEquals(dimension / 2, palette.height(testX, testZ, (value) -> value == 0));
 
             // Test edge cases - coordinates at boundaries
             palette.fill(0);
             palette.set(dimension - 1, dimension - 1, dimension - 1, 10);
-            assertEquals(dimension - 1, palette.height(dimension - 1, dimension - 1, (x, y, z, value) -> value != 0));
+            assertEquals(dimension - 1, palette.height(dimension - 1, dimension - 1, (value) -> value != 0));
 
             // Test with complex predicate
             palette.fill(0);
             for (int y = 0; y < dimension; y++) {
                 palette.set(0, y, 0, y + 1);
             }
-            // Find highest block with value > 5
+            // Find the highest block with value > 5
             int expectedHeight = -1;
             for (int y = dimension - 1; y >= 0; y--) {
                 if (y + 1 > 5) {
@@ -911,49 +806,49 @@ public class PaletteTest {
                     break;
                 }
             }
-            assertEquals(expectedHeight, palette.height(0, 0, (x, y, z, value) -> value > 5));
+            assertEquals(expectedHeight, palette.height(0, 0, (value) -> value > 5));
         }
     }
 
     @Test
     public void heightValidation() {
-        Palette palette = Palette.blocks();
+        final Palette palette = Palette.blocks();
         final int dimension = palette.dimension();
 
         // Test invalid coordinates
-        assertThrows(IllegalArgumentException.class, () -> palette.height(-1, 0, (x, y, z, value) -> true));
-        assertThrows(IllegalArgumentException.class, () -> palette.height(0, -1, (x, y, z, value) -> true));
-        assertThrows(IllegalArgumentException.class, () -> palette.height(dimension, 0, (x, y, z, value) -> true));
-        assertThrows(IllegalArgumentException.class, () -> palette.height(0, dimension, (x, y, z, value) -> true));
+        assertThrows(IllegalArgumentException.class, () -> palette.height(-1, 0, (_) -> true));
+        assertThrows(IllegalArgumentException.class, () -> palette.height(0, -1, (_) -> true));
+        assertThrows(IllegalArgumentException.class, () -> palette.height(dimension, 0, (_) -> true));
+        assertThrows(IllegalArgumentException.class, () -> palette.height(0, dimension, (_) -> true));
     }
 
     @Test
     public void heightOptimization() {
         // Test single-value palette optimization
-        Palette singleValuePalette = Palette.blocks();
+        final Palette singleValuePalette = Palette.blocks();
         singleValuePalette.fill(42);
         
         // Should find the value at the top
-        assertEquals(15, singleValuePalette.height(0, 0, (x, y, z, value) -> value == 42));
-        assertEquals(-1, singleValuePalette.height(0, 0, (x, y, z, value) -> value == 0));
+        assertEquals(15, singleValuePalette.height(0, 0, (value) -> value == 42));
+        assertEquals(-1, singleValuePalette.height(0, 0, (value) -> value == 0));
         
         // Test multi-value palette optimization
-        Palette multiValuePalette = Palette.blocks();
+        final Palette multiValuePalette = Palette.blocks();
         multiValuePalette.set(5, 10, 5, 100);
         multiValuePalette.set(5, 8, 5, 200);
         multiValuePalette.set(5, 12, 5, 300);
         
         // Should find the highest matching block
-        assertEquals(12, multiValuePalette.height(5, 5, (x, y, z, value) -> value != 0));
-        assertEquals(10, multiValuePalette.height(5, 5, (x, y, z, value) -> value == 100));
-        assertEquals(8, multiValuePalette.height(5, 5, (x, y, z, value) -> value == 200));
-        assertEquals(12, multiValuePalette.height(5, 5, (x, y, z, value) -> value == 300));
-        assertEquals(-1, multiValuePalette.height(5, 5, (x, y, z, value) -> value == 999));
+        assertEquals(12, multiValuePalette.height(5, 5, (value) -> value != 0));
+        assertEquals(10, multiValuePalette.height(5, 5, (value) -> value == 100));
+        assertEquals(8, multiValuePalette.height(5, 5, (value) -> value == 200));
+        assertEquals(12, multiValuePalette.height(5, 5, (value) -> value == 300));
+        assertEquals(-1, multiValuePalette.height(5, 5, (value) -> value == 999));
     }
 
     @Test
     public void count() {
-        Palette testPalette = Palette.blocks();
+        final Palette testPalette = Palette.blocks();
         testPalette.fill(5000);
         assertEquals(4096, testPalette.count());
 
@@ -973,17 +868,17 @@ public class PaletteTest {
 
     @Test
     public void loadCount() {
-        Palette testPalette = Palette.empty(4, 4, 8, 12);
-        int[] palette = new int[] { 10, 2, 4, 0 };
+        final Palette testPalette = Palette.empty(4, 4, 8, 12);
+        final int[] palette = new int[] { 10, 2, 4, 0 };
         // 12 palette values that lead to 0 and 6 zeroed palette values
-        long[] values = new long[] { 0x01230123, 0x00130013, 0x33333333, 0x22222222 };
+        final long[] values = new long[] { 0x01230123, 0x00130013, 0x33333333, 0x22222222 };
         testPalette.load(palette, values);
         assertEquals(testPalette.maxSize() - 12, testPalette.count());
     }
 
     @Test
     public void partialFill() {
-        for (Palette palette : testPalettes()) {
+        for (final Palette palette : testPalettes()) {
             final int dimension = palette.dimension();
             final int dimensionMinus = dimension - 1;
 
@@ -1048,72 +943,14 @@ public class PaletteTest {
     }
 
     @Test
-    public void bulkPlacementHighValue() {
-        int value = 1 << 16;
-        for (Palette palette : testPalettes()) {
-            final int dimension = palette.dimension();
-
-            for (int x = 0, idx = 0; x < dimension; x++) {
-                for (int y = 0; y < dimension; y++) {
-                    for (int z = 0; z < dimension; z++, idx++) {
-                        palette.set(x, y, z, value + idx);
-                    }
-                }
-            }
-
-            for (int x = 0, idx = 0; x < dimension; x++) {
-                for (int y = 0; y < dimension; y++) {
-                    for (int z = 0; z < dimension; z++, idx++) {
-                        assertEquals(value + idx, palette.get(x, y, z));
-                    }
-                }
-            }
-        }
-    }
-
-    @Test
-    public void directPlacementHighValue() {
-        final PaletteImpl palette = (PaletteImpl) Palette.blocks();
-
-        palette.makeDirect();
-        assertEquals(Palette.BLOCK_PALETTE_DIRECT_BITS, palette.bitsPerEntry());
-
-        palette.set(0, 0, 0, 1 << 20);
-        assertEquals(21, palette.bitsPerEntry()); // 1 << 20 needs 21 bits to represent
-
-        assertEquals(1 << 20, palette.get(0, 0, 0));
-    }
-
-    @Test
-    public void fillHighValue() {
-        final PaletteImpl palette = (PaletteImpl) Palette.blocks();
-
-        palette.fill(1 << 20);
-        palette.set(0, 0, 0, 10);
-
-        palette.makeDirect();
-
-        assertEquals(10, palette.get(0, 0, 0));
-        assertEquals(1 << 20, palette.get(1, 1, 1));
-    }
-
-    @Test
-    public void setAllHighValue() {
-        final Palette palette = Palette.blocks();
-        final int value = 1 << 16;
-        final AtomicInteger index = new AtomicInteger();
-        palette.setAll((_, _, _) -> {
-            final int idx = index.getPlain();
-            index.setPlain(idx + 1);
-            return value + idx;
-        });
-
-        for (int y = 0, idx = 0; y < 16; y++) {
-            for (int z = 0; z < 16; z++) {
-                for (int x = 0; x < 16; x++, idx++) {
-                    assertEquals(value + idx, palette.get(x, y, z));
-                }
-            }
+    public void outOfBoundsValueThrows() {
+        for (final Palette palette : testPalettes()) {
+            assertThrows(Exception.class, () -> palette.set(0, 0, 0, 1 << 20));
+            assertThrows(Exception.class, () -> palette.set(0, 0, 0, -1));
+            assertThrows(Exception.class, () -> palette.fill(1 << 20));
+            assertThrows(Exception.class, () -> palette.fill(0, 0, 0, 0, 0, 0, 1 << 20));
+            assertThrows(Exception.class, () -> palette.setAll((_, _, _) -> 1 << 20));
+            assertThrows(Exception.class, () -> palette.replaceAll((_, _, _, _) -> 1 << 20));
         }
     }
 


### PR DESCRIPTION
## Proposed changes

`fill` has a new overload that partially fills the palette with a cuboid.

This PR optimizes several functions by using the new `PaletteIndexMap`:
- `setAll` and `replaceAll` don't immediately default to direct palette anymore.
- `optimize` now makes a new index map directly and returns early if no optimization is possible.

Fixed bugs:
- `copyFrom` now handles negative offsets properly.
- `replace(int oldValue, int newValue)` now properly replaces values if the new value already exists in the palette.
- High values are now properly accounted for in direct palettes.

Miscellaneous optimizations:
- `copyFrom` now defaults to `fill` if the source palette is single value or filled with air.
- `Palettes#remap` now only allocates if forced to.
- `load` now calls `remap` instead of manually setting all values.

Breaking changes:
- `copyFrom` now throws an exception if offset is out of bounds.
- `Palettes` is now marked as internal and some unnecessary methods were removed.
- `Palette#BLOCK_PALETTE_DIRECT_BITS` is now marked as internal.
- `Palette#offset(int)` has been removed.
- `Palette#height` now takes an `IntPredicate` instead of an `EntryPredicate`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

The old system of using an `Int2IntMap` and `IntArrayList` was a mess, using 5 lines of code just to initialize the palette with a single value. 
This led to several bugs in previous development and was too clunky to use locally in functions like `setAll`.
The new `PaletteIndexMap` is also more performant, as it reduces total allocations and exposes several internal functions that reduce double work.