### PR TITLE
refactor: Make Metadata classes sealed & fix nullability

### DIFF
--- a/src/main/java/net/minestom/server/entity/Metadata.java
+++ b/src/main/java/net/minestom/server/entity/Metadata.java
@@ -49,7 +49,7 @@ public final class Metadata {
         return new MetadataImpl.EntryImpl<>(TYPE_CHAT, value, NetworkBuffer.COMPONENT);
     }
 
-    public static Entry<Component> OptComponent(@Nullable Component value) {
+    public static Entry<@Nullable Component> OptComponent(@Nullable Component value) {
         return new MetadataImpl.EntryImpl<>(TYPE_OPT_CHAT, value, NetworkBuffer.OPT_CHAT);
     }
 
@@ -69,7 +69,7 @@ public final class Metadata {
         return new MetadataImpl.EntryImpl<>(TYPE_BLOCK_POSITION, value, NetworkBuffer.BLOCK_POSITION);
     }
 
-    public static Entry<Point> OptBlockPosition(@Nullable Point value) {
+    public static Entry<@Nullable Point> OptBlockPosition(@Nullable Point value) {
         return new MetadataImpl.EntryImpl<>(TYPE_OPT_BLOCK_POSITION, value, NetworkBuffer.OPT_BLOCK_POSITION);
     }
 
@@ -77,7 +77,7 @@ public final class Metadata {
         return new MetadataImpl.EntryImpl<>(TYPE_DIRECTION, value, NetworkBuffer.DIRECTION);
     }
 
-    public static Entry<UUID> OptUUID(@Nullable UUID value) {
+    public static Entry<@Nullable UUID> OptUUID(@Nullable UUID value) {
         return new MetadataImpl.EntryImpl<>(TYPE_OPT_UUID, value, NetworkBuffer.UUID.optional());
     }
 
@@ -85,7 +85,7 @@ public final class Metadata {
         return new MetadataImpl.EntryImpl<>(TYPE_BLOCKSTATE, value, Block.STATE_NETWORK_TYPE);
     }
 
-    public static Entry<Block> OptBlockState(@Nullable Block value) {
+    public static Entry<@Nullable Block> OptBlockState(@Nullable Block value) {
         return new MetadataImpl.EntryImpl<>(TYPE_OPT_BLOCKSTATE, value, new NetworkBuffer.Type<>() {
             @Override
             public void write(NetworkBuffer buffer, @Nullable Block value) {
@@ -112,15 +112,15 @@ public final class Metadata {
         return new MetadataImpl.EntryImpl<>(TYPE_VILLAGERDATA, data, VillagerMeta.VillagerData.NETWORK_TYPE);
     }
 
-    public static Entry<Integer> OptVarInt(@Nullable Integer value) {
+    public static Entry<@Nullable Integer> OptVarInt(@Nullable Integer value) {
         return new MetadataImpl.EntryImpl<>(TYPE_OPT_VARINT, value, new NetworkBuffer.Type<>() {
             @Override
-            public void write(NetworkBuffer buffer, Integer value) {
+            public void write(NetworkBuffer buffer, @Nullable Integer value) {
                 buffer.write(NetworkBuffer.VAR_INT, value == null ? 0 : value + 1);
             }
 
             @Override
-            public Integer read(NetworkBuffer buffer) {
+            public @Nullable Integer read(NetworkBuffer buffer) {
                 int value = buffer.read(NetworkBuffer.VAR_INT);
                 return value == 0 ? null : value - 1;
             }
@@ -247,13 +247,12 @@ public final class Metadata {
         return (byte) NEXT_ID.getAndIncrement();
     }
 
-    public sealed interface Entry<T> permits MetadataImpl.EntryImpl {
+    public sealed interface Entry<T extends @UnknownNullability Object> permits MetadataImpl.EntryImpl {
         @SuppressWarnings({"unchecked", "rawtypes"})
         NetworkBuffer.Type<Entry<?>> SERIALIZER = (NetworkBuffer.Type) MetadataImpl.EntryImpl.SERIALIZER;
 
         int type();
 
-        @UnknownNullability
         T value();
     }
 }

--- a/src/main/java/net/minestom/server/entity/MetadataDef.java
+++ b/src/main/java/net/minestom/server/entity/MetadataDef.java
@@ -19,6 +19,7 @@ import net.minestom.server.registry.Holder;
 import net.minestom.server.registry.RegistryKey;
 import net.minestom.server.utils.Direction;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
 
 import java.util.List;
 import java.util.UUID;
@@ -651,12 +652,12 @@ public sealed class MetadataDef {
         return MetadataDefImpl.count(clazz);
     }
 
-    public sealed interface Entry<T> {
+    public sealed interface Entry<T extends @UnknownNullability Object> {
         int index();
 
         T defaultValue();
 
-        record Index<T>(int index, Function<T, Metadata.Entry<T>> function, T defaultValue) implements Entry<T> {
+        record Index<T extends @UnknownNullability Object>(int index, Function<T, Metadata.Entry<T>> function, T defaultValue) implements Entry<T> {
         }
 
         record BitMask(int index, byte bitMask, Boolean defaultValue) implements Entry<Boolean> {

--- a/src/main/java/net/minestom/server/entity/MetadataDefImpl.java
+++ b/src/main/java/net/minestom/server/entity/MetadataDefImpl.java
@@ -1,5 +1,7 @@
 package net.minestom.server.entity;
 
+import org.jetbrains.annotations.UnknownNullability;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -7,7 +9,7 @@ import java.util.function.Function;
 final class MetadataDefImpl {
     static final Map<String, Integer> MAX_INDEX = new HashMap<>();
 
-    static <T> MetadataDef.Entry.Index<T> index(int index, Function<T, Metadata.Entry<T>> function, T defaultValue) {
+    static <T extends @UnknownNullability Object> MetadataDef.Entry.Index<T> index(int index, Function<T, Metadata.Entry<T>> function, T defaultValue) {
         final String caller = caller();
         storeMaxIndex(caller, index);
         final int superIndex = findSuperIndex(caller);

--- a/src/main/java/net/minestom/server/entity/MetadataHolder.java
+++ b/src/main/java/net/minestom/server/entity/MetadataHolder.java
@@ -37,6 +37,7 @@ import net.minestom.server.entity.metadata.water.fish.*;
 import net.minestom.server.network.packet.server.play.EntityMetaDataPacket;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
@@ -66,13 +67,13 @@ public final class MetadataHolder {
         this.entity = entity;
     }
 
-    public <T> T get(MetadataDef.Entry<T> entry) {
+    public <T extends @UnknownNullability Object> T get(MetadataDef.Entry<T> entry) {
         final int id = entry.index();
 
         final Metadata.Entry<?> value = this.entries.get(id);
         if (value == null) return entry.defaultValue();
         return switch (entry) {
-            case MetadataDef.Entry.Index<T> v -> (T) value.value();
+            case MetadataDef.Entry.Index<T> _ -> (T) value.value();
             case MetadataDef.Entry.BitMask bitMask -> {
                 final byte maskValue = (byte) value.value();
                 yield (T) ((Boolean) getMaskBit(maskValue, bitMask.bitMask()));
@@ -84,7 +85,7 @@ public final class MetadataHolder {
         };
     }
 
-    public <T> void set(MetadataDef.Entry<T> entry, T value) {
+    public <T extends @UnknownNullability Object> void set(MetadataDef.Entry<T> entry, T value) {
         final int id = entry.index();
 
         Metadata.Entry<?> result = switch (entry) {

--- a/src/main/java/net/minestom/server/entity/metadata/AbstractVehicleMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/AbstractVehicleMeta.java
@@ -6,32 +6,32 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.minecart.AbstractMinecartMeta;
 import net.minestom.server.entity.metadata.other.BoatMeta;
 
-public sealed class AbstractVehicleMeta extends EntityMeta permits AbstractMinecartMeta, BoatMeta {
-    public AbstractVehicleMeta(Entity entity, MetadataHolder metadata) {
+public sealed abstract class AbstractVehicleMeta extends EntityMeta permits AbstractMinecartMeta, BoatMeta {
+    protected AbstractVehicleMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 
     public int getShakingTicks() {
-        return metadata.get(MetadataDef.AbstractVehicle.SHAKING_POWER);
+        return get(MetadataDef.AbstractVehicle.SHAKING_POWER);
     }
 
     public void setShakingTicks(int value) {
-        metadata.set(MetadataDef.AbstractVehicle.SHAKING_POWER, value);
+        set(MetadataDef.AbstractVehicle.SHAKING_POWER, value);
     }
 
     public int getShakingDirection() {
-        return metadata.get(MetadataDef.AbstractVehicle.SHAKING_DIRECTION);
+        return get(MetadataDef.AbstractVehicle.SHAKING_DIRECTION);
     }
 
     public void setShakingDirection(int value) {
-        metadata.set(MetadataDef.AbstractVehicle.SHAKING_DIRECTION, value);
+        set(MetadataDef.AbstractVehicle.SHAKING_DIRECTION, value);
     }
 
     public float getShakingMultiplier() {
-        return metadata.get(MetadataDef.AbstractVehicle.SHAKING_MULTIPLIER);
+        return get(MetadataDef.AbstractVehicle.SHAKING_MULTIPLIER);
     }
 
     public void setShakingMultiplier(float value) {
-        metadata.set(MetadataDef.AbstractVehicle.SHAKING_MULTIPLIER, value);
+        set(MetadataDef.AbstractVehicle.SHAKING_MULTIPLIER, value);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/AbstractVehicleMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/AbstractVehicleMeta.java
@@ -3,8 +3,10 @@ package net.minestom.server.entity.metadata;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import net.minestom.server.entity.metadata.minecart.AbstractMinecartMeta;
+import net.minestom.server.entity.metadata.other.BoatMeta;
 
-public class AbstractVehicleMeta extends EntityMeta {
+public sealed class AbstractVehicleMeta extends EntityMeta permits AbstractMinecartMeta, BoatMeta {
     public AbstractVehicleMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/AgeableMobMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/AgeableMobMeta.java
@@ -4,8 +4,11 @@ import net.minestom.server.collision.BoundingBox;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import net.minestom.server.entity.metadata.animal.AnimalMeta;
+import net.minestom.server.entity.metadata.villager.AbstractVillagerMeta;
+import net.minestom.server.entity.metadata.water.AgeableWaterAnimalMeta;
 
-public class AgeableMobMeta extends PathfinderMobMeta {
+public sealed class AgeableMobMeta extends PathfinderMobMeta permits AnimalMeta, AbstractVillagerMeta, AgeableWaterAnimalMeta {
     protected AgeableMobMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/AgeableMobMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/AgeableMobMeta.java
@@ -8,13 +8,13 @@ import net.minestom.server.entity.metadata.animal.AnimalMeta;
 import net.minestom.server.entity.metadata.villager.AbstractVillagerMeta;
 import net.minestom.server.entity.metadata.water.AgeableWaterAnimalMeta;
 
-public sealed class AgeableMobMeta extends PathfinderMobMeta permits AnimalMeta, AbstractVillagerMeta, AgeableWaterAnimalMeta {
+public sealed abstract class AgeableMobMeta extends PathfinderMobMeta permits AnimalMeta, AbstractVillagerMeta, AgeableWaterAnimalMeta {
     protected AgeableMobMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 
     public boolean isBaby() {
-        return metadata.get(MetadataDef.AgeableMob.IS_BABY);
+        return get(MetadataDef.AgeableMob.IS_BABY);
     }
 
     public void setBaby(boolean value) {
@@ -31,7 +31,7 @@ public sealed class AgeableMobMeta extends PathfinderMobMeta permits AnimalMeta,
                 entity.setBoundingBox(width, bb.height() * 2, width);
             }
         });
-        metadata.set(MetadataDef.AgeableMob.IS_BABY, value);
+        set(MetadataDef.AgeableMob.IS_BABY, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java
@@ -7,13 +7,18 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.EntityPose;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import net.minestom.server.entity.metadata.display.AbstractDisplayMeta;
+import net.minestom.server.entity.metadata.item.*;
+import net.minestom.server.entity.metadata.other.*;
+import net.minestom.server.entity.metadata.projectile.*;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
 
 import java.lang.ref.WeakReference;
 import java.util.function.Consumer;
 
-public class EntityMeta {
+public sealed class EntityMeta permits AbstractVehicleMeta, LivingEntityMeta, AbstractDisplayMeta, EyeOfEnderMeta, FireballMeta, ItemEntityMeta, SmallFireballMeta, ThrownItemProjectileMeta, AreaEffectCloudMeta, EndCrystalMeta, EvokerFangsMeta, ExperienceOrbMeta, FallingBlockMeta, FishingHookMeta, HangingMeta, InteractionMeta, LeashKnotMeta, LightningBoltMeta, LlamaSpitMeta, MarkerMeta, OminousItemSpawnerMeta, PrimedTntMeta, ShulkerBulletMeta, TraderLlamaMeta, AbstractArrowMeta, AbstractWindChargeMeta, DragonFireballMeta, FireworkRocketMeta, WitherSkullMeta {
     private final WeakReference<Entity> entityRef;
     protected final MetadataHolder metadata;
 
@@ -210,7 +215,7 @@ public class EntityMeta {
      * @return The value associated with the specified metadata entry.
      */
     @ApiStatus.Experimental
-    public <T> T get(MetadataDef.Entry<T> entry) {
+    public <T extends @UnknownNullability Object> T get(MetadataDef.Entry<T> entry) {
         return metadata.get(entry);
     }
 
@@ -222,7 +227,7 @@ public class EntityMeta {
      * @param <T>   The type of the metadata value.
      */
     @ApiStatus.Experimental
-    public <T> void set(MetadataDef.Entry<T> entry, T value) {
+    public <T extends @UnknownNullability Object> void set(MetadataDef.Entry<T> entry, T value) {
         metadata.set(entry, value);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java
@@ -18,13 +18,14 @@ import org.jetbrains.annotations.UnknownNullability;
 import java.lang.ref.WeakReference;
 import java.util.function.Consumer;
 
-public sealed class EntityMeta permits AbstractVehicleMeta, LivingEntityMeta, AbstractDisplayMeta, EyeOfEnderMeta, FireballMeta, ItemEntityMeta, SmallFireballMeta, ThrownItemProjectileMeta, AreaEffectCloudMeta, EndCrystalMeta, EvokerFangsMeta, ExperienceOrbMeta, FallingBlockMeta, FishingHookMeta, HangingMeta, InteractionMeta, LeashKnotMeta, LightningBoltMeta, LlamaSpitMeta, MarkerMeta, OminousItemSpawnerMeta, PrimedTntMeta, ShulkerBulletMeta, TraderLlamaMeta, AbstractArrowMeta, AbstractWindChargeMeta, DragonFireballMeta, FireworkRocketMeta, WitherSkullMeta {
-    private final WeakReference<Entity> entityRef;
-    protected final MetadataHolder metadata;
+public sealed abstract class EntityMeta permits AbstractVehicleMeta, LivingEntityMeta, AbstractDisplayMeta, EyeOfEnderMeta, FireballMeta, ItemEntityMeta, SmallFireballMeta, ThrownItemProjectileMeta, AreaEffectCloudMeta, EndCrystalMeta, EvokerFangsMeta, ExperienceOrbMeta, FallingBlockMeta, FishingHookMeta, HangingMeta, InteractionMeta, LeashKnotMeta, LightningBoltMeta, LlamaSpitMeta, MarkerMeta, OminousItemSpawnerMeta, PrimedTntMeta, ShulkerBulletMeta, TraderLlamaMeta, AbstractArrowMeta, AbstractWindChargeMeta, DragonFireballMeta, FireworkRocketMeta, WitherSkullMeta {
+    private final WeakReference<? extends Entity> entityRef;
+    private final MetadataHolder metadata;
 
-    public EntityMeta(@Nullable Entity entity, MetadataHolder metadata) {
+    protected EntityMeta(@Nullable Entity entity, MetadataHolder metadata) {
         this.entityRef = new WeakReference<>(entity);
         this.metadata = metadata;
+        super();
     }
 
     /**
@@ -40,72 +41,72 @@ public sealed class EntityMeta permits AbstractVehicleMeta, LivingEntityMeta, Ab
      *
      * @param notifyAboutChanges if to notify entity viewers about this meta changes.
      */
-    public void setNotifyAboutChanges(boolean notifyAboutChanges) {
+    public final void setNotifyAboutChanges(boolean notifyAboutChanges) {
         this.metadata.setNotifyAboutChanges(notifyAboutChanges);
     }
 
     public boolean isOnFire() {
-        return metadata.get(MetadataDef.IS_ON_FIRE);
+        return get(MetadataDef.IS_ON_FIRE);
     }
 
     public void setOnFire(boolean value) {
-        metadata.set(MetadataDef.IS_ON_FIRE, value);
+        set(MetadataDef.IS_ON_FIRE, value);
     }
 
     public boolean isSneaking() {
-        return metadata.get(MetadataDef.IS_CROUCHING);
+        return get(MetadataDef.IS_CROUCHING);
     }
 
     public void setSneaking(boolean value) {
-        metadata.set(MetadataDef.IS_CROUCHING, value);
+        set(MetadataDef.IS_CROUCHING, value);
     }
 
     public boolean isSprinting() {
-        return metadata.get(MetadataDef.IS_SPRINTING);
+        return get(MetadataDef.IS_SPRINTING);
     }
 
     public void setSprinting(boolean value) {
-        metadata.set(MetadataDef.IS_SPRINTING, value);
+        set(MetadataDef.IS_SPRINTING, value);
     }
 
     public boolean isSwimming() {
-        return metadata.get(MetadataDef.IS_SWIMMING);
+        return get(MetadataDef.IS_SWIMMING);
     }
 
     public void setSwimming(boolean value) {
-        metadata.set(MetadataDef.IS_SWIMMING, value);
+        set(MetadataDef.IS_SWIMMING, value);
     }
 
     public boolean isInvisible() {
-        return metadata.get(MetadataDef.IS_INVISIBLE);
+        return get(MetadataDef.IS_INVISIBLE);
     }
 
     public void setInvisible(boolean value) {
-        metadata.set(MetadataDef.IS_INVISIBLE, value);
+        set(MetadataDef.IS_INVISIBLE, value);
     }
 
     public boolean isHasGlowingEffect() {
-        return metadata.get(MetadataDef.HAS_GLOWING_EFFECT);
+        return get(MetadataDef.HAS_GLOWING_EFFECT);
     }
 
     public void setHasGlowingEffect(boolean value) {
-        metadata.set(MetadataDef.HAS_GLOWING_EFFECT, value);
+        set(MetadataDef.HAS_GLOWING_EFFECT, value);
     }
 
     public boolean isFlyingWithElytra() {
-        return metadata.get(MetadataDef.IS_FLYING_WITH_ELYTRA);
+        return get(MetadataDef.IS_FLYING_WITH_ELYTRA);
     }
 
     public void setFlyingWithElytra(boolean value) {
-        metadata.set(MetadataDef.IS_FLYING_WITH_ELYTRA, value);
+        set(MetadataDef.IS_FLYING_WITH_ELYTRA, value);
     }
 
     public int getAirTicks() {
-        return metadata.get(MetadataDef.AIR_TICKS);
+        return get(MetadataDef.AIR_TICKS);
     }
 
     public void setAirTicks(int value) {
-        metadata.set(MetadataDef.AIR_TICKS, value);
+        set(MetadataDef.AIR_TICKS, value);
     }
 
     /**
@@ -113,7 +114,7 @@ public sealed class EntityMeta permits AbstractVehicleMeta, LivingEntityMeta, Ab
      */
     @Deprecated
     public @Nullable Component getCustomName() {
-        return metadata.get(MetadataDef.CUSTOM_NAME);
+        return get(MetadataDef.CUSTOM_NAME);
     }
 
     /**
@@ -121,50 +122,50 @@ public sealed class EntityMeta permits AbstractVehicleMeta, LivingEntityMeta, Ab
      */
     @Deprecated
     public void setCustomName(@Nullable Component value) {
-        metadata.set(MetadataDef.CUSTOM_NAME, value);
+        set(MetadataDef.CUSTOM_NAME, value);
     }
 
     public boolean isCustomNameVisible() {
-        return metadata.get(MetadataDef.CUSTOM_NAME_VISIBLE);
+        return get(MetadataDef.CUSTOM_NAME_VISIBLE);
     }
 
     public void setCustomNameVisible(boolean value) {
-        metadata.set(MetadataDef.CUSTOM_NAME_VISIBLE, value);
+        set(MetadataDef.CUSTOM_NAME_VISIBLE, value);
     }
 
     public boolean isSilent() {
-        return metadata.get(MetadataDef.IS_SILENT);
+        return get(MetadataDef.IS_SILENT);
     }
 
     public void setSilent(boolean value) {
-        metadata.set(MetadataDef.IS_SILENT, value);
+        set(MetadataDef.IS_SILENT, value);
     }
 
     public boolean isHasNoGravity() {
-        return metadata.get(MetadataDef.HAS_NO_GRAVITY);
+        return get(MetadataDef.HAS_NO_GRAVITY);
     }
 
     public void setHasNoGravity(boolean value) {
-        metadata.set(MetadataDef.HAS_NO_GRAVITY, value);
+        set(MetadataDef.HAS_NO_GRAVITY, value);
     }
 
     public EntityPose getPose() {
-        return metadata.get(MetadataDef.POSE);
+        return get(MetadataDef.POSE);
     }
 
     public void setPose(EntityPose value) {
-        metadata.set(MetadataDef.POSE, value);
+        set(MetadataDef.POSE, value);
     }
 
     public int getTickFrozen() {
-        return metadata.get(MetadataDef.TICKS_FROZEN);
+        return get(MetadataDef.TICKS_FROZEN);
     }
 
     public void setTickFrozen(int tickFrozen) {
-        metadata.set(MetadataDef.TICKS_FROZEN, tickFrozen);
+        set(MetadataDef.TICKS_FROZEN, tickFrozen);
     }
 
-    protected void consumeEntity(Consumer<Entity> consumer) {
+    protected final void consumeEntity(Consumer<? super Entity> consumer) {
         Entity entity = this.entityRef.get();
         if (entity != null) {
             consumer.accept(entity);
@@ -198,13 +199,13 @@ public sealed class EntityMeta permits AbstractVehicleMeta, LivingEntityMeta, Ab
     @SuppressWarnings("unchecked")
     protected <T> @Nullable T get(DataComponent<T> component) {
         if (component == DataComponents.CUSTOM_NAME)
-            return (T) metadata.get(MetadataDef.CUSTOM_NAME);
+            return (T) get(MetadataDef.CUSTOM_NAME);
         return null;
     }
 
     protected <T> void set(DataComponent<T> component, T value) {
         if (component == DataComponents.CUSTOM_NAME)
-            metadata.set(MetadataDef.CUSTOM_NAME, (Component) value);
+            set(MetadataDef.CUSTOM_NAME, (Component) value);
     }
 
     /**
@@ -215,7 +216,7 @@ public sealed class EntityMeta permits AbstractVehicleMeta, LivingEntityMeta, Ab
      * @return The value associated with the specified metadata entry.
      */
     @ApiStatus.Experimental
-    public <T extends @UnknownNullability Object> T get(MetadataDef.Entry<T> entry) {
+    public final <T extends @UnknownNullability Object> T get(MetadataDef.Entry<T> entry) {
         return metadata.get(entry);
     }
 
@@ -227,7 +228,7 @@ public sealed class EntityMeta permits AbstractVehicleMeta, LivingEntityMeta, Ab
      * @param <T>   The type of the metadata value.
      */
     @ApiStatus.Experimental
-    public <T extends @UnknownNullability Object> void set(MetadataDef.Entry<T> entry, T value) {
+    public final <T extends @UnknownNullability Object> void set(MetadataDef.Entry<T> entry, T value) {
         metadata.set(entry, value);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/LivingEntityMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/LivingEntityMeta.java
@@ -12,65 +12,65 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public sealed class LivingEntityMeta extends EntityMeta permits MobMeta, AvatarMeta, ArmorStandMeta {
+public sealed abstract class LivingEntityMeta extends EntityMeta permits MobMeta, AvatarMeta, ArmorStandMeta {
     protected LivingEntityMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 
     public boolean isHandActive() {
-        return metadata.get(MetadataDef.LivingEntity.IS_HAND_ACTIVE);
+        return get(MetadataDef.LivingEntity.IS_HAND_ACTIVE);
     }
 
     public void setHandActive(boolean value) {
-        metadata.set(MetadataDef.LivingEntity.IS_HAND_ACTIVE, value);
+        set(MetadataDef.LivingEntity.IS_HAND_ACTIVE, value);
     }
 
     public PlayerHand getActiveHand() {
-        return metadata.get(MetadataDef.LivingEntity.ACTIVE_HAND) ? PlayerHand.OFF : PlayerHand.MAIN;
+        return get(MetadataDef.LivingEntity.ACTIVE_HAND) ? PlayerHand.OFF : PlayerHand.MAIN;
     }
 
     public void setActiveHand(PlayerHand hand) {
-        metadata.set(MetadataDef.LivingEntity.ACTIVE_HAND, hand == PlayerHand.OFF);
+        set(MetadataDef.LivingEntity.ACTIVE_HAND, hand == PlayerHand.OFF);
     }
 
     public boolean isInRiptideSpinAttack() {
-        return metadata.get(MetadataDef.LivingEntity.IS_RIPTIDE_SPIN_ATTACK);
+        return get(MetadataDef.LivingEntity.IS_RIPTIDE_SPIN_ATTACK);
     }
 
     public void setInRiptideSpinAttack(boolean value) {
-        metadata.set(MetadataDef.LivingEntity.IS_RIPTIDE_SPIN_ATTACK, value);
+        set(MetadataDef.LivingEntity.IS_RIPTIDE_SPIN_ATTACK, value);
     }
 
     public float getHealth() {
-        return metadata.get(MetadataDef.LivingEntity.HEALTH);
+        return get(MetadataDef.LivingEntity.HEALTH);
     }
 
     public void setHealth(float value) {
-        metadata.set(MetadataDef.LivingEntity.HEALTH, value);
+        set(MetadataDef.LivingEntity.HEALTH, value);
     }
 
     public List<Particle> getEffectParticles() {
-        return metadata.get(MetadataDef.LivingEntity.POTION_EFFECT_PARTICLES);
+        return get(MetadataDef.LivingEntity.POTION_EFFECT_PARTICLES);
     }
 
     public void setEffectParticles(List<Particle> value) {
-        metadata.set(MetadataDef.LivingEntity.POTION_EFFECT_PARTICLES, value);
+        set(MetadataDef.LivingEntity.POTION_EFFECT_PARTICLES, value);
     }
 
     public boolean isPotionEffectAmbient() {
-        return metadata.get(MetadataDef.LivingEntity.IS_POTION_EFFECT_AMBIANT);
+        return get(MetadataDef.LivingEntity.IS_POTION_EFFECT_AMBIANT);
     }
 
     public void setPotionEffectAmbient(boolean value) {
-        metadata.set(MetadataDef.LivingEntity.IS_POTION_EFFECT_AMBIANT, value);
+        set(MetadataDef.LivingEntity.IS_POTION_EFFECT_AMBIANT, value);
     }
 
     public int getArrowCount() {
-        return metadata.get(MetadataDef.LivingEntity.NUMBER_OF_ARROWS);
+        return get(MetadataDef.LivingEntity.NUMBER_OF_ARROWS);
     }
 
     public void setArrowCount(int value) {
-        metadata.set(MetadataDef.LivingEntity.NUMBER_OF_ARROWS, value);
+        set(MetadataDef.LivingEntity.NUMBER_OF_ARROWS, value);
     }
 
     /**
@@ -79,7 +79,7 @@ public sealed class LivingEntityMeta extends EntityMeta permits MobMeta, AvatarM
      * @return The amount of bee stingers
      */
     public int getBeeStingerCount() {
-        return metadata.get(MetadataDef.LivingEntity.NUMBER_OF_BEE_STINGERS);
+        return get(MetadataDef.LivingEntity.NUMBER_OF_BEE_STINGERS);
     }
 
     /**
@@ -88,16 +88,16 @@ public sealed class LivingEntityMeta extends EntityMeta permits MobMeta, AvatarM
      * @param value The amount of bee stingers to set, use 0 to clear all stingers
      */
     public void setBeeStingerCount(int value) {
-        metadata.set(MetadataDef.LivingEntity.NUMBER_OF_BEE_STINGERS, value);
+        set(MetadataDef.LivingEntity.NUMBER_OF_BEE_STINGERS, value);
     }
 
     @Nullable
     public Point getBedInWhichSleepingPosition() {
-        return metadata.get(MetadataDef.LivingEntity.LOCATION_OF_BED);
+        return get(MetadataDef.LivingEntity.LOCATION_OF_BED);
     }
 
     public void setBedInWhichSleepingPosition(@Nullable Point value) {
-        metadata.set(MetadataDef.LivingEntity.LOCATION_OF_BED, value);
+        set(MetadataDef.LivingEntity.LOCATION_OF_BED, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/LivingEntityMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/LivingEntityMeta.java
@@ -5,12 +5,14 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.PlayerHand;
+import net.minestom.server.entity.metadata.avatar.AvatarMeta;
+import net.minestom.server.entity.metadata.other.ArmorStandMeta;
 import net.minestom.server.particle.Particle;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public class LivingEntityMeta extends EntityMeta {
+public sealed class LivingEntityMeta extends EntityMeta permits MobMeta, AvatarMeta, ArmorStandMeta {
     protected LivingEntityMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/MobMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/MobMeta.java
@@ -2,33 +2,33 @@ package net.minestom.server.entity.metadata;
 
 import module net.minestom.server;
 
-public sealed class MobMeta extends LivingEntityMeta permits PathfinderMobMeta, AmbientCreatureMeta, FlyingMeta, EnderDragonMeta, SlimeMeta {
+public sealed abstract class MobMeta extends LivingEntityMeta permits PathfinderMobMeta, AmbientCreatureMeta, FlyingMeta, EnderDragonMeta, SlimeMeta {
     protected MobMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 
     public boolean isNoAi() {
-        return metadata.get(MetadataDef.Mob.NO_AI);
+        return get(MetadataDef.Mob.NO_AI);
     }
 
     public void setNoAi(boolean value) {
-        metadata.set(MetadataDef.Mob.NO_AI, value);
+        set(MetadataDef.Mob.NO_AI, value);
     }
 
     public boolean isLeftHanded() {
-        return metadata.get(MetadataDef.Mob.IS_LEFT_HANDED);
+        return get(MetadataDef.Mob.IS_LEFT_HANDED);
     }
 
     public void setLeftHanded(boolean value) {
-        metadata.set(MetadataDef.Mob.IS_LEFT_HANDED, value);
+        set(MetadataDef.Mob.IS_LEFT_HANDED, value);
     }
 
     public boolean isAggressive() {
-        return metadata.get(MetadataDef.Mob.IS_AGGRESSIVE);
+        return get(MetadataDef.Mob.IS_AGGRESSIVE);
     }
 
     public void setAggressive(boolean value) {
-        metadata.set(MetadataDef.Mob.IS_AGGRESSIVE, value);
+        set(MetadataDef.Mob.IS_AGGRESSIVE, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/MobMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/MobMeta.java
@@ -1,10 +1,8 @@
 package net.minestom.server.entity.metadata;
 
-import net.minestom.server.entity.Entity;
-import net.minestom.server.entity.MetadataDef;
-import net.minestom.server.entity.MetadataHolder;
+import module net.minestom.server;
 
-public class MobMeta extends LivingEntityMeta {
+public sealed class MobMeta extends LivingEntityMeta permits PathfinderMobMeta, AmbientCreatureMeta, FlyingMeta, EnderDragonMeta, SlimeMeta {
     protected MobMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/ObjectDataProvider.java
+++ b/src/main/java/net/minestom/server/entity/metadata/ObjectDataProvider.java
@@ -1,7 +1,13 @@
 package net.minestom.server.entity.metadata;
 
+import net.minestom.server.entity.metadata.item.FireballMeta;
+import net.minestom.server.entity.metadata.item.ItemEntityMeta;
+import net.minestom.server.entity.metadata.item.SmallFireballMeta;
+import net.minestom.server.entity.metadata.other.*;
+import net.minestom.server.entity.metadata.projectile.*;
+
 // https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Object_Data
-public interface ObjectDataProvider {
+public sealed interface ObjectDataProvider permits FireballMeta, ItemEntityMeta, SmallFireballMeta, FallingBlockMeta, FishingHookMeta, HangingMeta, LlamaSpitMeta, ShulkerBulletMeta, AbstractWindChargeMeta, ArrowMeta, DragonFireballMeta, SpectralArrowMeta, WitherSkullMeta {
 
     int getObjectData();
 

--- a/src/main/java/net/minestom/server/entity/metadata/PathfinderMobMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/PathfinderMobMeta.java
@@ -2,8 +2,12 @@ package net.minestom.server.entity.metadata;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import net.minestom.server.entity.metadata.golem.AbstractGolemMeta;
+import net.minestom.server.entity.metadata.monster.MonsterMeta;
+import net.minestom.server.entity.metadata.other.AllayMeta;
+import net.minestom.server.entity.metadata.water.WaterAnimalMeta;
 
-public class PathfinderMobMeta extends MobMeta {
+public sealed class PathfinderMobMeta extends MobMeta permits AgeableMobMeta, AbstractGolemMeta, MonsterMeta, AllayMeta, WaterAnimalMeta {
     protected PathfinderMobMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/PathfinderMobMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/PathfinderMobMeta.java
@@ -7,7 +7,7 @@ import net.minestom.server.entity.metadata.monster.MonsterMeta;
 import net.minestom.server.entity.metadata.other.AllayMeta;
 import net.minestom.server.entity.metadata.water.WaterAnimalMeta;
 
-public sealed class PathfinderMobMeta extends MobMeta permits AgeableMobMeta, AbstractGolemMeta, MonsterMeta, AllayMeta, WaterAnimalMeta {
+public sealed abstract class PathfinderMobMeta extends MobMeta permits AgeableMobMeta, AbstractGolemMeta, MonsterMeta, AllayMeta, WaterAnimalMeta {
     protected PathfinderMobMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/ambient/AmbientCreatureMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/ambient/AmbientCreatureMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.MobMeta;
 
-public class AmbientCreatureMeta extends MobMeta {
+public sealed abstract class AmbientCreatureMeta extends MobMeta permits BatMeta {
     protected AmbientCreatureMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/ambient/BatMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/ambient/BatMeta.java
@@ -10,11 +10,11 @@ public final class BatMeta extends AmbientCreatureMeta {
     }
 
     public boolean isHanging() {
-        return metadata.get(MetadataDef.Bat.IS_HANGING);
+        return get(MetadataDef.Bat.IS_HANGING);
     }
 
     public void setHanging(boolean value) {
-        metadata.set(MetadataDef.Bat.IS_HANGING, value);
+        set(MetadataDef.Bat.IS_HANGING, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/ambient/BatMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/ambient/BatMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class BatMeta extends AmbientCreatureMeta {
+public final class BatMeta extends AmbientCreatureMeta {
     public BatMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/AbstractHorseMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/AbstractHorseMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class AbstractHorseMeta extends AnimalMeta {
+public sealed abstract class AbstractHorseMeta extends AnimalMeta permits CamelMeta, ChestedHorseMeta, HorseMeta, SkeletonHorseMeta, ZombieHorseMeta {
     protected AbstractHorseMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/AbstractHorseMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/AbstractHorseMeta.java
@@ -10,43 +10,43 @@ public sealed abstract class AbstractHorseMeta extends AnimalMeta permits CamelM
     }
 
     public boolean isTamed() {
-        return metadata.get(MetadataDef.AbstractHorse.IS_TAME);
+        return get(MetadataDef.AbstractHorse.IS_TAME);
     }
 
     public void setTamed(boolean value) {
-        metadata.set(MetadataDef.AbstractHorse.IS_TAME, value);
+        set(MetadataDef.AbstractHorse.IS_TAME, value);
     }
 
     public boolean isHasBred() {
-        return metadata.get(MetadataDef.AbstractHorse.HAS_BRED);
+        return get(MetadataDef.AbstractHorse.HAS_BRED);
     }
 
     public void setHasBred(boolean value) {
-        metadata.set(MetadataDef.AbstractHorse.HAS_BRED, value);
+        set(MetadataDef.AbstractHorse.HAS_BRED, value);
     }
 
     public boolean isEating() {
-        return metadata.get(MetadataDef.AbstractHorse.IS_EATING);
+        return get(MetadataDef.AbstractHorse.IS_EATING);
     }
 
     public void setEating(boolean value) {
-        metadata.set(MetadataDef.AbstractHorse.IS_EATING, value);
+        set(MetadataDef.AbstractHorse.IS_EATING, value);
     }
 
     public boolean isRearing() {
-        return metadata.get(MetadataDef.AbstractHorse.IS_REARING);
+        return get(MetadataDef.AbstractHorse.IS_REARING);
     }
 
     public void setRearing(boolean value) {
-        metadata.set(MetadataDef.AbstractHorse.IS_REARING, value);
+        set(MetadataDef.AbstractHorse.IS_REARING, value);
     }
 
     public boolean isMouthOpen() {
-        return metadata.get(MetadataDef.AbstractHorse.IS_MOUTH_OPEN);
+        return get(MetadataDef.AbstractHorse.IS_MOUTH_OPEN);
     }
 
     public void setMouthOpen(boolean value) {
-        metadata.set(MetadataDef.AbstractHorse.IS_MOUTH_OPEN, value);
+        set(MetadataDef.AbstractHorse.IS_MOUTH_OPEN, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/AbstractNautilusMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/AbstractNautilusMeta.java
@@ -5,8 +5,8 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.animal.tameable.TameableAnimalMeta;
 
-public class AbstractNautilusMeta extends TameableAnimalMeta {
-    public AbstractNautilusMeta(Entity entity, MetadataHolder metadata) {
+public sealed abstract class AbstractNautilusMeta extends TameableAnimalMeta permits NautilusMeta, ZombieNautilusMeta {
+    protected AbstractNautilusMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/AbstractNautilusMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/AbstractNautilusMeta.java
@@ -11,11 +11,11 @@ public sealed abstract class AbstractNautilusMeta extends TameableAnimalMeta per
     }
 
     public boolean isDashing() {
-        return metadata.get(MetadataDef.AbstractNautilus.DASH);
+        return get(MetadataDef.AbstractNautilus.DASH);
     }
 
     public void setDashing(boolean value) {
-        metadata.set(MetadataDef.AbstractNautilus.DASH, value);
+        set(MetadataDef.AbstractNautilus.DASH, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/AnimalMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/AnimalMeta.java
@@ -3,8 +3,9 @@ package net.minestom.server.entity.metadata.animal;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.AgeableMobMeta;
+import net.minestom.server.entity.metadata.animal.tameable.TameableAnimalMeta;
 
-public class AnimalMeta extends AgeableMobMeta {
+public sealed abstract class AnimalMeta extends AgeableMobMeta permits AbstractHorseMeta, ArmadilloMeta, BeeMeta, ChickenMeta, CowMeta, FoxMeta, FrogMeta, GoatMeta, HappyGhastMeta, HoglinMeta, MooshroomMeta, OcelotMeta, PandaMeta, PigMeta, PolarBearMeta, RabbitMeta, SheepMeta, SnifferMeta, StriderMeta, TurtleMeta, TameableAnimalMeta, net.minestom.server.entity.metadata.water.AxolotlMeta {
     protected AnimalMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/ArmadilloMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/ArmadilloMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.network.NetworkBuffer;
 
-public class ArmadilloMeta extends AnimalMeta {
+public final class ArmadilloMeta extends AnimalMeta {
     public ArmadilloMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/ArmadilloMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/ArmadilloMeta.java
@@ -11,11 +11,11 @@ public final class ArmadilloMeta extends AnimalMeta {
     }
 
     public State getState() {
-        return metadata.get(MetadataDef.Armadillo.STATE);
+        return get(MetadataDef.Armadillo.STATE);
     }
 
     public void setState(State value) {
-        metadata.set(MetadataDef.Armadillo.STATE, value);
+        set(MetadataDef.Armadillo.STATE, value);
     }
 
     public enum State {

--- a/src/main/java/net/minestom/server/entity/metadata/animal/BeeMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/BeeMeta.java
@@ -10,35 +10,35 @@ public final class BeeMeta extends AnimalMeta {
     }
 
     public boolean isAngry() {
-        return metadata.get(MetadataDef.Bee.IS_ANGRY);
+        return get(MetadataDef.Bee.IS_ANGRY);
     }
 
     public void setAngry(boolean value) {
-        metadata.set(MetadataDef.Bee.IS_ANGRY, value);
+        set(MetadataDef.Bee.IS_ANGRY, value);
     }
 
     public boolean isHasStung() {
-        return metadata.get(MetadataDef.Bee.HAS_STUNG);
+        return get(MetadataDef.Bee.HAS_STUNG);
     }
 
     public void setHasStung(boolean value) {
-        metadata.set(MetadataDef.Bee.HAS_STUNG, value);
+        set(MetadataDef.Bee.HAS_STUNG, value);
     }
 
     public boolean isHasNectar() {
-        return metadata.get(MetadataDef.Bee.HAS_NECTAR);
+        return get(MetadataDef.Bee.HAS_NECTAR);
     }
 
     public void setHasNectar(boolean value) {
-        metadata.set(MetadataDef.Bee.HAS_NECTAR, value);
+        set(MetadataDef.Bee.HAS_NECTAR, value);
     }
 
     public long getAngerTicks() {
-        return metadata.get(MetadataDef.Bee.ANGER_TIME_TICKS);
+        return get(MetadataDef.Bee.ANGER_TIME_TICKS);
     }
 
     public void setAngerTicks(long value) {
-        metadata.set(MetadataDef.Bee.ANGER_TIME_TICKS, value);
+        set(MetadataDef.Bee.ANGER_TIME_TICKS, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/BeeMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/BeeMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class BeeMeta extends AnimalMeta {
+public final class BeeMeta extends AnimalMeta {
     public BeeMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/CamelHuskMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/CamelHuskMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.animal;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class CamelHuskMeta extends CamelMeta {
+public final class CamelHuskMeta extends CamelMeta {
     public CamelHuskMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/CamelMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/CamelMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class CamelMeta extends AbstractHorseMeta {
+public sealed class CamelMeta extends AbstractHorseMeta permits CamelHuskMeta {
     public CamelMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/CamelMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/CamelMeta.java
@@ -10,18 +10,18 @@ public sealed class CamelMeta extends AbstractHorseMeta permits CamelHuskMeta {
     }
 
     public boolean isDashing() {
-        return metadata.get(MetadataDef.Camel.DASHING);
+        return get(MetadataDef.Camel.DASHING);
     }
 
     public void setDashing(boolean value) {
-        metadata.set(MetadataDef.Camel.DASHING, value);
+        set(MetadataDef.Camel.DASHING, value);
     }
 
     public long getLastPoseChangeTick() {
-        return metadata.get(MetadataDef.Camel.LAST_POSE_CHANGE_TICK);
+        return get(MetadataDef.Camel.LAST_POSE_CHANGE_TICK);
     }
 
     public void setLastPoseChangeTick(long value) {
-        metadata.set(MetadataDef.Camel.LAST_POSE_CHANGE_TICK, value);
+        set(MetadataDef.Camel.LAST_POSE_CHANGE_TICK, value);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/ChestedHorseMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/ChestedHorseMeta.java
@@ -10,11 +10,11 @@ public sealed abstract class ChestedHorseMeta extends AbstractHorseMeta permits 
     }
 
     public boolean isHasChest() {
-        return metadata.get(MetadataDef.ChestedHorse.HAS_CHEST);
+        return get(MetadataDef.ChestedHorse.HAS_CHEST);
     }
 
     public void setHasChest(boolean value) {
-        metadata.set(MetadataDef.ChestedHorse.HAS_CHEST, value);
+        set(MetadataDef.ChestedHorse.HAS_CHEST, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/ChestedHorseMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/ChestedHorseMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class ChestedHorseMeta extends AbstractHorseMeta {
+public sealed abstract class ChestedHorseMeta extends AbstractHorseMeta permits DonkeyMeta, LlamaMeta, MuleMeta {
     protected ChestedHorseMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/ChickenMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/ChickenMeta.java
@@ -8,7 +8,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.registry.RegistryKey;
 import org.jetbrains.annotations.Nullable;
 
-public class ChickenMeta extends AnimalMeta {
+public final class ChickenMeta extends AnimalMeta {
     public ChickenMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/ChickenMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/ChickenMeta.java
@@ -19,7 +19,7 @@ public final class ChickenMeta extends AnimalMeta {
      */
     @Deprecated
     public RegistryKey<ChickenVariant> getVariant() {
-        return metadata.get(MetadataDef.Chicken.VARIANT);
+        return get(MetadataDef.Chicken.VARIANT);
     }
 
     /**
@@ -27,7 +27,7 @@ public final class ChickenMeta extends AnimalMeta {
      */
     @Deprecated
     public void setVariant(RegistryKey<ChickenVariant> variant) {
-        metadata.set(MetadataDef.Chicken.VARIANT, variant);
+        set(MetadataDef.Chicken.VARIANT, variant);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/animal/CowMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/CowMeta.java
@@ -18,7 +18,7 @@ public final class CowMeta extends AnimalMeta {
      */
     @Deprecated
     public RegistryKey<CowVariant> getVariant() {
-        return metadata.get(MetadataDef.Cow.VARIANT);
+        return get(MetadataDef.Cow.VARIANT);
     }
 
     /**
@@ -26,7 +26,7 @@ public final class CowMeta extends AnimalMeta {
      */
     @Deprecated
     public void setVariant(RegistryKey<CowVariant> variant) {
-        metadata.set(MetadataDef.Cow.VARIANT, variant);
+        set(MetadataDef.Cow.VARIANT, variant);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/animal/CowMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/CowMeta.java
@@ -8,7 +8,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.registry.RegistryKey;
 import org.jetbrains.annotations.Nullable;
 
-public class CowMeta extends AnimalMeta {
+public final class CowMeta extends AnimalMeta {
     public CowMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/DonkeyMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/DonkeyMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.animal;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class DonkeyMeta extends ChestedHorseMeta {
+public final class DonkeyMeta extends ChestedHorseMeta {
     public DonkeyMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/FoxMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/FoxMeta.java
@@ -22,7 +22,7 @@ public final class FoxMeta extends AnimalMeta {
      */
     @Deprecated
     public FoxMeta.Variant getVariant() {
-        return Variant.VALUES[metadata.get(MetadataDef.Fox.VARIANT)];
+        return Variant.VALUES[get(MetadataDef.Fox.VARIANT)];
     }
 
     /**
@@ -30,81 +30,81 @@ public final class FoxMeta extends AnimalMeta {
      */
     @Deprecated
     public void setVariant(FoxMeta.Variant variant) {
-        metadata.set(MetadataDef.Fox.VARIANT, variant.ordinal());
+        set(MetadataDef.Fox.VARIANT, variant.ordinal());
     }
 
     public boolean isSitting() {
-        return metadata.get(MetadataDef.Fox.IS_SITTING);
+        return get(MetadataDef.Fox.IS_SITTING);
     }
 
     public void setSitting(boolean value) {
-        metadata.set(MetadataDef.Fox.IS_SITTING, value);
+        set(MetadataDef.Fox.IS_SITTING, value);
     }
 
     public boolean isFoxSneaking() {
-        return metadata.get(MetadataDef.Fox.IS_CROUCHING);
+        return get(MetadataDef.Fox.IS_CROUCHING);
     }
 
     public void setFoxSneaking(boolean value) {
-        metadata.set(MetadataDef.Fox.IS_CROUCHING, value);
+        set(MetadataDef.Fox.IS_CROUCHING, value);
     }
 
     public boolean isInterested() {
-        return metadata.get(MetadataDef.Fox.IS_INTERESTED);
+        return get(MetadataDef.Fox.IS_INTERESTED);
     }
 
     public void setInterested(boolean value) {
-        metadata.set(MetadataDef.Fox.IS_INTERESTED, value);
+        set(MetadataDef.Fox.IS_INTERESTED, value);
     }
 
     public boolean isPouncing() {
-        return metadata.get(MetadataDef.Fox.IS_POUNCING);
+        return get(MetadataDef.Fox.IS_POUNCING);
     }
 
     public void setPouncing(boolean value) {
-        metadata.set(MetadataDef.Fox.IS_POUNCING, value);
+        set(MetadataDef.Fox.IS_POUNCING, value);
     }
 
     public boolean isSleeping() {
-        return metadata.get(MetadataDef.Fox.IS_SLEEPING);
+        return get(MetadataDef.Fox.IS_SLEEPING);
     }
 
     public void setSleeping(boolean value) {
-        metadata.set(MetadataDef.Fox.IS_SLEEPING, value);
+        set(MetadataDef.Fox.IS_SLEEPING, value);
     }
 
     public boolean isFaceplanted() {
-        return metadata.get(MetadataDef.Fox.IS_FACEPLANTED);
+        return get(MetadataDef.Fox.IS_FACEPLANTED);
     }
 
     public void setFaceplanted(boolean value) {
-        metadata.set(MetadataDef.Fox.IS_FACEPLANTED, value);
+        set(MetadataDef.Fox.IS_FACEPLANTED, value);
     }
 
     public boolean isDefending() {
-        return metadata.get(MetadataDef.Fox.IS_DEFENDING);
+        return get(MetadataDef.Fox.IS_DEFENDING);
     }
 
     public void setDefending(boolean value) {
-        metadata.set(MetadataDef.Fox.IS_DEFENDING, value);
+        set(MetadataDef.Fox.IS_DEFENDING, value);
     }
 
     @Nullable
     public UUID getFirstUUID() {
-        return metadata.get(MetadataDef.Fox.FIRST_UUID);
+        return get(MetadataDef.Fox.FIRST_UUID);
     }
 
     public void setFirstUUID(@Nullable UUID value) {
-        metadata.set(MetadataDef.Fox.FIRST_UUID, value);
+        set(MetadataDef.Fox.FIRST_UUID, value);
     }
 
     @Nullable
     public UUID getSecondUUID() {
-        return metadata.get(MetadataDef.Fox.SECOND_UUID);
+        return get(MetadataDef.Fox.SECOND_UUID);
     }
 
     public void setSecondUUID(@Nullable UUID value) {
-        metadata.set(MetadataDef.Fox.SECOND_UUID, value);
+        set(MetadataDef.Fox.SECOND_UUID, value);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/animal/FoxMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/FoxMeta.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
-public class FoxMeta extends AnimalMeta {
+public final class FoxMeta extends AnimalMeta {
     public FoxMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/FrogMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/FrogMeta.java
@@ -8,7 +8,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.registry.RegistryKey;
 import org.jetbrains.annotations.Nullable;
 
-public class FrogMeta extends AnimalMeta {
+public final class FrogMeta extends AnimalMeta {
     public FrogMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/FrogMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/FrogMeta.java
@@ -18,7 +18,7 @@ public final class FrogMeta extends AnimalMeta {
      */
     @Deprecated
     public RegistryKey<FrogVariant> getVariant() {
-        return metadata.get(MetadataDef.Frog.VARIANT);
+        return get(MetadataDef.Frog.VARIANT);
     }
 
     /**
@@ -26,15 +26,15 @@ public final class FrogMeta extends AnimalMeta {
      */
     @Deprecated
     public void setVariant(RegistryKey<FrogVariant> value) {
-        metadata.set(MetadataDef.Frog.VARIANT, value);
+        set(MetadataDef.Frog.VARIANT, value);
     }
 
     public @Nullable Integer getTongueTarget() {
-        return metadata.get(MetadataDef.Frog.TONGUE_TARGET);
+        return get(MetadataDef.Frog.TONGUE_TARGET);
     }
 
     public void setTongueTarget(@Nullable Integer value) {
-        metadata.set(MetadataDef.Frog.TONGUE_TARGET, value);
+        set(MetadataDef.Frog.TONGUE_TARGET, value);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/animal/GoatMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/GoatMeta.java
@@ -10,26 +10,26 @@ public final class GoatMeta extends AnimalMeta {
     }
 
     public boolean isScreaming() {
-        return metadata.get(MetadataDef.Goat.IS_SCREAMING_GOAT);
+        return get(MetadataDef.Goat.IS_SCREAMING_GOAT);
     }
 
     public void setScreaming(boolean screaming) {
-        metadata.set(MetadataDef.Goat.IS_SCREAMING_GOAT, screaming);
+        set(MetadataDef.Goat.IS_SCREAMING_GOAT, screaming);
     }
 
     public boolean hasLeftHorn() {
-        return metadata.get(MetadataDef.Goat.HAS_LEFT_HORN);
+        return get(MetadataDef.Goat.HAS_LEFT_HORN);
     }
 
     public void setLeftHorn(boolean leftHorn) {
-        metadata.set(MetadataDef.Goat.HAS_LEFT_HORN, leftHorn);
+        set(MetadataDef.Goat.HAS_LEFT_HORN, leftHorn);
     }
 
     public boolean hasRightHorn() {
-        return metadata.get(MetadataDef.Goat.HAS_RIGHT_HORN);
+        return get(MetadataDef.Goat.HAS_RIGHT_HORN);
     }
 
     public void setRightHorn(boolean rightHorn) {
-        metadata.set(MetadataDef.Goat.HAS_RIGHT_HORN, rightHorn);
+        set(MetadataDef.Goat.HAS_RIGHT_HORN, rightHorn);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/GoatMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/GoatMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class GoatMeta extends AnimalMeta {
+public final class GoatMeta extends AnimalMeta {
     public GoatMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/HappyGhastMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/HappyGhastMeta.java
@@ -11,18 +11,18 @@ public final class HappyGhastMeta extends AnimalMeta {
     }
 
     public boolean isLeashHolder() {
-        return metadata.get(MetadataDef.HappyGhast.IS_LEASH_HOLDER);
+        return get(MetadataDef.HappyGhast.IS_LEASH_HOLDER);
     }
 
     public void setLeashHolder(boolean value) {
-        metadata.set(MetadataDef.HappyGhast.IS_LEASH_HOLDER, value);
+        set(MetadataDef.HappyGhast.IS_LEASH_HOLDER, value);
     }
 
     public boolean isStaysStill() {
-        return metadata.get(MetadataDef.HappyGhast.STAYS_STILL);
+        return get(MetadataDef.HappyGhast.STAYS_STILL);
     }
 
     public void setStaysStill(boolean value) {
-        metadata.set(MetadataDef.HappyGhast.STAYS_STILL, value);
+        set(MetadataDef.HappyGhast.STAYS_STILL, value);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/HappyGhastMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/HappyGhastMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class HappyGhastMeta extends AnimalMeta {
+public final class HappyGhastMeta extends AnimalMeta {
 
     public HappyGhastMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);

--- a/src/main/java/net/minestom/server/entity/metadata/animal/HoglinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/HoglinMeta.java
@@ -10,11 +10,11 @@ public final class HoglinMeta extends AnimalMeta {
     }
 
     public boolean isImmuneToZombification() {
-        return metadata.get(MetadataDef.Hoglin.IMMUNE_ZOMBIFICATION);
+        return get(MetadataDef.Hoglin.IMMUNE_ZOMBIFICATION);
     }
 
     public void setImmuneToZombification(boolean value) {
-        metadata.set(MetadataDef.Hoglin.IMMUNE_ZOMBIFICATION, value);
+        set(MetadataDef.Hoglin.IMMUNE_ZOMBIFICATION, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/HoglinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/HoglinMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class HoglinMeta extends AnimalMeta {
+public final class HoglinMeta extends AnimalMeta {
     public HoglinMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/HorseMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/HorseMeta.java
@@ -9,7 +9,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.network.NetworkBuffer;
 import org.jetbrains.annotations.Nullable;
 
-public class HorseMeta extends AbstractHorseMeta {
+public final class HorseMeta extends AbstractHorseMeta {
     public HorseMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/HorseMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/HorseMeta.java
@@ -19,7 +19,7 @@ public final class HorseMeta extends AbstractHorseMeta {
      */
     @Deprecated
     public Variant getVariant() {
-        return getVariantFromID(metadata.get(MetadataDef.Horse.VARIANT));
+        return getVariantFromID(get(MetadataDef.Horse.VARIANT));
     }
 
     /**
@@ -27,7 +27,7 @@ public final class HorseMeta extends AbstractHorseMeta {
      */
     @Deprecated
     public void setVariant(Variant variant) {
-        metadata.set(MetadataDef.Horse.VARIANT, getVariantID(variant.marking, variant.color));
+        set(MetadataDef.Horse.VARIANT, getVariantID(variant.marking, variant.color));
     }
 
     public static int getVariantID(Marking marking, Color color) {

--- a/src/main/java/net/minestom/server/entity/metadata/animal/LlamaMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/LlamaMeta.java
@@ -9,7 +9,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.network.NetworkBuffer;
 import org.jetbrains.annotations.Nullable;
 
-public class LlamaMeta extends ChestedHorseMeta {
+public final class LlamaMeta extends ChestedHorseMeta {
     public LlamaMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/LlamaMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/LlamaMeta.java
@@ -15,19 +15,19 @@ public final class LlamaMeta extends ChestedHorseMeta {
     }
 
     public int getStrength() {
-        return metadata.get(MetadataDef.Llama.STRENGTH);
+        return get(MetadataDef.Llama.STRENGTH);
     }
 
     public void setStrength(int value) {
-        metadata.set(MetadataDef.Llama.STRENGTH, value);
+        set(MetadataDef.Llama.STRENGTH, value);
     }
 
     public int getCarpetColor() {
-        return metadata.get(MetadataDef.Llama.CARPET_COLOR);
+        return get(MetadataDef.Llama.CARPET_COLOR);
     }
 
     public void setCarpetColor(int value) {
-        metadata.set(MetadataDef.Llama.CARPET_COLOR, value);
+        set(MetadataDef.Llama.CARPET_COLOR, value);
     }
 
     /**
@@ -35,7 +35,7 @@ public final class LlamaMeta extends ChestedHorseMeta {
      */
     @Deprecated
     public Variant getVariant() {
-        return Variant.VALUES[metadata.get(MetadataDef.Llama.VARIANT)];
+        return Variant.VALUES[get(MetadataDef.Llama.VARIANT)];
     }
 
     /**
@@ -43,7 +43,7 @@ public final class LlamaMeta extends ChestedHorseMeta {
      */
     @Deprecated
     public void setVariant(Variant value) {
-        metadata.set(MetadataDef.Llama.VARIANT, value.ordinal());
+        set(MetadataDef.Llama.VARIANT, value.ordinal());
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/animal/MooshroomMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/MooshroomMeta.java
@@ -9,7 +9,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.network.NetworkBuffer;
 import org.jetbrains.annotations.Nullable;
 
-public class MooshroomMeta extends AnimalMeta {
+public final class MooshroomMeta extends AnimalMeta {
     public MooshroomMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/MooshroomMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/MooshroomMeta.java
@@ -19,7 +19,7 @@ public final class MooshroomMeta extends AnimalMeta {
      */
     @Deprecated
     public Variant getVariant() {
-        return Variant.VALUES[metadata.get(MetadataDef.Mooshroom.VARIANT)];
+        return Variant.VALUES[get(MetadataDef.Mooshroom.VARIANT)];
     }
 
     /**
@@ -27,7 +27,7 @@ public final class MooshroomMeta extends AnimalMeta {
      */
     @Deprecated
     public void setVariant(Variant value) {
-        metadata.set(MetadataDef.Mooshroom.VARIANT, value.ordinal());
+        set(MetadataDef.Mooshroom.VARIANT, value.ordinal());
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/animal/MuleMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/MuleMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.animal;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class MuleMeta extends ChestedHorseMeta {
+public final class MuleMeta extends ChestedHorseMeta {
     public MuleMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/NautilusMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/NautilusMeta.java
@@ -1,11 +1,9 @@
 package net.minestom.server.entity.metadata.animal;
 
 import net.minestom.server.entity.Entity;
-import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
-import net.minestom.server.entity.metadata.animal.tameable.TameableAnimalMeta;
 
-public class NautilusMeta extends AbstractNautilusMeta {
+public final class NautilusMeta extends AbstractNautilusMeta {
     public NautilusMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/OcelotMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/OcelotMeta.java
@@ -10,11 +10,11 @@ public final class OcelotMeta extends AnimalMeta {
     }
 
     public boolean isTrusting() {
-        return metadata.get(MetadataDef.Ocelot.IS_TRUSTING);
+        return get(MetadataDef.Ocelot.IS_TRUSTING);
     }
 
     public void setTrusting(boolean value) {
-        metadata.set(MetadataDef.Ocelot.IS_TRUSTING, value);
+        set(MetadataDef.Ocelot.IS_TRUSTING, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/OcelotMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/OcelotMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class OcelotMeta extends AnimalMeta {
+public final class OcelotMeta extends AnimalMeta {
     public OcelotMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/PandaMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/PandaMeta.java
@@ -10,75 +10,75 @@ public final class PandaMeta extends AnimalMeta {
     }
 
     public int getBreedTimer() {
-        return metadata.get(MetadataDef.Panda.BREED_TIMER);
+        return get(MetadataDef.Panda.BREED_TIMER);
     }
 
     public void setBreedTimer(int value) {
-        metadata.set(MetadataDef.Panda.BREED_TIMER, value);
+        set(MetadataDef.Panda.BREED_TIMER, value);
     }
 
     public int getSneezeTimer() {
-        return metadata.get(MetadataDef.Panda.SNEEZE_TIMER);
+        return get(MetadataDef.Panda.SNEEZE_TIMER);
     }
 
     public void setSneezeTimer(int value) {
-        metadata.set(MetadataDef.Panda.SNEEZE_TIMER, value);
+        set(MetadataDef.Panda.SNEEZE_TIMER, value);
     }
 
     public int getEatTimer() {
-        return metadata.get(MetadataDef.Panda.EAT_TIMER);
+        return get(MetadataDef.Panda.EAT_TIMER);
     }
 
     public void setEatTimer(int value) {
-        metadata.set(MetadataDef.Panda.EAT_TIMER, value);
+        set(MetadataDef.Panda.EAT_TIMER, value);
     }
 
     public Gene getMainGene() {
-        return Gene.VALUES[metadata.get(MetadataDef.Panda.MAIN_GENE)];
+        return Gene.VALUES[get(MetadataDef.Panda.MAIN_GENE)];
     }
 
     public void setMainGene(Gene value) {
-        metadata.set(MetadataDef.Panda.MAIN_GENE, (byte) value.ordinal());
+        set(MetadataDef.Panda.MAIN_GENE, (byte) value.ordinal());
     }
 
     public Gene getHiddenGene() {
-        return Gene.VALUES[metadata.get(MetadataDef.Panda.HIDDEN_GENE)];
+        return Gene.VALUES[get(MetadataDef.Panda.HIDDEN_GENE)];
     }
 
     public void setHiddenGene(Gene value) {
-        metadata.set(MetadataDef.Panda.HIDDEN_GENE, (byte) value.ordinal());
+        set(MetadataDef.Panda.HIDDEN_GENE, (byte) value.ordinal());
     }
 
     public boolean isSneezing() {
-        return metadata.get(MetadataDef.Panda.IS_SNEEZING);
+        return get(MetadataDef.Panda.IS_SNEEZING);
     }
 
     public void setSneezing(boolean value) {
-        metadata.set(MetadataDef.Panda.IS_SNEEZING, value);
+        set(MetadataDef.Panda.IS_SNEEZING, value);
     }
 
     public boolean isRolling() {
-        return metadata.get(MetadataDef.Panda.IS_ROLLING);
+        return get(MetadataDef.Panda.IS_ROLLING);
     }
 
     public void setRolling(boolean value) {
-        metadata.set(MetadataDef.Panda.IS_ROLLING, value);
+        set(MetadataDef.Panda.IS_ROLLING, value);
     }
 
     public boolean isSitting() {
-        return metadata.get(MetadataDef.Panda.IS_SITTING);
+        return get(MetadataDef.Panda.IS_SITTING);
     }
 
     public void setSitting(boolean value) {
-        metadata.set(MetadataDef.Panda.IS_SITTING, value);
+        set(MetadataDef.Panda.IS_SITTING, value);
     }
 
     public boolean isOnBack() {
-        return metadata.get(MetadataDef.Panda.IS_ON_BACK);
+        return get(MetadataDef.Panda.IS_ON_BACK);
     }
 
     public void setOnBack(boolean value) {
-        metadata.set(MetadataDef.Panda.IS_ON_BACK, value);
+        set(MetadataDef.Panda.IS_ON_BACK, value);
     }
 
     public enum Gene {

--- a/src/main/java/net/minestom/server/entity/metadata/animal/PandaMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/PandaMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class PandaMeta extends AnimalMeta {
+public final class PandaMeta extends AnimalMeta {
     public PandaMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/PigMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/PigMeta.java
@@ -14,11 +14,11 @@ public final class PigMeta extends AnimalMeta {
     }
 
     public int getTimeToBoost() {
-        return metadata.get(MetadataDef.Pig.BOOST_TIME);
+        return get(MetadataDef.Pig.BOOST_TIME);
     }
 
     public void setTimeToBoost(int value) {
-        metadata.set(MetadataDef.Pig.BOOST_TIME, value);
+        set(MetadataDef.Pig.BOOST_TIME, value);
     }
 
     /**
@@ -26,7 +26,7 @@ public final class PigMeta extends AnimalMeta {
      */
     @Deprecated
     public RegistryKey<PigVariant> getVariant() {
-        return metadata.get(MetadataDef.Pig.VARIANT);
+        return get(MetadataDef.Pig.VARIANT);
     }
 
     /**
@@ -34,7 +34,7 @@ public final class PigMeta extends AnimalMeta {
      */
     @Deprecated
     public void setVariant(RegistryKey<PigVariant> value) {
-        metadata.set(MetadataDef.Pig.VARIANT, value);
+        set(MetadataDef.Pig.VARIANT, value);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/animal/PigMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/PigMeta.java
@@ -8,7 +8,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.registry.RegistryKey;
 import org.jetbrains.annotations.Nullable;
 
-public class PigMeta extends AnimalMeta {
+public final class PigMeta extends AnimalMeta {
     public PigMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/PolarBearMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/PolarBearMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class PolarBearMeta extends AnimalMeta {
+public final class PolarBearMeta extends AnimalMeta {
     public PolarBearMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/PolarBearMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/PolarBearMeta.java
@@ -10,11 +10,11 @@ public final class PolarBearMeta extends AnimalMeta {
     }
 
     public boolean isStandingUp() {
-        return metadata.get(MetadataDef.PolarBear.IS_STANDING_UP);
+        return get(MetadataDef.PolarBear.IS_STANDING_UP);
     }
 
     public void setStandingUp(boolean value) {
-        metadata.set(MetadataDef.PolarBear.IS_STANDING_UP, value);
+        set(MetadataDef.PolarBear.IS_STANDING_UP, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/RabbitMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/RabbitMeta.java
@@ -9,7 +9,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.network.NetworkBuffer;
 import org.jetbrains.annotations.Nullable;
 
-public class RabbitMeta extends AnimalMeta {
+public final class RabbitMeta extends AnimalMeta {
     public RabbitMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/RabbitMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/RabbitMeta.java
@@ -20,7 +20,7 @@ public final class RabbitMeta extends AnimalMeta {
     @Deprecated
     public void setVariant(RabbitMeta.Variant variant) {
         int id = variant == Variant.KILLER_BUNNY ? 99 : variant.ordinal();
-        metadata.set(MetadataDef.Rabbit.TYPE, id);
+        set(MetadataDef.Rabbit.TYPE, id);
     }
 
     /**
@@ -28,7 +28,7 @@ public final class RabbitMeta extends AnimalMeta {
      */
     @Deprecated
     public RabbitMeta.Variant getVariant() {
-        int id = metadata.get(MetadataDef.Rabbit.TYPE);
+        int id = get(MetadataDef.Rabbit.TYPE);
         if (id == 99) {
             return Variant.KILLER_BUNNY;
         }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/SheepMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/SheepMeta.java
@@ -20,7 +20,7 @@ public final class SheepMeta extends AnimalMeta {
      */
     @Deprecated
     public DyeColor getColor() {
-        return DYE_VALUES[metadata.get(MetadataDef.Sheep.COLOR_ID)];
+        return DYE_VALUES[get(MetadataDef.Sheep.COLOR_ID)];
     }
 
     /**
@@ -28,15 +28,15 @@ public final class SheepMeta extends AnimalMeta {
      */
     @Deprecated
     public void setColor(DyeColor color) {
-        metadata.set(MetadataDef.Sheep.COLOR_ID, (byte) color.ordinal());
+        set(MetadataDef.Sheep.COLOR_ID, (byte) color.ordinal());
     }
 
     public boolean isSheared() {
-        return metadata.get(MetadataDef.Sheep.IS_SHEARED);
+        return get(MetadataDef.Sheep.IS_SHEARED);
     }
 
     public void setSheared(boolean value) {
-        metadata.set(MetadataDef.Sheep.IS_SHEARED, value);
+        set(MetadataDef.Sheep.IS_SHEARED, value);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/animal/SheepMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/SheepMeta.java
@@ -8,7 +8,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import org.jetbrains.annotations.Nullable;
 
-public class SheepMeta extends AnimalMeta {
+public final class SheepMeta extends AnimalMeta {
     private static final DyeColor[] DYE_VALUES = DyeColor.values();
 
     public SheepMeta(Entity entity, MetadataHolder metadata) {

--- a/src/main/java/net/minestom/server/entity/metadata/animal/SkeletonHorseMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/SkeletonHorseMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.animal;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class SkeletonHorseMeta extends AbstractHorseMeta {
+public final class SkeletonHorseMeta extends AbstractHorseMeta {
     public SkeletonHorseMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/SnifferMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/SnifferMeta.java
@@ -11,19 +11,19 @@ public final class SnifferMeta extends AnimalMeta {
     }
 
     public State getState() {
-        return metadata.get(MetadataDef.Sniffer.STATE);
+        return get(MetadataDef.Sniffer.STATE);
     }
 
     public void setState(State value) {
-        metadata.set(MetadataDef.Sniffer.STATE, value);
+        set(MetadataDef.Sniffer.STATE, value);
     }
 
     public int getDropSeedAtTick() {
-        return metadata.get(MetadataDef.Sniffer.DROP_SEED_AT_TICK);
+        return get(MetadataDef.Sniffer.DROP_SEED_AT_TICK);
     }
 
     public void setDropSeedAtTick(int value) {
-        metadata.set(MetadataDef.Sniffer.DROP_SEED_AT_TICK, value);
+        set(MetadataDef.Sniffer.DROP_SEED_AT_TICK, value);
     }
 
     public enum State {

--- a/src/main/java/net/minestom/server/entity/metadata/animal/SnifferMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/SnifferMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.network.NetworkBuffer;
 
-public class SnifferMeta extends AnimalMeta {
+public final class SnifferMeta extends AnimalMeta {
     public SnifferMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/StriderMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/StriderMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class StriderMeta extends AnimalMeta {
+public final class StriderMeta extends AnimalMeta {
     public StriderMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/StriderMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/StriderMeta.java
@@ -10,19 +10,19 @@ public final class StriderMeta extends AnimalMeta {
     }
 
     public int getTimeToBoost() {
-        return metadata.get(MetadataDef.Strider.FUNGUS_BOOST);
+        return get(MetadataDef.Strider.FUNGUS_BOOST);
     }
 
     public void setTimeToBoost(int value) {
-        metadata.set(MetadataDef.Strider.FUNGUS_BOOST, value);
+        set(MetadataDef.Strider.FUNGUS_BOOST, value);
     }
 
     public boolean isShaking() {
-        return metadata.get(MetadataDef.Strider.IS_SHAKING);
+        return get(MetadataDef.Strider.IS_SHAKING);
     }
 
     public void setShaking(boolean value) {
-        metadata.set(MetadataDef.Strider.IS_SHAKING, value);
+        set(MetadataDef.Strider.IS_SHAKING, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/TurtleMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/TurtleMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class TurtleMeta extends AnimalMeta {
+public final class TurtleMeta extends AnimalMeta {
     public TurtleMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/TurtleMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/TurtleMeta.java
@@ -10,19 +10,19 @@ public final class TurtleMeta extends AnimalMeta {
     }
 
     public boolean isHasEgg() {
-        return metadata.get(MetadataDef.Turtle.HAS_EGG);
+        return get(MetadataDef.Turtle.HAS_EGG);
     }
 
     public void setHasEgg(boolean value) {
-        metadata.set(MetadataDef.Turtle.HAS_EGG, value);
+        set(MetadataDef.Turtle.HAS_EGG, value);
     }
 
     public boolean isLayingEgg() {
-        return metadata.get(MetadataDef.Turtle.IS_LAYING_EGG);
+        return get(MetadataDef.Turtle.IS_LAYING_EGG);
     }
 
     public void setLayingEgg(boolean value) {
-        metadata.set(MetadataDef.Turtle.IS_LAYING_EGG, value);
+        set(MetadataDef.Turtle.IS_LAYING_EGG, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/ZombieHorseMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/ZombieHorseMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.animal;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class ZombieHorseMeta extends AbstractHorseMeta {
+public final class ZombieHorseMeta extends AbstractHorseMeta {
     public ZombieHorseMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/ZombieNautilusMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/ZombieNautilusMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.registry.RegistryKey;
 
-public class ZombieNautilusMeta extends AbstractNautilusMeta {
+public final class ZombieNautilusMeta extends AbstractNautilusMeta {
     public ZombieNautilusMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/ZombieNautilusMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/ZombieNautilusMeta.java
@@ -11,11 +11,11 @@ public final class ZombieNautilusMeta extends AbstractNautilusMeta {
     }
 
     public RegistryKey<ZombieNautilusVariant> getVariant() {
-        return this.metadata.get(MetadataDef.ZombieNautilus.VARIANT);
+        return this.get(MetadataDef.ZombieNautilus.VARIANT);
     }
 
     public void setVariant(RegistryKey<ZombieNautilusVariant> value) {
-        this.metadata.set(MetadataDef.ZombieNautilus.VARIANT, value);
+        this.set(MetadataDef.ZombieNautilus.VARIANT, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/tameable/CatMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/tameable/CatMeta.java
@@ -9,7 +9,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.registry.RegistryKey;
 import org.jetbrains.annotations.Nullable;
 
-public class CatMeta extends TameableAnimalMeta {
+public final class CatMeta extends TameableAnimalMeta {
     private static final DyeColor[] DYE_VALUES = DyeColor.values();
 
     public CatMeta(Entity entity, MetadataHolder metadata) {

--- a/src/main/java/net/minestom/server/entity/metadata/animal/tameable/CatMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/tameable/CatMeta.java
@@ -21,7 +21,7 @@ public final class CatMeta extends TameableAnimalMeta {
      */
     @Deprecated
     public RegistryKey<CatVariant> getVariant() {
-        return metadata.get(MetadataDef.Cat.VARIANT);
+        return get(MetadataDef.Cat.VARIANT);
     }
 
     /**
@@ -29,23 +29,23 @@ public final class CatMeta extends TameableAnimalMeta {
      */
     @Deprecated
     public void setVariant(RegistryKey<CatVariant> value) {
-        metadata.set(MetadataDef.Cat.VARIANT, value);
+        set(MetadataDef.Cat.VARIANT, value);
     }
 
     public boolean isLying() {
-        return metadata.get(MetadataDef.Cat.IS_LYING);
+        return get(MetadataDef.Cat.IS_LYING);
     }
 
     public void setLying(boolean value) {
-        metadata.set(MetadataDef.Cat.IS_LYING, value);
+        set(MetadataDef.Cat.IS_LYING, value);
     }
 
     public boolean isRelaxed() {
-        return metadata.get(MetadataDef.Cat.IS_RELAXED);
+        return get(MetadataDef.Cat.IS_RELAXED);
     }
 
     public void setRelaxed(boolean value) {
-        metadata.set(MetadataDef.Cat.IS_RELAXED, value);
+        set(MetadataDef.Cat.IS_RELAXED, value);
     }
 
     /**
@@ -53,7 +53,7 @@ public final class CatMeta extends TameableAnimalMeta {
      */
     @Deprecated
     public DyeColor getCollarColor() {
-        return DYE_VALUES[metadata.get(MetadataDef.Cat.COLLAR_COLOR)];
+        return DYE_VALUES[get(MetadataDef.Cat.COLLAR_COLOR)];
     }
 
     /**
@@ -61,7 +61,7 @@ public final class CatMeta extends TameableAnimalMeta {
      */
     @Deprecated
     public void setCollarColor(DyeColor value) {
-        metadata.set(MetadataDef.Cat.COLLAR_COLOR, value.ordinal());
+        set(MetadataDef.Cat.COLLAR_COLOR, value.ordinal());
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/animal/tameable/ParrotMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/tameable/ParrotMeta.java
@@ -9,7 +9,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.network.NetworkBuffer;
 import org.jetbrains.annotations.Nullable;
 
-public class ParrotMeta extends TameableAnimalMeta {
+public final class ParrotMeta extends TameableAnimalMeta {
     public ParrotMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/tameable/ParrotMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/tameable/ParrotMeta.java
@@ -19,7 +19,7 @@ public final class ParrotMeta extends TameableAnimalMeta {
      */
     @Deprecated
     public Color getColor() {
-        return Color.VALUES[metadata.get(MetadataDef.Parrot.VARIANT)];
+        return Color.VALUES[get(MetadataDef.Parrot.VARIANT)];
     }
 
     /**
@@ -27,7 +27,7 @@ public final class ParrotMeta extends TameableAnimalMeta {
      */
     @Deprecated
     public void setColor(Color value) {
-        metadata.set(MetadataDef.Parrot.VARIANT, value.ordinal());
+        set(MetadataDef.Parrot.VARIANT, value.ordinal());
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/animal/tameable/TameableAnimalMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/tameable/TameableAnimalMeta.java
@@ -3,12 +3,13 @@ package net.minestom.server.entity.metadata.animal.tameable;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import net.minestom.server.entity.metadata.animal.AbstractNautilusMeta;
 import net.minestom.server.entity.metadata.animal.AnimalMeta;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
-public class TameableAnimalMeta extends AnimalMeta {
+public sealed abstract class TameableAnimalMeta extends AnimalMeta permits AbstractNautilusMeta, CatMeta, ParrotMeta, WolfMeta {
     protected TameableAnimalMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/tameable/TameableAnimalMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/tameable/TameableAnimalMeta.java
@@ -15,28 +15,28 @@ public sealed abstract class TameableAnimalMeta extends AnimalMeta permits Abstr
     }
 
     public boolean isSitting() {
-        return metadata.get(MetadataDef.TameableAnimal.IS_SITTING);
+        return get(MetadataDef.TameableAnimal.IS_SITTING);
     }
 
     public void setSitting(boolean value) {
-        metadata.set(MetadataDef.TameableAnimal.IS_SITTING, value);
+        set(MetadataDef.TameableAnimal.IS_SITTING, value);
     }
 
     public boolean isTamed() {
-        return metadata.get(MetadataDef.TameableAnimal.IS_TAMED);
+        return get(MetadataDef.TameableAnimal.IS_TAMED);
     }
 
     public void setTamed(boolean value) {
-        metadata.set(MetadataDef.TameableAnimal.IS_TAMED, value);
+        set(MetadataDef.TameableAnimal.IS_TAMED, value);
     }
 
     @Nullable
     public UUID getOwner() {
-        return metadata.get(MetadataDef.TameableAnimal.OWNER);
+        return get(MetadataDef.TameableAnimal.OWNER);
     }
 
     public void setOwner(@Nullable UUID value) {
-        metadata.set(MetadataDef.TameableAnimal.OWNER, value);
+        set(MetadataDef.TameableAnimal.OWNER, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/tameable/WolfMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/tameable/WolfMeta.java
@@ -15,11 +15,11 @@ public final class WolfMeta extends TameableAnimalMeta {
     }
 
     public boolean isBegging() {
-        return metadata.get(MetadataDef.Wolf.IS_BEGGING);
+        return get(MetadataDef.Wolf.IS_BEGGING);
     }
 
     public void setBegging(boolean value) {
-        metadata.set(MetadataDef.Wolf.IS_BEGGING, value);
+        set(MetadataDef.Wolf.IS_BEGGING, value);
     }
 
     /**
@@ -27,7 +27,7 @@ public final class WolfMeta extends TameableAnimalMeta {
      */
     @Deprecated
     public DyeColor getCollarColor() {
-        return DyeColor.values()[metadata.get(MetadataDef.Wolf.COLLAR_COLOR)];
+        return DyeColor.values()[get(MetadataDef.Wolf.COLLAR_COLOR)];
     }
 
     /**
@@ -35,15 +35,15 @@ public final class WolfMeta extends TameableAnimalMeta {
      */
     @Deprecated
     public void setCollarColor(DyeColor value) {
-        metadata.set(MetadataDef.Wolf.COLLAR_COLOR, value.ordinal());
+        set(MetadataDef.Wolf.COLLAR_COLOR, value.ordinal());
     }
 
     public long getAngerTime() {
-        return metadata.get(MetadataDef.Wolf.ANGER_TIME);
+        return get(MetadataDef.Wolf.ANGER_TIME);
     }
 
     public void setAngerTime(long value) {
-        metadata.set(MetadataDef.Wolf.ANGER_TIME, value);
+        set(MetadataDef.Wolf.ANGER_TIME, value);
     }
 
     /**
@@ -51,7 +51,7 @@ public final class WolfMeta extends TameableAnimalMeta {
      */
     @Deprecated
     public RegistryKey<WolfVariant> getVariant() {
-        return metadata.get(MetadataDef.Wolf.VARIANT);
+        return get(MetadataDef.Wolf.VARIANT);
     }
 
     /**
@@ -59,7 +59,7 @@ public final class WolfMeta extends TameableAnimalMeta {
      */
     @Deprecated
     public void setVariant(RegistryKey<WolfVariant> value) {
-        metadata.set(MetadataDef.Wolf.VARIANT, value);
+        set(MetadataDef.Wolf.VARIANT, value);
     }
 
     /**
@@ -67,7 +67,7 @@ public final class WolfMeta extends TameableAnimalMeta {
      */
     @Deprecated
     public RegistryKey<WolfSoundVariant> getSoundVariant() {
-        return metadata.get(MetadataDef.Wolf.SOUND_VARIANT);
+        return get(MetadataDef.Wolf.SOUND_VARIANT);
     }
 
     /**
@@ -75,7 +75,7 @@ public final class WolfMeta extends TameableAnimalMeta {
      */
     @Deprecated
     public void setSoundVariant(RegistryKey<WolfSoundVariant> value) {
-        metadata.set(MetadataDef.Wolf.SOUND_VARIANT, value);
+        set(MetadataDef.Wolf.SOUND_VARIANT, value);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/animal/tameable/WolfMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/tameable/WolfMeta.java
@@ -9,7 +9,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.registry.RegistryKey;
 import org.jetbrains.annotations.Nullable;
 
-public class WolfMeta extends TameableAnimalMeta {
+public final class WolfMeta extends TameableAnimalMeta {
     public WolfMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/avatar/AvatarMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/avatar/AvatarMeta.java
@@ -13,75 +13,75 @@ public sealed abstract class AvatarMeta extends LivingEntityMeta permits Mannequ
     }
     
     public MainHand getMainHand() {
-        return metadata.get(MetadataDef.Avatar.MAIN_HAND);
+        return get(MetadataDef.Avatar.MAIN_HAND);
     }
 
     public void setMainHand(MainHand value) {
-        metadata.set(MetadataDef.Avatar.MAIN_HAND, value);
+        set(MetadataDef.Avatar.MAIN_HAND, value);
     }
 
     public boolean isCapeEnabled() {
-        return metadata.get(MetadataDef.Avatar.IS_CAPE_ENABLED);
+        return get(MetadataDef.Avatar.IS_CAPE_ENABLED);
     }
 
     public void setCapeEnabled(boolean value) {
-        metadata.set(MetadataDef.Avatar.IS_CAPE_ENABLED, value);
+        set(MetadataDef.Avatar.IS_CAPE_ENABLED, value);
     }
 
     public boolean isJacketEnabled() {
-        return metadata.get(MetadataDef.Avatar.IS_JACKET_ENABLED);
+        return get(MetadataDef.Avatar.IS_JACKET_ENABLED);
     }
 
     public void setJacketEnabled(boolean value) {
-        metadata.set(MetadataDef.Avatar.IS_JACKET_ENABLED, value);
+        set(MetadataDef.Avatar.IS_JACKET_ENABLED, value);
     }
 
     public boolean isLeftSleeveEnabled() {
-        return metadata.get(MetadataDef.Avatar.IS_LEFT_SLEEVE_ENABLED);
+        return get(MetadataDef.Avatar.IS_LEFT_SLEEVE_ENABLED);
     }
 
     public void setLeftSleeveEnabled(boolean value) {
-        metadata.set(MetadataDef.Avatar.IS_LEFT_SLEEVE_ENABLED, value);
+        set(MetadataDef.Avatar.IS_LEFT_SLEEVE_ENABLED, value);
     }
 
     public boolean isRightSleeveEnabled() {
-        return metadata.get(MetadataDef.Avatar.IS_RIGHT_SLEEVE_ENABLED);
+        return get(MetadataDef.Avatar.IS_RIGHT_SLEEVE_ENABLED);
     }
 
     public void setRightSleeveEnabled(boolean value) {
-        metadata.set(MetadataDef.Avatar.IS_RIGHT_SLEEVE_ENABLED, value);
+        set(MetadataDef.Avatar.IS_RIGHT_SLEEVE_ENABLED, value);
     }
 
     public boolean isLeftLegEnabled() {
-        return metadata.get(MetadataDef.Avatar.IS_LEFT_PANTS_LEG_ENABLED);
+        return get(MetadataDef.Avatar.IS_LEFT_PANTS_LEG_ENABLED);
     }
 
     public void setLeftLegEnabled(boolean value) {
-        metadata.set(MetadataDef.Avatar.IS_LEFT_PANTS_LEG_ENABLED, value);
+        set(MetadataDef.Avatar.IS_LEFT_PANTS_LEG_ENABLED, value);
     }
 
     public boolean isRightLegEnabled() {
-        return metadata.get(MetadataDef.Avatar.IS_RIGHT_PANTS_LEG_ENABLED);
+        return get(MetadataDef.Avatar.IS_RIGHT_PANTS_LEG_ENABLED);
     }
 
     public void setRightLegEnabled(boolean value) {
-        metadata.set(MetadataDef.Avatar.IS_RIGHT_PANTS_LEG_ENABLED, value);
+        set(MetadataDef.Avatar.IS_RIGHT_PANTS_LEG_ENABLED, value);
     }
 
     public boolean isHatEnabled() {
-        return metadata.get(MetadataDef.Avatar.IS_HAT_ENABLED);
+        return get(MetadataDef.Avatar.IS_HAT_ENABLED);
     }
 
     public void setHatEnabled(boolean value) {
-        metadata.set(MetadataDef.Avatar.IS_HAT_ENABLED, value);
+        set(MetadataDef.Avatar.IS_HAT_ENABLED, value);
     }
 
     public byte getDisplayedSkinParts() {
-        return metadata.get(MetadataDef.Avatar.DISPLAYED_MODEL_PARTS_FLAGS);
+        return get(MetadataDef.Avatar.DISPLAYED_MODEL_PARTS_FLAGS);
     }
 
     public void setDisplayedSkinParts(byte skinDisplayByte) {
-        metadata.set(MetadataDef.Avatar.DISPLAYED_MODEL_PARTS_FLAGS, skinDisplayByte);
+        set(MetadataDef.Avatar.DISPLAYED_MODEL_PARTS_FLAGS, skinDisplayByte);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/avatar/AvatarMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/avatar/AvatarMeta.java
@@ -6,7 +6,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.LivingEntityMeta;
 
-public class AvatarMeta extends LivingEntityMeta {
+public sealed abstract class AvatarMeta extends LivingEntityMeta permits MannequinMeta, PlayerMeta {
 
     protected AvatarMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);

--- a/src/main/java/net/minestom/server/entity/metadata/avatar/MannequinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/avatar/MannequinMeta.java
@@ -14,27 +14,27 @@ public final class MannequinMeta extends AvatarMeta {
     }
 
     public ResolvableProfile getProfile() {
-        return metadata.get(MetadataDef.Mannequin.PROFILE);
+        return get(MetadataDef.Mannequin.PROFILE);
     }
 
     public void setProfile(ResolvableProfile value) {
-        metadata.set(MetadataDef.Mannequin.PROFILE, value);
+        set(MetadataDef.Mannequin.PROFILE, value);
     }
 
     public boolean isImmovable() {
-        return metadata.get(MetadataDef.Mannequin.IMMOVABLE);
+        return get(MetadataDef.Mannequin.IMMOVABLE);
     }
 
     public void setImmovable(boolean value) {
-        metadata.set(MetadataDef.Mannequin.IMMOVABLE, value);
+        set(MetadataDef.Mannequin.IMMOVABLE, value);
     }
 
     public @Nullable Component getDescription() {
-        return metadata.get(MetadataDef.Mannequin.DESCRIPTION);
+        return get(MetadataDef.Mannequin.DESCRIPTION);
     }
 
     public void setDescription(@Nullable Component value) {
-        metadata.set(MetadataDef.Mannequin.DESCRIPTION, value);
+        set(MetadataDef.Mannequin.DESCRIPTION, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/avatar/MannequinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/avatar/MannequinMeta.java
@@ -7,11 +7,8 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.network.player.ResolvableProfile;
 import org.jetbrains.annotations.Nullable;
 
-public class MannequinMeta extends AvatarMeta {
-// ublic static final Entry<ResolvableProfile> PROFILE = index(0, Metadata::ResolvableProfile, ResolvableProfile.EMPTY);
-//        public static final Entry<Boolean> IMMOVABLE = index(1, Metadata::Boolean, false);
-//        public static final Entry<@Nullable Component> DESCRIPTION = index(2, Metadata::OptComponent, Component.translatable("entity.minecraft.mannequin.label"));
-//
+public final class MannequinMeta extends AvatarMeta {
+
     public MannequinMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/avatar/PlayerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/avatar/PlayerMeta.java
@@ -11,35 +11,35 @@ public final class PlayerMeta extends AvatarMeta {
     }
 
     public float getAdditionalHearts() {
-        return metadata.get(MetadataDef.Player.ADDITIONAL_HEARTS);
+        return get(MetadataDef.Player.ADDITIONAL_HEARTS);
     }
 
     public void setAdditionalHearts(float value) {
-        metadata.set(MetadataDef.Player.ADDITIONAL_HEARTS, value);
+        set(MetadataDef.Player.ADDITIONAL_HEARTS, value);
     }
 
     public int getScore() {
-        return metadata.get(MetadataDef.Player.SCORE);
+        return get(MetadataDef.Player.SCORE);
     }
 
     public void setScore(int value) {
-        metadata.set(MetadataDef.Player.SCORE, value);
+        set(MetadataDef.Player.SCORE, value);
     }
 
     public @Nullable Integer getLeftShoulderEntityData() {
-        return metadata.get(MetadataDef.Player.LEFT_SHOULDER_ENTITY_DATA);
+        return get(MetadataDef.Player.LEFT_SHOULDER_ENTITY_DATA);
     }
 
     public void setLeftShoulderEntityData(@Nullable Integer value) {
-        metadata.set(MetadataDef.Player.LEFT_SHOULDER_ENTITY_DATA, value);
+        set(MetadataDef.Player.LEFT_SHOULDER_ENTITY_DATA, value);
     }
 
     public @Nullable Integer getRightShoulderEntityData() {
-        return metadata.get(MetadataDef.Player.RIGHT_SHOULDER_ENTITY_DATA);
+        return get(MetadataDef.Player.RIGHT_SHOULDER_ENTITY_DATA);
     }
 
     public void setRightShoulderEntityData(@Nullable Integer value) {
-        metadata.set(MetadataDef.Player.RIGHT_SHOULDER_ENTITY_DATA, value);
+        set(MetadataDef.Player.RIGHT_SHOULDER_ENTITY_DATA, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/avatar/PlayerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/avatar/PlayerMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import org.jetbrains.annotations.Nullable;
 
-public class PlayerMeta extends AvatarMeta {
+public final class PlayerMeta extends AvatarMeta {
     public PlayerMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/display/AbstractDisplayMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/display/AbstractDisplayMeta.java
@@ -7,7 +7,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 
-public class AbstractDisplayMeta extends EntityMeta {
+public sealed abstract class AbstractDisplayMeta extends EntityMeta permits BlockDisplayMeta, ItemDisplayMeta, TextDisplayMeta {
     protected AbstractDisplayMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/display/AbstractDisplayMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/display/AbstractDisplayMeta.java
@@ -13,77 +13,77 @@ public sealed abstract class AbstractDisplayMeta extends EntityMeta permits Bloc
     }
 
     public int getTransformationInterpolationStartDelta() {
-        return metadata.get(MetadataDef.Display.INTERPOLATION_DELAY);
+        return get(MetadataDef.Display.INTERPOLATION_DELAY);
     }
 
     public void setTransformationInterpolationStartDelta(int value) {
-        metadata.set(MetadataDef.Display.INTERPOLATION_DELAY, value);
+        set(MetadataDef.Display.INTERPOLATION_DELAY, value);
     }
 
     public int getTransformationInterpolationDuration() {
-        return metadata.get(MetadataDef.Display.TRANSFORMATION_INTERPOLATION_DURATION);
+        return get(MetadataDef.Display.TRANSFORMATION_INTERPOLATION_DURATION);
     }
 
     public void setTransformationInterpolationDuration(int value) {
-        metadata.set(MetadataDef.Display.TRANSFORMATION_INTERPOLATION_DURATION, value);
+        set(MetadataDef.Display.TRANSFORMATION_INTERPOLATION_DURATION, value);
     }
 
     public int getPosRotInterpolationDuration() {
-        return metadata.get(MetadataDef.Display.POSITION_ROTATION_INTERPOLATION_DURATION);
+        return get(MetadataDef.Display.POSITION_ROTATION_INTERPOLATION_DURATION);
     }
 
     public void setPosRotInterpolationDuration(int value) {
-        metadata.set(MetadataDef.Display.POSITION_ROTATION_INTERPOLATION_DURATION, value);
+        set(MetadataDef.Display.POSITION_ROTATION_INTERPOLATION_DURATION, value);
     }
 
     public Point getTranslation() {
-        return metadata.get(MetadataDef.Display.TRANSLATION);
+        return get(MetadataDef.Display.TRANSLATION);
     }
 
     public void setTranslation(Point value) {
-        metadata.set(MetadataDef.Display.TRANSLATION, value);
+        set(MetadataDef.Display.TRANSLATION, value);
     }
 
     public Vec getScale() {
-        return metadata.get(MetadataDef.Display.SCALE).asVec();
+        return get(MetadataDef.Display.SCALE).asVec();
     }
 
     public void setScale(Vec value) {
-        metadata.set(MetadataDef.Display.SCALE, value);
+        set(MetadataDef.Display.SCALE, value);
     }
 
     public float [] getLeftRotation() {
         //todo replace with actual quaternion type
-        return metadata.get(MetadataDef.Display.ROTATION_LEFT);
+        return get(MetadataDef.Display.ROTATION_LEFT);
     }
 
     public void setLeftRotation(float [] value) {
-        metadata.set(MetadataDef.Display.ROTATION_LEFT, value);
+        set(MetadataDef.Display.ROTATION_LEFT, value);
     }
 
     public float [] getRightRotation() {
         //todo replace with actual quaternion type
-        return metadata.get(MetadataDef.Display.ROTATION_RIGHT);
+        return get(MetadataDef.Display.ROTATION_RIGHT);
     }
 
     public void setRightRotation(float [] value) {
-        metadata.set(MetadataDef.Display.ROTATION_RIGHT, value);
+        set(MetadataDef.Display.ROTATION_RIGHT, value);
     }
 
     public BillboardConstraints getBillboardRenderConstraints() {
-        return BillboardConstraints.VALUES[metadata.get(MetadataDef.Display.BILLBOARD_CONSTRAINTS)];
+        return BillboardConstraints.VALUES[get(MetadataDef.Display.BILLBOARD_CONSTRAINTS)];
     }
 
     public void setBillboardRenderConstraints(BillboardConstraints value) {
-        metadata.set(MetadataDef.Display.BILLBOARD_CONSTRAINTS, (byte) value.ordinal());
+        set(MetadataDef.Display.BILLBOARD_CONSTRAINTS, (byte) value.ordinal());
     }
 
     public int getBrightnessOverride() {
-        return metadata.get(MetadataDef.Display.BRIGHTNESS_OVERRIDE);
+        return get(MetadataDef.Display.BRIGHTNESS_OVERRIDE);
     }
 
     public void setBrightnessOverride(int value) {
-        metadata.set(MetadataDef.Display.BRIGHTNESS_OVERRIDE, value);
+        set(MetadataDef.Display.BRIGHTNESS_OVERRIDE, value);
     }
 
     public void setBrightness(int blockLight, int skyLight) {
@@ -107,51 +107,51 @@ public sealed abstract class AbstractDisplayMeta extends EntityMeta permits Bloc
     }
 
     public float getViewRange() {
-        return metadata.get(MetadataDef.Display.VIEW_RANGE);
+        return get(MetadataDef.Display.VIEW_RANGE);
     }
 
     public void setViewRange(float value) {
-        metadata.set(MetadataDef.Display.VIEW_RANGE, value);
+        set(MetadataDef.Display.VIEW_RANGE, value);
     }
 
     public float getShadowRadius() {
-        return metadata.get(MetadataDef.Display.SHADOW_RADIUS);
+        return get(MetadataDef.Display.SHADOW_RADIUS);
     }
 
     public void setShadowRadius(float value) {
-        metadata.set(MetadataDef.Display.SHADOW_RADIUS, value);
+        set(MetadataDef.Display.SHADOW_RADIUS, value);
     }
 
     public float getShadowStrength() {
-        return metadata.get(MetadataDef.Display.SHADOW_STRENGTH);
+        return get(MetadataDef.Display.SHADOW_STRENGTH);
     }
 
     public void setShadowStrength(float value) {
-        metadata.set(MetadataDef.Display.SHADOW_STRENGTH, value);
+        set(MetadataDef.Display.SHADOW_STRENGTH, value);
     }
 
     public float getWidth() {
-        return metadata.get(MetadataDef.Display.WIDTH);
+        return get(MetadataDef.Display.WIDTH);
     }
 
     public void setWidth(float value) {
-        metadata.set(MetadataDef.Display.WIDTH, value);
+        set(MetadataDef.Display.WIDTH, value);
     }
 
     public float getHeight() {
-        return metadata.get(MetadataDef.Display.HEIGHT);
+        return get(MetadataDef.Display.HEIGHT);
     }
 
     public void setHeight(float value) {
-        metadata.set(MetadataDef.Display.HEIGHT, value);
+        set(MetadataDef.Display.HEIGHT, value);
     }
 
     public int getGlowColorOverride() {
-        return metadata.get(MetadataDef.Display.GLOW_COLOR_OVERRIDE);
+        return get(MetadataDef.Display.GLOW_COLOR_OVERRIDE);
     }
 
     public void setGlowColorOverride(int value) {
-        metadata.set(MetadataDef.Display.GLOW_COLOR_OVERRIDE, value);
+        set(MetadataDef.Display.GLOW_COLOR_OVERRIDE, value);
     }
 
     public enum BillboardConstraints {

--- a/src/main/java/net/minestom/server/entity/metadata/display/BlockDisplayMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/display/BlockDisplayMeta.java
@@ -11,10 +11,10 @@ public final class BlockDisplayMeta extends AbstractDisplayMeta {
     }
 
     public Block getBlockStateId() {
-        return metadata.get(MetadataDef.BlockDisplay.DISPLAYED_BLOCK_STATE);
+        return get(MetadataDef.BlockDisplay.DISPLAYED_BLOCK_STATE);
     }
 
     public void setBlockState(Block value) {
-        metadata.set(MetadataDef.BlockDisplay.DISPLAYED_BLOCK_STATE, value);
+        set(MetadataDef.BlockDisplay.DISPLAYED_BLOCK_STATE, value);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/display/BlockDisplayMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/display/BlockDisplayMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.instance.block.Block;
 
-public class BlockDisplayMeta extends AbstractDisplayMeta {
+public final class BlockDisplayMeta extends AbstractDisplayMeta {
     public BlockDisplayMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/display/ItemDisplayMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/display/ItemDisplayMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.item.ItemStack;
 
-public class ItemDisplayMeta extends AbstractDisplayMeta {
+public final class ItemDisplayMeta extends AbstractDisplayMeta {
     public ItemDisplayMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/display/ItemDisplayMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/display/ItemDisplayMeta.java
@@ -11,19 +11,19 @@ public final class ItemDisplayMeta extends AbstractDisplayMeta {
     }
 
     public ItemStack getItemStack() {
-        return metadata.get(MetadataDef.ItemDisplay.DISPLAYED_ITEM);
+        return get(MetadataDef.ItemDisplay.DISPLAYED_ITEM);
     }
 
     public void setItemStack(ItemStack value) {
-        metadata.set(MetadataDef.ItemDisplay.DISPLAYED_ITEM, value);
+        set(MetadataDef.ItemDisplay.DISPLAYED_ITEM, value);
     }
 
     public DisplayContext getDisplayContext() {
-        return DisplayContext.VALUES[metadata.get(MetadataDef.ItemDisplay.DISPLAY_TYPE)];
+        return DisplayContext.VALUES[get(MetadataDef.ItemDisplay.DISPLAY_TYPE)];
     }
 
     public void setDisplayContext(DisplayContext value) {
-        metadata.set(MetadataDef.ItemDisplay.DISPLAY_TYPE, (byte) value.ordinal());
+        set(MetadataDef.ItemDisplay.DISPLAY_TYPE, (byte) value.ordinal());
     }
 
     public enum DisplayContext {

--- a/src/main/java/net/minestom/server/entity/metadata/display/TextDisplayMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/display/TextDisplayMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class TextDisplayMeta extends AbstractDisplayMeta {
+public final class TextDisplayMeta extends AbstractDisplayMeta {
     public TextDisplayMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/display/TextDisplayMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/display/TextDisplayMeta.java
@@ -11,83 +11,83 @@ public final class TextDisplayMeta extends AbstractDisplayMeta {
     }
 
     public Component getText() {
-        return metadata.get(MetadataDef.TextDisplay.TEXT);
+        return get(MetadataDef.TextDisplay.TEXT);
     }
 
     public void setText(Component value) {
-        metadata.set(MetadataDef.TextDisplay.TEXT, value);
+        set(MetadataDef.TextDisplay.TEXT, value);
     }
 
     public int getLineWidth() {
-        return metadata.get(MetadataDef.TextDisplay.LINE_WIDTH);
+        return get(MetadataDef.TextDisplay.LINE_WIDTH);
     }
 
     public void setLineWidth(int value) {
-        metadata.set(MetadataDef.TextDisplay.LINE_WIDTH, value);
+        set(MetadataDef.TextDisplay.LINE_WIDTH, value);
     }
 
     public int getBackgroundColor() {
-        return metadata.get(MetadataDef.TextDisplay.BACKGROUND_COLOR);
+        return get(MetadataDef.TextDisplay.BACKGROUND_COLOR);
     }
 
     public void setBackgroundColor(int value) {
-        metadata.set(MetadataDef.TextDisplay.BACKGROUND_COLOR, value);
+        set(MetadataDef.TextDisplay.BACKGROUND_COLOR, value);
     }
 
     public byte getTextOpacity() {
-        return metadata.get(MetadataDef.TextDisplay.TEXT_OPACITY);
+        return get(MetadataDef.TextDisplay.TEXT_OPACITY);
     }
 
     public void setTextOpacity(byte value) {
-        metadata.set(MetadataDef.TextDisplay.TEXT_OPACITY, value);
+        set(MetadataDef.TextDisplay.TEXT_OPACITY, value);
     }
 
     public boolean isShadow() {
-        return metadata.get(MetadataDef.TextDisplay.HAS_SHADOW);
+        return get(MetadataDef.TextDisplay.HAS_SHADOW);
     }
 
     public void setShadow(boolean value) {
-        metadata.set(MetadataDef.TextDisplay.HAS_SHADOW, value);
+        set(MetadataDef.TextDisplay.HAS_SHADOW, value);
     }
 
     public boolean isSeeThrough() {
-        return metadata.get(MetadataDef.TextDisplay.IS_SEE_THROUGH);
+        return get(MetadataDef.TextDisplay.IS_SEE_THROUGH);
     }
 
     public void setSeeThrough(boolean value) {
-        metadata.set(MetadataDef.TextDisplay.IS_SEE_THROUGH, value);
+        set(MetadataDef.TextDisplay.IS_SEE_THROUGH, value);
     }
 
     public boolean isUseDefaultBackground() {
-        return metadata.get(MetadataDef.TextDisplay.USE_DEFAULT_BACKGROUND_COLOR);
+        return get(MetadataDef.TextDisplay.USE_DEFAULT_BACKGROUND_COLOR);
     }
 
     public void setUseDefaultBackground(boolean value) {
-        metadata.set(MetadataDef.TextDisplay.USE_DEFAULT_BACKGROUND_COLOR, value);
+        set(MetadataDef.TextDisplay.USE_DEFAULT_BACKGROUND_COLOR, value);
     }
 
     public boolean isAlignLeft() {
-        return metadata.get(MetadataDef.TextDisplay.ALIGN_LEFT);
+        return get(MetadataDef.TextDisplay.ALIGN_LEFT);
     }
 
     public void setAlignLeft(boolean value) {
-        metadata.set(MetadataDef.TextDisplay.ALIGN_LEFT, value);
+        set(MetadataDef.TextDisplay.ALIGN_LEFT, value);
     }
 
     public boolean isAlignRight() {
-        return metadata.get(MetadataDef.TextDisplay.ALIGN_RIGHT);
+        return get(MetadataDef.TextDisplay.ALIGN_RIGHT);
     }
 
     public void setAlignRight(boolean value) {
-        metadata.set(MetadataDef.TextDisplay.ALIGN_RIGHT, value);
+        set(MetadataDef.TextDisplay.ALIGN_RIGHT, value);
     }
 
     public Alignment getAlignment() {
-        return Alignment.fromId(metadata.get(MetadataDef.TextDisplay.ALIGNMENT));
+        return Alignment.fromId(get(MetadataDef.TextDisplay.ALIGNMENT));
     }
 
     public void setAlignment(Alignment value) {
-        metadata.set(MetadataDef.TextDisplay.ALIGNMENT, (byte) value.ordinal());
+        set(MetadataDef.TextDisplay.ALIGNMENT, (byte) value.ordinal());
     }
 
     public enum Alignment {

--- a/src/main/java/net/minestom/server/entity/metadata/flying/FlyingMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/flying/FlyingMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.MobMeta;
 
-public class FlyingMeta extends MobMeta {
+public sealed abstract class FlyingMeta extends MobMeta permits GhastMeta, PhantomMeta {
     protected FlyingMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/flying/GhastMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/flying/GhastMeta.java
@@ -10,11 +10,11 @@ public final class GhastMeta extends FlyingMeta {
     }
 
     public boolean isAttacking() {
-        return metadata.get(MetadataDef.Ghast.IS_ATTACKING);
+        return get(MetadataDef.Ghast.IS_ATTACKING);
     }
 
     public void setAttacking(boolean value) {
-        metadata.set(MetadataDef.Ghast.IS_ATTACKING, value);
+        set(MetadataDef.Ghast.IS_ATTACKING, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/flying/GhastMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/flying/GhastMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class GhastMeta extends FlyingMeta {
+public final class GhastMeta extends FlyingMeta {
     public GhastMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/flying/PhantomMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/flying/PhantomMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class PhantomMeta extends FlyingMeta {
+public final class PhantomMeta extends FlyingMeta {
     public PhantomMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/flying/PhantomMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/flying/PhantomMeta.java
@@ -10,11 +10,11 @@ public final class PhantomMeta extends FlyingMeta {
     }
 
     public int getSize() {
-        return metadata.get(MetadataDef.Phantom.SIZE);
+        return get(MetadataDef.Phantom.SIZE);
     }
 
     public void setSize(int value) {
-        metadata.set(MetadataDef.Phantom.SIZE, value);
+        set(MetadataDef.Phantom.SIZE, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/golem/AbstractGolemMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/golem/AbstractGolemMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.PathfinderMobMeta;
 
-public sealed class AbstractGolemMeta extends PathfinderMobMeta permits CopperGolemMeta, IronGolemMeta, ShulkerMeta, SnowGolemMeta {
+public sealed abstract class AbstractGolemMeta extends PathfinderMobMeta permits CopperGolemMeta, IronGolemMeta, ShulkerMeta, SnowGolemMeta {
     protected AbstractGolemMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/golem/AbstractGolemMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/golem/AbstractGolemMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.PathfinderMobMeta;
 
-public class AbstractGolemMeta extends PathfinderMobMeta {
+public sealed class AbstractGolemMeta extends PathfinderMobMeta permits CopperGolemMeta, IronGolemMeta, ShulkerMeta, SnowGolemMeta {
     protected AbstractGolemMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/golem/CopperGolemMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/golem/CopperGolemMeta.java
@@ -13,19 +13,19 @@ public final class CopperGolemMeta extends AbstractGolemMeta {
     }
 
     public WeatherState getWeatherState() {
-        return metadata.get(MetadataDef.CopperGolem.WEATHER_STATE);
+        return get(MetadataDef.CopperGolem.WEATHER_STATE);
     }
 
     public void setWeatherState(WeatherState weatherState) {
-        metadata.set(MetadataDef.CopperGolem.WEATHER_STATE, weatherState);
+        set(MetadataDef.CopperGolem.WEATHER_STATE, weatherState);
     }
 
     public State getState() {
-        return metadata.get(MetadataDef.CopperGolem.STATE);
+        return get(MetadataDef.CopperGolem.STATE);
     }
 
     public void setState(State state) {
-        metadata.set(MetadataDef.CopperGolem.STATE, state);
+        set(MetadataDef.CopperGolem.STATE, state);
     }
 
     public enum WeatherState {

--- a/src/main/java/net/minestom/server/entity/metadata/golem/CopperGolemMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/golem/CopperGolemMeta.java
@@ -5,27 +5,26 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.network.NetworkBuffer;
-import org.jetbrains.annotations.NotNull;
 
-public class CopperGolemMeta extends AbstractGolemMeta {
+public final class CopperGolemMeta extends AbstractGolemMeta {
 
-    public CopperGolemMeta(@NotNull Entity entity, @NotNull MetadataHolder metadata) {
+    public CopperGolemMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 
-    public @NotNull WeatherState getWeatherState() {
+    public WeatherState getWeatherState() {
         return metadata.get(MetadataDef.CopperGolem.WEATHER_STATE);
     }
 
-    public void setWeatherState(@NotNull WeatherState weatherState) {
+    public void setWeatherState(WeatherState weatherState) {
         metadata.set(MetadataDef.CopperGolem.WEATHER_STATE, weatherState);
     }
 
-    public @NotNull State getState() {
+    public State getState() {
         return metadata.get(MetadataDef.CopperGolem.STATE);
     }
 
-    public void setState(@NotNull State state) {
+    public void setState(State state) {
         metadata.set(MetadataDef.CopperGolem.STATE, state);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/golem/IronGolemMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/golem/IronGolemMeta.java
@@ -10,11 +10,11 @@ public final class IronGolemMeta extends AbstractGolemMeta {
     }
 
     public boolean isPlayerCreated() {
-        return metadata.get(MetadataDef.IronGolem.IS_PLAYER_CREATED);
+        return get(MetadataDef.IronGolem.IS_PLAYER_CREATED);
     }
 
     public void setPlayerCreated(boolean value) {
-        metadata.set(MetadataDef.IronGolem.IS_PLAYER_CREATED, value);
+        set(MetadataDef.IronGolem.IS_PLAYER_CREATED, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/golem/IronGolemMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/golem/IronGolemMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class IronGolemMeta extends AbstractGolemMeta {
+public final class IronGolemMeta extends AbstractGolemMeta {
     public IronGolemMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/golem/ShulkerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/golem/ShulkerMeta.java
@@ -17,19 +17,19 @@ public final class ShulkerMeta extends AbstractGolemMeta {
     }
 
     public Direction getAttachFace() {
-        return metadata.get(MetadataDef.Shulker.ATTACH_FACE);
+        return get(MetadataDef.Shulker.ATTACH_FACE);
     }
 
     public void setAttachFace(Direction value) {
-        metadata.set(MetadataDef.Shulker.ATTACH_FACE, value);
+        set(MetadataDef.Shulker.ATTACH_FACE, value);
     }
 
     public byte getShieldHeight() {
-        return metadata.get(MetadataDef.Shulker.SHIELD_HEIGHT);
+        return get(MetadataDef.Shulker.SHIELD_HEIGHT);
     }
 
     public void setShieldHeight(byte value) {
-        metadata.set(MetadataDef.Shulker.SHIELD_HEIGHT, value);
+        set(MetadataDef.Shulker.SHIELD_HEIGHT, value);
     }
 
     /**
@@ -37,7 +37,7 @@ public final class ShulkerMeta extends AbstractGolemMeta {
      */
     @Deprecated
     public DyeColor getColor() {
-        return DYE_VALUES[metadata.get(MetadataDef.Shulker.COLOR)];
+        return DYE_VALUES[get(MetadataDef.Shulker.COLOR)];
     }
 
     /**
@@ -45,7 +45,7 @@ public final class ShulkerMeta extends AbstractGolemMeta {
      */
     @Deprecated
     public void setColor(DyeColor value) {
-        metadata.set(MetadataDef.Shulker.COLOR, (byte) value.ordinal());
+        set(MetadataDef.Shulker.COLOR, (byte) value.ordinal());
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/golem/ShulkerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/golem/ShulkerMeta.java
@@ -9,7 +9,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.utils.Direction;
 import org.jetbrains.annotations.Nullable;
 
-public class ShulkerMeta extends AbstractGolemMeta {
+public final class ShulkerMeta extends AbstractGolemMeta {
     private static final DyeColor[] DYE_VALUES = DyeColor.values();
 
     public ShulkerMeta(Entity entity, MetadataHolder metadata) {

--- a/src/main/java/net/minestom/server/entity/metadata/golem/SnowGolemMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/golem/SnowGolemMeta.java
@@ -10,11 +10,11 @@ public final class SnowGolemMeta extends AbstractGolemMeta {
     }
 
     public boolean isHasPumpkinHat() {
-        return metadata.get(MetadataDef.SnowGolem.PUMPKIN_HAT);
+        return get(MetadataDef.SnowGolem.PUMPKIN_HAT);
     }
 
     public void setHasPumpkinHat(boolean value) {
-        metadata.set(MetadataDef.SnowGolem.PUMPKIN_HAT, value);
+        set(MetadataDef.SnowGolem.PUMPKIN_HAT, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/golem/SnowGolemMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/golem/SnowGolemMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class SnowGolemMeta extends AbstractGolemMeta {
+public final class SnowGolemMeta extends AbstractGolemMeta {
     public SnowGolemMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/item/EyeOfEnderMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/EyeOfEnderMeta.java
@@ -6,7 +6,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.item.ItemStack;
 
-public class EyeOfEnderMeta extends EntityMeta {
+public final class EyeOfEnderMeta extends EntityMeta {
     public EyeOfEnderMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/item/EyeOfEnderMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/EyeOfEnderMeta.java
@@ -12,11 +12,11 @@ public final class EyeOfEnderMeta extends EntityMeta {
     }
 
     public ItemStack getItem() {
-        return metadata.get(MetadataDef.EyeOfEnder.ITEM);
+        return get(MetadataDef.EyeOfEnder.ITEM);
     }
 
     public void setItem(ItemStack value) {
-        metadata.set(MetadataDef.EyeOfEnder.ITEM, value);
+        set(MetadataDef.EyeOfEnder.ITEM, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/item/FireballMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/FireballMeta.java
@@ -9,8 +9,8 @@ import net.minestom.server.entity.metadata.projectile.ProjectileMeta;
 import net.minestom.server.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
-public class FireballMeta extends EntityMeta implements ObjectDataProvider, ProjectileMeta {
-    private Entity shooter;
+public final class FireballMeta extends EntityMeta implements ObjectDataProvider, ProjectileMeta {
+    private @Nullable Entity shooter;
 
     public FireballMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);

--- a/src/main/java/net/minestom/server/entity/metadata/item/FireballMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/FireballMeta.java
@@ -17,11 +17,11 @@ public final class FireballMeta extends EntityMeta implements ObjectDataProvider
     }
 
     public ItemStack getItem() {
-        return metadata.get(MetadataDef.Fireball.ITEM);
+        return get(MetadataDef.Fireball.ITEM);
     }
 
     public void setItem(ItemStack value) {
-        metadata.set(MetadataDef.Fireball.ITEM, value);
+        set(MetadataDef.Fireball.ITEM, value);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/item/ItemEntityMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/ItemEntityMeta.java
@@ -7,7 +7,7 @@ import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.entity.metadata.ObjectDataProvider;
 import net.minestom.server.item.ItemStack;
 
-public class ItemEntityMeta extends EntityMeta implements ObjectDataProvider {
+public final class ItemEntityMeta extends EntityMeta implements ObjectDataProvider {
     public ItemEntityMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/item/ItemEntityMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/ItemEntityMeta.java
@@ -13,11 +13,11 @@ public final class ItemEntityMeta extends EntityMeta implements ObjectDataProvid
     }
 
     public ItemStack getItem() {
-        return metadata.get(MetadataDef.ItemEntity.ITEM);
+        return get(MetadataDef.ItemEntity.ITEM);
     }
 
     public void setItem(ItemStack value) {
-        metadata.set(MetadataDef.ItemEntity.ITEM, value);
+        set(MetadataDef.ItemEntity.ITEM, value);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/item/LingeringPotionMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/LingeringPotionMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.item;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class LingeringPotionMeta extends ThrownItemProjectileMeta {
+public final class LingeringPotionMeta extends ThrownItemProjectileMeta {
     public LingeringPotionMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/item/SmallFireballMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/SmallFireballMeta.java
@@ -9,8 +9,8 @@ import net.minestom.server.entity.metadata.projectile.ProjectileMeta;
 import net.minestom.server.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
-public class SmallFireballMeta extends EntityMeta implements ObjectDataProvider, ProjectileMeta {
-    private Entity shooter;
+public final class SmallFireballMeta extends EntityMeta implements ObjectDataProvider, ProjectileMeta {
+    private @Nullable Entity shooter;
 
     public SmallFireballMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);

--- a/src/main/java/net/minestom/server/entity/metadata/item/SmallFireballMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/SmallFireballMeta.java
@@ -17,11 +17,11 @@ public final class SmallFireballMeta extends EntityMeta implements ObjectDataPro
     }
 
     public ItemStack getItem() {
-        return metadata.get(MetadataDef.SmartFireball.ITEM);
+        return get(MetadataDef.SmartFireball.ITEM);
     }
 
     public void setItem(ItemStack item) {
-        metadata.set(MetadataDef.SmartFireball.ITEM, item);
+        set(MetadataDef.SmartFireball.ITEM, item);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/item/SnowballMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/SnowballMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.item;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class SnowballMeta extends ThrownItemProjectileMeta {
+public final class SnowballMeta extends ThrownItemProjectileMeta {
     public SnowballMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/item/SplashPotionMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/SplashPotionMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.item;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class SplashPotionMeta extends ThrownItemProjectileMeta {
+public final class SplashPotionMeta extends ThrownItemProjectileMeta {
     public SplashPotionMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/item/ThrownEggMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/ThrownEggMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.item;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class ThrownEggMeta extends ThrownItemProjectileMeta {
+public final class ThrownEggMeta extends ThrownItemProjectileMeta {
     public ThrownEggMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/item/ThrownEnderPearlMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/ThrownEnderPearlMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.item;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class ThrownEnderPearlMeta extends ThrownItemProjectileMeta {
+public final class ThrownEnderPearlMeta extends ThrownItemProjectileMeta {
     public ThrownEnderPearlMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/item/ThrownExperienceBottleMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/ThrownExperienceBottleMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.item;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class ThrownExperienceBottleMeta extends ThrownItemProjectileMeta {
+public final class ThrownExperienceBottleMeta extends ThrownItemProjectileMeta {
     public ThrownExperienceBottleMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/item/ThrownItemProjectileMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/ThrownItemProjectileMeta.java
@@ -6,7 +6,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.item.ItemStack;
 
-class ThrownItemProjectileMeta extends EntityMeta {
+public abstract sealed class ThrownItemProjectileMeta extends EntityMeta permits LingeringPotionMeta, SnowballMeta, SplashPotionMeta, ThrownEggMeta, ThrownEnderPearlMeta, ThrownExperienceBottleMeta {
     protected ThrownItemProjectileMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/item/ThrownItemProjectileMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/ThrownItemProjectileMeta.java
@@ -6,17 +6,17 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.item.ItemStack;
 
-public abstract sealed class ThrownItemProjectileMeta extends EntityMeta permits LingeringPotionMeta, SnowballMeta, SplashPotionMeta, ThrownEggMeta, ThrownEnderPearlMeta, ThrownExperienceBottleMeta {
+public sealed abstract class ThrownItemProjectileMeta extends EntityMeta permits LingeringPotionMeta, SnowballMeta, SplashPotionMeta, ThrownEggMeta, ThrownEnderPearlMeta, ThrownExperienceBottleMeta {
     protected ThrownItemProjectileMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 
     public ItemStack getItem() {
-        return metadata.get(MetadataDef.ThrownItemProjectile.ITEM);
+        return get(MetadataDef.ThrownItemProjectile.ITEM);
     }
 
     public void setItem(ItemStack item) {
-        metadata.set(MetadataDef.ThrownItemProjectile.ITEM, item);
+        set(MetadataDef.ThrownItemProjectile.ITEM, item);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/AbstractMinecartContainerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/AbstractMinecartContainerMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.minecart;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public abstract class AbstractMinecartContainerMeta extends AbstractMinecartMeta {
+public abstract sealed class AbstractMinecartContainerMeta extends AbstractMinecartMeta permits ChestMinecartMeta, HopperMinecartMeta {
     protected AbstractMinecartContainerMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/AbstractMinecartContainerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/AbstractMinecartContainerMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.minecart;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public abstract sealed class AbstractMinecartContainerMeta extends AbstractMinecartMeta permits ChestMinecartMeta, HopperMinecartMeta {
+public sealed abstract class AbstractMinecartContainerMeta extends AbstractMinecartMeta permits ChestMinecartMeta, HopperMinecartMeta {
     protected AbstractMinecartContainerMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/AbstractMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/AbstractMinecartMeta.java
@@ -7,26 +7,26 @@ import net.minestom.server.entity.metadata.AbstractVehicleMeta;
 import net.minestom.server.instance.block.Block;
 import org.jetbrains.annotations.Nullable;
 
-public abstract sealed class AbstractMinecartMeta extends AbstractVehicleMeta permits AbstractMinecartContainerMeta, CommandBlockMinecartMeta, FurnaceMinecartMeta, MinecartMeta, SpawnerMinecartMeta, TntMinecartMeta {
+public sealed abstract class AbstractMinecartMeta extends AbstractVehicleMeta permits AbstractMinecartContainerMeta, CommandBlockMinecartMeta, FurnaceMinecartMeta, MinecartMeta, SpawnerMinecartMeta, TntMinecartMeta {
     protected AbstractMinecartMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 
     public @Nullable Block getCustomBlockState() {
-        return metadata.get(MetadataDef.AbstractMinecart.CUSTOM_BLOCK_STATE);
+        return get(MetadataDef.AbstractMinecart.CUSTOM_BLOCK_STATE);
     }
 
     public void setCustomBlockState(@Nullable Block value) {
-        metadata.set(MetadataDef.AbstractMinecart.CUSTOM_BLOCK_STATE, value);
+        set(MetadataDef.AbstractMinecart.CUSTOM_BLOCK_STATE, value);
     }
 
     // in 16th of a block
     public int getCustomBlockYPosition() {
-        return metadata.get(MetadataDef.AbstractMinecart.CUSTOM_BLOCK_Y_POSITION);
+        return get(MetadataDef.AbstractMinecart.CUSTOM_BLOCK_Y_POSITION);
     }
 
     public void setCustomBlockYPosition(int value) {
-        metadata.set(MetadataDef.AbstractMinecart.CUSTOM_BLOCK_Y_POSITION, value);
+        set(MetadataDef.AbstractMinecart.CUSTOM_BLOCK_Y_POSITION, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/AbstractMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/AbstractMinecartMeta.java
@@ -7,7 +7,7 @@ import net.minestom.server.entity.metadata.AbstractVehicleMeta;
 import net.minestom.server.instance.block.Block;
 import org.jetbrains.annotations.Nullable;
 
-public abstract class AbstractMinecartMeta extends AbstractVehicleMeta {
+public abstract sealed class AbstractMinecartMeta extends AbstractVehicleMeta permits AbstractMinecartContainerMeta, CommandBlockMinecartMeta, FurnaceMinecartMeta, MinecartMeta, SpawnerMinecartMeta, TntMinecartMeta {
     protected AbstractMinecartMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/ChestMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/ChestMinecartMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.minecart;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class ChestMinecartMeta extends AbstractMinecartContainerMeta {
+public final class ChestMinecartMeta extends AbstractMinecartContainerMeta {
     public ChestMinecartMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/CommandBlockMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/CommandBlockMinecartMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class CommandBlockMinecartMeta extends AbstractMinecartMeta {
+public final class CommandBlockMinecartMeta extends AbstractMinecartMeta {
     public CommandBlockMinecartMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/CommandBlockMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/CommandBlockMinecartMeta.java
@@ -11,18 +11,18 @@ public final class CommandBlockMinecartMeta extends AbstractMinecartMeta {
     }
 
     public String getCommand() {
-        return metadata.get(MetadataDef.MinecartCommandBlock.COMMAND);
+        return get(MetadataDef.MinecartCommandBlock.COMMAND);
     }
 
     public void setCommand(String value) {
-        metadata.set(MetadataDef.MinecartCommandBlock.COMMAND, value);
+        set(MetadataDef.MinecartCommandBlock.COMMAND, value);
     }
 
     public Component getLastOutput() {
-        return metadata.get(MetadataDef.MinecartCommandBlock.LAST_OUTPUT);
+        return get(MetadataDef.MinecartCommandBlock.LAST_OUTPUT);
     }
 
     public void setLastOutput(Component value) {
-        metadata.set(MetadataDef.MinecartCommandBlock.LAST_OUTPUT, value);
+        set(MetadataDef.MinecartCommandBlock.LAST_OUTPUT, value);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/FurnaceMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/FurnaceMinecartMeta.java
@@ -10,11 +10,11 @@ public final class FurnaceMinecartMeta extends AbstractMinecartMeta {
     }
 
     public boolean isHasFuel() {
-        return metadata.get(MetadataDef.MinecartFurnace.HAS_FUEL);
+        return get(MetadataDef.MinecartFurnace.HAS_FUEL);
     }
 
     public void setHasFuel(boolean value) {
-        metadata.set(MetadataDef.MinecartFurnace.HAS_FUEL, value);
+        set(MetadataDef.MinecartFurnace.HAS_FUEL, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/FurnaceMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/FurnaceMinecartMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class FurnaceMinecartMeta extends AbstractMinecartMeta {
+public final class FurnaceMinecartMeta extends AbstractMinecartMeta {
     public FurnaceMinecartMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/HopperMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/HopperMinecartMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.minecart;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class HopperMinecartMeta extends AbstractMinecartContainerMeta {
+public final class HopperMinecartMeta extends AbstractMinecartContainerMeta {
     public HopperMinecartMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/MinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/MinecartMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.minecart;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class MinecartMeta extends AbstractMinecartMeta {
+public final class MinecartMeta extends AbstractMinecartMeta {
     public MinecartMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/SpawnerMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/SpawnerMinecartMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.minecart;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class SpawnerMinecartMeta extends AbstractMinecartMeta {
+public final class SpawnerMinecartMeta extends AbstractMinecartMeta {
     public SpawnerMinecartMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/TntMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/TntMinecartMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.minecart;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class TntMinecartMeta extends AbstractMinecartMeta {
+public final class TntMinecartMeta extends AbstractMinecartMeta {
     public TntMinecartMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/BasePiglinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/BasePiglinMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class BasePiglinMeta extends MonsterMeta {
+public sealed abstract class BasePiglinMeta extends MonsterMeta permits PiglinBruteMeta, PiglinMeta {
     protected BasePiglinMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/BasePiglinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/BasePiglinMeta.java
@@ -10,11 +10,11 @@ public sealed abstract class BasePiglinMeta extends MonsterMeta permits PiglinBr
     }
 
     public boolean isImmuneToZombification() {
-        return metadata.get(MetadataDef.BasePiglin.IMMUNE_ZOMBIFICATION);
+        return get(MetadataDef.BasePiglin.IMMUNE_ZOMBIFICATION);
     }
 
     public void setImmuneToZombification(boolean value) {
-        metadata.set(MetadataDef.BasePiglin.IMMUNE_ZOMBIFICATION, value);
+        set(MetadataDef.BasePiglin.IMMUNE_ZOMBIFICATION, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/BlazeMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/BlazeMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class BlazeMeta extends MonsterMeta {
+public final class BlazeMeta extends MonsterMeta {
     public BlazeMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/BlazeMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/BlazeMeta.java
@@ -10,11 +10,11 @@ public final class BlazeMeta extends MonsterMeta {
     }
 
     public boolean isOnFire() {
-        return metadata.get(MetadataDef.Blaze.IS_ON_FIRE);
+        return get(MetadataDef.Blaze.IS_ON_FIRE);
     }
 
     public void setOnFire(boolean value) {
-        metadata.set(MetadataDef.Blaze.IS_ON_FIRE, value);
+        set(MetadataDef.Blaze.IS_ON_FIRE, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/BreezeMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/BreezeMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.monster;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class BreezeMeta extends MonsterMeta {
+public final class BreezeMeta extends MonsterMeta {
     public BreezeMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/CaveSpiderMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/CaveSpiderMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.monster;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class CaveSpiderMeta extends SpiderMeta {
+public final class CaveSpiderMeta extends SpiderMeta {
     public CaveSpiderMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/CreakingMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/CreakingMeta.java
@@ -12,34 +12,34 @@ public final class CreakingMeta extends MonsterMeta {
     }
 
     public boolean canMove() {
-        return metadata.get(MetadataDef.Creaking.CAN_MOVE);
+        return get(MetadataDef.Creaking.CAN_MOVE);
     }
 
     public void setCanMove(boolean value) {
-        metadata.set(MetadataDef.Creaking.CAN_MOVE, value);
+        set(MetadataDef.Creaking.CAN_MOVE, value);
     }
 
     public boolean isActive() {
-        return metadata.get(MetadataDef.Creaking.IS_ACTIVE);
+        return get(MetadataDef.Creaking.IS_ACTIVE);
     }
 
     public void setActive(boolean value) {
-        metadata.set(MetadataDef.Creaking.IS_ACTIVE, value);
+        set(MetadataDef.Creaking.IS_ACTIVE, value);
     }
 
     public boolean isTearingDown() {
-        return metadata.get(MetadataDef.Creaking.IS_TEARING_DOWN);
+        return get(MetadataDef.Creaking.IS_TEARING_DOWN);
     }
 
     public void setTearingDown(boolean value) {
-        metadata.set(MetadataDef.Creaking.IS_TEARING_DOWN, value);
+        set(MetadataDef.Creaking.IS_TEARING_DOWN, value);
     }
 
     public @Nullable Point getHomePos() {
-        return metadata.get(MetadataDef.Creaking.HOME_POS);
+        return get(MetadataDef.Creaking.HOME_POS);
     }
 
     public void setHomePos(@Nullable Point value) {
-        metadata.set(MetadataDef.Creaking.HOME_POS, value);
+        set(MetadataDef.Creaking.HOME_POS, value);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/CreakingMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/CreakingMeta.java
@@ -6,7 +6,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import org.jetbrains.annotations.Nullable;
 
-public class CreakingMeta extends MonsterMeta {
+public final class CreakingMeta extends MonsterMeta {
     public CreakingMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/CreeperMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/CreeperMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class CreeperMeta extends MonsterMeta {
+public final class CreeperMeta extends MonsterMeta {
     public CreeperMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/CreeperMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/CreeperMeta.java
@@ -10,28 +10,28 @@ public final class CreeperMeta extends MonsterMeta {
     }
 
     public State getState() {
-        int id = metadata.get(MetadataDef.Creeper.STATE);
+        int id = get(MetadataDef.Creeper.STATE);
         return id == -1 ? State.IDLE : State.FUSE;
     }
 
     public void setState(State value) {
-        metadata.set(MetadataDef.Creeper.STATE, value == State.IDLE ? -1 : 1);
+        set(MetadataDef.Creeper.STATE, value == State.IDLE ? -1 : 1);
     }
 
     public boolean isCharged() {
-        return metadata.get(MetadataDef.Creeper.IS_CHARGED);
+        return get(MetadataDef.Creeper.IS_CHARGED);
     }
 
     public void setCharged(boolean value) {
-        metadata.set(MetadataDef.Creeper.IS_CHARGED, value);
+        set(MetadataDef.Creeper.IS_CHARGED, value);
     }
 
     public boolean isIgnited() {
-        return metadata.get(MetadataDef.Creeper.IS_IGNITED);
+        return get(MetadataDef.Creeper.IS_IGNITED);
     }
 
     public void setIgnited(boolean value) {
-        metadata.set(MetadataDef.Creeper.IS_IGNITED, value);
+        set(MetadataDef.Creeper.IS_IGNITED, value);
     }
 
     public enum State {

--- a/src/main/java/net/minestom/server/entity/metadata/monster/ElderGuardianMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/ElderGuardianMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.monster;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class ElderGuardianMeta extends GuardianMeta {
+public final class ElderGuardianMeta extends GuardianMeta {
     public ElderGuardianMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/EndermanMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/EndermanMeta.java
@@ -6,7 +6,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.instance.block.Block;
 import org.jetbrains.annotations.Nullable;
 
-public class EndermanMeta extends MonsterMeta {
+public final class EndermanMeta extends MonsterMeta {
     public EndermanMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/EndermanMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/EndermanMeta.java
@@ -12,27 +12,27 @@ public final class EndermanMeta extends MonsterMeta {
     }
 
     public @Nullable Block getCarriedBlock() {
-        return metadata.get(MetadataDef.Enderman.CARRIED_BLOCK);
+        return get(MetadataDef.Enderman.CARRIED_BLOCK);
     }
 
     public void setCarriedBlock(@Nullable Block value) {
-        metadata.set(MetadataDef.Enderman.CARRIED_BLOCK, value);
+        set(MetadataDef.Enderman.CARRIED_BLOCK, value);
     }
 
     public boolean isScreaming() {
-        return metadata.get(MetadataDef.Enderman.IS_SCREAMING);
+        return get(MetadataDef.Enderman.IS_SCREAMING);
     }
 
     public void setScreaming(boolean value) {
-        metadata.set(MetadataDef.Enderman.IS_SCREAMING, value);
+        set(MetadataDef.Enderman.IS_SCREAMING, value);
     }
 
     public boolean isStaring() {
-        return metadata.get(MetadataDef.Enderman.IS_STARING);
+        return get(MetadataDef.Enderman.IS_STARING);
     }
 
     public void setStaring(boolean value) {
-        metadata.set(MetadataDef.Enderman.IS_STARING, value);
+        set(MetadataDef.Enderman.IS_STARING, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/EndermiteMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/EndermiteMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.monster;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class EndermiteMeta extends MonsterMeta {
+public final class EndermiteMeta extends MonsterMeta {
     public EndermiteMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/GiantMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/GiantMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.monster;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class GiantMeta extends MonsterMeta {
+public final class GiantMeta extends MonsterMeta {
     public GiantMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/GuardianMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/GuardianMeta.java
@@ -14,20 +14,20 @@ public sealed class GuardianMeta extends MonsterMeta permits ElderGuardianMeta {
     }
 
     public boolean isRetractingSpikes() {
-        return metadata.get(MetadataDef.Guardian.IS_RETRACTING_SPIKES);
+        return get(MetadataDef.Guardian.IS_RETRACTING_SPIKES);
     }
 
     public void setRetractingSpikes(boolean value) {
-        metadata.set(MetadataDef.Guardian.IS_RETRACTING_SPIKES, value);
+        set(MetadataDef.Guardian.IS_RETRACTING_SPIKES, value);
     }
 
     public int getTargetEntityId() {
-        return metadata.get(MetadataDef.Guardian.TARGET_EID);
+        return get(MetadataDef.Guardian.TARGET_EID);
     }
 
     @ApiStatus.Internal
     public void setTargetEntityId(int value) {
-        metadata.set(MetadataDef.Guardian.TARGET_EID, value);
+        set(MetadataDef.Guardian.TARGET_EID, value);
     }
 
     public @Nullable Entity getTarget() {

--- a/src/main/java/net/minestom/server/entity/metadata/monster/GuardianMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/GuardianMeta.java
@@ -6,8 +6,8 @@ import net.minestom.server.entity.MetadataHolder;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
-public class GuardianMeta extends MonsterMeta {
-    private Entity target;
+public sealed class GuardianMeta extends MonsterMeta permits ElderGuardianMeta {
+    private @Nullable Entity target;
 
     public GuardianMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
@@ -30,7 +30,7 @@ public class GuardianMeta extends MonsterMeta {
         metadata.set(MetadataDef.Guardian.TARGET_EID, value);
     }
 
-    public Entity getTarget() {
+    public @Nullable Entity getTarget() {
         return this.target;
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/MonsterMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/MonsterMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.PathfinderMobMeta;
 
-public class MonsterMeta extends PathfinderMobMeta {
+public sealed abstract class MonsterMeta extends PathfinderMobMeta permits BasePiglinMeta, BlazeMeta, BreezeMeta, CreakingMeta, CreeperMeta, EndermanMeta, EndermiteMeta, GiantMeta, GuardianMeta, SilverfishMeta, SpiderMeta, VexMeta, WardenMeta, WitherMeta, ZoglinMeta, net.minestom.server.entity.metadata.monster.raider.RaiderMeta, net.minestom.server.entity.metadata.monster.skeleton.AbstractSkeletonMeta, net.minestom.server.entity.metadata.monster.zombie.ZombieMeta {
     protected MonsterMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/PiglinBruteMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/PiglinBruteMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.monster;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class PiglinBruteMeta extends BasePiglinMeta {
+public final class PiglinBruteMeta extends BasePiglinMeta {
     public PiglinBruteMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/PiglinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/PiglinMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class PiglinMeta extends BasePiglinMeta {
+public final class PiglinMeta extends BasePiglinMeta {
     public PiglinMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/PiglinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/PiglinMeta.java
@@ -11,7 +11,7 @@ public final class PiglinMeta extends BasePiglinMeta {
     }
 
     public boolean isBaby() {
-        return metadata.get(MetadataDef.Piglin.IS_BABY);
+        return get(MetadataDef.Piglin.IS_BABY);
     }
 
     public void setBaby(boolean value) {
@@ -28,23 +28,23 @@ public final class PiglinMeta extends BasePiglinMeta {
                 entity.setBoundingBox(width, bb.height() * 2, width);
             }
         });
-        metadata.set(MetadataDef.Piglin.IS_BABY, value);
+        set(MetadataDef.Piglin.IS_BABY, value);
     }
 
     public boolean isChargingCrossbow() {
-        return metadata.get(MetadataDef.Piglin.IS_CHARGING_CROSSBOW);
+        return get(MetadataDef.Piglin.IS_CHARGING_CROSSBOW);
     }
 
     public void setChargingCrossbow(boolean value) {
-        metadata.set(MetadataDef.Piglin.IS_CHARGING_CROSSBOW, value);
+        set(MetadataDef.Piglin.IS_CHARGING_CROSSBOW, value);
     }
 
     public boolean isDancing() {
-        return metadata.get(MetadataDef.Piglin.IS_DANCING);
+        return get(MetadataDef.Piglin.IS_DANCING);
     }
 
     public void setDancing(boolean value) {
-        metadata.set(MetadataDef.Piglin.IS_DANCING, value);
+        set(MetadataDef.Piglin.IS_DANCING, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/SilverfishMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/SilverfishMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.monster;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class SilverfishMeta extends MonsterMeta {
+public final class SilverfishMeta extends MonsterMeta {
     public SilverfishMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/SpiderMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/SpiderMeta.java
@@ -10,11 +10,11 @@ public sealed class SpiderMeta extends MonsterMeta permits CaveSpiderMeta {
     }
 
     public boolean isClimbing() {
-        return metadata.get(MetadataDef.Spider.IS_CLIMBING);
+        return get(MetadataDef.Spider.IS_CLIMBING);
     }
 
     public void setClimbing(boolean value) {
-        metadata.set(MetadataDef.Spider.IS_CLIMBING, value);
+        set(MetadataDef.Spider.IS_CLIMBING, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/SpiderMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/SpiderMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class SpiderMeta extends MonsterMeta {
+public sealed class SpiderMeta extends MonsterMeta permits CaveSpiderMeta {
     public SpiderMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/VexMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/VexMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class VexMeta extends MonsterMeta {
+public final class VexMeta extends MonsterMeta {
     public VexMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/VexMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/VexMeta.java
@@ -10,11 +10,11 @@ public final class VexMeta extends MonsterMeta {
     }
 
     public boolean isAttacking() {
-        return metadata.get(MetadataDef.Vex.IS_ATTACKING);
+        return get(MetadataDef.Vex.IS_ATTACKING);
     }
 
     public void setAttacking(boolean value) {
-        metadata.set(MetadataDef.Vex.IS_ATTACKING, value);
+        set(MetadataDef.Vex.IS_ATTACKING, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/WardenMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/WardenMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class WardenMeta extends MonsterMeta {
+public final class WardenMeta extends MonsterMeta {
     public WardenMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/WardenMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/WardenMeta.java
@@ -10,11 +10,11 @@ public final class WardenMeta extends MonsterMeta {
     }
 
     public int getAngerLevel() {
-        return metadata.get(MetadataDef.Warden.ANGER_LEVEL);
+        return get(MetadataDef.Warden.ANGER_LEVEL);
     }
 
     public void setAngerLevel(int value) {
-        metadata.set(MetadataDef.Warden.ANGER_LEVEL, value);
+        set(MetadataDef.Warden.ANGER_LEVEL, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/WitherMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/WitherMeta.java
@@ -16,12 +16,12 @@ public final class WitherMeta extends MonsterMeta {
     }
 
     public int getCenterHeadEntityId() {
-        return metadata.get(MetadataDef.Wither.CENTER_HEAD_TARGET);
+        return get(MetadataDef.Wither.CENTER_HEAD_TARGET);
     }
 
     @ApiStatus.Internal
     public void setCenterHeadEntityId(int value) {
-        metadata.set(MetadataDef.Wither.CENTER_HEAD_TARGET, value);
+        set(MetadataDef.Wither.CENTER_HEAD_TARGET, value);
     }
 
     @Nullable
@@ -35,12 +35,12 @@ public final class WitherMeta extends MonsterMeta {
     }
 
     public int getLeftHeadEntityId() {
-        return metadata.get(MetadataDef.Wither.LEFT_HEAD_TARGET);
+        return get(MetadataDef.Wither.LEFT_HEAD_TARGET);
     }
 
     @ApiStatus.Internal
     public void setLeftHeadEntityId(int value) {
-        metadata.set(MetadataDef.Wither.LEFT_HEAD_TARGET, value);
+        set(MetadataDef.Wither.LEFT_HEAD_TARGET, value);
     }
 
     @Nullable
@@ -54,12 +54,12 @@ public final class WitherMeta extends MonsterMeta {
     }
 
     public int getRightHeadEntityId() {
-        return metadata.get(MetadataDef.Wither.RIGHT_HEAD_TARGET);
+        return get(MetadataDef.Wither.RIGHT_HEAD_TARGET);
     }
 
     @ApiStatus.Internal
     public void setRightHeadEntityId(int value) {
-        metadata.set(MetadataDef.Wither.RIGHT_HEAD_TARGET, value);
+        set(MetadataDef.Wither.RIGHT_HEAD_TARGET, value);
     }
 
     @Nullable
@@ -73,11 +73,11 @@ public final class WitherMeta extends MonsterMeta {
     }
 
     public int getInvulnerableTime() {
-        return metadata.get(MetadataDef.Wither.INVULNERABLE_TIME);
+        return get(MetadataDef.Wither.INVULNERABLE_TIME);
     }
 
     public void setInvulnerableTime(int value) {
-        metadata.set(MetadataDef.Wither.INVULNERABLE_TIME, value);
+        set(MetadataDef.Wither.INVULNERABLE_TIME, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/WitherMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/WitherMeta.java
@@ -6,10 +6,10 @@ import net.minestom.server.entity.MetadataHolder;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
-public class WitherMeta extends MonsterMeta {
-    private Entity centerHead;
-    private Entity leftHead;
-    private Entity rightHead;
+public final class WitherMeta extends MonsterMeta {
+    private @Nullable Entity centerHead;
+    private @Nullable Entity leftHead;
+    private @Nullable Entity rightHead;
 
     public WitherMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);

--- a/src/main/java/net/minestom/server/entity/metadata/monster/ZoglinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/ZoglinMeta.java
@@ -11,7 +11,7 @@ public final class ZoglinMeta extends MonsterMeta {
     }
 
     public boolean isBaby() {
-        return metadata.get(MetadataDef.Zoglin.IS_BABY);
+        return get(MetadataDef.Zoglin.IS_BABY);
     }
 
     public void setBaby(boolean value) {
@@ -28,7 +28,7 @@ public final class ZoglinMeta extends MonsterMeta {
                 entity.setBoundingBox(width, bb.height() * 2, width);
             }
         });
-        metadata.set(MetadataDef.Zoglin.IS_BABY, value);
+        set(MetadataDef.Zoglin.IS_BABY, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/ZoglinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/ZoglinMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class ZoglinMeta extends MonsterMeta {
+public final class ZoglinMeta extends MonsterMeta {
     public ZoglinMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/AbstractIllagerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/AbstractIllagerMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.monster.raider;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class AbstractIllagerMeta extends RaiderMeta {
+public sealed abstract class AbstractIllagerMeta extends RaiderMeta permits PillagerMeta, SpellcasterIllagerMeta, VindicatorMeta {
     protected AbstractIllagerMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/EvokerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/EvokerMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.monster.raider;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class EvokerMeta extends SpellcasterIllagerMeta {
+public final class EvokerMeta extends SpellcasterIllagerMeta {
     public EvokerMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/IllusionerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/IllusionerMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.monster.raider;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class IllusionerMeta extends SpellcasterIllagerMeta {
+public final class IllusionerMeta extends SpellcasterIllagerMeta {
     public IllusionerMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/PillagerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/PillagerMeta.java
@@ -10,11 +10,11 @@ public final class PillagerMeta extends AbstractIllagerMeta {
     }
 
     public boolean isChargingCrossbow() {
-        return metadata.get(MetadataDef.Pillager.IS_CHARGING);
+        return get(MetadataDef.Pillager.IS_CHARGING);
     }
 
     public void setChargingCrossbow(boolean value) {
-        metadata.set(MetadataDef.Pillager.IS_CHARGING, value);
+        set(MetadataDef.Pillager.IS_CHARGING, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/PillagerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/PillagerMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class PillagerMeta extends AbstractIllagerMeta {
+public final class PillagerMeta extends AbstractIllagerMeta {
     public PillagerMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/RaiderMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/RaiderMeta.java
@@ -5,17 +5,17 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.monster.MonsterMeta;
 
-public sealed class RaiderMeta extends MonsterMeta permits AbstractIllagerMeta, RavagerMeta, WitchMeta {
+public sealed abstract class RaiderMeta extends MonsterMeta permits AbstractIllagerMeta, RavagerMeta, WitchMeta {
     protected RaiderMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 
     public boolean isCelebrating() {
-        return metadata.get(MetadataDef.Raider.IS_CELEBRATING);
+        return get(MetadataDef.Raider.IS_CELEBRATING);
     }
 
     public void setCelebrating(boolean value) {
-        metadata.set(MetadataDef.Raider.IS_CELEBRATING, value);
+        set(MetadataDef.Raider.IS_CELEBRATING, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/RaiderMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/RaiderMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.monster.MonsterMeta;
 
-public class RaiderMeta extends MonsterMeta {
+public sealed class RaiderMeta extends MonsterMeta permits AbstractIllagerMeta, RavagerMeta, WitchMeta {
     protected RaiderMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/RavagerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/RavagerMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.monster.raider;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class RavagerMeta extends RaiderMeta {
+public final class RavagerMeta extends RaiderMeta {
     public RavagerMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/SpellcasterIllagerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/SpellcasterIllagerMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class SpellcasterIllagerMeta extends AbstractIllagerMeta {
+public sealed abstract class SpellcasterIllagerMeta extends AbstractIllagerMeta permits EvokerMeta, IllusionerMeta {
     protected SpellcasterIllagerMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/SpellcasterIllagerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/SpellcasterIllagerMeta.java
@@ -10,11 +10,11 @@ public sealed abstract class SpellcasterIllagerMeta extends AbstractIllagerMeta 
     }
 
     public Spell getSpell() {
-        return Spell.VALUES[metadata.get(MetadataDef.SpellcasterIllager.SPELL)];
+        return Spell.VALUES[get(MetadataDef.SpellcasterIllager.SPELL)];
     }
 
     public void setSpell(Spell spell) {
-        metadata.set(MetadataDef.SpellcasterIllager.SPELL, (byte) spell.ordinal());
+        set(MetadataDef.SpellcasterIllager.SPELL, (byte) spell.ordinal());
     }
 
     public enum Spell {

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/VindicatorMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/VindicatorMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.monster.raider;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class VindicatorMeta extends AbstractIllagerMeta {
+public final class VindicatorMeta extends AbstractIllagerMeta {
     public VindicatorMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/WitchMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/WitchMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class WitchMeta extends RaiderMeta {
+public final class WitchMeta extends RaiderMeta {
     public WitchMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/WitchMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/WitchMeta.java
@@ -10,11 +10,11 @@ public final class WitchMeta extends RaiderMeta {
     }
 
     public boolean isDrinkingPotion() {
-        return metadata.get(MetadataDef.Witch.IS_DRINKING_POTION);
+        return get(MetadataDef.Witch.IS_DRINKING_POTION);
     }
 
     public void setDrinkingPotion(boolean value) {
-        super.metadata.set(MetadataDef.Witch.IS_DRINKING_POTION, value);
+        super.set(MetadataDef.Witch.IS_DRINKING_POTION, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/AbstractSkeletonMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/AbstractSkeletonMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.monster.MonsterMeta;
 
-public class AbstractSkeletonMeta extends MonsterMeta {
+public sealed abstract class AbstractSkeletonMeta extends MonsterMeta permits BoggedMeta, ParchedMeta, SkeletonMeta, StrayMeta, WitherSkeletonMeta {
     protected AbstractSkeletonMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/BoggedMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/BoggedMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class BoggedMeta extends AbstractSkeletonMeta {
+public final class BoggedMeta extends AbstractSkeletonMeta {
     public BoggedMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/BoggedMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/BoggedMeta.java
@@ -10,10 +10,10 @@ public final class BoggedMeta extends AbstractSkeletonMeta {
     }
 
     public boolean isSheared() {
-        return metadata.get(MetadataDef.Bogged.IS_SHEARED);
+        return get(MetadataDef.Bogged.IS_SHEARED);
     }
 
     public void setSheared(boolean value) {
-        metadata.set(MetadataDef.Bogged.IS_SHEARED, value);
+        set(MetadataDef.Bogged.IS_SHEARED, value);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/ParchedMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/ParchedMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.monster.skeleton;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class ParchedMeta extends AbstractSkeletonMeta {
+public final class ParchedMeta extends AbstractSkeletonMeta {
     public ParchedMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/SkeletonMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/SkeletonMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.monster.skeleton;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class SkeletonMeta extends AbstractSkeletonMeta {
+public final class SkeletonMeta extends AbstractSkeletonMeta {
     public SkeletonMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/StrayMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/StrayMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.monster.skeleton;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class StrayMeta extends AbstractSkeletonMeta {
+public final class StrayMeta extends AbstractSkeletonMeta {
     public StrayMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/WitherSkeletonMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/WitherSkeletonMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.monster.skeleton;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class WitherSkeletonMeta extends AbstractSkeletonMeta {
+public final class WitherSkeletonMeta extends AbstractSkeletonMeta {
     public WitherSkeletonMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/zombie/DrownedMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/zombie/DrownedMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.monster.zombie;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class DrownedMeta extends ZombieMeta {
+public final class DrownedMeta extends ZombieMeta {
     public DrownedMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/zombie/HuskMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/zombie/HuskMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.monster.zombie;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class HuskMeta extends ZombieMeta {
+public final class HuskMeta extends ZombieMeta {
     public HuskMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/zombie/ZombieMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/zombie/ZombieMeta.java
@@ -12,7 +12,7 @@ public sealed class ZombieMeta extends MonsterMeta permits DrownedMeta, HuskMeta
     }
 
     public boolean isBaby() {
-        return metadata.get(MetadataDef.Zombie.IS_BABY);
+        return get(MetadataDef.Zombie.IS_BABY);
     }
 
     public void setBaby(boolean value) {
@@ -29,15 +29,15 @@ public sealed class ZombieMeta extends MonsterMeta permits DrownedMeta, HuskMeta
                 entity.setBoundingBox(width, bb.height() * 2, width);
             }
         });
-        metadata.set(MetadataDef.Zombie.IS_BABY, value);
+        set(MetadataDef.Zombie.IS_BABY, value);
     }
 
     public boolean isBecomingDrowned() {
-        return metadata.get(MetadataDef.Zombie.IS_BECOMING_DROWNED);
+        return get(MetadataDef.Zombie.IS_BECOMING_DROWNED);
     }
 
     public void setBecomingDrowned(boolean value) {
-        metadata.set(MetadataDef.Zombie.IS_BECOMING_DROWNED, value);
+        set(MetadataDef.Zombie.IS_BECOMING_DROWNED, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/zombie/ZombieMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/zombie/ZombieMeta.java
@@ -6,7 +6,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.monster.MonsterMeta;
 
-public class ZombieMeta extends MonsterMeta {
+public sealed class ZombieMeta extends MonsterMeta permits DrownedMeta, HuskMeta, ZombieVillagerMeta, ZombifiedPiglinMeta {
     public ZombieMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/zombie/ZombieVillagerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/zombie/ZombieVillagerMeta.java
@@ -9,7 +9,7 @@ import net.minestom.server.entity.VillagerType;
 import net.minestom.server.entity.metadata.villager.VillagerMeta;
 import org.jetbrains.annotations.Nullable;
 
-public class ZombieVillagerMeta extends ZombieMeta {
+public final class ZombieVillagerMeta extends ZombieMeta {
     public ZombieVillagerMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/zombie/ZombieVillagerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/zombie/ZombieVillagerMeta.java
@@ -15,19 +15,19 @@ public final class ZombieVillagerMeta extends ZombieMeta {
     }
 
     public boolean isConverting() {
-        return metadata.get(MetadataDef.ZombieVillager.IS_CONVERTING);
+        return get(MetadataDef.ZombieVillager.IS_CONVERTING);
     }
 
     public void setConverting(boolean value) {
-        metadata.set(MetadataDef.ZombieVillager.IS_CONVERTING, value);
+        set(MetadataDef.ZombieVillager.IS_CONVERTING, value);
     }
 
     public VillagerMeta.VillagerData getVillagerData() {
-        return metadata.get(MetadataDef.ZombieVillager.VILLAGER_DATA);
+        return get(MetadataDef.ZombieVillager.VILLAGER_DATA);
     }
 
     public void setVillagerData(VillagerMeta.VillagerData data) {
-        metadata.set(MetadataDef.Villager.VARIANT, data);
+        set(MetadataDef.Villager.VARIANT, data);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/monster/zombie/ZombifiedPiglinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/zombie/ZombifiedPiglinMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.monster.zombie;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class ZombifiedPiglinMeta extends ZombieMeta {
+public final class ZombifiedPiglinMeta extends ZombieMeta {
     public ZombifiedPiglinMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/other/AllayMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/AllayMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.PathfinderMobMeta;
 
-public class AllayMeta extends PathfinderMobMeta {
+public final class AllayMeta extends PathfinderMobMeta {
     public AllayMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/other/AllayMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/AllayMeta.java
@@ -11,19 +11,19 @@ public final class AllayMeta extends PathfinderMobMeta {
     }
 
     public boolean isDancing() {
-        return metadata.get(MetadataDef.Allay.IS_DANCING);
+        return get(MetadataDef.Allay.IS_DANCING);
     }
 
     public void setDancing(boolean value) {
-        metadata.set(MetadataDef.Allay.IS_DANCING, value);
+        set(MetadataDef.Allay.IS_DANCING, value);
     }
 
     public boolean canDuplicate() {
-        return metadata.get(MetadataDef.Allay.CAN_DUPLICATE);
+        return get(MetadataDef.Allay.CAN_DUPLICATE);
     }
 
     public void setCanDuplicate(boolean value) {
-        metadata.set(MetadataDef.Allay.CAN_DUPLICATE, value);
+        set(MetadataDef.Allay.CAN_DUPLICATE, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/other/AreaEffectCloudMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/AreaEffectCloudMeta.java
@@ -6,7 +6,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.particle.Particle;
 
-public class AreaEffectCloudMeta extends EntityMeta {
+public final class AreaEffectCloudMeta extends EntityMeta {
     public AreaEffectCloudMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/other/AreaEffectCloudMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/AreaEffectCloudMeta.java
@@ -12,27 +12,27 @@ public final class AreaEffectCloudMeta extends EntityMeta {
     }
 
     public float getRadius() {
-        return metadata.get(MetadataDef.AreaEffectCloud.RADIUS);
+        return get(MetadataDef.AreaEffectCloud.RADIUS);
     }
 
     public void setRadius(float value) {
-        metadata.set(MetadataDef.AreaEffectCloud.RADIUS, value);
+        set(MetadataDef.AreaEffectCloud.RADIUS, value);
     }
 
     public boolean isWaiting() {
-        return metadata.get(MetadataDef.AreaEffectCloud.WAITING);
+        return get(MetadataDef.AreaEffectCloud.WAITING);
     }
 
     public void setWaiting(boolean value) {
-        metadata.set(MetadataDef.AreaEffectCloud.WAITING, value);
+        set(MetadataDef.AreaEffectCloud.WAITING, value);
     }
 
     public Particle getParticle() {
-        return metadata.get(MetadataDef.AreaEffectCloud.PARTICLE);
+        return get(MetadataDef.AreaEffectCloud.PARTICLE);
     }
 
     public void setParticle(Particle value) {
-        metadata.set(MetadataDef.AreaEffectCloud.PARTICLE, value);
+        set(MetadataDef.AreaEffectCloud.PARTICLE, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/other/ArmorStandMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/ArmorStandMeta.java
@@ -12,83 +12,83 @@ public final class ArmorStandMeta extends LivingEntityMeta {
     }
 
     public boolean isSmall() {
-        return metadata.get(MetadataDef.ArmorStand.IS_SMALL);
+        return get(MetadataDef.ArmorStand.IS_SMALL);
     }
 
     public void setSmall(boolean value) {
-        metadata.set(MetadataDef.ArmorStand.IS_SMALL, value);
+        set(MetadataDef.ArmorStand.IS_SMALL, value);
     }
 
     public boolean isHasArms() {
-        return metadata.get(MetadataDef.ArmorStand.HAS_ARMS);
+        return get(MetadataDef.ArmorStand.HAS_ARMS);
     }
 
     public void setHasArms(boolean value) {
-        metadata.set(MetadataDef.ArmorStand.HAS_ARMS, value);
+        set(MetadataDef.ArmorStand.HAS_ARMS, value);
     }
 
     public boolean isHasNoBasePlate() {
-        return metadata.get(MetadataDef.ArmorStand.HAS_NO_BASE_PLATE);
+        return get(MetadataDef.ArmorStand.HAS_NO_BASE_PLATE);
     }
 
     public void setHasNoBasePlate(boolean value) {
-        metadata.set(MetadataDef.ArmorStand.HAS_NO_BASE_PLATE, value);
+        set(MetadataDef.ArmorStand.HAS_NO_BASE_PLATE, value);
     }
 
     public boolean isMarker() {
-        return metadata.get(MetadataDef.ArmorStand.IS_MARKER);
+        return get(MetadataDef.ArmorStand.IS_MARKER);
     }
 
     public void setMarker(boolean value) {
-        metadata.set(MetadataDef.ArmorStand.IS_MARKER, value);
+        set(MetadataDef.ArmorStand.IS_MARKER, value);
     }
 
     public Vec getHeadRotation() {
-        return metadata.get(MetadataDef.ArmorStand.HEAD_ROTATION).asVec();
+        return get(MetadataDef.ArmorStand.HEAD_ROTATION).asVec();
     }
 
     public void setHeadRotation(Vec value) {
-        metadata.set(MetadataDef.ArmorStand.HEAD_ROTATION, value);
+        set(MetadataDef.ArmorStand.HEAD_ROTATION, value);
     }
 
     public Vec getBodyRotation() {
-        return metadata.get(MetadataDef.ArmorStand.BODY_ROTATION).asVec();
+        return get(MetadataDef.ArmorStand.BODY_ROTATION).asVec();
     }
 
     public void setBodyRotation(Vec value) {
-        metadata.set(MetadataDef.ArmorStand.BODY_ROTATION, value);
+        set(MetadataDef.ArmorStand.BODY_ROTATION, value);
     }
 
     public Vec getLeftArmRotation() {
-        return metadata.get(MetadataDef.ArmorStand.LEFT_ARM_ROTATION).asVec();
+        return get(MetadataDef.ArmorStand.LEFT_ARM_ROTATION).asVec();
     }
 
     public void setLeftArmRotation(Vec value) {
-        metadata.set(MetadataDef.ArmorStand.LEFT_ARM_ROTATION, value);
+        set(MetadataDef.ArmorStand.LEFT_ARM_ROTATION, value);
     }
 
     public Vec getRightArmRotation() {
-        return metadata.get(MetadataDef.ArmorStand.RIGHT_ARM_ROTATION).asVec();
+        return get(MetadataDef.ArmorStand.RIGHT_ARM_ROTATION).asVec();
     }
 
     public void setRightArmRotation(Vec value) {
-        metadata.set(MetadataDef.ArmorStand.RIGHT_ARM_ROTATION, value);
+        set(MetadataDef.ArmorStand.RIGHT_ARM_ROTATION, value);
     }
 
     public Vec getLeftLegRotation() {
-        return metadata.get(MetadataDef.ArmorStand.LEFT_LEG_ROTATION).asVec();
+        return get(MetadataDef.ArmorStand.LEFT_LEG_ROTATION).asVec();
     }
 
     public void setLeftLegRotation(Vec value) {
-        metadata.set(MetadataDef.ArmorStand.LEFT_LEG_ROTATION, value);
+        set(MetadataDef.ArmorStand.LEFT_LEG_ROTATION, value);
     }
 
     public Vec getRightLegRotation() {
-        return metadata.get(MetadataDef.ArmorStand.RIGHT_LEG_ROTATION).asVec();
+        return get(MetadataDef.ArmorStand.RIGHT_LEG_ROTATION).asVec();
     }
 
     public void setRightLegRotation(Vec value) {
-        metadata.set(MetadataDef.ArmorStand.RIGHT_LEG_ROTATION, value);
+        set(MetadataDef.ArmorStand.RIGHT_LEG_ROTATION, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/other/ArmorStandMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/ArmorStandMeta.java
@@ -6,7 +6,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.LivingEntityMeta;
 
-public class ArmorStandMeta extends LivingEntityMeta {
+public final class ArmorStandMeta extends LivingEntityMeta {
     public ArmorStandMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/other/BoatMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/BoatMeta.java
@@ -11,26 +11,26 @@ public final class BoatMeta extends AbstractVehicleMeta {
     }
 
     public boolean isLeftPaddleTurning() {
-        return metadata.get(MetadataDef.Boat.IS_LEFT_PADDLE_TURNING);
+        return get(MetadataDef.Boat.IS_LEFT_PADDLE_TURNING);
     }
 
     public void setLeftPaddleTurning(boolean value) {
-        metadata.set(MetadataDef.Boat.IS_LEFT_PADDLE_TURNING, value);
+        set(MetadataDef.Boat.IS_LEFT_PADDLE_TURNING, value);
     }
 
     public boolean isRightPaddleTurning() {
-        return metadata.get(MetadataDef.Boat.IS_RIGHT_PADDLE_TURNING);
+        return get(MetadataDef.Boat.IS_RIGHT_PADDLE_TURNING);
     }
 
     public void setRightPaddleTurning(boolean value) {
-        metadata.set(MetadataDef.Boat.IS_RIGHT_PADDLE_TURNING, value);
+        set(MetadataDef.Boat.IS_RIGHT_PADDLE_TURNING, value);
     }
 
     public int getSplashTimer() {
-        return metadata.get(MetadataDef.Boat.SPLASH_TIMER);
+        return get(MetadataDef.Boat.SPLASH_TIMER);
     }
 
     public void setSplashTimer(int value) {
-        metadata.set(MetadataDef.Boat.SPLASH_TIMER, value);
+        set(MetadataDef.Boat.SPLASH_TIMER, value);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/other/BoatMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/BoatMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.AbstractVehicleMeta;
 
-public class BoatMeta extends AbstractVehicleMeta {
+public final class BoatMeta extends AbstractVehicleMeta {
     public BoatMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/other/EndCrystalMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/EndCrystalMeta.java
@@ -7,7 +7,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import org.jetbrains.annotations.Nullable;
 
-public class EndCrystalMeta extends EntityMeta {
+public final class EndCrystalMeta extends EntityMeta {
     public EndCrystalMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/other/EndCrystalMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/EndCrystalMeta.java
@@ -13,19 +13,19 @@ public final class EndCrystalMeta extends EntityMeta {
     }
 
     public @Nullable Point getBeamTarget() {
-        return metadata.get(MetadataDef.EndCrystal.BEAM_TARGET);
+        return get(MetadataDef.EndCrystal.BEAM_TARGET);
     }
 
     public void setBeamTarget(@Nullable Point value) {
-        metadata.set(MetadataDef.EndCrystal.BEAM_TARGET, value);
+        set(MetadataDef.EndCrystal.BEAM_TARGET, value);
     }
 
     public boolean isShowingBottom() {
-        return metadata.get(MetadataDef.EndCrystal.SHOW_BOTTOM);
+        return get(MetadataDef.EndCrystal.SHOW_BOTTOM);
     }
 
     public void setShowingBottom(boolean value) {
-        metadata.set(MetadataDef.EndCrystal.SHOW_BOTTOM, value);
+        set(MetadataDef.EndCrystal.SHOW_BOTTOM, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/other/EnderDragonMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/EnderDragonMeta.java
@@ -11,11 +11,11 @@ public final class EnderDragonMeta extends MobMeta {
     }
 
     public Phase getPhase() {
-        return Phase.VALUES[metadata.get(MetadataDef.EnderDragon.DRAGON_PHASE)];
+        return Phase.VALUES[get(MetadataDef.EnderDragon.DRAGON_PHASE)];
     }
 
     public void setPhase(Phase value) {
-        metadata.set(MetadataDef.EnderDragon.DRAGON_PHASE, value.ordinal());
+        set(MetadataDef.EnderDragon.DRAGON_PHASE, value.ordinal());
     }
 
     public enum Phase {

--- a/src/main/java/net/minestom/server/entity/metadata/other/EnderDragonMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/EnderDragonMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.MobMeta;
 
-public class EnderDragonMeta extends MobMeta {
+public final class EnderDragonMeta extends MobMeta {
     public EnderDragonMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/other/EvokerFangsMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/EvokerFangsMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 
-public class EvokerFangsMeta extends EntityMeta {
+public final class EvokerFangsMeta extends EntityMeta {
     public EvokerFangsMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/other/ExperienceOrbMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/ExperienceOrbMeta.java
@@ -12,10 +12,10 @@ public final class ExperienceOrbMeta extends EntityMeta {
     }
 
     public int getValue() {
-        return metadata.get(MetadataDef.ExperienceOrb.VALUE);
+        return get(MetadataDef.ExperienceOrb.VALUE);
     }
 
     public void setValue(int value) {
-        metadata.set(MetadataDef.ExperienceOrb.VALUE, value);
+        set(MetadataDef.ExperienceOrb.VALUE, value);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/other/ExperienceOrbMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/ExperienceOrbMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 
-public class ExperienceOrbMeta extends EntityMeta {
+public final class ExperienceOrbMeta extends EntityMeta {
 
     public ExperienceOrbMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);

--- a/src/main/java/net/minestom/server/entity/metadata/other/FallingBlockMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/FallingBlockMeta.java
@@ -16,11 +16,11 @@ public final class FallingBlockMeta extends EntityMeta implements ObjectDataProv
     }
 
     public Point getSpawnPosition() {
-        return metadata.get(MetadataDef.FallingBlock.SPAWN_POSITION);
+        return get(MetadataDef.FallingBlock.SPAWN_POSITION);
     }
 
     public void setSpawnPosition(Point value) {
-        metadata.set(MetadataDef.FallingBlock.SPAWN_POSITION, value);
+        set(MetadataDef.FallingBlock.SPAWN_POSITION, value);
     }
 
     public Block getBlock() {

--- a/src/main/java/net/minestom/server/entity/metadata/other/FallingBlockMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/FallingBlockMeta.java
@@ -8,7 +8,7 @@ import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.entity.metadata.ObjectDataProvider;
 import net.minestom.server.instance.block.Block;
 
-public class FallingBlockMeta extends EntityMeta implements ObjectDataProvider {
+public final class FallingBlockMeta extends EntityMeta implements ObjectDataProvider {
     private Block block = Block.STONE;
 
     public FallingBlockMeta(Entity entity, MetadataHolder metadata) {

--- a/src/main/java/net/minestom/server/entity/metadata/other/FishingHookMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/FishingHookMeta.java
@@ -17,12 +17,12 @@ public final class FishingHookMeta extends EntityMeta implements ObjectDataProvi
     }
 
     public int getHookedEntityId() {
-        return metadata.get(MetadataDef.FishingHook.HOOKED);
+        return get(MetadataDef.FishingHook.HOOKED);
     }
 
     @ApiStatus.Internal
     public void setHookedEntityId(int value) {
-        metadata.set(MetadataDef.FishingHook.HOOKED, value);
+        set(MetadataDef.FishingHook.HOOKED, value);
     }
 
     @Nullable
@@ -37,11 +37,11 @@ public final class FishingHookMeta extends EntityMeta implements ObjectDataProvi
     }
 
     public boolean isCatchable() {
-        return metadata.get(MetadataDef.FishingHook.IS_CATCHABLE);
+        return get(MetadataDef.FishingHook.IS_CATCHABLE);
     }
 
     public void setCatchable(boolean value) {
-        metadata.set(MetadataDef.FishingHook.IS_CATCHABLE, value);
+        set(MetadataDef.FishingHook.IS_CATCHABLE, value);
     }
 
     @Nullable

--- a/src/main/java/net/minestom/server/entity/metadata/other/FishingHookMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/FishingHookMeta.java
@@ -8,9 +8,9 @@ import net.minestom.server.entity.metadata.ObjectDataProvider;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
-public class FishingHookMeta extends EntityMeta implements ObjectDataProvider {
-    private Entity hooked;
-    private Entity owner;
+public final class FishingHookMeta extends EntityMeta implements ObjectDataProvider {
+    private @Nullable Entity hooked;
+    private @Nullable Entity owner;
 
     public FishingHookMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);

--- a/src/main/java/net/minestom/server/entity/metadata/other/GlowItemFrameMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/GlowItemFrameMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.other;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class GlowItemFrameMeta extends ItemFrameMeta {
+public final class GlowItemFrameMeta extends ItemFrameMeta {
     public GlowItemFrameMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/other/HangingMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/HangingMeta.java
@@ -8,7 +8,7 @@ import net.minestom.server.entity.metadata.ObjectDataProvider;
 import net.minestom.server.utils.Direction;
 import org.jetbrains.annotations.Nullable;
 
-public class HangingMeta extends EntityMeta implements ObjectDataProvider {
+public sealed abstract class HangingMeta extends EntityMeta implements ObjectDataProvider permits ItemFrameMeta, PaintingMeta {
 
     protected HangingMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);

--- a/src/main/java/net/minestom/server/entity/metadata/other/HangingMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/HangingMeta.java
@@ -15,11 +15,11 @@ public sealed abstract class HangingMeta extends EntityMeta implements ObjectDat
     }
 
     public Direction getDirection() {
-        return metadata.get(MetadataDef.Hanging.DIRECTION);
+        return get(MetadataDef.Hanging.DIRECTION);
     }
 
     public void setDirection(Direction direction) {
-        metadata.set(MetadataDef.Hanging.DIRECTION, direction);
+        set(MetadataDef.Hanging.DIRECTION, direction);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/other/InteractionMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/InteractionMeta.java
@@ -12,26 +12,26 @@ public final class InteractionMeta extends EntityMeta {
     }
 
     public float getWidth() {
-        return metadata.get(MetadataDef.Interaction.WIDTH);
+        return get(MetadataDef.Interaction.WIDTH);
     }
 
     public void setWidth(float value) {
-        metadata.set(MetadataDef.Interaction.WIDTH, value);
+        set(MetadataDef.Interaction.WIDTH, value);
     }
 
     public float getHeight() {
-        return metadata.get(MetadataDef.Interaction.HEIGHT);
+        return get(MetadataDef.Interaction.HEIGHT);
     }
 
     public void setHeight(float value) {
-        metadata.set(MetadataDef.Interaction.HEIGHT, value);
+        set(MetadataDef.Interaction.HEIGHT, value);
     }
 
     public boolean getResponse() {
-        return metadata.get(MetadataDef.Interaction.RESPONSIVE);
+        return get(MetadataDef.Interaction.RESPONSIVE);
     }
 
     public void setResponse(boolean response) {
-        metadata.set(MetadataDef.Interaction.RESPONSIVE, response);
+        set(MetadataDef.Interaction.RESPONSIVE, response);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/other/InteractionMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/InteractionMeta.java
@@ -6,7 +6,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import org.jetbrains.annotations.Nullable;
 
-public class InteractionMeta extends EntityMeta {
+public final class InteractionMeta extends EntityMeta {
     public InteractionMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/other/ItemFrameMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/ItemFrameMeta.java
@@ -6,7 +6,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.utils.Rotation;
 
-public class ItemFrameMeta extends HangingMeta {
+public sealed class ItemFrameMeta extends HangingMeta permits GlowItemFrameMeta {
     public ItemFrameMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/other/ItemFrameMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/ItemFrameMeta.java
@@ -12,19 +12,19 @@ public sealed class ItemFrameMeta extends HangingMeta permits GlowItemFrameMeta 
     }
 
     public ItemStack getItem() {
-        return metadata.get(MetadataDef.ItemFrame.ITEM);
+        return get(MetadataDef.ItemFrame.ITEM);
     }
 
     public void setItem(ItemStack value) {
-        metadata.set(MetadataDef.ItemFrame.ITEM, value);
+        set(MetadataDef.ItemFrame.ITEM, value);
     }
 
     public Rotation getRotation() {
-        return Rotation.values()[metadata.get(MetadataDef.ItemFrame.ROTATION)];
+        return Rotation.values()[get(MetadataDef.ItemFrame.ROTATION)];
     }
 
     public void setRotation(Rotation value) {
-        metadata.set(MetadataDef.ItemFrame.ROTATION, value.ordinal());
+        set(MetadataDef.ItemFrame.ROTATION, value.ordinal());
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/other/LeashKnotMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/LeashKnotMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 
-public class LeashKnotMeta extends EntityMeta {
+public final class LeashKnotMeta extends EntityMeta {
     public LeashKnotMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/other/LightningBoltMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/LightningBoltMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 
-public class LightningBoltMeta extends EntityMeta {
+public final class LightningBoltMeta extends EntityMeta {
     public LightningBoltMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/other/LlamaSpitMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/LlamaSpitMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.entity.metadata.ObjectDataProvider;
 
-public class LlamaSpitMeta extends EntityMeta implements ObjectDataProvider {
+public final class LlamaSpitMeta extends EntityMeta implements ObjectDataProvider {
     public LlamaSpitMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/other/MagmaCubeMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/MagmaCubeMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.other;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class MagmaCubeMeta extends SlimeMeta {
+public final class MagmaCubeMeta extends SlimeMeta {
     public MagmaCubeMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/other/MarkerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/MarkerMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 
-public class MarkerMeta extends EntityMeta {
+public final class MarkerMeta extends EntityMeta {
     public MarkerMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/other/OminousItemSpawnerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/OminousItemSpawnerMeta.java
@@ -6,7 +6,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.item.ItemStack;
 
-public class OminousItemSpawnerMeta extends EntityMeta {
+public final class OminousItemSpawnerMeta extends EntityMeta {
     public OminousItemSpawnerMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/other/OminousItemSpawnerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/OminousItemSpawnerMeta.java
@@ -12,11 +12,11 @@ public final class OminousItemSpawnerMeta extends EntityMeta {
     }
 
     public ItemStack getItem() {
-        return metadata.get(MetadataDef.OminousItemSpawner.ITEM);
+        return get(MetadataDef.OminousItemSpawner.ITEM);
     }
 
     public void setItem(ItemStack value) {
-        metadata.set(MetadataDef.OminousItemSpawner.ITEM, value);
+        set(MetadataDef.OminousItemSpawner.ITEM, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/other/PaintingMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/PaintingMeta.java
@@ -8,7 +8,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.registry.Holder;
 import org.jetbrains.annotations.Nullable;
 
-public class PaintingMeta extends HangingMeta {
+public final class PaintingMeta extends HangingMeta {
 
     public PaintingMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);

--- a/src/main/java/net/minestom/server/entity/metadata/other/PaintingMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/PaintingMeta.java
@@ -19,7 +19,7 @@ public final class PaintingMeta extends HangingMeta {
      */
     @Deprecated
     public Holder<PaintingVariant> getVariant() {
-        return metadata.get(MetadataDef.Painting.VARIANT);
+        return get(MetadataDef.Painting.VARIANT);
     }
 
     /**
@@ -27,7 +27,7 @@ public final class PaintingMeta extends HangingMeta {
      */
     @Deprecated
     public void setVariant(Holder<PaintingVariant> value) {
-        metadata.set(MetadataDef.Painting.VARIANT, value);
+        set(MetadataDef.Painting.VARIANT, value);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/other/PrimedTntMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/PrimedTntMeta.java
@@ -12,19 +12,19 @@ public final class PrimedTntMeta extends EntityMeta {
     }
 
     public int getFuseTime() {
-        return metadata.get(MetadataDef.PrimedTnt.FUSE_TIME);
+        return get(MetadataDef.PrimedTnt.FUSE_TIME);
     }
 
     public void setFuseTime(int value) {
-        metadata.set(MetadataDef.PrimedTnt.FUSE_TIME, value);
+        set(MetadataDef.PrimedTnt.FUSE_TIME, value);
     }
 
     public Block getBlockState() {
-        return metadata.get(MetadataDef.PrimedTnt.BLOCK_STATE);
+        return get(MetadataDef.PrimedTnt.BLOCK_STATE);
     }
 
     public void setBlockState(Block block) {
-        metadata.set(MetadataDef.PrimedTnt.BLOCK_STATE, block);
+        set(MetadataDef.PrimedTnt.BLOCK_STATE, block);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/other/PrimedTntMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/PrimedTntMeta.java
@@ -6,7 +6,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.instance.block.Block;
 
-public class PrimedTntMeta extends EntityMeta {
+public final class PrimedTntMeta extends EntityMeta {
     public PrimedTntMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/other/ShulkerBulletMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/ShulkerBulletMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.entity.metadata.ObjectDataProvider;
 
-public class ShulkerBulletMeta extends EntityMeta implements ObjectDataProvider {
+public final class ShulkerBulletMeta extends EntityMeta implements ObjectDataProvider {
     public ShulkerBulletMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/other/SlimeMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/SlimeMeta.java
@@ -11,7 +11,7 @@ public sealed class SlimeMeta extends MobMeta permits MagmaCubeMeta {
     }
 
     public int getSize() {
-        return metadata.get(MetadataDef.Slime.SIZE);
+        return get(MetadataDef.Slime.SIZE);
     }
 
     public void setSize(int value) {
@@ -19,7 +19,7 @@ public sealed class SlimeMeta extends MobMeta permits MagmaCubeMeta {
             float boxSize = 0.51000005f * value;
             entity.setBoundingBox(boxSize, boxSize, boxSize);
         });
-        metadata.set(MetadataDef.Slime.SIZE, value);
+        set(MetadataDef.Slime.SIZE, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/other/SlimeMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/SlimeMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.MobMeta;
 
-public class SlimeMeta extends MobMeta {
+public sealed class SlimeMeta extends MobMeta permits MagmaCubeMeta {
     public SlimeMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/other/TraderLlamaMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/TraderLlamaMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 
-public class TraderLlamaMeta extends EntityMeta {
+public final class TraderLlamaMeta extends EntityMeta {
     public TraderLlamaMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/AbstractArrowMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/AbstractArrowMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 
-public class AbstractArrowMeta extends EntityMeta {
+public sealed abstract class AbstractArrowMeta extends EntityMeta permits ArrowMeta, SpectralArrowMeta, ThrownTridentMeta {
     protected AbstractArrowMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/AbstractArrowMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/AbstractArrowMeta.java
@@ -11,35 +11,35 @@ public sealed abstract class AbstractArrowMeta extends EntityMeta permits ArrowM
     }
 
     public boolean isCritical() {
-        return metadata.get(MetadataDef.AbstractArrow.IS_CRITICAL);
+        return get(MetadataDef.AbstractArrow.IS_CRITICAL);
     }
 
     public void setCritical(boolean value) {
-        metadata.set(MetadataDef.AbstractArrow.IS_CRITICAL, value);
+        set(MetadataDef.AbstractArrow.IS_CRITICAL, value);
     }
 
     public boolean isNoClip() {
-        return metadata.get(MetadataDef.AbstractArrow.IS_NO_CLIP);
+        return get(MetadataDef.AbstractArrow.IS_NO_CLIP);
     }
 
     public void setNoClip(boolean value) {
-        metadata.set(MetadataDef.AbstractArrow.IS_NO_CLIP, value);
+        set(MetadataDef.AbstractArrow.IS_NO_CLIP, value);
     }
 
     public byte getPiercingLevel() {
-        return metadata.get(MetadataDef.AbstractArrow.PIERCING_LEVEL);
+        return get(MetadataDef.AbstractArrow.PIERCING_LEVEL);
     }
 
     public void setPiercingLevel(byte value) {
-        metadata.set(MetadataDef.AbstractArrow.PIERCING_LEVEL, value);
+        set(MetadataDef.AbstractArrow.PIERCING_LEVEL, value);
     }
 
     public boolean isInGround() {
-        return metadata.get(MetadataDef.AbstractArrow.IN_GROUND);
+        return get(MetadataDef.AbstractArrow.IN_GROUND);
     }
 
     public void setInGround(boolean value) {
-        metadata.set(MetadataDef.AbstractArrow.IN_GROUND, value);
+        set(MetadataDef.AbstractArrow.IN_GROUND, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/AbstractWindChargeMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/AbstractWindChargeMeta.java
@@ -6,10 +6,10 @@ import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.entity.metadata.ObjectDataProvider;
 import org.jetbrains.annotations.Nullable;
 
-public class AbstractWindChargeMeta extends EntityMeta implements ObjectDataProvider, ProjectileMeta {
-    private Entity shooter;
+public sealed abstract class AbstractWindChargeMeta extends EntityMeta implements ObjectDataProvider, ProjectileMeta permits BreezeWindChargeMeta, WindChargeMeta {
+    private @Nullable Entity shooter;
 
-    public AbstractWindChargeMeta(@Nullable Entity entity, MetadataHolder metadata) {
+    protected AbstractWindChargeMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/ArrowMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/ArrowMeta.java
@@ -6,8 +6,8 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.ObjectDataProvider;
 import org.jetbrains.annotations.Nullable;
 
-public class ArrowMeta extends AbstractArrowMeta implements ObjectDataProvider, ProjectileMeta {
-    private Entity shooter;
+public final class ArrowMeta extends AbstractArrowMeta implements ObjectDataProvider, ProjectileMeta {
+    private @Nullable Entity shooter;
 
     public ArrowMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/ArrowMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/ArrowMeta.java
@@ -14,11 +14,11 @@ public final class ArrowMeta extends AbstractArrowMeta implements ObjectDataProv
     }
 
     public int getColor() {
-        return metadata.get(MetadataDef.Arrow.COLOR);
+        return get(MetadataDef.Arrow.COLOR);
     }
 
     public void setColor(int value) {
-        metadata.set(MetadataDef.Arrow.COLOR, value);
+        set(MetadataDef.Arrow.COLOR, value);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/BreezeWindChargeMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/BreezeWindChargeMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.projectile;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class BreezeWindChargeMeta extends AbstractWindChargeMeta {
+public final class BreezeWindChargeMeta extends AbstractWindChargeMeta {
     public BreezeWindChargeMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/DragonFireballMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/DragonFireballMeta.java
@@ -6,8 +6,8 @@ import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.entity.metadata.ObjectDataProvider;
 import org.jetbrains.annotations.Nullable;
 
-public class DragonFireballMeta extends EntityMeta implements ObjectDataProvider, ProjectileMeta {
-    private Entity shooter;
+public final class DragonFireballMeta extends EntityMeta implements ObjectDataProvider, ProjectileMeta {
+    private @Nullable Entity shooter;
 
     public DragonFireballMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/FireworkRocketMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/FireworkRocketMeta.java
@@ -16,21 +16,21 @@ public final class FireworkRocketMeta extends EntityMeta implements ProjectileMe
     }
 
     public ItemStack getFireworkInfo() {
-        return metadata.get(MetadataDef.FireworkRocketEntity.ITEM);
+        return get(MetadataDef.FireworkRocketEntity.ITEM);
     }
 
     public void setFireworkInfo(ItemStack value) {
-        metadata.set(MetadataDef.FireworkRocketEntity.ITEM, value);
+        set(MetadataDef.FireworkRocketEntity.ITEM, value);
     }
 
     @Nullable
     public Integer getShooterEntityId() {
-        return metadata.get(MetadataDef.FireworkRocketEntity.SHOOTER_ENTITY_ID);
+        return get(MetadataDef.FireworkRocketEntity.SHOOTER_ENTITY_ID);
     }
 
     @ApiStatus.Internal
     public void setShooterEntityId(@Nullable Integer value) {
-        metadata.set(MetadataDef.FireworkRocketEntity.SHOOTER_ENTITY_ID, value);
+        set(MetadataDef.FireworkRocketEntity.SHOOTER_ENTITY_ID, value);
     }
 
     @Override
@@ -47,11 +47,11 @@ public final class FireworkRocketMeta extends EntityMeta implements ProjectileMe
     }
 
     public boolean isShotAtAngle() {
-        return metadata.get(MetadataDef.FireworkRocketEntity.IS_SHOT_AT_ANGLE);
+        return get(MetadataDef.FireworkRocketEntity.IS_SHOT_AT_ANGLE);
     }
 
     public void setShotAtAngle(boolean value) {
-        metadata.set(MetadataDef.FireworkRocketEntity.IS_SHOT_AT_ANGLE, value);
+        set(MetadataDef.FireworkRocketEntity.IS_SHOT_AT_ANGLE, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/FireworkRocketMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/FireworkRocketMeta.java
@@ -8,8 +8,8 @@ import net.minestom.server.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
-public class FireworkRocketMeta extends EntityMeta implements ProjectileMeta {
-    private Entity shooter;
+public final class FireworkRocketMeta extends EntityMeta implements ProjectileMeta {
+    private @Nullable Entity shooter;
 
     public FireworkRocketMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/ProjectileMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/ProjectileMeta.java
@@ -1,9 +1,11 @@
 package net.minestom.server.entity.metadata.projectile;
 
 import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.metadata.item.FireballMeta;
+import net.minestom.server.entity.metadata.item.SmallFireballMeta;
 import org.jetbrains.annotations.Nullable;
 
-public interface ProjectileMeta {
+public sealed interface ProjectileMeta permits FireballMeta, SmallFireballMeta, AbstractWindChargeMeta, ArrowMeta, DragonFireballMeta, FireworkRocketMeta, SpectralArrowMeta, WitherSkullMeta {
 
     @Nullable
     Entity getShooter();

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/SpectralArrowMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/SpectralArrowMeta.java
@@ -5,8 +5,8 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.ObjectDataProvider;
 import org.jetbrains.annotations.Nullable;
 
-public class SpectralArrowMeta extends AbstractArrowMeta implements ObjectDataProvider, ProjectileMeta {
-    private Entity shooter;
+public final class SpectralArrowMeta extends AbstractArrowMeta implements ObjectDataProvider, ProjectileMeta {
+    private @Nullable Entity shooter;
 
     public SpectralArrowMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/ThrownTridentMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/ThrownTridentMeta.java
@@ -10,19 +10,19 @@ public final class ThrownTridentMeta extends AbstractArrowMeta {
     }
 
     public byte getLoyaltyLevel() {
-        return metadata.get(MetadataDef.ThrownTrident.LOYALTY_LEVEL);
+        return get(MetadataDef.ThrownTrident.LOYALTY_LEVEL);
     }
 
     public void setLoyaltyLevel(byte value) {
-        metadata.set(MetadataDef.ThrownTrident.LOYALTY_LEVEL, value);
+        set(MetadataDef.ThrownTrident.LOYALTY_LEVEL, value);
     }
 
     public boolean isHasEnchantmentGlint() {
-        return metadata.get(MetadataDef.ThrownTrident.HAS_ENCHANTMENT_GLINT);
+        return get(MetadataDef.ThrownTrident.HAS_ENCHANTMENT_GLINT);
     }
 
     public void setHasEnchantmentGlint(boolean value) {
-        metadata.set(MetadataDef.ThrownTrident.HAS_ENCHANTMENT_GLINT, value);
+        set(MetadataDef.ThrownTrident.HAS_ENCHANTMENT_GLINT, value);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/ThrownTridentMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/ThrownTridentMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class ThrownTridentMeta extends AbstractArrowMeta {
+public final class ThrownTridentMeta extends AbstractArrowMeta {
     public ThrownTridentMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/WindChargeMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/WindChargeMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.projectile;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class WindChargeMeta extends AbstractWindChargeMeta {
+public final class WindChargeMeta extends AbstractWindChargeMeta {
     public WindChargeMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/WitherSkullMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/WitherSkullMeta.java
@@ -7,8 +7,8 @@ import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.entity.metadata.ObjectDataProvider;
 import org.jetbrains.annotations.Nullable;
 
-public class WitherSkullMeta extends EntityMeta implements ObjectDataProvider, ProjectileMeta {
-    private Entity shooter;
+public final class WitherSkullMeta extends EntityMeta implements ObjectDataProvider, ProjectileMeta {
+    private @Nullable Entity shooter;
 
     public WitherSkullMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/WitherSkullMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/WitherSkullMeta.java
@@ -15,11 +15,11 @@ public final class WitherSkullMeta extends EntityMeta implements ObjectDataProvi
     }
 
     public boolean isInvulnerable() {
-        return metadata.get(MetadataDef.WitherSkull.IS_INVULNERABLE);
+        return get(MetadataDef.WitherSkull.IS_INVULNERABLE);
     }
 
     public void setInvulnerable(boolean value) {
-        metadata.set(MetadataDef.WitherSkull.IS_INVULNERABLE, value);
+        set(MetadataDef.WitherSkull.IS_INVULNERABLE, value);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/villager/AbstractVillagerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/villager/AbstractVillagerMeta.java
@@ -5,16 +5,16 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.AgeableMobMeta;
 
-public sealed class AbstractVillagerMeta extends AgeableMobMeta permits VillagerMeta {
+public sealed abstract class AbstractVillagerMeta extends AgeableMobMeta permits VillagerMeta {
     protected AbstractVillagerMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 
     public int getHeadShakeTimer() {
-        return metadata.get(MetadataDef.AbstractVillager.HEAD_SHAKE_TIMER);
+        return get(MetadataDef.AbstractVillager.HEAD_SHAKE_TIMER);
     }
 
     public void setHeadShakeTimer(int value) {
-        metadata.set(MetadataDef.AbstractVillager.HEAD_SHAKE_TIMER, value);
+        set(MetadataDef.AbstractVillager.HEAD_SHAKE_TIMER, value);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/villager/AbstractVillagerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/villager/AbstractVillagerMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.AgeableMobMeta;
 
-public class AbstractVillagerMeta extends AgeableMobMeta {
+public sealed class AbstractVillagerMeta extends AgeableMobMeta permits VillagerMeta {
     protected AbstractVillagerMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/villager/VillagerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/villager/VillagerMeta.java
@@ -7,7 +7,7 @@ import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.NetworkBufferTemplate;
 import org.jetbrains.annotations.Nullable;
 
-public class VillagerMeta extends AbstractVillagerMeta {
+public sealed class VillagerMeta extends AbstractVillagerMeta permits WanderingTraderMeta {
     public VillagerMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/villager/VillagerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/villager/VillagerMeta.java
@@ -13,11 +13,11 @@ public sealed class VillagerMeta extends AbstractVillagerMeta permits WanderingT
     }
 
     public VillagerData getVillagerData() {
-        return metadata.get(MetadataDef.Villager.VARIANT);
+        return get(MetadataDef.Villager.VARIANT);
     }
 
     public void setVillagerData(VillagerData data) {
-        metadata.set(MetadataDef.Villager.VARIANT, data);
+        set(MetadataDef.Villager.VARIANT, data);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/villager/WanderingTraderMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/villager/WanderingTraderMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.villager;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class WanderingTraderMeta extends VillagerMeta {
+public final class WanderingTraderMeta extends VillagerMeta {
     public WanderingTraderMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/water/AgeableWaterAnimalMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/AgeableWaterAnimalMeta.java
@@ -4,8 +4,8 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.AgeableMobMeta;
 
-public class AgeableWaterAnimalMeta extends AgeableMobMeta {
-    public AgeableWaterAnimalMeta(Entity entity, MetadataHolder metadata) {
+public sealed abstract class AgeableWaterAnimalMeta extends AgeableMobMeta permits DolphinMeta, GlowSquidMeta, SquidMeta {
+    protected AgeableWaterAnimalMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/water/AxolotlMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/AxolotlMeta.java
@@ -10,7 +10,7 @@ import net.minestom.server.entity.metadata.animal.AnimalMeta;
 import net.minestom.server.network.NetworkBuffer;
 import org.jetbrains.annotations.Nullable;
 
-public class AxolotlMeta extends AnimalMeta {
+public final class AxolotlMeta extends AnimalMeta {
     public AxolotlMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/water/AxolotlMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/AxolotlMeta.java
@@ -20,7 +20,7 @@ public final class AxolotlMeta extends AnimalMeta {
      */
     @Deprecated
     public Variant getVariant() {
-        return Variant.VALUES[metadata.get(MetadataDef.Axolotl.VARIANT)];
+        return Variant.VALUES[get(MetadataDef.Axolotl.VARIANT)];
     }
 
     /**
@@ -28,23 +28,23 @@ public final class AxolotlMeta extends AnimalMeta {
      */
     @Deprecated
     public void setVariant(Variant variant) {
-        metadata.set(MetadataDef.Axolotl.VARIANT, variant.ordinal());
+        set(MetadataDef.Axolotl.VARIANT, variant.ordinal());
     }
 
     public boolean isPlayingDead() {
-        return metadata.get(MetadataDef.Axolotl.IS_PLAYING_DEAD);
+        return get(MetadataDef.Axolotl.IS_PLAYING_DEAD);
     }
 
     public void setPlayingDead(boolean playingDead) {
-        metadata.set(MetadataDef.Axolotl.IS_PLAYING_DEAD, playingDead);
+        set(MetadataDef.Axolotl.IS_PLAYING_DEAD, playingDead);
     }
 
     public boolean isFromBucket() {
-        return metadata.get(MetadataDef.Axolotl.IS_FROM_BUCKET);
+        return get(MetadataDef.Axolotl.IS_FROM_BUCKET);
     }
 
     public void setFromBucket(boolean fromBucket) {
-        metadata.set(MetadataDef.Axolotl.IS_FROM_BUCKET, fromBucket);
+        set(MetadataDef.Axolotl.IS_FROM_BUCKET, fromBucket);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/water/DolphinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/DolphinMeta.java
@@ -11,26 +11,26 @@ public final class DolphinMeta extends AgeableWaterAnimalMeta {
     }
 
     public Point getTreasurePosition() {
-        return metadata.get(MetadataDef.Dolphin.TREASURE_POSITION);
+        return get(MetadataDef.Dolphin.TREASURE_POSITION);
     }
 
     public void setTreasurePosition(Point value) {
-        metadata.set(MetadataDef.Dolphin.TREASURE_POSITION, value);
+        set(MetadataDef.Dolphin.TREASURE_POSITION, value);
     }
 
     public boolean isHasFish() {
-        return metadata.get(MetadataDef.Dolphin.HAS_FISH);
+        return get(MetadataDef.Dolphin.HAS_FISH);
     }
 
     public void setHasFish(boolean value) {
-        metadata.set(MetadataDef.Dolphin.HAS_FISH, value);
+        set(MetadataDef.Dolphin.HAS_FISH, value);
     }
 
     public int getMoistureLevel() {
-        return metadata.get(MetadataDef.Dolphin.MOISTURE_LEVEL);
+        return get(MetadataDef.Dolphin.MOISTURE_LEVEL);
     }
 
     public void setMoistureLevel(int value) {
-        metadata.set(MetadataDef.Dolphin.MOISTURE_LEVEL, value);
+        set(MetadataDef.Dolphin.MOISTURE_LEVEL, value);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/water/DolphinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/DolphinMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class DolphinMeta extends AgeableWaterAnimalMeta {
+public final class DolphinMeta extends AgeableWaterAnimalMeta {
     public DolphinMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/water/GlowSquidMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/GlowSquidMeta.java
@@ -10,11 +10,11 @@ public final class GlowSquidMeta extends AgeableWaterAnimalMeta {
     }
 
     private int getDarkTicksRemaining() {
-        return metadata.get(MetadataDef.GlowSquid.DARK_TICKS_REMAINING);
+        return get(MetadataDef.GlowSquid.DARK_TICKS_REMAINING);
     }
 
     private void setDarkTicksRemaining(int ticks) {
-        metadata.set(MetadataDef.GlowSquid.DARK_TICKS_REMAINING, ticks);
+        set(MetadataDef.GlowSquid.DARK_TICKS_REMAINING, ticks);
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/water/GlowSquidMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/GlowSquidMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class GlowSquidMeta extends AgeableWaterAnimalMeta {
+public final class GlowSquidMeta extends AgeableWaterAnimalMeta {
     public GlowSquidMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/water/SquidMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/SquidMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.water;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class SquidMeta extends AgeableWaterAnimalMeta {
+public final class SquidMeta extends AgeableWaterAnimalMeta {
     public SquidMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/water/WaterAnimalMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/WaterAnimalMeta.java
@@ -3,8 +3,9 @@ package net.minestom.server.entity.metadata.water;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.PathfinderMobMeta;
+import net.minestom.server.entity.metadata.water.fish.AbstractFishMeta;
 
-public class WaterAnimalMeta extends PathfinderMobMeta {
+public sealed abstract class WaterAnimalMeta extends PathfinderMobMeta permits AbstractFishMeta {
     protected WaterAnimalMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/water/fish/AbstractFishMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/fish/AbstractFishMeta.java
@@ -5,7 +5,7 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.water.WaterAnimalMeta;
 
-public class AbstractFishMeta extends WaterAnimalMeta {
+public sealed class AbstractFishMeta extends WaterAnimalMeta permits CodMeta, PufferfishMeta, SalmonMeta, TadpoleMeta, TropicalFishMeta {
     protected AbstractFishMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/water/fish/AbstractFishMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/fish/AbstractFishMeta.java
@@ -5,16 +5,16 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.water.WaterAnimalMeta;
 
-public sealed class AbstractFishMeta extends WaterAnimalMeta permits CodMeta, PufferfishMeta, SalmonMeta, TadpoleMeta, TropicalFishMeta {
+public sealed abstract class AbstractFishMeta extends WaterAnimalMeta permits CodMeta, PufferfishMeta, SalmonMeta, TadpoleMeta, TropicalFishMeta {
     protected AbstractFishMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 
     public boolean isFromBucket() {
-        return metadata.get(MetadataDef.AbstractFish.FROM_BUCKET);
+        return get(MetadataDef.AbstractFish.FROM_BUCKET);
     }
 
     public void setFromBucket(boolean value) {
-        metadata.set(MetadataDef.AbstractFish.FROM_BUCKET, value);
+        set(MetadataDef.AbstractFish.FROM_BUCKET, value);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/water/fish/CodMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/fish/CodMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.water.fish;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class CodMeta extends AbstractFishMeta {
+public final class CodMeta extends AbstractFishMeta {
     public CodMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/water/fish/PufferfishMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/fish/PufferfishMeta.java
@@ -4,7 +4,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 
-public class PufferfishMeta extends AbstractFishMeta {
+public final class PufferfishMeta extends AbstractFishMeta {
     public PufferfishMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
         updateBoundingBox(State.UNPUFFED);

--- a/src/main/java/net/minestom/server/entity/metadata/water/fish/PufferfishMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/fish/PufferfishMeta.java
@@ -11,11 +11,11 @@ public final class PufferfishMeta extends AbstractFishMeta {
     }
 
     public State getState() {
-        return State.VALUES[metadata.get(MetadataDef.PufferFish.PUFF_STATE)];
+        return State.VALUES[get(MetadataDef.PufferFish.PUFF_STATE)];
     }
 
     public void setState(State state) {
-        metadata.set(MetadataDef.PufferFish.PUFF_STATE, state.ordinal());
+        set(MetadataDef.PufferFish.PUFF_STATE, state.ordinal());
         updateBoundingBox(state);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/water/fish/SalmonMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/fish/SalmonMeta.java
@@ -13,7 +13,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class SalmonMeta extends AbstractFishMeta {
+public final class SalmonMeta extends AbstractFishMeta {
     public SalmonMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/water/fish/SalmonMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/fish/SalmonMeta.java
@@ -23,7 +23,7 @@ public final class SalmonMeta extends AbstractFishMeta {
      */
     @Deprecated
     public SalmonMeta.Size getSize() {
-        return Size.VALUES[metadata.get(MetadataDef.Salmon.SIZE)];
+        return Size.VALUES[get(MetadataDef.Salmon.SIZE)];
     }
 
     /**
@@ -31,7 +31,7 @@ public final class SalmonMeta extends AbstractFishMeta {
      */
     @Deprecated
     public void setSize(SalmonMeta.Size size) {
-        metadata.set(MetadataDef.Salmon.SIZE, size.ordinal());
+        set(MetadataDef.Salmon.SIZE, size.ordinal());
     }
 
     @Override

--- a/src/main/java/net/minestom/server/entity/metadata/water/fish/TadpoleMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/fish/TadpoleMeta.java
@@ -3,7 +3,7 @@ package net.minestom.server.entity.metadata.water.fish;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 
-public class TadpoleMeta extends AbstractFishMeta {
+public final class TadpoleMeta extends AbstractFishMeta {
     public TadpoleMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/water/fish/TropicalFishMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/fish/TropicalFishMeta.java
@@ -10,7 +10,7 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.network.NetworkBuffer;
 import org.jetbrains.annotations.Nullable;
 
-public class TropicalFishMeta extends AbstractFishMeta {
+public final class TropicalFishMeta extends AbstractFishMeta {
     public TropicalFishMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/water/fish/TropicalFishMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/fish/TropicalFishMeta.java
@@ -20,7 +20,7 @@ public final class TropicalFishMeta extends AbstractFishMeta {
      */
     @Deprecated
     public Variant getVariant() {
-        return Variant.fromPackedId(metadata.get(MetadataDef.TropicalFish.VARIANT));
+        return Variant.fromPackedId(get(MetadataDef.TropicalFish.VARIANT));
     }
 
     /**
@@ -28,7 +28,7 @@ public final class TropicalFishMeta extends AbstractFishMeta {
      */
     @Deprecated
     public void setVariant(Variant variant) {
-        metadata.set(MetadataDef.TropicalFish.VARIANT, variant.packedId());
+        set(MetadataDef.TropicalFish.VARIANT, variant.packedId());
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes
### Motivation
As MetadataDef is declared sealed and all implementations are final, there is no reason to allow the wrapper objects around EntityMeta to also be extendable, as the implementations are created through `MetadataHolder.createMeta`.

### Changes
Seals all EntityMeta implementations, abstracts the protected ones (protects more aswell). As MetadataDef is declared as sealed/final. This should only be a breaking change to users who extend EntityMeta, but its unlikely due to its implementation being looked up for an EntityType.

Also fixes nullability annotations relating to Metadata.

Also hides the underlying MetadataHolder, as it should be possible to create your own implementation for your classes to modify the behavior of how its stored/used.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

In the future we should remove stacktrace reflection from MetadataDef.
In the future we should add the final modifier to Entity.entityMeta and Entity.metadata, Entity.entityType. If it becomes easier to copy entities.