### PR TITLE
chore: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Minestom/core-maintainers


### PR DESCRIPTION
Should allow reviewers to be notified when a pull request is ready for review, even if it was promoted from draft.

Draft until write perms are granted to the team.