### PR TITLE
fix: change Armadillo class to extend AgeableMob to fix metadata indices disconnecting clients

### DIFF
--- a/src/main/java/net/minestom/server/entity/MetadataDef.java
+++ b/src/main/java/net/minestom/server/entity/MetadataDef.java
@@ -272,7 +272,7 @@ public sealed class MetadataDef {
         public static final Entry<Boolean> CAN_DUPLICATE = index(1, Metadata::Boolean, true);
     }
 
-    public static final class Armadillo extends Mob {
+    public static final class Armadillo extends AgeableMob {
         public static final Entry<ArmadilloMeta.State> STATE = index(0, Metadata::ArmadilloState,
                                                                      ArmadilloMeta.State.IDLE);
     }


### PR DESCRIPTION
## Proposed changes

What it says on the tin. This fixes armadillo metadata so it correctly inherits from AgeableMob as seen in the current client decomp: `Armadillo extends Animal` and `Animal extends AgeableMob`. Also looked at some other definitions connected to AgeableMob, those seem all fine.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I wonder if it would be possible to have an automated way of checking these things. I thought about it for a second but I did not have a good idea.