### PR TITLE
refactor: Use BlockVec instead of Vec for generators.

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -93,7 +93,8 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         HoverEventSource<ShowEntity>, Sound.Emitter, Shape, AcquirableSource<Entity>, DataComponent.Holder, Pointered, Identified {
     // This is somewhat arbitrary, but we don't want to hit the max int ever because it is very easy to
     // overflow while working with a position at the max int (for example, looping over a bounding box)
-    static final int MAX_COORDINATE = 2_000_000_000;
+    @ApiStatus.Internal
+    public static final int MAX_COORDINATE = 2_000_000_000;
 
     private static final AtomicInteger LAST_ENTITY_ID = new AtomicInteger();
 
@@ -229,13 +230,19 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
 
     /// Clamps position to {@link Entity#MAX_COORDINATE}
     protected Pos clampPosition(Pos newPosition) {
-        if (newPosition.x() >= MAX_COORDINATE || newPosition.x() <= -MAX_COORDINATE ||
-                newPosition.y() >= MAX_COORDINATE || newPosition.y() <= -MAX_COORDINATE ||
-                newPosition.z() >= MAX_COORDINATE || newPosition.z() <= -MAX_COORDINATE) {
+        double x = newPosition.x();
+        double y = newPosition.y();
+        double z = newPosition.z();
+        if (Double.isNaN(x) || Double.isNaN(y) || Double.isNaN(z)) {
+            return new Pos(0, 0, 0, newPosition.yaw(), newPosition.pitch());
+        }
+        if (x >= MAX_COORDINATE || x <= -MAX_COORDINATE ||
+                y >= MAX_COORDINATE || y <= -MAX_COORDINATE ||
+                z >= MAX_COORDINATE || z <= -MAX_COORDINATE) {
             newPosition = newPosition.withCoord(
-                    MathUtils.clamp(newPosition.x(), -MAX_COORDINATE, MAX_COORDINATE),
-                    MathUtils.clamp(newPosition.y(), -MAX_COORDINATE, MAX_COORDINATE),
-                    MathUtils.clamp(newPosition.z(), -MAX_COORDINATE, MAX_COORDINATE)
+                    MathUtils.clamp(x, -MAX_COORDINATE, MAX_COORDINATE),
+                    MathUtils.clamp(y, -MAX_COORDINATE, MAX_COORDINATE),
+                    MathUtils.clamp(z, -MAX_COORDINATE, MAX_COORDINATE)
             );
         }
         return newPosition;

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -227,7 +227,8 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         this(entityType, UUID.randomUUID());
     }
 
-    protected void setPositionInternal(Pos newPosition, float headRotation) {
+    /// Clamps position to {@link Entity#MAX_COORDINATE}
+    protected Pos clampPosition(Pos newPosition) {
         if (newPosition.x() >= MAX_COORDINATE || newPosition.x() <= -MAX_COORDINATE ||
                 newPosition.y() >= MAX_COORDINATE || newPosition.y() <= -MAX_COORDINATE ||
                 newPosition.z() >= MAX_COORDINATE || newPosition.z() <= -MAX_COORDINATE) {
@@ -237,7 +238,11 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
                     MathUtils.clamp(newPosition.z(), -MAX_COORDINATE, MAX_COORDINATE)
             );
         }
-        this.position = newPosition;
+        return newPosition;
+    }
+
+    protected void setPositionInternal(Pos newPosition, float headRotation) {
+        this.position = clampPosition(newPosition);
         this.headRotation = headRotation;
     }
 
@@ -373,7 +378,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         EntityTeleportEvent event = new EntityTeleportEvent(this, position, flags);
         EventDispatcher.call(event);
 
-        final Pos globalPosition = PositionUtils.getPositionWithRelativeFlags(this.position, position, flags);
+        final Pos globalPosition = clampPosition(PositionUtils.getPositionWithRelativeFlags(this.position, position, flags));
         final Vec globalVelocity = PositionUtils.getVelocityWithRelativeFlags(this.velocity, velocity, flags);
 
         final Runnable endCallback = () -> {
@@ -390,6 +395,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
             // Chunks need to be loaded before the teleportation can happen
             return ChunkUtils.optionalLoadAll(instance, chunks, null).thenRun(endCallback);
         }
+        // Assumes globalPosition is already clamped
         final Pos currentPosition = this.position;
         if (!currentPosition.sameChunk(globalPosition)) {
             // Ensure that the chunk is loaded
@@ -870,6 +876,8 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         if (this instanceof Player player) instance.bossBars().forEach(player::showBossBar);
         EventsJFR.newInstanceJoin(getUuid(), instance.getUuid()).commit();
 
+        spawnPosition = clampPosition(spawnPosition); // Cap spawnPositon to Entity max distance.
+
         this.isActive = true;
         setPositionInternal(spawnPosition, spawnPosition.yaw());
         this.previousPosition = spawnPosition;
@@ -885,7 +893,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
                     player.sendPacket(instance.createTimePacket());
                     player.sendPackets(instance.getWeather().createWeatherPackets());
                 }
-                instance.getEntityTracker().register(this, spawnPosition, trackingTarget, trackingUpdate);
+                instance.getEntityTracker().register(this, position, trackingTarget, trackingUpdate);
                 spawn();
                 EventDispatcher.call(new EntitySpawnEvent(this, instance));
             } catch (Exception e) {
@@ -1328,7 +1336,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     @ApiStatus.Internal
     public void refreshPosition(final Pos newPosition, boolean ignoreView, boolean sendPackets) {
         final var previousPosition = this.position;
-        final Pos position = ignoreView ? previousPosition.withCoord(newPosition) : newPosition;
+        final Pos position = clampPosition(ignoreView ? previousPosition.withCoord(newPosition) : newPosition);
         final Pos lastSyncedPosition = this.lastSyncedPosition;
         if (position.equals(lastSyncedPosition)) return;
         setPositionInternal(position, ignoreView ? headRotation : position.yaw());
@@ -1389,7 +1397,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
      */
     private void updatePassengerPosition(Point newPosition, Entity passenger, int passengerIndex) {
         final Pos oldPassengerPos = passenger.position;
-        final Pos newPassengerPos = newPosition.add(EntityUtils.getPassengerPositionOffset(this, passenger, passengerIndex)).asPos();
+        final Pos newPassengerPos = passenger.clampPosition(newPosition.add(EntityUtils.getPassengerPositionOffset(this, passenger, passengerIndex)).asPos());
         passenger.setPositionInternal(newPassengerPos, newPassengerPos.yaw());
         passenger.previousPosition = oldPassengerPos;
         passenger.refreshCoordinate(newPassengerPos);

--- a/src/main/java/net/minestom/server/instance/generator/GenerationUnit.java
+++ b/src/main/java/net/minestom/server/instance/generator/GenerationUnit.java
@@ -1,7 +1,7 @@
 package net.minestom.server.instance.generator;
 
+import net.minestom.server.coordinate.BlockVec;
 import net.minestom.server.coordinate.Point;
-import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.block.Block;
 
 import java.util.List;
@@ -28,21 +28,21 @@ public interface GenerationUnit {
      *
      * @return the size of this unit
      */
-    Point size();
+    BlockVec size();
 
     /**
      * The absolute start (min x, y, z) of this unit.
      *
      * @return the absolute start
      */
-    Point absoluteStart();
+    BlockVec absoluteStart();
 
     /**
      * The absolute end (max x, y, z) of this unit.
      *
      * @return the absolute end
      */
-    Point absoluteEnd();
+    BlockVec absoluteEnd();
 
     /**
      * Creates a fork of this unit, which will be applied to the instance whenever possible.
@@ -74,17 +74,17 @@ public interface GenerationUnit {
      *
      * @return the contained sections
      */
-    default Set<Vec> sections() {
+    default Set<BlockVec> sections() {
         final Point start = absoluteStart(), end = absoluteEnd();
         final int minX = start.sectionX(), minY = start.sectionY(), minZ = start.sectionZ();
         final int maxX = end.sectionX(), maxY = end.sectionY(), maxZ = end.sectionZ();
         final int count = (maxX - minX) * (maxY - minY) * (maxZ - minZ);
-        Vec[] sections = new Vec[count];
+        BlockVec[] sections = new BlockVec[count];
         int index = 0;
         for (int sectionX = minX; sectionX < maxX; sectionX++) {
             for (int sectionY = minY; sectionY < maxY; sectionY++) {
                 for (int sectionZ = minZ; sectionZ < maxZ; sectionZ++) {
-                    sections[index++] = new Vec(sectionX, sectionY, sectionZ);
+                    sections[index++] = new BlockVec(sectionX, sectionY, sectionZ);
                 }
             }
         }

--- a/src/main/java/net/minestom/server/instance/generator/GeneratorImpl.java
+++ b/src/main/java/net/minestom/server/instance/generator/GeneratorImpl.java
@@ -94,32 +94,26 @@ public final class GeneratorImpl {
 
         @Override
         public void setBlock(int x, int y, int z, Block block) {
-            final Fork cachedFork = this.fork;
-            Fork fork = setBlock(cachedFork, x, y, z, block);
-            if (fork != cachedFork) {
-                this.fork = fork;
-            }
-        }
-
-        private Fork setBlock(@Nullable Fork fork, int x, int y, int z, Block block) {
-            fork = resize(fork, x, y, z);
+            resize(x, y, z);
+            final Fork fork = this.fork;
             GenerationUnit section = findAbsolute(fork.sections(), fork.minSection(), fork.width(), fork.height(), fork.depth(), x, y, z);
             assert section.absoluteStart().sectionX() == globalToChunk(x) &&
                     section.absoluteStart().sectionY() == globalToChunk(y) &&
                     section.absoluteStart().sectionZ() == globalToChunk(z) :
                     "Invalid section " + section.absoluteStart() + " for " + x + ", " + y + ", " + z;
             section.modifier().setBlock(x, y, z, block);
-            return fork;
         }
 
-        private Fork resize(@Nullable Fork fork, int x, int y, int z) {
+        private void resize(int x, int y, int z) {
             final int sectionX = globalToChunk(x);
             final int sectionY = globalToChunk(y);
             final int sectionZ = globalToChunk(z);
+            final Fork fork = this.fork;
             if (fork == null) {
                 var minSection = BlockVec.SECTION.mul(sectionX, sectionY, sectionZ);
                 var sections = List.of(section(biomeRegistry, new GenSection(), sectionX, sectionY, sectionZ, true));
-                return new Fork(minSection, 1, 1, 1, sections);
+                this.fork = new Fork(minSection, 1, 1, 1, sections);
+                return;
             }
             // Section exists, we need to check the bounds
             final BlockVec minSection = fork.minSection();
@@ -128,7 +122,7 @@ public final class GeneratorImpl {
             final int maxZ = minSection.blockZ() + fork.depth() * SECTION_SIZE;
             if (x >= minSection.blockX() && y >= minSection.blockY() && z >= minSection.blockZ() &&
                     x < maxX && y < maxY && z < maxZ) {
-                return fork; // inside bounds, no resize needed
+                return; // inside bounds, no resize needed
             }
             // Find new min and max
             final BlockVec section = BlockVec.SECTION.mul(sectionX, sectionY, sectionZ);
@@ -163,7 +157,7 @@ public final class GeneratorImpl {
                     newSections[i] = unit;
                 }
             }
-            return new Fork(newMin, newWidth, newHeight, newDepth, List.of(newSections));
+            this.fork = new Fork(newMin, newWidth, newHeight, newDepth, List.of(newSections));
         }
     }
 

--- a/src/main/java/net/minestom/server/instance/generator/GeneratorImpl.java
+++ b/src/main/java/net/minestom/server/instance/generator/GeneratorImpl.java
@@ -2,8 +2,9 @@ package net.minestom.server.instance.generator;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import net.minestom.server.coordinate.Area;
+import net.minestom.server.coordinate.BlockVec;
 import net.minestom.server.coordinate.Point;
-import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.palette.Palette;
 import net.minestom.server.registry.DynamicRegistry;
@@ -12,6 +13,7 @@ import net.minestom.server.utils.validate.Check;
 import net.minestom.server.world.biome.Biome;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
 
 import java.util.List;
 import java.util.Objects;
@@ -35,8 +37,8 @@ public final class GeneratorImpl {
     static GenerationUnit section(DynamicRegistry<Biome> biomeRegistry, GenSection section,
                                   int sectionX, int sectionY, int sectionZ,
                                   boolean fork) {
-        final Vec start = Vec.SECTION.mul(sectionX, sectionY, sectionZ);
-        final Vec end = start.add(Vec.SECTION);
+        final BlockVec start = BlockVec.SECTION.mul(sectionX, sectionY, sectionZ);
+        final BlockVec end = start.add(BlockVec.SECTION);
         final UnitModifier modifier = new SectionModifierImpl(biomeRegistry, start, end, section, fork);
         return unit(biomeRegistry, modifier, start, end, null);
     }
@@ -46,19 +48,14 @@ public final class GeneratorImpl {
     }
 
     public static UnitImpl chunk(DynamicRegistry<Biome> biomeRegistry, GenSection[] chunkSections, int chunkX, int minSection, int chunkZ) {
-        final Vec start = Vec.SECTION.mul(chunkX, minSection, chunkZ);
+        final BlockVec start = BlockVec.SECTION.mul(chunkX, minSection, chunkZ);
         return area(biomeRegistry, start, 1, chunkSections.length, 1, chunkSections);
     }
 
-    public static UnitImpl area(DynamicRegistry<Biome> biomeRegistry, Vec start, int width, int height, int depth, GenSection[] areaSections) {
-        if (width == 0 || height == 0 || depth == 0) {
-            throw new IllegalArgumentException("Width, height and depth must be greater than 0, got " + width + ", " + height + ", " + depth);
-        }
-        if (areaSections.length != width * height * depth) {
-            throw new IllegalArgumentException("Invalid section count, expected " + width * height * depth + " but got " + areaSections.length);
-        }
-
-        final int sectionCount = areaSections.length;
+    public static UnitImpl area(DynamicRegistry<Biome> biomeRegistry, BlockVec start, int width, int height, int depth, GenSection[] areaSections) {
+        Check.argCondition(width <= 0 || height <= 0 || depth <= 0, "Width, height and depth must be greater than 0, got {0}, {1}, {2}", width, height, depth);
+        final int sectionCount = width * height * depth;
+        Check.argCondition(sectionCount != areaSections.length, "Invalid section count, expected {0} but got {1}", sectionCount, areaSections.length);
         GenerationUnit[] sectionsArray = new GenerationUnit[sectionCount];
         final int startSectionX = start.sectionX(), startSectionY = start.sectionY(), startSectionZ = start.sectionZ();
         for (int i = 0; i < sectionCount; i++) {
@@ -70,32 +67,26 @@ public final class GeneratorImpl {
             sectionsArray[i] = sectionUnit;
         }
         final List<GenerationUnit> sections = List.of(sectionsArray);
-        final Vec size = Vec.SECTION.mul(width, height, depth);
-        final Vec end = start.add(size);
+        final BlockVec size = BlockVec.SECTION.mul(width, height, depth);
+        final BlockVec end = start.add(size);
         final UnitModifier modifier = new AreaModifierImpl(size, start, end, width, height, depth, sections);
         return unit(biomeRegistry, modifier, start, end, sections);
     }
 
-    public static UnitImpl unit(DynamicRegistry<Biome> biomeRegistry, UnitModifier modifier, Vec start, Vec end,
+    public static UnitImpl unit(DynamicRegistry<Biome> biomeRegistry, UnitModifier modifier, BlockVec start, BlockVec end,
                                 @Nullable List<GenerationUnit> divided) {
-        if (start.x() > end.x() || start.y() > end.y() || start.z() > end.z()) {
-            throw new IllegalArgumentException("absoluteStart must be before absoluteEnd");
-        }
-        if (start.x() % 16 != 0 || start.y() % 16 != 0 || start.z() % 16 != 0) {
-            throw new IllegalArgumentException("absoluteStart must be a multiple of 16");
-        }
-        if (end.x() % 16 != 0 || end.y() % 16 != 0 || end.z() % 16 != 0) {
-            throw new IllegalArgumentException("absoluteEnd must be a multiple of 16");
-        }
-        final Vec size = end.sub(start);
+        Check.argCondition(start.blockX() > end.blockX() || start.blockY() > end.blockY() || start.blockZ() > end.blockZ(), "absoluteStart must be before absoluteEnd, got {0} and {1}", start, end);
+        Check.argCondition(start.blockX() % SECTION_SIZE != 0 || start.blockY() % SECTION_SIZE != 0 || start.blockZ() % SECTION_SIZE != 0, "absoluteStart must be a multiple of 16");
+        Check.argCondition(end.blockX() % SECTION_SIZE != 0 || end.blockY() % SECTION_SIZE != 0 || end.blockZ() % SECTION_SIZE != 0, "absoluteEnd must be a multiple of 16");
+        final BlockVec size = end.sub(start);
         return new UnitImpl(biomeRegistry, modifier, size, start, end, divided, new CopyOnWriteArrayList<>());
     }
 
     static final class DynamicFork implements Block.Setter {
         final DynamicRegistry<Biome> biomeRegistry;
-        Vec minSection;
-        int width, height, depth;
-        List<GenerationUnit> sections;
+        @Nullable Fork fork;
+
+        record Fork(BlockVec minSection, int width, int height, int depth, List<GenerationUnit> sections) {}
 
         DynamicFork(DynamicRegistry<Biome> biomeRegistry) {
             this.biomeRegistry = biomeRegistry;
@@ -103,72 +94,81 @@ public final class GeneratorImpl {
 
         @Override
         public void setBlock(int x, int y, int z, Block block) {
-            resize(x, y, z);
-            GenerationUnit section = findAbsolute(sections, minSection, width, height, depth, x, y, z);
+            final Fork cachedFork = this.fork;
+            Fork fork = setBlock(cachedFork, x, y, z, block);
+            if (fork != cachedFork) {
+                this.fork = fork;
+            }
+        }
+
+        private Fork setBlock(@Nullable Fork fork, int x, int y, int z, Block block) {
+            fork = resize(fork, x, y, z);
+            GenerationUnit section = findAbsolute(fork.sections(), fork.minSection(), fork.width(), fork.height(), fork.depth(), x, y, z);
             assert section.absoluteStart().sectionX() == globalToChunk(x) &&
                     section.absoluteStart().sectionY() == globalToChunk(y) &&
                     section.absoluteStart().sectionZ() == globalToChunk(z) :
                     "Invalid section " + section.absoluteStart() + " for " + x + ", " + y + ", " + z;
             section.modifier().setBlock(x, y, z, block);
+            return fork;
         }
 
-        private void resize(int x, int y, int z) {
+        private Fork resize(@Nullable Fork fork, int x, int y, int z) {
             final int sectionX = globalToChunk(x);
             final int sectionY = globalToChunk(y);
             final int sectionZ = globalToChunk(z);
-            if (sections == null) {
-                this.minSection = Vec.SECTION.mul(sectionX, sectionY, sectionZ);
-                this.width = 1;
-                this.height = 1;
-                this.depth = 1;
-                this.sections = List.of(section(biomeRegistry, new GenSection(), sectionX, sectionY, sectionZ, true));
-            } else if (x < minSection.x() || y < minSection.y() || z < minSection.z() ||
-                    x >= minSection.x() + width * 16 || y >= minSection.y() + height * 16 || z >= minSection.z() + depth * 16) {
-                // Resize necessary
-                final Vec newMin = new Vec(Math.min(minSection.x(), sectionX * 16),
-                        Math.min(minSection.y(), sectionY * 16),
-                        Math.min(minSection.z(), sectionZ * 16));
-                final Vec newMax = new Vec(Math.max(minSection.x() + width * 16, sectionX * 16 + 16),
-                        Math.max(minSection.y() + height * 16, sectionY * 16 + 16),
-                        Math.max(minSection.z() + depth * 16, sectionZ * 16 + 16));
-                final int newWidth = globalToChunk(newMax.x() - newMin.x());
-                final int newHeight = globalToChunk(newMax.y() - newMin.y());
-                final int newDepth = globalToChunk(newMax.z() - newMin.z());
-                // Resize
-                GenerationUnit[] newSections = new GenerationUnit[newWidth * newHeight * newDepth];
-                // Copy old sections
-                for (GenerationUnit s : sections) {
-                    final Point start = s.absoluteStart();
-                    final int newX = globalToChunk(start.x() - newMin.x());
-                    final int newY = globalToChunk(start.y() - newMin.y());
-                    final int newZ = globalToChunk(start.z() - newMin.z());
-                    final int index = findIndex(newWidth, newHeight, newDepth, newX, newY, newZ);
-                    newSections[index] = s;
-                }
-                // Fill new sections
-                final int startX = newMin.sectionX();
-                final int startY = newMin.sectionY();
-                final int startZ = newMin.sectionZ();
-                for (int i = 0; i < newSections.length; i++) {
-                    if (newSections[i] == null) {
-                        final int newX = indexToX(i, newWidth) + startX;
-                        final int newY = indexToY(i, newWidth, newHeight) + startY;
-                        final int newZ = indexToZ(i, newWidth, newHeight) + startZ;
-                        final GenerationUnit unit = section(biomeRegistry, new GenSection(), newX, newY, newZ, true);
-                        newSections[i] = unit;
-                    }
-                }
-                this.sections = List.of(newSections);
-                this.minSection = newMin;
-                this.width = newWidth;
-                this.height = newHeight;
-                this.depth = newDepth;
+            if (fork == null) {
+                var minSection = BlockVec.SECTION.mul(sectionX, sectionY, sectionZ);
+                var sections = List.of(section(biomeRegistry, new GenSection(), sectionX, sectionY, sectionZ, true));
+                return new Fork(minSection, 1, 1, 1, sections);
             }
+            // Section exists, we need to check the bounds
+            final BlockVec minSection = fork.minSection();
+            final int maxX = minSection.blockX() + fork.width() * SECTION_SIZE;
+            final int maxY = minSection.blockY() + fork.height() * SECTION_SIZE;
+            final int maxZ = minSection.blockZ() + fork.depth() * SECTION_SIZE;
+            if (x >= minSection.blockX() && y >= minSection.blockY() && z >= minSection.blockZ() &&
+                    x < maxX && y < maxY && z < maxZ) {
+                return fork; // inside bounds, no resize needed
+            }
+            // Find new min and max
+            final BlockVec section = BlockVec.SECTION.mul(sectionX, sectionY, sectionZ);
+            final BlockVec newMin = minSection.min(section);
+            final BlockVec newMax = section.add(SECTION_SIZE).max(maxX, maxY, maxZ);
+            // Determine new fork size
+            final int newWidth = globalToChunk(newMax.blockX() - newMin.blockX());
+            final int newHeight = globalToChunk(newMax.blockY() - newMin.blockY());
+            final int newDepth = globalToChunk(newMax.blockZ() - newMin.blockZ());
+            final int sectionCount = newWidth * newHeight * newDepth;
+            // Resize
+            @UnknownNullability GenerationUnit[] newSections = new GenerationUnit[sectionCount];
+            // Copy old sections
+            for (GenerationUnit s : fork.sections()) {
+                final Point start = s.absoluteStart();
+                final int newX = globalToChunk(start.blockX() - newMin.blockX());
+                final int newY = globalToChunk(start.blockY() - newMin.blockY());
+                final int newZ = globalToChunk(start.blockZ() - newMin.blockZ());
+                final int index = findIndex(newWidth, newHeight, newDepth, newX, newY, newZ);
+                newSections[index] = s;
+            }
+            // Fill new sections
+            final int startX = newMin.sectionX();
+            final int startY = newMin.sectionY();
+            final int startZ = newMin.sectionZ();
+            for (int i = 0; i < sectionCount; i++) {
+                if (newSections[i] == null) {
+                    final int newX = indexToX(i, newWidth) + startX;
+                    final int newY = indexToY(i, newWidth, newHeight) + startY;
+                    final int newZ = indexToZ(i, newWidth, newHeight) + startZ;
+                    final GenerationUnit unit = section(biomeRegistry, new GenSection(), newX, newY, newZ, true);
+                    newSections[i] = unit;
+                }
+            }
+            return new Fork(newMin, newWidth, newHeight, newDepth, List.of(newSections));
         }
     }
 
     public record UnitImpl(DynamicRegistry<Biome> biomeRegistry, UnitModifier modifier,
-                           Vec size, Vec absoluteStart, Vec absoluteEnd,
+                           BlockVec size, BlockVec absoluteStart, BlockVec absoluteEnd,
                            @Nullable List<GenerationUnit> divided,
                            List<UnitImpl> forks) implements GenerationUnit {
         @Override
@@ -176,8 +176,8 @@ public final class GeneratorImpl {
             final int startX = start.blockX(), startY = start.blockY(), startZ = start.blockZ();
             final int endX = end.blockX(), endY = end.blockY(), endZ = end.blockZ();
 
-            final int minSectionX = floorSection(startX) / 16, minSectionY = floorSection(startY) / 16, minSectionZ = floorSection(startZ) / 16;
-            final int maxSectionX = ceilSection(endX) / 16, maxSectionY = ceilSection(endY) / 16, maxSectionZ = ceilSection(endZ) / 16;
+            final int minSectionX = floorSection(startX) / SECTION_SIZE, minSectionY = floorSection(startY) / SECTION_SIZE, minSectionZ = floorSection(startZ) / SECTION_SIZE;
+            final int maxSectionX = ceilSection(endX) / SECTION_SIZE, maxSectionY = ceilSection(endY) / SECTION_SIZE, maxSectionZ = ceilSection(endZ) / SECTION_SIZE;
 
             final int width = maxSectionX - minSectionX;
             final int height = maxSectionY - minSectionY;
@@ -195,7 +195,7 @@ public final class GeneratorImpl {
                 }
             }
             final List<GenerationUnit> sections = List.of(units);
-            final Vec startSection = Vec.SECTION.mul(minSectionX, minSectionY, minSectionZ);
+            final BlockVec startSection = BlockVec.SECTION.mul(minSectionX, minSectionY, minSectionZ);
             return registerFork(startSection, sections, width, height, depth);
         }
 
@@ -203,14 +203,10 @@ public final class GeneratorImpl {
         public void fork(Consumer<Block.Setter> consumer) {
             DynamicFork dynamicFork = new DynamicFork(biomeRegistry);
             consumer.accept(dynamicFork);
-            final Vec startSection = dynamicFork.minSection;
-            if (startSection == null)
+            final DynamicFork.Fork dynamicForkData = dynamicFork.fork;
+            if (dynamicForkData == null)
                 return; // No block has been placed
-            final int width = dynamicFork.width;
-            final int height = dynamicFork.height;
-            final int depth = dynamicFork.depth;
-            final List<GenerationUnit> sections = dynamicFork.sections;
-            registerFork(startSection, sections, width, height, depth);
+            registerFork(dynamicForkData.minSection(), dynamicForkData.sections(), dynamicForkData.width(), dynamicForkData.height(), dynamicForkData.depth());
         }
 
         @Override
@@ -218,10 +214,10 @@ public final class GeneratorImpl {
             return Objects.requireNonNullElseGet(divided, GenerationUnit.super::subdivide);
         }
 
-        private GenerationUnit registerFork(Vec start, List<GenerationUnit> sections,
+        private GenerationUnit registerFork(BlockVec start, List<GenerationUnit> sections,
                                             int width, int height, int depth) {
-            final Vec end = start.add(width * 16, height * 16, depth * 16);
-            final Vec size = end.sub(start);
+            final BlockVec end = start.add(width * SECTION_SIZE, height * SECTION_SIZE, depth * SECTION_SIZE);
+            final BlockVec size = end.sub(start);
             final AreaModifierImpl modifier = new AreaModifierImpl(size, start, end, width, height, depth, sections);
             final UnitImpl fork = new UnitImpl(biomeRegistry, modifier, size, start, end, sections, forks);
             forks.add(fork);
@@ -229,12 +225,12 @@ public final class GeneratorImpl {
         }
     }
 
-    public record SectionModifierImpl(DynamicRegistry<Biome> biomeRegistry, Vec start, Vec end,
+    public record SectionModifierImpl(DynamicRegistry<Biome> biomeRegistry, BlockVec start, BlockVec end,
                                       GenSection genSection, boolean fork) implements GenericModifier {
 
         @Override
         public void setBiome(int x, int y, int z, RegistryKey<Biome> biome) {
-            if (fork) throw new IllegalStateException("Cannot modify biomes of a fork");
+            Check.stateCondition(fork, "Cannot modify biomes of a fork");
             final int id = biomeRegistry.getId(biome);
             Check.argCondition(id == -1, "Biome has not been registered: {0}", biome);
             this.genSection.biomes.set(
@@ -271,9 +267,9 @@ public final class GeneratorImpl {
         public void fill(Block block) {
             this.genSection.specials.clear();
             if (requireCache(block)) {
-                for (int x = 0; x < 16; x++) {
-                    for (int y = 0; y < 16; y++) {
-                        for (int z = 0; z < 16; z++) {
+                for (int x = 0; x < SECTION_SIZE; x++) {
+                    for (int y = 0; y < SECTION_SIZE; y++) {
+                        for (int z = 0; z < SECTION_SIZE; z++) {
                             this.genSection.specials.put(chunkBlockIndex(x, y, z), block);
                         }
                     }
@@ -314,15 +310,15 @@ public final class GeneratorImpl {
 
         @Override
         public void fillBiome(RegistryKey<Biome> biome) {
-            if (fork) throw new IllegalStateException("Cannot modify biomes of a fork");
+            Check.stateCondition(fork, "Cannot modify biomes of a fork");
             final int id = biomeRegistry.getId(biome);
             Check.argCondition(id == -1, "Biome has not been registered: {0}", biome);
             this.genSection.biomes.fill(id);
         }
 
         @Override
-        public Vec size() {
-            return Vec.SECTION;
+        public BlockVec size() {
+            return BlockVec.SECTION;
         }
 
         private int retrieveBlockId(Block block) {
@@ -365,14 +361,14 @@ public final class GeneratorImpl {
         }
     }
 
-    public record AreaModifierImpl(Vec size, Vec start, Vec end,
+    public record AreaModifierImpl(BlockVec size, BlockVec start, BlockVec end,
                                    int width, int height, int depth,
                                    List<GenerationUnit> sections) implements GenericModifier {
         @Override
         public void setBlock(int x, int y, int z, Block block) {
             checkBorder(x, y, z);
             final GenerationUnit section = findAbsoluteSection(x, y, z);
-            y -= start.y();
+            y -= start.blockY();
             section.modifier().setBlock(x, y, z, block);
         }
 
@@ -380,15 +376,14 @@ public final class GeneratorImpl {
         public void setBiome(int x, int y, int z, RegistryKey<Biome> biome) {
             checkBorder(x, y, z);
             final GenerationUnit section = findAbsoluteSection(x, y, z);
-            y -= start.y();
+            y -= start.blockY();
             section.modifier().setBiome(x, y, z, biome);
         }
 
         @Override
         public void setRelative(int x, int y, int z, Block block) {
-            if (x < 0 || x >= size.x() || y < 0 || y >= size.y() || z < 0 || z >= size.z()) {
-                throw new IllegalArgumentException("x, y and z must be in the chunk: " + x + ", " + y + ", " + z);
-            }
+            Check.argCondition(x < 0 || x >= size.blockX() || y < 0 || y >= size.blockY() || z < 0 || z >= size.blockZ(),
+                    "x, y and z must be in the chunk: {0}, {1}, {2}", x, y, z);
             final GenerationUnit section = findRelativeSection(x, y, z);
             x = globalToSectionRelative(x);
             y = globalToSectionRelative(y);
@@ -432,7 +427,7 @@ public final class GeneratorImpl {
 
         @Override
         public void fillHeight(int minHeight, int maxHeight, Block block) {
-            final Vec start = this.start;
+            final BlockVec start = this.start;
             final int startX = start.blockX(), startY = start.blockY(), startZ = start.blockZ();
             final int endY = end.blockY();
             minHeight = Math.max(minHeight, startY);
@@ -444,12 +439,12 @@ public final class GeneratorImpl {
             final boolean startOffset = minMultiple != minHeight;
             final boolean endOffset = maxMultiple != maxHeight;
             if (startOffset || endOffset) {
-                final int firstFill = Math.min(minMultiple + 16, maxHeight);
+                final int firstFill = Math.min(minMultiple + SECTION_SIZE, maxHeight);
                 final int lastFill = startOffset ? Math.max(firstFill, floorSection(maxHeight)) : floorSection(maxHeight);
                 for (int x = 0; x < width; x++) {
                     for (int z = 0; z < depth; z++) {
-                        final int sectionX = startX + x * 16;
-                        final int sectionZ = startZ + z * 16;
+                        final int sectionX = startX + x * SECTION_SIZE;
+                        final int sectionZ = startZ + z * SECTION_SIZE;
                         // Fill start
                         if (startOffset) {
                             final GenerationUnit section = findAbsoluteSection(sectionX, minMultiple, sectionZ);
@@ -464,12 +459,12 @@ public final class GeneratorImpl {
                 }
             }
             // Middle sections (to fill)
-            final int startSection = (minMultiple) / 16 + (startOffset ? 1 : 0);
-            final int endSection = (maxMultiple) / 16 + (endOffset ? -1 : 0);
+            final int startSection = (minMultiple) / SECTION_SIZE + (startOffset ? 1 : 0);
+            final int endSection = (maxMultiple) / SECTION_SIZE + (endOffset ? -1 : 0);
             for (int i = startSection; i < endSection; i++) {
                 for (int x = 0; x < width; x++) {
                     for (int z = 0; z < depth; z++) {
-                        final GenerationUnit section = findAbsoluteSection(startX + x * 16, i * 16, startZ + z * 16);
+                        final GenerationUnit section = findAbsoluteSection(startX + x * SECTION_SIZE, i * SECTION_SIZE, startZ + z * SECTION_SIZE);
                         section.modifier().fill(block);
                     }
                 }
@@ -481,30 +476,28 @@ public final class GeneratorImpl {
         }
 
         private GenerationUnit findRelativeSection(int x, int y, int z) {
-            return findAbsolute(sections, Vec.ZERO, width, height, depth, x, y, z);
+            return findAbsolute(sections, BlockVec.ZERO, width, height, depth, x, y, z);
         }
 
         private void checkBorder(int x, int y, int z) {
-            final int startX = start.blockX(), startY = start.blockY(), startZ = start.blockZ();
-            final int endX = end.blockX(), endY = end.blockY(), endZ = end.blockZ();
-            if (x < startX || x >= endX || y < startY || y >= endY || z < startZ || z >= endZ) {
-                final String format = String.format("Invalid coordinates: %d, %d, %d for area %s %s", x, y, z, start, end);
-                throw new IllegalArgumentException(format);
-            }
+            final boolean outside = x < start.blockX() || x >= end.blockX()
+                    || y < start.blockY() || y >= end.blockY()
+                    || z < start.blockZ() || z >= end.blockZ();
+            Check.argCondition(outside, "Invalid coordinates: {0}, {1}, {2} for area {3} {4}", x, y, z, start, end);
         }
     }
 
     sealed interface GenericModifier extends UnitModifier
             permits AreaModifierImpl, SectionModifierImpl {
-        Vec size();
+        BlockVec size();
 
-        Vec start();
+        BlockVec start();
 
-        Vec end();
+        BlockVec end();
 
         @Override
         default void setAll(Supplier supplier) {
-            final Vec start = start(), end = end();
+            final BlockVec start = start(), end = end();
             final int startX = start.blockX(), startY = start.blockY(), startZ = start.blockZ();
             final int endX = end.blockX(), endY = end.blockY(), endZ = end.blockZ();
             for (int x = startX; x < endX; x++) {
@@ -518,7 +511,7 @@ public final class GeneratorImpl {
 
         @Override
         default void setAllRelative(Supplier supplier) {
-            final Vec size = size();
+            final BlockVec size = size();
             final int endX = size.blockX(), endY = size.blockY(), endZ = size.blockZ();
             for (int x = 0; x < endX; x++) {
                 for (int y = 0; y < endY; y++) {
@@ -549,8 +542,8 @@ public final class GeneratorImpl {
 
         @Override
         default void fillHeight(int minHeight, int maxHeight, Block block) {
-            final Vec start = start();
-            final Vec end = end();
+            final BlockVec start = start();
+            final BlockVec end = end();
             final int startY = start.blockY(), endY = end.blockY();
             if (startY >= minHeight && endY <= maxHeight) {
                 // Fast path if the unit is fully contained in the height range
@@ -562,7 +555,7 @@ public final class GeneratorImpl {
         }
     }
 
-    private static GenerationUnit findAbsolute(List<GenerationUnit> units, Vec start,
+    private static GenerationUnit findAbsolute(List<GenerationUnit> units, BlockVec start,
                                                int width, int height, int depth,
                                                int x, int y, int z) {
         final int startX = start.blockX(), startY = start.blockY(), startZ = start.blockZ();

--- a/src/main/java/net/minestom/server/listener/PlayerPositionListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerPositionListener.java
@@ -3,6 +3,7 @@ package net.minestom.server.listener;
 import net.kyori.adventure.text.Component;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
+import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.Player;
 import net.minestom.server.entity.RelativeFlags;
 import net.minestom.server.event.EventDispatcher;
@@ -14,8 +15,7 @@ import net.minestom.server.utils.chunk.ChunkUtils;
 import org.jetbrains.annotations.ApiStatus;
 
 public class PlayerPositionListener {
-    private static final double MAX_COORDINATE = 30_000_000;
-    private static final Component KICK_MESSAGE = Component.text("You moved too far away!");
+    static final Component KICK_MESSAGE = Component.text("You moved too far away!");
 
     public static void playerPacketListener(ClientPlayerPositionStatusPacket packet, Player player) {
         // TODO: Should we expose horizontal collision here and the methods below?
@@ -49,9 +49,10 @@ public class PlayerPositionListener {
     private static void processMovement(Player player, Pos packetPosition, boolean onGround) {
         // Prevent the player from moving too far
         // Doubles close to max size can cause overflow, or simply have precision issues
-        if (Math.abs(packetPosition.x()) > MAX_COORDINATE ||
-                Math.abs(packetPosition.y()) > MAX_COORDINATE ||
-                Math.abs(packetPosition.z()) > MAX_COORDINATE) {
+        if (!Double.isFinite(packetPosition.x()) || !Double.isFinite(packetPosition.y()) || !Double.isFinite(packetPosition.z()) ||
+                Math.abs(packetPosition.x()) > Entity.MAX_COORDINATE ||
+                Math.abs(packetPosition.y()) > Entity.MAX_COORDINATE ||
+                Math.abs(packetPosition.z()) > Entity.MAX_COORDINATE) {
             player.kick(KICK_MESSAGE);
             return;
         }

--- a/src/main/java/net/minestom/server/listener/PlayerVehicleListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerVehicleListener.java
@@ -13,7 +13,16 @@ public class PlayerVehicleListener {
         if (vehicle == null)
             return;
 
-        vehicle.refreshPosition(packet.position());
+        final var position = packet.position();
+        if (!Double.isFinite(position.x()) || !Double.isFinite(position.y()) || !Double.isFinite(position.z()) ||
+                Math.abs(position.x()) > Entity.MAX_COORDINATE ||
+                Math.abs(position.y()) > Entity.MAX_COORDINATE ||
+                Math.abs(position.z()) > Entity.MAX_COORDINATE) {
+            player.kick(PlayerPositionListener.KICK_MESSAGE);
+            return;
+        }
+
+        vehicle.refreshPosition(position);
 
         // This packet causes weird screen distortion
         /*VehicleMovePacket vehicleMovePacket = new VehicleMovePacket();

--- a/src/test/java/net/minestom/server/instance/generator/GeneratorForkConsumerIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/generator/GeneratorForkConsumerIntegrationTest.java
@@ -36,19 +36,17 @@ public class GeneratorForkConsumerIntegrationTest {
     public void local(Env env) {
         var manager = env.process().instance();
         var instance = manager.createInstanceContainer();
-        instance.setGenerator(unit -> {
-            unit.fork(setter -> {
-                var dynamic = (GeneratorImpl.DynamicFork) setter;
-                assertNull(dynamic.fork);
-                setter.setBlock(unit.absoluteStart(), Block.STONE);
-                final var fork = dynamic.fork;
-                assertNotNull(fork);
-                assertEquals(unit.absoluteStart(), fork.minSection());
-                assertEquals(1, fork.width());
-                assertEquals(1, fork.height());
-                assertEquals(1, fork.depth());
-            });
-        });
+        instance.setGenerator(unit -> unit.fork(setter -> {
+            var dynamic = (GeneratorImpl.DynamicFork) setter;
+            assertNull(dynamic.fork);
+            setter.setBlock(unit.absoluteStart(), Block.STONE);
+            final var fork = dynamic.fork;
+            assertNotNull(fork);
+            assertEquals(unit.absoluteStart(), fork.minSection());
+            assertEquals(1, fork.width());
+            assertEquals(1, fork.height());
+            assertEquals(1, fork.depth());
+        }));
         instance.loadChunk(0, 0).join();
         assertEquals(Block.STONE, instance.getBlock(0, -64, 0));
     }

--- a/src/test/java/net/minestom/server/instance/generator/GeneratorForkConsumerIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/generator/GeneratorForkConsumerIntegrationTest.java
@@ -10,8 +10,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @EnvTest
 public class GeneratorForkConsumerIntegrationTest {
@@ -37,18 +36,19 @@ public class GeneratorForkConsumerIntegrationTest {
     public void local(Env env) {
         var manager = env.process().instance();
         var instance = manager.createInstanceContainer();
-        instance.setGenerator(unit -> unit.fork(setter -> {
-            var dynamic = (GeneratorImpl.DynamicFork) setter;
-            assertNull(dynamic.minSection);
-            assertEquals(0, dynamic.width);
-            assertEquals(0, dynamic.height);
-            assertEquals(0, dynamic.depth);
-            setter.setBlock(unit.absoluteStart(), Block.STONE);
-            assertEquals(unit.absoluteStart(), dynamic.minSection);
-            assertEquals(1, dynamic.width);
-            assertEquals(1, dynamic.height);
-            assertEquals(1, dynamic.depth);
-        }));
+        instance.setGenerator(unit -> {
+            unit.fork(setter -> {
+                var dynamic = (GeneratorImpl.DynamicFork) setter;
+                assertNull(dynamic.fork);
+                setter.setBlock(unit.absoluteStart(), Block.STONE);
+                final var fork = dynamic.fork;
+                assertNotNull(fork);
+                assertEquals(unit.absoluteStart(), fork.minSection());
+                assertEquals(1, fork.width());
+                assertEquals(1, fork.height());
+                assertEquals(1, fork.depth());
+            });
+        });
         instance.loadChunk(0, 0).join();
         assertEquals(Block.STONE, instance.getBlock(0, -64, 0));
     }
@@ -72,16 +72,15 @@ public class GeneratorForkConsumerIntegrationTest {
         var instance = manager.createInstanceContainer();
         instance.setGenerator(unit -> unit.fork(setter -> {
             var dynamic = (GeneratorImpl.DynamicFork) setter;
-            assertNull(dynamic.minSection);
-            assertEquals(0, dynamic.width);
-            assertEquals(0, dynamic.height);
-            assertEquals(0, dynamic.depth);
+            assertNull(dynamic.fork);
             setter.setBlock(unit.absoluteStart(), Block.STONE);
             setter.setBlock(unit.absoluteStart().add(0, 0, 16), Block.GRASS_BLOCK);
-            assertEquals(unit.absoluteStart(), dynamic.minSection);
-            assertEquals(1, dynamic.width);
-            assertEquals(1, dynamic.height);
-            assertEquals(2, dynamic.depth);
+            final var fork = dynamic.fork;
+            assertNotNull(fork);
+            assertEquals(unit.absoluteStart(), fork.minSection());
+            assertEquals(1, fork.width());
+            assertEquals(1, fork.height());
+            assertEquals(2, fork.depth());
         }));
         instance.loadChunk(0, 0).join();
         instance.setGenerator(null);
@@ -96,16 +95,15 @@ public class GeneratorForkConsumerIntegrationTest {
         var instance = manager.createInstanceContainer();
         instance.setGenerator(unit -> unit.fork(setter -> {
             var dynamic = (GeneratorImpl.DynamicFork) setter;
-            assertNull(dynamic.minSection);
-            assertEquals(0, dynamic.width);
-            assertEquals(0, dynamic.height);
-            assertEquals(0, dynamic.depth);
+            assertNull(dynamic.fork);
             setter.setBlock(unit.absoluteStart(), Block.STONE);
             setter.setBlock(unit.absoluteStart().add(16, 0, 0), Block.GRASS_BLOCK);
-            assertEquals(unit.absoluteStart(), dynamic.minSection);
-            assertEquals(2, dynamic.width);
-            assertEquals(1, dynamic.height);
-            assertEquals(1, dynamic.depth);
+            final var fork = dynamic.fork;
+            assertNotNull(fork);
+            assertEquals(unit.absoluteStart(), fork.minSection());
+            assertEquals(2, fork.width());
+            assertEquals(1, fork.height());
+            assertEquals(1, fork.depth());
         }));
         instance.loadChunk(0, 0).join();
         instance.setGenerator(null);
@@ -120,16 +118,15 @@ public class GeneratorForkConsumerIntegrationTest {
         var instance = manager.createInstanceContainer();
         instance.setGenerator(unit -> unit.fork(setter -> {
             var dynamic = (GeneratorImpl.DynamicFork) setter;
-            assertNull(dynamic.minSection);
-            assertEquals(0, dynamic.width);
-            assertEquals(0, dynamic.height);
-            assertEquals(0, dynamic.depth);
+            assertNull(dynamic.fork);
             setter.setBlock(unit.absoluteStart(), Block.STONE);
             setter.setBlock(unit.absoluteStart().add(0, 16, 0), Block.GRASS_BLOCK);
-            assertEquals(unit.absoluteStart(), dynamic.minSection);
-            assertEquals(1, dynamic.width);
-            assertEquals(2, dynamic.height);
-            assertEquals(1, dynamic.depth);
+            var fork = dynamic.fork;
+            assertNotNull(fork);
+            assertEquals(unit.absoluteStart(), fork.minSection());
+            assertEquals(1, fork.width());
+            assertEquals(2, fork.height());
+            assertEquals(1, fork.depth());
         }));
         instance.loadChunk(0, 0).join();
         assertEquals(Block.STONE, instance.getBlock(0, -64, 0));
@@ -156,9 +153,11 @@ public class GeneratorForkConsumerIntegrationTest {
                     points.add(start.add(0, i, 0));
                     points.add(start.add(0, -i, 0));
                 }
-                assertEquals(2, dynamic.width);
-                assertEquals(2, dynamic.height);
-                assertEquals(1, dynamic.depth);
+                var fork = dynamic.fork;
+                assertNotNull(fork);
+                assertEquals(2, fork.width());
+                assertEquals(2, fork.height());
+                assertEquals(1, fork.depth());
             });
         });
         instance.loadChunk(0, 0).join();

--- a/src/test/java/net/minestom/server/instance/generator/GeneratorTest.java
+++ b/src/test/java/net/minestom/server/instance/generator/GeneratorTest.java
@@ -1,9 +1,9 @@
 package net.minestom.server.instance.generator;
 
 import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.minestom.server.coordinate.BlockVec;
 import net.minestom.server.coordinate.CoordConversion;
 import net.minestom.server.coordinate.Point;
-import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.generator.GeneratorImpl.GenSection;
 import net.minestom.server.utils.MathUtils;
@@ -25,12 +25,12 @@ import static org.junit.jupiter.api.Assertions.*;
 public class GeneratorTest {
     @Test
     public void unitSize() {
-        assertDoesNotThrow(() -> dummyUnit(Vec.ZERO, Vec.SECTION));
-        assertDoesNotThrow(() -> dummyUnit(Vec.SECTION, new Vec(32)));
-        assertThrows(IllegalArgumentException.class, () -> dummyUnit(new Vec(15), Vec.ZERO));
-        assertThrows(IllegalArgumentException.class, () -> dummyUnit(new Vec(15), new Vec(32)));
-        assertThrows(IllegalArgumentException.class, () -> dummyUnit(new Vec(15), new Vec(31)));
-        assertThrows(IllegalArgumentException.class, () -> dummyUnit(Vec.ZERO, new Vec(15)));
+        assertDoesNotThrow(() -> dummyUnit(BlockVec.ZERO, BlockVec.SECTION));
+        assertDoesNotThrow(() -> dummyUnit(BlockVec.SECTION, new BlockVec(32)));
+        assertThrows(IllegalArgumentException.class, () -> dummyUnit(new BlockVec(15), BlockVec.ZERO));
+        assertThrows(IllegalArgumentException.class, () -> dummyUnit(new BlockVec(15), new BlockVec(32)));
+        assertThrows(IllegalArgumentException.class, () -> dummyUnit(new BlockVec(15), new BlockVec(31)));
+        assertThrows(IllegalArgumentException.class, () -> dummyUnit(BlockVec.ZERO, new BlockVec(15)));
     }
 
     @ParameterizedTest
@@ -81,9 +81,9 @@ public class GeneratorTest {
         GenSection[] sections = new GenSection[sectionCount];
         Arrays.setAll(sections, i -> new GenSection());
         GenerationUnit chunk = GeneratorImpl.chunk(null, sections, chunkX, minSection, chunkZ);
-        assertEquals(new Vec(16, sectionCount * 16, 16), chunk.size());
-        assertEquals(new Vec(chunkX * 16, minSection * 16, chunkZ * 16), chunk.absoluteStart());
-        assertEquals(new Vec(chunkX * 16 + 16, maxSection * 16, chunkZ * 16 + 16), chunk.absoluteEnd());
+        assertEquals(new BlockVec(16, sectionCount * 16, 16), chunk.size());
+        assertEquals(new BlockVec(chunkX * 16, minSection * 16, chunkZ * 16), chunk.absoluteStart());
+        assertEquals(new BlockVec(chunkX * 16 + 16, maxSection * 16, chunkZ * 16 + 16), chunk.absoluteEnd());
     }
 
     @Test
@@ -96,9 +96,9 @@ public class GeneratorTest {
         GenSection[] sections = new GenSection[sectionCount];
         Arrays.setAll(sections, i -> new GenSection());
         GenerationUnit chunk = GeneratorImpl.chunk(null, sections, chunkX, minSection, chunkZ);
-        assertEquals(new Vec(16, sectionCount * 16, 16), chunk.size());
-        assertEquals(new Vec(chunkX * 16, minSection * 16, chunkZ * 16), chunk.absoluteStart());
-        assertEquals(new Vec(chunkX * 16 + 16, maxSection * 16, chunkZ * 16 + 16), chunk.absoluteEnd());
+        assertEquals(new BlockVec(16, sectionCount * 16, 16), chunk.size());
+        assertEquals(new BlockVec(chunkX * 16, minSection * 16, chunkZ * 16), chunk.absoluteStart());
+        assertEquals(new BlockVec(chunkX * 16 + 16, maxSection * 16, chunkZ * 16 + 16), chunk.absoluteEnd());
     }
 
     @Test
@@ -107,9 +107,9 @@ public class GeneratorTest {
         final int sectionY = -5;
         final int sectionZ = -2;
         GenerationUnit section = GeneratorImpl.section(null, new GenSection(), sectionX, sectionY, sectionZ);
-        assertEquals(Vec.SECTION, section.size());
-        assertEquals(new Vec(sectionX * 16, sectionY * 16, sectionZ * 16), section.absoluteStart());
-        assertEquals(new Vec(sectionX * 16 + 16, sectionY * 16 + 16, sectionZ * 16 + 16), section.absoluteEnd());
+        assertEquals(BlockVec.SECTION, section.size());
+        assertEquals(new BlockVec(sectionX * 16, sectionY * 16, sectionZ * 16), section.absoluteStart());
+        assertEquals(new BlockVec(sectionX * 16 + 16, sectionY * 16 + 16, sectionZ * 16 + 16), section.absoluteEnd());
     }
 
     @Test
@@ -126,8 +126,8 @@ public class GeneratorTest {
         assertEquals(sectionCount, subUnits.size());
         for (int i = 0; i < sectionCount; i++) {
             var subUnit = subUnits.get(i);
-            assertEquals(Vec.SECTION, subUnit.size());
-            assertEquals(new Vec(chunkX * 16, (i + minSection) * 16, chunkZ * 16), subUnit.absoluteStart());
+            assertEquals(BlockVec.SECTION, subUnit.size());
+            assertEquals(new BlockVec(chunkX * 16, (i + minSection) * 16, chunkZ * 16), subUnit.absoluteStart());
             assertEquals(subUnit.absoluteStart().add(16), subUnit.absoluteEnd());
         }
     }
@@ -167,7 +167,7 @@ public class GeneratorTest {
             var modifier = chunk.modifier();
             Set<Point> points = new HashSet<>();
             modifier.setAll((x, y, z) -> {
-                assertTrue(points.add(new Vec(x, y, z)), "Duplicate point: " + x + ", " + y + ", " + z);
+                assertTrue(points.add(new BlockVec(x, y, z)), "Duplicate point: " + x + ", " + y + ", " + z);
                 assertEquals(chunkX, CoordConversion.globalToChunk(x));
                 assertEquals(chunkZ, CoordConversion.globalToChunk(z));
                 return Block.STONE;
@@ -225,7 +225,7 @@ public class GeneratorTest {
                 assertTrue(MathUtils.isBetween(x, 0, 16), "x out of bounds: " + x);
                 assertTrue(MathUtils.isBetween(y, 0, sectionCount * 16), "y out of bounds: " + y);
                 assertTrue(MathUtils.isBetween(z, 0, 16), "z out of bounds: " + z);
-                assertTrue(points.add(new Vec(x, y, z)), "Duplicate point: " + x + ", " + y + ", " + z);
+                assertTrue(points.add(new BlockVec(x, y, z)), "Duplicate point: " + x + ", " + y + ", " + z);
                 return Block.STONE;
             });
             assertEquals(SECTION_BLOCK_COUNT * sectionCount, points.size());
@@ -374,22 +374,22 @@ public class GeneratorTest {
         }
 
         var expectedStones = Set.of(
-                new Vec(-2, -2, 8),
-                new Vec(-2, -1, 8),
-                new Vec(-2, 0, 8),
-                new Vec(-2, 1, 8),
-                new Vec(-1, -2, 8),
-                new Vec(-1, -1, 8),
-                new Vec(-1, 0, 8),
-                new Vec(-1, 1, 8),
-                new Vec(0, -2, 8),
-                new Vec(0, -1, 8),
-                new Vec(0, 0, 8),
-                new Vec(0, 1, 8),
-                new Vec(1, -2, 8),
-                new Vec(1, -1, 8),
-                new Vec(1, 0, 8),
-                new Vec(1, 1, 8)
+                new BlockVec(-2, -2, 8),
+                new BlockVec(-2, -1, 8),
+                new BlockVec(-2, 0, 8),
+                new BlockVec(-2, 1, 8),
+                new BlockVec(-1, -2, 8),
+                new BlockVec(-1, -1, 8),
+                new BlockVec(-1, 0, 8),
+                new BlockVec(-1, 1, 8),
+                new BlockVec(0, -2, 8),
+                new BlockVec(0, -1, 8),
+                new BlockVec(0, 0, 8),
+                new BlockVec(0, 1, 8),
+                new BlockVec(1, -2, 8),
+                new BlockVec(1, -1, 8),
+                new BlockVec(1, 0, 8),
+                new BlockVec(1, 1, 8)
         );
 
         assertEquals(expectedStones.size(), stones.size());
@@ -399,26 +399,26 @@ public class GeneratorTest {
     @Test
     public void sectionsSingleSection() {
         // Test a unit that covers exactly one section
-        var unit = dummyUnit(new Vec(0, 0, 0), new Vec(16, 16, 16));
+        var unit = dummyUnit(new BlockVec(0, 0, 0), new BlockVec(16, 16, 16));
         var sections = unit.sections();
 
         assertEquals(1, sections.size());
-        assertTrue(sections.contains(new Vec(0, 0, 0)));
+        assertTrue(sections.contains(new BlockVec(0, 0, 0)));
     }
 
     @Test
     public void sectionsMultipleSections() {
         // Test a unit that covers multiple sections (2x2x2 = 8 sections)
-        var unit = dummyUnit(new Vec(0, 0, 0), new Vec(32, 32, 32));
+        var unit = dummyUnit(new BlockVec(0, 0, 0), new BlockVec(32, 32, 32));
         var sections = unit.sections();
 
         assertEquals(8, sections.size());
         // Check all expected sections are present
         Set<Point> expectedSections = Set.of(
-                new Vec(0, 0, 0), new Vec(0, 0, 1),
-                new Vec(0, 1, 0), new Vec(0, 1, 1),
-                new Vec(1, 0, 0), new Vec(1, 0, 1),
-                new Vec(1, 1, 0), new Vec(1, 1, 1)
+                new BlockVec(0, 0, 0), new BlockVec(0, 0, 1),
+                new BlockVec(0, 1, 0), new BlockVec(0, 1, 1),
+                new BlockVec(1, 0, 0), new BlockVec(1, 0, 1),
+                new BlockVec(1, 1, 0), new BlockVec(1, 1, 1)
         );
         assertEquals(expectedSections, sections);
     }
@@ -426,25 +426,25 @@ public class GeneratorTest {
     @Test
     public void sectionsNegativeCoordinates() {
         // Test a unit with negative coordinates
-        var unit = dummyUnit(new Vec(-32, -16, -48), new Vec(-16, 0, -32));
+        var unit = dummyUnit(new BlockVec(-32, -16, -48), new BlockVec(-16, 0, -32));
         var sections = unit.sections();
 
         assertEquals(1, sections.size());
-        assertTrue(sections.contains(new Vec(-2, -1, -3)));
+        assertTrue(sections.contains(new BlockVec(-2, -1, -3)));
     }
 
     @Test
     public void sectionsAsymmetricUnit() {
         // Test a unit that is not square (different dimensions)
-        var unit = dummyUnit(new Vec(16, 0, 0), new Vec(64, 16, 32));
+        var unit = dummyUnit(new BlockVec(16, 0, 0), new BlockVec(64, 16, 32));
         var sections = unit.sections();
 
         // 3 sections wide (x), 1 section high (y), 2 sections deep (z) = 6 sections
         assertEquals(6, sections.size());
         Set<Point> expectedSections = Set.of(
-                new Vec(1, 0, 0), new Vec(1, 0, 1),
-                new Vec(2, 0, 0), new Vec(2, 0, 1),
-                new Vec(3, 0, 0), new Vec(3, 0, 1)
+                new BlockVec(1, 0, 0), new BlockVec(1, 0, 1),
+                new BlockVec(2, 0, 0), new BlockVec(2, 0, 1),
+                new BlockVec(3, 0, 0), new BlockVec(3, 0, 1)
         );
         assertEquals(expectedSections, sections);
     }
@@ -452,7 +452,7 @@ public class GeneratorTest {
     @Test
     public void sectionsLargeUnit() {
         // Test a larger unit to verify the algorithm scales
-        var unit = dummyUnit(new Vec(0, 0, 0), new Vec(48, 64, 32));
+        var unit = dummyUnit(new BlockVec(0, 0, 0), new BlockVec(48, 64, 32));
         var sections = unit.sections();
 
         // 3 sections wide (x), 4 sections high (y), 2 sections deep (z) = 24 sections
@@ -469,16 +469,16 @@ public class GeneratorTest {
     @Test
     public void sectionsOffsetCoordinates() {
         // Test a unit that doesn't start at section boundaries but is aligned to sections
-        var unit = dummyUnit(new Vec(32, 48, 16), new Vec(64, 80, 48));
+        var unit = dummyUnit(new BlockVec(32, 48, 16), new BlockVec(64, 80, 48));
         var sections = unit.sections();
 
         // 2 sections wide (x), 2 sections high (y), 2 sections deep (z) = 8 sections
         assertEquals(8, sections.size());
         Set<Point> expectedSections = Set.of(
-                new Vec(2, 3, 1), new Vec(2, 3, 2),
-                new Vec(2, 4, 1), new Vec(2, 4, 2),
-                new Vec(3, 3, 1), new Vec(3, 3, 2),
-                new Vec(3, 4, 1), new Vec(3, 4, 2)
+                new BlockVec(2, 3, 1), new BlockVec(2, 3, 2),
+                new BlockVec(2, 4, 1), new BlockVec(2, 4, 2),
+                new BlockVec(3, 3, 1), new BlockVec(3, 3, 2),
+                new BlockVec(3, 4, 1), new BlockVec(3, 4, 2)
         );
         assertEquals(expectedSections, sections);
     }
@@ -517,13 +517,13 @@ public class GeneratorTest {
 
         var sections = sectionUnit.sections();
         assertEquals(1, sections.size());
-        assertTrue(sections.contains(new Vec(sectionX, sectionY, sectionZ)));
+        assertTrue(sections.contains(new BlockVec(sectionX, sectionY, sectionZ)));
     }
 
     @Test
     public void sectionsReturnType() {
         // Test that sections() returns an immutable set
-        var unit = dummyUnit(new Vec(0, 0, 0), new Vec(32, 16, 16));
+        var unit = dummyUnit(new BlockVec(0, 0, 0), new BlockVec(32, 16, 16));
         var sections = unit.sections();
 
         // Verify it's a Set and contains the expected number of elements
@@ -531,13 +531,13 @@ public class GeneratorTest {
         assertEquals(2, sections.size()); // 2x1x1 = 2 sections
 
         // Verify immutability by attempting to modify (should throw exception)
-        assertThrows(UnsupportedOperationException.class, () -> sections.add(new Vec(99, 99, 99)));
+        assertThrows(UnsupportedOperationException.class, () -> sections.add(new BlockVec(99, 99, 99)));
     }
 
     @Test
     public void sectionsCoordinateConsistency() {
         // Test that section coordinates are consistent with the unit's absolute coordinates
-        var unit = dummyUnit(new Vec(48, 64, 32), new Vec(80, 96, 64));
+        var unit = dummyUnit(new BlockVec(48, 64, 32), new BlockVec(80, 96, 64));
         var sections = unit.sections();
 
         Point start = unit.absoluteStart();
@@ -566,7 +566,7 @@ public class GeneratorTest {
         assertEquals(expectedCount, sections.size());
     }
 
-    static GenerationUnit dummyUnit(Vec start, Vec end) {
+    static GenerationUnit dummyUnit(BlockVec start, BlockVec end) {
         return unit(null, null, start, end, null);
     }
 }


### PR DESCRIPTION
## Proposed changes

Use BlockVecs for generators instead of Vec. Should be faster to compare integers than doubles. 

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
Quite a breaking change if you relied on the return type being a Vec not BlockVec.

Generators has alot of existing test cases. Will break if fix is not included as loading a chunk far away will overflow the integer.