### PR TITLE
fix: Mannequin MetadataDef & Metadata nullability

### DIFF
--- a/demo/src/main/java/net/minestom/demo/entity/MannequinEntity.java
+++ b/demo/src/main/java/net/minestom/demo/entity/MannequinEntity.java
@@ -35,7 +35,7 @@ public class MannequinEntity extends Entity {
 
         // Enable skin layers
         player.sendPackets(new EntityMetaDataPacket(getEntityId(), Map.of(
-                MetadataDef.Mannequin.DISPLAYED_MODEL_PARTS_FLAGS.index(), Metadata.Byte((byte) 127)
+                MetadataDef.Player.DISPLAYED_MODEL_PARTS_FLAGS.index(), Metadata.Byte((byte) 127)
         )));
     }
 

--- a/demo/src/main/java/net/minestom/demo/entity/MannequinEntity.java
+++ b/demo/src/main/java/net/minestom/demo/entity/MannequinEntity.java
@@ -35,7 +35,7 @@ public class MannequinEntity extends Entity {
 
         // Enable skin layers
         player.sendPackets(new EntityMetaDataPacket(getEntityId(), Map.of(
-                MetadataDef.Avatar.DISPLAYED_MODEL_PARTS_FLAGS.index(), Metadata.Byte((byte) 127)
+                MetadataDef.Mannequin.DISPLAYED_MODEL_PARTS_FLAGS.index(), Metadata.Byte((byte) 127)
         )));
     }
 

--- a/src/main/java/net/minestom/server/entity/Metadata.java
+++ b/src/main/java/net/minestom/server/entity/Metadata.java
@@ -49,7 +49,7 @@ public final class Metadata {
         return new MetadataImpl.EntryImpl<>(TYPE_CHAT, value, NetworkBuffer.COMPONENT);
     }
 
