### PR TITLE
Metadata fix

### DIFF
--- a/src/main/java/net/minestom/server/entity/MetadataHolder.java
+++ b/src/main/java/net/minestom/server/entity/MetadataHolder.java
@@ -115,7 +115,6 @@ public final class MetadataHolder {
                 }
             } else {
                 entity.sendPacketToViewersAndSelf(new EntityMetaDataPacket(entity.getEntityId(), Map.of(id, result)));
-                new Exception("metadata set stack trace, result=" + result).printStackTrace();
             }
         }
     }

--- a/src/main/java/net/minestom/server/entity/MetadataHolder.java
+++ b/src/main/java/net/minestom/server/entity/MetadataHolder.java
@@ -88,7 +88,7 @@ public final class MetadataHolder {
         final int id = entry.index();
 
         T current = get(entry);
-        if (current.equals(value)) return;
+        if (current != null && current.equals(value)) return;
 
         Metadata.Entry<?> result = switch (entry) {
             case MetadataDef.Entry.Index<T> v -> v.function().apply(value);

--- a/src/main/java/net/minestom/server/entity/MetadataHolder.java
+++ b/src/main/java/net/minestom/server/entity/MetadataHolder.java
@@ -42,6 +42,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.BiFunction;
 
 public final class MetadataHolder {
@@ -88,7 +89,7 @@ public final class MetadataHolder {
         final int id = entry.index();
 
         T current = get(entry);
-        if (current != null && current.equals(value)) return;
+        if (Objects.equals(current, value)) return;
 
         Metadata.Entry<?> result = switch (entry) {
             case MetadataDef.Entry.Index<T> v -> v.function().apply(value);

--- a/src/main/java/net/minestom/server/entity/MetadataHolder.java
+++ b/src/main/java/net/minestom/server/entity/MetadataHolder.java
@@ -87,6 +87,9 @@ public final class MetadataHolder {
     public <T> void set(MetadataDef.Entry<T> entry, T value) {
         final int id = entry.index();
 
+        T current = get(entry);
+        if (current.equals(value)) return;
+
         Metadata.Entry<?> result = switch (entry) {
             case MetadataDef.Entry.Index<T> v -> v.function().apply(value);
             case MetadataDef.Entry.BitMask bitMask -> {
@@ -112,6 +115,7 @@ public final class MetadataHolder {
                 }
             } else {
                 entity.sendPacketToViewersAndSelf(new EntityMetaDataPacket(entity.getEntityId(), Map.of(id, result)));
+                new Exception("metadata set stack trace, result=" + result).printStackTrace();
             }
         }
     }

--- a/src/test/java/net/minestom/server/entity/PlayerSprintingMetadataTest.java
+++ b/src/test/java/net/minestom/server/entity/PlayerSprintingMetadataTest.java
@@ -1,0 +1,36 @@
+package net.minestom.server.entity;
+
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.network.packet.client.play.ClientEntityActionPacket;
+import net.minestom.server.network.packet.client.play.ClientInputPacket;
+import net.minestom.server.network.packet.server.play.EntityMetaDataPacket;
+import net.minestom.testing.Env;
+import net.minestom.testing.EnvTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@EnvTest
+public class PlayerSprintingMetadataTest {
+
+    @Test
+    public void sprintingMetadata(Env env) {
+        var instance = env.createFlatInstance();
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0, 40, 0));
+
+        player.addPacketToQueue(new ClientInputPacket(true, false, false, false, false, false, true));
+        player.addPacketToQueue(new ClientEntityActionPacket(
+                player.getEntityId(),
+                ClientEntityActionPacket.Action.START_SPRINTING,
+                0
+        ));
+
+        var tracker = connection.trackIncoming(EntityMetaDataPacket.class);
+        player.interpretPacketQueue();
+
+        var packets = tracker.collect();
+        assertEquals(1, packets.size(), "Expected single packet, got multiple");
+    }
+
+}


### PR DESCRIPTION
## Proposed changes

This solves the so-called sprinting bug and possibly more bugs regarding metadata changes.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

There has been a bug in Minestom since 1.21.4 (if I recall correctly), this bug essentially makes you jitter or stop sprinting for a brief moment if you use your "Walk Forward" key twice to sprint.
This really bothered me, since I primarily use this to sprint, and that's not great for parkouring servers like Hollow Cube.

So, this became a four hour journey of trying to understand the Minestom codebase, and the cause is quite simple.
Essentially, when the player sends the Entity Action packet "START_SPRINTING", it also sends a different packet called Player Input, this contains the status of all the Movement keys at that time. 

The MetadataHolder sends a EntityMetadataPacket right after setting the specific entry (in most cases), which caused a sort-of race condition on the client due to the SNEAKING value that's being sent by the Player Input packet. Since the sneaking value is false in most cases, it literally sends an empty metadata packet, clearing the sprinting value that is sent before.
- Client sends Input packet
- Client sends Entity Action packet (start sprinting)
- Server sends EntityMetadataPacket with sneaking set to true (value of 8)
- Server sends EntityMetadataPacket with no metadata (value of 0) (same tick btw)
- Client sends Entity Action packet (stop sprinting)

I feel like the instant update of the MetadataHolder might be a bug of it's own, for now I've added a comparison between the current value and the set value and that fixes it. It could be fixed on a higher level (EntityMeta), but this solves any other potential issues.

TL;DR: Metadata got reset due to Player Input being sent in the same tick