### PR TITLE
fix: custom model data crash exploit

### DIFF
--- a/src/main/java/net/minestom/server/item/component/CustomModelData.java
+++ b/src/main/java/net/minestom/server/item/component/CustomModelData.java
@@ -13,11 +13,13 @@ public record CustomModelData(
         List<Float> floats, List<Boolean> flags,
         List<String> strings, List<RGBLike> colors
 ) {
+    private static final int MAX_ENTRIES = 256;
+
     public static final NetworkBuffer.Type<CustomModelData> NETWORK_TYPE = NetworkBufferTemplate.template(
-            NetworkBuffer.FLOAT.list(), CustomModelData::floats,
-            NetworkBuffer.BOOLEAN.list(), CustomModelData::flags,
-            NetworkBuffer.STRING.list(), CustomModelData::strings,
-            Color.NETWORK_TYPE.list(), CustomModelData::colors,
+            NetworkBuffer.FLOAT.list(MAX_ENTRIES), CustomModelData::floats,
+            NetworkBuffer.BOOLEAN.list(MAX_ENTRIES), CustomModelData::flags,
+            NetworkBuffer.STRING.list(MAX_ENTRIES), CustomModelData::strings,
+            Color.NETWORK_TYPE.list(MAX_ENTRIES), CustomModelData::colors,
             CustomModelData::new);
     public static final Codec<CustomModelData> CODEC = StructCodec.struct(
             "floats", Codec.FLOAT.list().optional(List.of()), CustomModelData::floats,


### PR DESCRIPTION
Sending a `ClientCreativeInventoryActionPacket` with a malicious custom model data can cause a huge 16+ GB allocation and out-of-memory crash due to the unbounded list. You did not need to be in creative mode to trigger this.