### PR TITLE
Add modifiable position to AddEntityToInstanceEvent

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -830,21 +830,23 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
      * Changes the entity instance, i.e. spawns it.
      *
      * @param instance      the new instance of the entity
-     * @param spawnPosition the spawn position for the entity.
+     * @param defaultSpawnPosition the default spawn position for the entity.
      * @return a {@link CompletableFuture} called once the entity's instance has been set,
      * this is due to chunks needing to load
      * @throws IllegalStateException if {@code instance} has not been registered in {@link InstanceManager}
      */
-    public CompletableFuture<Void> setInstance(Instance instance, Pos spawnPosition) {
+    public CompletableFuture<Void> setInstance(Instance instance, Pos defaultSpawnPosition) {
         Check.stateCondition(!instance.isRegistered(),
                 "Instances need to be registered, please use InstanceManager#registerInstance or InstanceManager#registerSharedInstance");
         final Instance previousInstance = this.instance;
         if (Objects.equals(previousInstance, instance)) {
-            return teleport(spawnPosition); // Already in the instance, teleport to spawn point
+            return teleport(defaultSpawnPosition); // Already in the instance, teleport to spawn point
         }
-        AddEntityToInstanceEvent event = new AddEntityToInstanceEvent(instance, this);
+        AddEntityToInstanceEvent event = new AddEntityToInstanceEvent(instance, this, defaultSpawnPosition);
         EventDispatcher.call(event);
         if (event.isCancelled()) return null; // TODO what to return?
+
+        final Pos spawnPosition = event.getSpawnPosition();
 
         if (previousInstance != null) removeFromInstance(previousInstance);
         if (this instanceof Player player) instance.bossBars().forEach(player::showBossBar);

--- a/src/main/java/net/minestom/server/event/instance/AddEntityToInstanceEvent.java
+++ b/src/main/java/net/minestom/server/event/instance/AddEntityToInstanceEvent.java
@@ -1,8 +1,11 @@
 package net.minestom.server.event.instance;
 
+import net.minestom.server.coordinate.Point;
+import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.event.trait.CancellableEvent;
 import net.minestom.server.event.trait.EntityEvent;
+import net.minestom.server.event.trait.EntityInstanceEvent;
 import net.minestom.server.event.trait.InstanceEvent;
 import net.minestom.server.instance.Instance;
 
@@ -10,16 +13,18 @@ import net.minestom.server.instance.Instance;
  * Called by an Instance when an entity is added to it.
  * Can be used attach data.
  */
-public class AddEntityToInstanceEvent implements InstanceEvent, EntityEvent, CancellableEvent {
+public class AddEntityToInstanceEvent implements EntityInstanceEvent, CancellableEvent {
 
     private final Instance instance;
     private final Entity entity;
+    private Pos spawnPosition;
 
     private boolean cancelled;
 
-    public AddEntityToInstanceEvent(Instance instance, Entity entity) {
+    public AddEntityToInstanceEvent(Instance instance, Entity entity, Pos spawnPosition) {
         this.instance = instance;
         this.entity = entity;
+        this.spawnPosition = spawnPosition;
     }
 
     @Override
@@ -34,6 +39,33 @@ public class AddEntityToInstanceEvent implements InstanceEvent, EntityEvent, Can
      */
     public Entity getEntity() {
         return entity;
+    }
+
+    /**
+     * Gets the position where the entity will spawn in the new instance.
+     * This is the location specified in {@link Entity#setInstance(Instance, Pos)} unless modified.
+     * @return the position
+     */
+    public Pos getSpawnPosition() {
+        return spawnPosition;
+    }
+
+    /**
+     * Sets the position where the entity will spawn in the new instance.
+     * This can be used to override the location specified in {@link Entity#setInstance(Instance, Pos)}.
+     * @param position the new spawning position
+     */
+    public void setSpawnPosition(Pos position) {
+        this.spawnPosition = position;
+    }
+
+    /**
+     * Sets the position where the entity will spawn in the new instance.
+     * This can be used to override the location specified in {@link Entity#setInstance(Instance, Pos)}.
+     * @param position the new spawning position
+     */
+    public void setSpawnPosition(Point position) {
+        this.spawnPosition = position.asPos();
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

Adds getSpawnPosition() and setSpawnPosition() to AddEntityToInstanceEvent. This allows for event handlers to read or change the spawning position.

Not sure if this should target next - it is breaking but I doubt many people are directly constructing this event.

There is also currently no way to differentiate between events called from `setInstance(Instance)` and `setInstance(Instance, Pos)`. Making position null in that case might work, as this could just be set to its default (current entity position) when retrieving it after event handling.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)