-    public static Entry<Component> OptComponent(@Nullable Component value) {
+    public static Entry<@Nullable Component> OptComponent(@Nullable Component value) {
         return new MetadataImpl.EntryImpl<>(TYPE_OPT_CHAT, value, NetworkBuffer.OPT_CHAT);
     }
 
@@ -69,7 +69,7 @@ public final class Metadata {
         return new MetadataImpl.EntryImpl<>(TYPE_BLOCK_POSITION, value, NetworkBuffer.BLOCK_POSITION);
     }
 
-    public static Entry<Point> OptBlockPosition(@Nullable Point value) {
+    public static Entry<@Nullable Point> OptBlockPosition(@Nullable Point value) {
         return new MetadataImpl.EntryImpl<>(TYPE_OPT_BLOCK_POSITION, value, NetworkBuffer.OPT_BLOCK_POSITION);
     }
 
@@ -77,7 +77,7 @@ public final class Metadata {
         return new MetadataImpl.EntryImpl<>(TYPE_DIRECTION, value, NetworkBuffer.DIRECTION);
     }
 
-    public static Entry<UUID> OptUUID(@Nullable UUID value) {
+    public static Entry<@Nullable UUID> OptUUID(@Nullable UUID value) {
         return new MetadataImpl.EntryImpl<>(TYPE_OPT_UUID, value, NetworkBuffer.UUID.optional());
     }
 
@@ -85,8 +85,8 @@ public final class Metadata {
         return new MetadataImpl.EntryImpl<>(TYPE_BLOCKSTATE, value, Block.STATE_NETWORK_TYPE);
     }
 
-    public static Entry<Block> OptBlockState(@Nullable Block value) {
-        return new MetadataImpl.EntryImpl<>(TYPE_OPT_BLOCKSTATE, value, new NetworkBuffer.Type<>() {
+    public static Entry<@Nullable Block> OptBlockState(@Nullable Block value) {
+        return new MetadataImpl.EntryImpl<>(TYPE_OPT_BLOCKSTATE, value, new NetworkBuffer.Type<>() { //OPT_VAR_INT
             @Override
             public void write(NetworkBuffer buffer, @Nullable Block value) {
                 buffer.write(NetworkBuffer.VAR_INT, value == null ? 0 : value.id());
@@ -112,19 +112,8 @@ public final class Metadata {
         return new MetadataImpl.EntryImpl<>(TYPE_VILLAGERDATA, data, VillagerMeta.VillagerData.NETWORK_TYPE);
     }
 
-    public static Entry<Integer> OptVarInt(@Nullable Integer value) {
-        return new MetadataImpl.EntryImpl<>(TYPE_OPT_VARINT, value, new NetworkBuffer.Type<>() {
-            @Override
-            public void write(NetworkBuffer buffer, Integer value) {
-                buffer.write(NetworkBuffer.VAR_INT, value == null ? 0 : value + 1);
-            }
-
-            @Override
-            public Integer read(NetworkBuffer buffer) {
-                int value = buffer.read(NetworkBuffer.VAR_INT);
-                return value == 0 ? null : value - 1;
-            }
-        });
+    public static Entry<@Nullable Integer> OptVarInt(@Nullable Integer value) {
+        return new MetadataImpl.EntryImpl<>(TYPE_OPT_VARINT, value, NetworkBuffer.OPTIONAL_VAR_INT);
     }
 
     public static Entry<EntityPose> Pose(EntityPose value) {
@@ -187,7 +176,7 @@ public final class Metadata {
         return new MetadataImpl.EntryImpl<>(TYPE_VECTOR3, value, NetworkBuffer.VECTOR3);
     }
 
-    public static Entry<float[]> Quaternion(float [] value) {
+    public static Entry<float[]> Quaternion(float[] value) {
         return new MetadataImpl.EntryImpl<>(TYPE_QUATERNION, value, NetworkBuffer.QUATERNION);
     }
 
@@ -247,13 +236,11 @@ public final class Metadata {
         return (byte) NEXT_ID.getAndIncrement();
     }
 
-    public sealed interface Entry<T> permits MetadataImpl.EntryImpl {
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        NetworkBuffer.Type<Entry<?>> SERIALIZER = (NetworkBuffer.Type) MetadataImpl.EntryImpl.SERIALIZER;
+    public sealed interface Entry<T extends @UnknownNullability Object> permits MetadataImpl.EntryImpl {
+        NetworkBuffer.Type<Entry<?>> SERIALIZER = MetadataImpl.EntryImpl.SERIALIZER;
 
         int type();
 
-        @UnknownNullability
         T value();
     }
 }

--- a/src/main/java/net/minestom/server/entity/MetadataDef.java
+++ b/src/main/java/net/minestom/server/entity/MetadataDef.java
@@ -651,12 +651,12 @@ public sealed class MetadataDef {
         return MetadataDefImpl.count(clazz);
     }
 
-    public sealed interface Entry<T> {
+    public sealed interface Entry<T extends @UnknownNullability Object> {
         int index();
 
         T defaultValue();
 
-        record Index<T>(int index, Function<T, Metadata.Entry<T>> function, T defaultValue) implements Entry<T> {
+        record Index<T extends @UnknownNullability Object>(int index, Function<T, Metadata.Entry<T>> function, T defaultValue) implements Entry<T> {
         }
 
         record BitMask(int index, byte bitMask, Boolean defaultValue) implements Entry<Boolean> {

--- a/src/main/java/net/minestom/server/entity/MetadataDef.java
+++ b/src/main/java/net/minestom/server/entity/MetadataDef.java
@@ -19,6 +19,7 @@ import net.minestom.server.registry.Holder;
 import net.minestom.server.registry.RegistryKey;
 import net.minestom.server.utils.Direction;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
 
 import java.util.List;
 import java.util.UUID;
@@ -30,6 +31,10 @@ import static net.minestom.server.entity.MetadataDefImpl.*;
  * List of all entity metadata.
  * <p>
  * Classes must be used (and not interfaces) to enforce loading order.
+ * <p>
+ * When using this class directly, ensure that you are using fields on the most inner class,
+ * for example {@link Player#ENTITY_FLAGS} and not {@link MetadataDef#ENTITY_FLAGS}.
+ * You need do this as some classes have different default values.
  */
 @SuppressWarnings({"unused", "SpellCheckingInspection"})
 public sealed class MetadataDef {
@@ -240,6 +245,15 @@ public sealed class MetadataDef {
     }
 
     public static final class Mannequin extends Avatar {
+        // Maniquens have their model flags with all flags enabled compared to Avatar.
+        public static final Entry<Byte> DISPLAYED_MODEL_PARTS_FLAGS = index(-1, Metadata::Byte, (byte) 0x7F);
+        public static final Entry<Boolean> IS_CAPE_ENABLED = bitMask(-1, (byte) 0x01, true);
+        public static final Entry<Boolean> IS_JACKET_ENABLED = bitMask(-1, (byte) 0x02, true);
+        public static final Entry<Boolean> IS_LEFT_SLEEVE_ENABLED = bitMask(-1, (byte) 0x04, true);
+        public static final Entry<Boolean> IS_RIGHT_SLEEVE_ENABLED = bitMask(-1, (byte) 0x08, true);
+        public static final Entry<Boolean> IS_LEFT_PANTS_LEG_ENABLED = bitMask(-1, (byte) 0x10, true);
+        public static final Entry<Boolean> IS_RIGHT_PANTS_LEG_ENABLED = bitMask(-1, (byte) 0x20, true);
+        public static final Entry<Boolean> IS_HAT_ENABLED = bitMask(-1, (byte) 0x40, true);
         public static final Entry<ResolvableProfile> PROFILE = index(0, Metadata::ResolvableProfile, ResolvableProfile.EMPTY);
         public static final Entry<Boolean> IMMOVABLE = index(1, Metadata::Boolean, false);
         public static final Entry<@Nullable Component> DESCRIPTION = index(2, Metadata::OptComponent, Component.translatable("entity.minecraft.mannequin.label"));

--- a/src/main/java/net/minestom/server/entity/MetadataDefImpl.java
+++ b/src/main/java/net/minestom/server/entity/MetadataDefImpl.java
@@ -1,5 +1,7 @@
 package net.minestom.server.entity;
 
+import org.jetbrains.annotations.UnknownNullability;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -7,7 +9,7 @@ import java.util.function.Function;
 final class MetadataDefImpl {
     static final Map<String, Integer> MAX_INDEX = new HashMap<>();
 
-    static <T> MetadataDef.Entry.Index<T> index(int index, Function<T, Metadata.Entry<T>> function, T defaultValue) {
+    static <T extends @UnknownNullability Object> MetadataDef.Entry.Index<T> index(int index, Function<T, Metadata.Entry<T>> function, T defaultValue) {
         final String caller = caller();
         storeMaxIndex(caller, index);
         final int superIndex = findSuperIndex(caller);

--- a/src/main/java/net/minestom/server/entity/MetadataHolder.java
+++ b/src/main/java/net/minestom/server/entity/MetadataHolder.java
@@ -37,6 +37,7 @@ import net.minestom.server.entity.metadata.water.fish.*;
 import net.minestom.server.network.packet.server.play.EntityMetaDataPacket;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
@@ -56,7 +57,7 @@ public final class MetadataHolder {
         }
     }
 
-    private final Entity entity;
+    private final @Nullable Entity entity;
     private final Int2ObjectMap<Metadata.Entry<?>> entries = new Int2ObjectOpenHashMap<>();
 
     @SuppressWarnings("FieldMayBeFinal")
@@ -67,13 +68,14 @@ public final class MetadataHolder {
         this.entity = entity;
     }
 
-    public <T> T get(MetadataDef.Entry<T> entry) {
+    @SuppressWarnings("unchecked")
+    public <T extends @UnknownNullability Object> T get(MetadataDef.Entry<T> entry) {
         final int id = entry.index();
 
         final Metadata.Entry<?> value = this.entries.get(id);
         if (value == null) return entry.defaultValue();
         return switch (entry) {
-            case MetadataDef.Entry.Index<T> v -> (T) value.value();
+            case MetadataDef.Entry.Index<T> _ -> (T) value.value();
             case MetadataDef.Entry.BitMask bitMask -> {
                 final byte maskValue = (byte) value.value();
                 yield (T) ((Boolean) getMaskBit(maskValue, bitMask.bitMask()));
@@ -85,7 +87,7 @@ public final class MetadataHolder {
         };
     }
 
-    public <T> void set(MetadataDef.Entry<T> entry, T value) {
+    public <T extends @UnknownNullability Object> void set(MetadataDef.Entry<T> entry, T value) {
         final int id = entry.index();
 
         T current = get(entry);
@@ -166,7 +168,7 @@ public final class MetadataHolder {
         return Map.copyOf(this.entries);
     }
 
-    static final Map<String, BiFunction<Entity, MetadataHolder, EntityMeta>> ENTITY_META_SUPPLIER = createMetaMap();
+    static final Map<String, BiFunction<@Nullable Entity, MetadataHolder, EntityMeta>> ENTITY_META_SUPPLIER = createMetaMap();
 
     @ApiStatus.Internal
     public static EntityMeta createMeta(
@@ -177,7 +179,7 @@ public final class MetadataHolder {
         return ENTITY_META_SUPPLIER.get(entityType.name()).apply(entity, metadata);
     }
 
-    private static Map<String, BiFunction<Entity, MetadataHolder, EntityMeta>> createMetaMap() {
+    private static Map<String, BiFunction<@Nullable Entity, MetadataHolder, EntityMeta>> createMetaMap() {
         final Map<String, BiFunction<Entity, MetadataHolder, EntityMeta>> map = new HashMap<>();
         map.put("minecraft:acacia_boat", BoatMeta::new);
         map.put("minecraft:acacia_chest_boat", BoatMeta::new);

--- a/src/main/java/net/minestom/server/entity/MetadataImpl.java
+++ b/src/main/java/net/minestom/server/entity/MetadataImpl.java
@@ -76,17 +76,18 @@ final class MetadataImpl {
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
-    record EntryImpl<T>(int type, @UnknownNullability T value,
+    record EntryImpl<T extends @UnknownNullability Object>(int type, T value,
                         NetworkBuffer.Type<T> serializer) implements Metadata.Entry<T> {
-        static final NetworkBuffer.Type<EntryImpl<?>> SERIALIZER = new NetworkBuffer.Type<>() {
+        static final NetworkBuffer.Type<Entry<?>> SERIALIZER = new NetworkBuffer.Type<>() {
             @Override
-            public void write(NetworkBuffer buffer, EntryImpl value) {
-                buffer.write(VAR_INT, value.type);
-                buffer.write(value.serializer, value.value);
+            public void write(NetworkBuffer buffer, Entry value) {
+                final EntryImpl impl = (EntryImpl) value;
+                buffer.write(VAR_INT, impl.type);
+                buffer.write(impl.serializer, impl.value);
             }
 
             @Override
-            public EntryImpl read(NetworkBuffer buffer) {
+            public Entry read(NetworkBuffer buffer) {
                 final int type = buffer.read(VAR_INT);
                 final EntryImpl<?> value = (EntryImpl<?>) EMPTY_VALUES.get(type);
                 if (value == null) throw new UnsupportedOperationException("Unknown value type: " + type);

--- a/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java
@@ -9,12 +9,13 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
 
 import java.lang.ref.WeakReference;
 import java.util.function.Consumer;
 
 public class EntityMeta {
-    private final WeakReference<Entity> entityRef;
+    private final WeakReference<@Nullable Entity> entityRef;
     protected final MetadataHolder metadata;
 
     public EntityMeta(@Nullable Entity entity, MetadataHolder metadata) {
@@ -210,7 +211,7 @@ public class EntityMeta {
      * @return The value associated with the specified metadata entry.
      */
     @ApiStatus.Experimental
-    public <T> T get(MetadataDef.Entry<T> entry) {
+    public <T extends @UnknownNullability Object> T get(MetadataDef.Entry<T> entry) {
         return metadata.get(entry);
     }
 
@@ -222,7 +223,7 @@ public class EntityMeta {
      * @param <T>   The type of the metadata value.
      */
     @ApiStatus.Experimental
-    public <T> void set(MetadataDef.Entry<T> entry, T value) {
+    public <T extends @UnknownNullability Object> void set(MetadataDef.Entry<T> entry, T value) {
         metadata.set(entry, value);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/avatar/MannequinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/avatar/MannequinMeta.java
@@ -8,10 +8,6 @@ import net.minestom.server.network.player.ResolvableProfile;
 import org.jetbrains.annotations.Nullable;
 
 public class MannequinMeta extends AvatarMeta {
-// ublic static final Entry<ResolvableProfile> PROFILE = index(0, Metadata::ResolvableProfile, ResolvableProfile.EMPTY);
-//        public static final Entry<Boolean> IMMOVABLE = index(1, Metadata::Boolean, false);
-//        public static final Entry<@Nullable Component> DESCRIPTION = index(2, Metadata::OptComponent, Component.translatable("entity.minecraft.mannequin.label"));
-//
     public MannequinMeta(Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
@@ -40,4 +36,83 @@ public class MannequinMeta extends AvatarMeta {
         metadata.set(MetadataDef.Mannequin.DESCRIPTION, value);
     }
 
+    @Override
+    public boolean isCapeEnabled() {
+        return metadata.get(MetadataDef.Mannequin.IS_CAPE_ENABLED);
+    }
+
+    @Override
+    public void setCapeEnabled(boolean value) {
+        metadata.set(MetadataDef.Mannequin.IS_CAPE_ENABLED, value);
+    }
+
+    @Override
+    public boolean isJacketEnabled() {
+        return metadata.get(MetadataDef.Mannequin.IS_JACKET_ENABLED);
+    }
+
+    @Override
+    public void setJacketEnabled(boolean value) {
+        metadata.set(MetadataDef.Mannequin.IS_JACKET_ENABLED, value);
+    }
+
+    @Override
+    public boolean isLeftSleeveEnabled() {
+        return metadata.get(MetadataDef.Mannequin.IS_LEFT_SLEEVE_ENABLED);
+    }
+
+    @Override
+    public void setLeftSleeveEnabled(boolean value) {
+        metadata.set(MetadataDef.Mannequin.IS_LEFT_SLEEVE_ENABLED, value);
+    }
+
+    @Override
+    public boolean isRightSleeveEnabled() {
+        return metadata.get(MetadataDef.Mannequin.IS_RIGHT_SLEEVE_ENABLED);
+    }
+
+    @Override
+    public void setRightSleeveEnabled(boolean value) {
+        metadata.set(MetadataDef.Mannequin.IS_RIGHT_SLEEVE_ENABLED, value);
+    }
+
+    @Override
+    public boolean isLeftLegEnabled() {
+        return metadata.get(MetadataDef.Mannequin.IS_LEFT_PANTS_LEG_ENABLED);
+    }
+
+    @Override
+    public void setLeftLegEnabled(boolean value) {
+        metadata.set(MetadataDef.Mannequin.IS_LEFT_PANTS_LEG_ENABLED, value);
+    }
+
+    @Override
+    public boolean isRightLegEnabled() {
+        return metadata.get(MetadataDef.Mannequin.IS_RIGHT_PANTS_LEG_ENABLED);
+    }
+
+    @Override
+    public void setRightLegEnabled(boolean value) {
+        metadata.get(MetadataDef.Mannequin.IS_RIGHT_PANTS_LEG_ENABLED);
+    }
+
+    @Override
+    public boolean isHatEnabled() {
+        return metadata.get(MetadataDef.Mannequin.IS_HAT_ENABLED);
+    }
+
+    @Override
+    public void setHatEnabled(boolean value) {
+        metadata.set(MetadataDef.Mannequin.IS_HAT_ENABLED, value);
+    }
+
+    @Override
+    public byte getDisplayedSkinParts() {
+        return metadata.get(MetadataDef.Mannequin.DISPLAYED_MODEL_PARTS_FLAGS);
+    }
+
+    @Override
+    public void setDisplayedSkinParts(byte skinDisplayByte) {
+        metadata.set(MetadataDef.Mannequin.DISPLAYED_MODEL_PARTS_FLAGS, skinDisplayByte);
+    }
 }

--- a/src/test/java/net/minestom/server/entity/EntityMetaIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/EntityMetaIntegrationTest.java
@@ -2,6 +2,7 @@ package net.minestom.server.entity;
 
 import net.kyori.adventure.text.Component;
 import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.metadata.avatar.MannequinMeta;
 import net.minestom.server.entity.metadata.display.ItemDisplayMeta;
 import net.minestom.server.network.packet.server.play.EntityMetaDataPacket;
 import net.minestom.testing.Env;
@@ -166,5 +167,30 @@ public class EntityMetaIntegrationTest {
         assertEquals(1, packets.get(1).entries().get(MetadataDef.Display.INTERPOLATION_DELAY.index()).value());
         assertEquals(2, packets.get(2).entries().get(MetadataDef.Display.INTERPOLATION_DELAY.index()).value());
         assertEquals(3, packets.get(3).entries().get(MetadataDef.Display.INTERPOLATION_DELAY.index()).value());
+    }
+
+    @Test
+    public void testMannequin(Env env) {
+        // Ensure that mannequins have all skin layers by default, and that they can be changed by setting the metadata.
+        var connection = env.createConnection();
+        var instance = env.createFlatInstance();
+        var startPos = new Pos(0, 42, 1);
+
+        connection.connect(instance, startPos);
+        var incomingPackets = connection.trackIncoming(EntityMetaDataPacket.class);
+
+        var entity = new Entity(EntityType.MANNEQUIN);
+        var meta = (MannequinMeta) entity.getEntityMeta();
+        Assertions.assertTrue(meta.isCapeEnabled());
+        Assertions.assertEquals(0x7F, meta.getDisplayedSkinParts()); // all enabled
+        meta.setDisplayedSkinParts((byte) 0); // disable all
+        entity.setInstance(instance, startPos).join();
+
+        incomingPackets.assertSingle(packet -> {
+            assertEquals(packet.entityId(), entity.getEntityId());
+            var entry = packet.entries().get(MetadataDef.Mannequin.DISPLAYED_MODEL_PARTS_FLAGS.index());
+            assertEquals(Metadata.TYPE_BYTE, entry.type());
+            assertEquals((byte) 0, entry.value());
+        });
     }
 }


### PR DESCRIPTION
## Proposed changes

Fixes Mannequin MetadataDef & Metadata nullability.

Closes #3106 
 
## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments
This change does not fix any other wrappers for nullability issues, that can likely be delegated to #3017, though it likely needs a rebase now. 

We could introduce a defaultValue(T) on the MetdataDef.Entry though I dont want to introduce this API surface as its completely useless outside of defines and would likely give the wrong impression to anyone using it.