### PR TITLE
Fix linear palette deserialization bug

### DIFF
--- a/src/main/java/net/minestom/server/instance/palette/Palette.java
+++ b/src/main/java/net/minestom/server/instance/palette/Palette.java
@@ -264,6 +264,7 @@ public sealed interface Palette permits PaletteImpl {
                     final int[] palette = buffer.read(VAR_INT_ARRAY);
                     result.paletteToValueList = new IntArrayList(palette);
                     result.valueToPaletteMap = new Int2IntOpenHashMap(palette.length);
+                    result.valueToPaletteMap.defaultReturnValue(-1);
                     for (int i = 0; i < palette.length; i++) {
                         result.valueToPaletteMap.put(palette[i], i);
                     }

--- a/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
+++ b/src/test/java/net/minestom/server/instance/palette/PaletteTest.java
@@ -596,6 +596,23 @@ public class PaletteTest {
     }
 
     @Test
+    public void serializationBlockLinearMutation() {
+        NetworkBuffer buffer = NetworkBuffer.resizableBuffer();
+        Palette palette = Palette.blocks();
+        palette.set(0, 0, 0, 1);
+        palette.set(1, 0, 0, 2);
+
+        buffer.write(Palette.BLOCK_SERIALIZER, palette);
+        Palette deserialized = buffer.read(Palette.BLOCK_SERIALIZER);
+
+        deserialized.set(2, 0, 0, 3);
+
+        assertEquals(1, deserialized.get(0, 0, 0));
+        assertEquals(2, deserialized.get(1, 0, 0));
+        assertEquals(3, deserialized.get(2, 0, 0));
+    }
+
+    @Test
     public void serializationBlockDirect() {
         NetworkBuffer buffer = NetworkBuffer.resizableBuffer();
         Random random = new Random(12345);


### PR DESCRIPTION
## Proposed changes

This PR fixes a serialization bug in block palettes where the indirect/linear palette path was not fully restored after deserialization.

Specifically:
- The deserializer now initializes the indirect palette value-to-index map with a missing-value default of -1, matching runtime expectations.
- This prevents incorrect behavior when inserting new values into a deserialized linear palette.
- Added a regression test that:
  - serializes a linear block palette
  - deserializes it
  - mutates it with a new value
  - verifies all expected values are preserved

Fixes #3069

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...