### PR TITLE
Fix: PlayerChunkUnloadEvent race condition for async chunk loading

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -171,7 +171,7 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
     final ChunkRange.ChunkConsumer chunkRemover = (chunkX, chunkZ) -> {
         // Unload old chunks
         sendPacket(new UnloadChunkPacket(chunkX, chunkZ));
-        EventDispatcher.call(new PlayerChunkUnloadEvent(this, chunkX, chunkZ));
+        if (this.instance != null) this.instance.handlePlayerChunkUnload(this, chunkX, chunkZ);
     };
 
     private final AtomicInteger teleportId = new AtomicInteger();
@@ -2388,6 +2388,7 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
 
     /**
      * Gets the client's 'effective' view distance, which is the minimum of the client's view distance settings, and the local instance settings, plus one
+     *
      * @return The effective chunk view distance range of the client
      */
     public int effectiveViewDistance() {

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -29,6 +29,7 @@ import net.minestom.server.event.EventHandler;
 import net.minestom.server.event.EventNode;
 import net.minestom.server.event.instance.InstanceSectionInvalidateEvent;
 import net.minestom.server.event.instance.InstanceTickEvent;
+import net.minestom.server.event.player.PlayerChunkUnloadEvent;
 import net.minestom.server.event.trait.InstanceEvent;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockFace;
@@ -319,6 +320,12 @@ public abstract class Instance implements Block.Getter, Block.Setter,
      */
     public boolean isChunkLoaded(int chunkX, int chunkZ) {
         return getChunk(chunkX, chunkZ) != null;
+    }
+
+    public void handlePlayerChunkUnload(Player player, int chunkX, int chunkZ) {
+        Chunk chunk = getChunk(chunkX, chunkZ);
+        if (chunk == null) return;
+        EventDispatcher.call(new PlayerChunkUnloadEvent(player, chunkX, chunkZ));
     }
 
     /**

--- a/src/main/java/net/minestom/server/instance/SharedInstance.java
+++ b/src/main/java/net/minestom/server/instance/SharedInstance.java
@@ -118,6 +118,11 @@ public class SharedInstance extends Instance {
     }
 
     @Override
+    public void handlePlayerChunkUnload(Player player, int chunkX, int chunkZ) {
+        instanceContainer.handlePlayerChunkUnload(player, chunkX, chunkZ);
+    }
+
+    @Override
     public boolean isInVoid(Point point) {
         return instanceContainer.isInVoid(point);
     }


### PR DESCRIPTION
## Proposed changes

- Added a pending unload queue in `InstanceContainer` that stores player UUIDs when an unload is triggered for a non-existent chunk. When that chunk finishes loading, the queued unloads are processed and events fire with the now-available chunk.
- Modified `Player.chunkRemover` to call `instance.handlePlayerChunkUnload()` instead of firing the event directly, routing through the new queue system that checks if chunks exist before firing events.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

### Background

I use `PlayerChunkUnloadEvent` to implement custom chunk management in my server - specifically, unloading chunks when no players are viewing them to prevent unnecessary memory usage. This is a common pattern for servers that want fine-grained control over chunk lifecycle.

However, I noticed that when players flew around quickly, the loaded chunk count (via `Instance#getChunks().size()`) would continuously grow instead of remaining stable. Upon investigation, I discovered a race condition: when a player moves away from a chunk that's still loading asynchronously, `PlayerChunkUnloadEvent` fires immediately with just chunk coordinates. At that moment, the chunk doesn't exist in memory yet, so my event listener can't process it - there's no chunk to check viewers on or to unload. 

When the chunk eventually finishes loading, no unload event fires again. The chunk just sits in memory forever, orphaned. This makes `PlayerChunkUnloadEvent` unreliable for its intended use case of chunk lifecycle management.

### Solution

This fix introduces a pending unload queue that bridges the timing gap. When an unload is triggered for a chunk that doesn't exist yet, I queue the player's UUID. When that chunk loads, I process the pending unloads and fire events with the now-available chunk. This ensures the event fires reliably for all chunks, making it actually usable for chunk management.

### Before
<img width="2063" height="1035" alt="image" src="https://github.com/user-attachments/assets/97bbd9fa-6762-456a-955b-ec9bb2cd7fae" />

### After
<img width="2061" height="1035" alt="image" src="https://github.com/user-attachments/assets/a51fe058-113f-4216-b755-7bc0f510bb0b" />
