### PR TITLE
fix: ArgumentItemStack parsing

### DIFF
--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
 
 application {
     mainClass.set("net.minestom.demo.Main")
+    applicationDefaultJvmArgs += "-ea"
 }
 
 tasks.withType<ShadowJar> {

--- a/jmh-benchmarks/src/jmh/java/net/minestom/server/coordinate/PosBenchmark.java
+++ b/jmh-benchmarks/src/jmh/java/net/minestom/server/coordinate/PosBenchmark.java
@@ -1,0 +1,56 @@
+package net.minestom.server.coordinate;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(3)
+public class PosBenchmark {
+
+    @Param({"true", "false"})
+    boolean inside;
+
+    @Param({"1024", "4096"})
+    int sampleSize;
+
+    private int sampleBound;
+
+    private float[] randomPitches;
+    private float[] randomYaws;
+    private int pitchIndex = 0;
+    private int yawIndex = 0;
+
+    @Setup
+    public void setup() {
+        final int sampleSize = this.sampleSize;
+        sampleBound = sampleSize - 1;
+        randomPitches = new float[sampleSize];
+        randomYaws = new float[sampleSize];
+
+        Random r = new Random(67);
+        for (int i = 0; i < randomPitches.length; i++) {
+            randomPitches[i] = inside ? r.nextFloat(-90f, 90.0f) : r.nextFloat(-1000.0f, 1000.0f);
+        }
+        for (int i = 0; i < randomYaws.length; i++) {
+            randomYaws[i] = inside ? r.nextFloat(-179.99f, 180.0f) : r.nextFloat(-1000.0f, 1000.0f);
+        }
+    }
+
+    @Benchmark
+    public float fixYaw() {
+        float yaw = randomYaws[pitchIndex++ & sampleBound];
+        return Pos.fixYaw(yaw);
+    }
+
+    @Benchmark
+    public float fixPitch() {
+        float pitch = randomPitches[yawIndex++ & sampleBound];
+        return Pos.fixPitch(pitch);
+    }
+}

--- a/src/main/java/net/minestom/server/MinecraftServer.java
+++ b/src/main/java/net/minestom/server/MinecraftServer.java
@@ -199,7 +199,7 @@ public final class MinecraftServer implements MinecraftConstants {
         return serverProcess.bossBar();
     }
 
-    public static PacketParser<ClientPacket> getPacketParser() {
+    public static PacketParser.Client getPacketParser() {
         return serverProcess.packetParser();
     }
 

--- a/src/main/java/net/minestom/server/ServerProcess.java
+++ b/src/main/java/net/minestom/server/ServerProcess.java
@@ -101,7 +101,7 @@ public interface ServerProcess extends Registries, Snapshotable {
      * <p>
      * Can be used if you want to convert a buffer to a client packet object.
      */
-    PacketParser<ClientPacket> packetParser();
+    PacketParser.Client packetParser();
 
     /**
      * Exposed socket server.

--- a/src/main/java/net/minestom/server/ServerProcessImpl.java
+++ b/src/main/java/net/minestom/server/ServerProcessImpl.java
@@ -100,7 +100,7 @@ final class ServerProcessImpl implements ServerProcess {
 
     private final ConnectionManager connection;
     private final PacketListenerManager packetListener;
-    private final PacketParser<ClientPacket> packetParser;
+    private final PacketParser.Client packetParser;
     private final InstanceManager instance;
     private final BlockManager block;
     private final CommandManager command;
@@ -372,7 +372,7 @@ final class ServerProcessImpl implements ServerProcess {
     }
 
     @Override
-    public PacketParser<ClientPacket> packetParser() {
+    public PacketParser.Client packetParser() {
         return packetParser;
     }
 

--- a/src/main/java/net/minestom/server/Viewable.java
+++ b/src/main/java/net/minestom/server/Viewable.java
@@ -6,6 +6,7 @@ import net.minestom.server.entity.Player;
 import net.minestom.server.network.packet.server.SendablePacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.utils.PacketSendingUtils;
+import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.Collection;
 import java.util.List;
@@ -37,7 +38,8 @@ public interface Viewable {
      *
      * @return A Set containing all the element's viewers
      */
-    Set<Player> getViewers();
+    @Unmodifiable
+    Set<? extends Player> getViewers();
 
     /**
      * Gets if a player is seeing this viewable object.
@@ -65,7 +67,7 @@ public interface Viewable {
         }
     }
 
-    default void sendPacketsToViewers(Collection<SendablePacket> packets) {
+    default void sendPacketsToViewers(Collection<? extends SendablePacket> packets) {
         packets.forEach(this::sendPacketToViewers);
     }
 

--- a/src/main/java/net/minestom/server/advancements/AdvancementTab.java
+++ b/src/main/java/net/minestom/server/advancements/AdvancementTab.java
@@ -131,7 +131,7 @@ public class AdvancementTab implements Viewable {
     }
 
     @Override
-    public Set<Player> getViewers() {
+    public Set<? extends Player> getViewers() {
         return viewers;
     }
 

--- a/src/main/java/net/minestom/server/adventure/ComponentHolder.java
+++ b/src/main/java/net/minestom/server/adventure/ComponentHolder.java
@@ -18,7 +18,7 @@ public interface ComponentHolder<T> {
      *
      * @return the components
      */
-    Collection<Component> components();
+    Collection<? extends Component> components();
 
     /**
      * Returns a copy of this object. For each component this object holds, the operator
@@ -34,7 +34,7 @@ public interface ComponentHolder<T> {
      *
      * @param visitor the visitor
      */
-    default void visitComponents(Consumer<Component> visitor) {
+    default void visitComponents(Consumer<? super Component> visitor) {
         for (Component component : this.components()) {
             visitor.accept(component);
         }

--- a/src/main/java/net/minestom/server/adventure/audience/AudienceProvider.java
+++ b/src/main/java/net/minestom/server/adventure/audience/AudienceProvider.java
@@ -36,7 +36,7 @@ public interface AudienceProvider<A> {
      * @param filter the predicate
      * @return all players matching the predicate
      */
-    A players(Predicate<Player> filter);
+    A players(Predicate<? super Player> filter);
 
     /**
      * Gets the console as an audience.
@@ -78,7 +78,7 @@ public interface AudienceProvider<A> {
      * @param filter the predicate
      * @return all custom audience members stored using the key
      */
-    default A custom(Keyed keyed, Predicate<Audience> filter) {
+    default A custom(Keyed keyed, Predicate<? super Audience> filter) {
         return this.custom(keyed.key(), filter);
     }
 
@@ -90,7 +90,7 @@ public interface AudienceProvider<A> {
      * @param filter the predicate
      * @return all custom audience members stored using the key
      */
-    A custom(Key key, Predicate<Audience> filter);
+    A custom(Key key, Predicate<? super Audience> filter);
 
     /**
      * Gets all custom audience members.
@@ -105,7 +105,7 @@ public interface AudienceProvider<A> {
      * @param filter the predicate
      * @return all matching custom audience members
      */
-    A customs(Predicate<Audience> filter);
+    A customs(Predicate<? super Audience> filter);
 
     /**
      * Gets all audience members that match the given predicate.
@@ -113,7 +113,7 @@ public interface AudienceProvider<A> {
      * @param filter the predicate
      * @return all matching audience members
      */
-    A all(Predicate<Audience> filter);
+    A all(Predicate<? super Audience> filter);
 
     /**
      * Gets the audience registry used to register custom audiences.

--- a/src/main/java/net/minestom/server/adventure/audience/AudienceRegistry.java
+++ b/src/main/java/net/minestom/server/adventure/audience/AudienceRegistry.java
@@ -53,7 +53,7 @@ public class AudienceRegistry {
      * @param keyed     the provider of the key
      * @param audiences the audiences
      */
-    public void register(Keyed keyed, Collection<Audience> audiences) {
+    public void register(Keyed keyed, Collection<? extends Audience> audiences) {
         this.register(keyed.key(), audiences);
     }
 
@@ -77,7 +77,7 @@ public class AudienceRegistry {
      * @param key       the key to store the audiences under
      * @param audiences the audiences
      */
-    public void register(Key key, Collection<Audience> audiences) {
+    public void register(Key key, Collection<? extends Audience> audiences) {
         if (!audiences.isEmpty()) {
             this.registry.computeIfAbsent(key, this.provider).addAll(audiences);
         }
@@ -122,7 +122,7 @@ public class AudienceRegistry {
      * @param filter the predicate
      * @return the matching audience members
      */
-    public Iterable<? extends Audience> of(Predicate<Audience> filter) {
+    public Iterable<? extends Audience> of(Predicate<? super Audience> filter) {
         return this.registry.values().stream().flatMap(Collection::stream).filter(filter).toList();
     }
 }

--- a/src/main/java/net/minestom/server/adventure/audience/Audiences.java
+++ b/src/main/java/net/minestom/server/adventure/audience/Audiences.java
@@ -58,7 +58,7 @@ public class Audiences {
      * @param filter the predicate
      * @return all players matching the predicate
      */
-    public static Audience players(Predicate<Player> filter) {
+    public static Audience players(Predicate<? super Player> filter) {
         return PacketGroupingAudience.of(MinecraftServer.getConnectionManager().getOnlinePlayers().stream().filter(filter).toList());
     }
 
@@ -117,7 +117,7 @@ public class Audiences {
      * @param filter the predicate
      * @return all custom audience members stored using the key
      */
-    public static Audience custom(Keyed keyed, Predicate<Audience> filter) {
+    public static Audience custom(Keyed keyed, Predicate<? super Audience> filter) {
         return custom(keyed.key(), filter);
     }
 
@@ -129,7 +129,7 @@ public class Audiences {
      * @param filter the predicate
      * @return all custom audience members stored using the key
      */
-    public static Audience custom(Key key, Predicate<Audience> filter) {
+    public static Audience custom(Key key, Predicate<? super Audience> filter) {
         return Audience.audience(audience.iterable().custom(key, filter));
     }
 
@@ -139,7 +139,7 @@ public class Audiences {
      * @param filter the predicate
      * @return all matching custom audience members
      */
-    public static Audience customs(Predicate<Audience> filter) {
+    public static Audience customs(Predicate<? super Audience> filter) {
         return Audience.audience(audience.iterable().customs(filter));
     }
 
@@ -149,7 +149,7 @@ public class Audiences {
      * @param filter the predicate
      * @return all matching audience members
      */
-    public static Audience all(Predicate<Audience> filter) {
+    public static Audience all(Predicate<? super Audience> filter) {
         return Audience.audience(audience.iterable().all(filter));
     }
 

--- a/src/main/java/net/minestom/server/adventure/audience/IterableAudienceProvider.java
+++ b/src/main/java/net/minestom/server/adventure/audience/IterableAudienceProvider.java
@@ -38,7 +38,7 @@ class IterableAudienceProvider implements AudienceProvider<Iterable<? extends Au
     }
 
     @Override
-    public Iterable<? extends Audience> players(Predicate<Player> filter) {
+    public Iterable<? extends Audience> players(Predicate<? super Player> filter) {
         return MinecraftServer.getConnectionManager().getOnlinePlayers().stream().filter(filter).toList();
     }
 
@@ -66,17 +66,17 @@ class IterableAudienceProvider implements AudienceProvider<Iterable<? extends Au
     }
 
     @Override
-    public Iterable<? extends Audience> custom(Key key, Predicate<Audience> filter) {
+    public Iterable<? extends Audience> custom(Key key, Predicate<? super Audience> filter) {
         return StreamSupport.stream(this.registry.of(key).spliterator(), false).filter(filter).toList();
     }
 
     @Override
-    public Iterable<? extends Audience> customs(Predicate<Audience> filter) {
+    public Iterable<? extends Audience> customs(Predicate<? super Audience> filter) {
         return this.registry.of(filter);
     }
 
     @Override
-    public Iterable<? extends Audience> all(Predicate<Audience> filter) {
+    public Iterable<? extends Audience> all(Predicate<? super Audience> filter) {
         return StreamSupport.stream(this.all().spliterator(), false).filter(filter).toList();
     }
 

--- a/src/main/java/net/minestom/server/adventure/audience/PacketGroupingAudience.java
+++ b/src/main/java/net/minestom/server/adventure/audience/PacketGroupingAudience.java
@@ -36,7 +36,7 @@ public interface PacketGroupingAudience extends ForwardingAudience {
      * @param players the players
      * @return the audience
      */
-    static PacketGroupingAudience of(Collection<Player> players) {
+    static PacketGroupingAudience of(Collection<? extends Player> players) {
         return () -> players;
     }
 
@@ -45,7 +45,7 @@ public interface PacketGroupingAudience extends ForwardingAudience {
      *
      * @return the connections
      */
-    Collection<Player> getPlayers();
+    Collection<? extends Player> getPlayers();
 
     /**
      * Broadcast a ServerPacket to all players of this audience

--- a/src/main/java/net/minestom/server/adventure/audience/SingleAudienceProvider.java
+++ b/src/main/java/net/minestom/server/adventure/audience/SingleAudienceProvider.java
@@ -40,7 +40,7 @@ class SingleAudienceProvider implements AudienceProvider<Audience> {
     }
 
     @Override
-    public Audience players(Predicate<Player> filter) {
+    public Audience players(Predicate<? super Player> filter) {
         return PacketGroupingAudience.of(MinecraftServer.getConnectionManager().getOnlinePlayers().stream().filter(filter).toList());
     }
 
@@ -65,17 +65,17 @@ class SingleAudienceProvider implements AudienceProvider<Audience> {
     }
 
     @Override
-    public Audience custom(Key key, Predicate<Audience> filter) {
+    public Audience custom(Key key, Predicate<? super Audience> filter) {
         return Audience.audience(this.iterable().custom(key, filter));
     }
 
     @Override
-    public Audience customs(Predicate<Audience> filter) {
+    public Audience customs(Predicate<? super Audience> filter) {
         return Audience.audience(this.iterable().customs(filter));
     }
 
     @Override
-    public Audience all(Predicate<Audience> filter) {
+    public Audience all(Predicate<? super Audience> filter) {
         return Audience.audience(this.iterable().all(filter));
     }
 

--- a/src/main/java/net/minestom/server/adventure/bossbar/BossBarHolder.java
+++ b/src/main/java/net/minestom/server/adventure/bossbar/BossBarHolder.java
@@ -68,7 +68,7 @@ final class BossBarHolder implements Viewable {
     }
 
     @Override
-    public Set<Player> getViewers() {
+    public Set<? extends Player> getViewers() {
         return Collections.unmodifiableSet(this.players);
     }
 }

--- a/src/main/java/net/minestom/server/adventure/bossbar/BossBarManager.java
+++ b/src/main/java/net/minestom/server/adventure/bossbar/BossBarManager.java
@@ -70,9 +70,9 @@ public class BossBarManager {
      * @param players the players
      * @param bar     the boss bar
      */
-    public void addBossBar(Collection<Player> players, BossBar bar) {
+    public void addBossBar(Collection<? extends Player> players, BossBar bar) {
         BossBarHolder holder = this.getOrCreateHandler(bar);
-        Collection<Player> addedPlayers = players.stream().filter(holder::addViewer).toList();
+        Collection<? extends Player> addedPlayers = players.stream().filter(holder::addViewer).toList();
         if (!addedPlayers.isEmpty()) {
             PacketSendingUtils.sendGroupedPacket(addedPlayers, holder.createAddPacket());
         }
@@ -84,10 +84,10 @@ public class BossBarManager {
      * @param players the intended viewers
      * @param bar     the boss bar to hide
      */
-    public void removeBossBar(Collection<Player> players, BossBar bar) {
+    public void removeBossBar(Collection<? extends Player> players, BossBar bar) {
         BossBarHolder holder = this.bars.get(bar);
         if (holder != null) {
-            Collection<Player> removedPlayers = players.stream().filter(holder::removeViewer).toList();
+            Collection<? extends Player> removedPlayers = players.stream().filter(holder::removeViewer).toList();
             if (!removedPlayers.isEmpty()) {
                 PacketSendingUtils.sendGroupedPacket(removedPlayers, holder.createRemovePacket());
             }
@@ -143,7 +143,7 @@ public class BossBarManager {
      * @param bossBar the boss bar
      * @return the players
      */
-    public Collection<Player> getBossBarViewers(BossBar bossBar) {
+    public Collection<? extends Player> getBossBarViewers(BossBar bossBar) {
         BossBarHolder holder = this.bars.get(bossBar);
         return holder != null ?
                 Collections.unmodifiableCollection(holder.players) : List.of();

--- a/src/main/java/net/minestom/server/codec/StructCodec.java
+++ b/src/main/java/net/minestom/server/codec/StructCodec.java
@@ -187,8 +187,8 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new {@link StructCodec} template.
      */
     static <R, P1 extends @UnknownNullability Object> StructCodec<R> struct(
-            String name1, Codec<P1> codec1, Function<R, P1> getter1,
-            F1<P1, R> ctor
+            String name1, Codec<P1> codec1, Function<? super R, ? extends P1> getter1,
+            F1<? super P1, ? extends R> ctor
     ) {
         Objects.requireNonNull(name1, "name1");
         Objects.requireNonNull(codec1, "codec1");
@@ -228,9 +228,9 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new {@link StructCodec} template.
      */
     static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object> StructCodec<R> struct(
-            String name1, Codec<P1> codec1, Function<R, P1> getter1,
-            String name2, Codec<P2> codec2, Function<R, P2> getter2,
-            F2<P1, P2, R> ctor
+            String name1, Codec<P1> codec1, Function<? super R, ? extends P1> getter1,
+            String name2, Codec<P2> codec2, Function<? super R, ? extends P2> getter2,
+            F2<? super P1, ? super P2, ? extends R> ctor
     ) {
         Objects.requireNonNull(name1, "name1");
         Objects.requireNonNull(codec1, "codec1");
@@ -282,10 +282,10 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new {@link StructCodec} template.
      */
     static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object> StructCodec<R> struct(
-            String name1, Codec<P1> codec1, Function<R, P1> getter1,
-            String name2, Codec<P2> codec2, Function<R, P2> getter2,
-            String name3, Codec<P3> codec3, Function<R, P3> getter3,
-            F3<P1, P2, P3, R> ctor
+            String name1, Codec<P1> codec1, Function<? super R, ? extends P1> getter1,
+            String name2, Codec<P2> codec2, Function<? super R, ? extends P2> getter2,
+            String name3, Codec<P3> codec3, Function<? super R, ? extends P3> getter3,
+            F3<? super P1, ? super P2, ? super P3, ? extends R> ctor
     ) {
         Objects.requireNonNull(name1, "name1");
         Objects.requireNonNull(codec1, "codec1");
@@ -349,11 +349,11 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new {@link StructCodec} template.
      */
     static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object> StructCodec<R> struct(
-            String name1, Codec<P1> codec1, Function<R, P1> getter1,
-            String name2, Codec<P2> codec2, Function<R, P2> getter2,
-            String name3, Codec<P3> codec3, Function<R, P3> getter3,
-            String name4, Codec<P4> codec4, Function<R, P4> getter4,
-            F4<P1, P2, P3, P4, R> ctor
+            String name1, Codec<P1> codec1, Function<? super R, ? extends P1> getter1,
+            String name2, Codec<P2> codec2, Function<? super R, ? extends P2> getter2,
+            String name3, Codec<P3> codec3, Function<? super R, ? extends P3> getter3,
+            String name4, Codec<P4> codec4, Function<? super R, ? extends P4> getter4,
+            F4<? super P1, ? super P2, ? super P3, ? super P4, ? extends R> ctor
     ) {
         Objects.requireNonNull(name1, "name1");
         Objects.requireNonNull(codec1, "codec1");
@@ -429,12 +429,12 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new {@link StructCodec} template.
      */
     static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object> StructCodec<R> struct(
-            String name1, Codec<P1> codec1, Function<R, P1> getter1,
-            String name2, Codec<P2> codec2, Function<R, P2> getter2,
-            String name3, Codec<P3> codec3, Function<R, P3> getter3,
-            String name4, Codec<P4> codec4, Function<R, P4> getter4,
-            String name5, Codec<P5> codec5, Function<R, P5> getter5,
-            F5<P1, P2, P3, P4, P5, R> ctor
+            String name1, Codec<P1> codec1, Function<? super R, ? extends P1> getter1,
+            String name2, Codec<P2> codec2, Function<? super R, ? extends P2> getter2,
+            String name3, Codec<P3> codec3, Function<? super R, ? extends P3> getter3,
+            String name4, Codec<P4> codec4, Function<? super R, ? extends P4> getter4,
+            String name5, Codec<P5> codec5, Function<? super R, ? extends P5> getter5,
+            F5<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? extends R> ctor
     ) {
         Objects.requireNonNull(name1, "name1");
         Objects.requireNonNull(codec1, "codec1");
@@ -522,13 +522,13 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new {@link StructCodec} template.
      */
     static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object> StructCodec<R> struct(
-            String name1, Codec<P1> codec1, Function<R, P1> getter1,
-            String name2, Codec<P2> codec2, Function<R, P2> getter2,
-            String name3, Codec<P3> codec3, Function<R, P3> getter3,
-            String name4, Codec<P4> codec4, Function<R, P4> getter4,
-            String name5, Codec<P5> codec5, Function<R, P5> getter5,
-            String name6, Codec<P6> codec6, Function<R, P6> getter6,
-            F6<P1, P2, P3, P4, P5, P6, R> ctor
+            String name1, Codec<P1> codec1, Function<? super R, ? extends P1> getter1,
+            String name2, Codec<P2> codec2, Function<? super R, ? extends P2> getter2,
+            String name3, Codec<P3> codec3, Function<? super R, ? extends P3> getter3,
+            String name4, Codec<P4> codec4, Function<? super R, ? extends P4> getter4,
+            String name5, Codec<P5> codec5, Function<? super R, ? extends P5> getter5,
+            String name6, Codec<P6> codec6, Function<? super R, ? extends P6> getter6,
+            F6<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? extends R> ctor
     ) {
         Objects.requireNonNull(name1, "name1");
         Objects.requireNonNull(codec1, "codec1");
@@ -628,14 +628,14 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new {@link StructCodec} template.
      */
     static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object> StructCodec<R> struct(
-            String name1, Codec<P1> codec1, Function<R, P1> getter1,
-            String name2, Codec<P2> codec2, Function<R, P2> getter2,
-            String name3, Codec<P3> codec3, Function<R, P3> getter3,
-            String name4, Codec<P4> codec4, Function<R, P4> getter4,
-            String name5, Codec<P5> codec5, Function<R, P5> getter5,
-            String name6, Codec<P6> codec6, Function<R, P6> getter6,
-            String name7, Codec<P7> codec7, Function<R, P7> getter7,
-            F7<P1, P2, P3, P4, P5, P6, P7, R> ctor
+            String name1, Codec<P1> codec1, Function<? super R, ? extends P1> getter1,
+            String name2, Codec<P2> codec2, Function<? super R, ? extends P2> getter2,
+            String name3, Codec<P3> codec3, Function<? super R, ? extends P3> getter3,
+            String name4, Codec<P4> codec4, Function<? super R, ? extends P4> getter4,
+            String name5, Codec<P5> codec5, Function<? super R, ? extends P5> getter5,
+            String name6, Codec<P6> codec6, Function<? super R, ? extends P6> getter6,
+            String name7, Codec<P7> codec7, Function<? super R, ? extends P7> getter7,
+            F7<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? extends R> ctor
     ) {
         Objects.requireNonNull(name1, "name1");
         Objects.requireNonNull(codec1, "codec1");
@@ -748,15 +748,15 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new {@link StructCodec} template.
      */
     static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object> StructCodec<R> struct(
-            String name1, Codec<P1> codec1, Function<R, P1> getter1,
-            String name2, Codec<P2> codec2, Function<R, P2> getter2,
-            String name3, Codec<P3> codec3, Function<R, P3> getter3,
-            String name4, Codec<P4> codec4, Function<R, P4> getter4,
-            String name5, Codec<P5> codec5, Function<R, P5> getter5,
-            String name6, Codec<P6> codec6, Function<R, P6> getter6,
-            String name7, Codec<P7> codec7, Function<R, P7> getter7,
-            String name8, Codec<P8> codec8, Function<R, P8> getter8,
-            F8<P1, P2, P3, P4, P5, P6, P7, P8, R> ctor
+            String name1, Codec<P1> codec1, Function<? super R, ? extends P1> getter1,
+            String name2, Codec<P2> codec2, Function<? super R, ? extends P2> getter2,
+            String name3, Codec<P3> codec3, Function<? super R, ? extends P3> getter3,
+            String name4, Codec<P4> codec4, Function<? super R, ? extends P4> getter4,
+            String name5, Codec<P5> codec5, Function<? super R, ? extends P5> getter5,
+            String name6, Codec<P6> codec6, Function<? super R, ? extends P6> getter6,
+            String name7, Codec<P7> codec7, Function<? super R, ? extends P7> getter7,
+            String name8, Codec<P8> codec8, Function<? super R, ? extends P8> getter8,
+            F8<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? extends R> ctor
     ) {
         Objects.requireNonNull(name1, "name1");
         Objects.requireNonNull(codec1, "codec1");
@@ -880,16 +880,16 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new {@link StructCodec} template.
      */
     static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object> StructCodec<R> struct(
-            String name1, Codec<P1> codec1, Function<R, P1> getter1,
-            String name2, Codec<P2> codec2, Function<R, P2> getter2,
-            String name3, Codec<P3> codec3, Function<R, P3> getter3,
-            String name4, Codec<P4> codec4, Function<R, P4> getter4,
-            String name5, Codec<P5> codec5, Function<R, P5> getter5,
-            String name6, Codec<P6> codec6, Function<R, P6> getter6,
-            String name7, Codec<P7> codec7, Function<R, P7> getter7,
-            String name8, Codec<P8> codec8, Function<R, P8> getter8,
-            String name9, Codec<P9> codec9, Function<R, P9> getter9,
-            F9<P1, P2, P3, P4, P5, P6, P7, P8, P9, R> ctor
+            String name1, Codec<P1> codec1, Function<? super R, ? extends P1> getter1,
+            String name2, Codec<P2> codec2, Function<? super R, ? extends P2> getter2,
+            String name3, Codec<P3> codec3, Function<? super R, ? extends P3> getter3,
+            String name4, Codec<P4> codec4, Function<? super R, ? extends P4> getter4,
+            String name5, Codec<P5> codec5, Function<? super R, ? extends P5> getter5,
+            String name6, Codec<P6> codec6, Function<? super R, ? extends P6> getter6,
+            String name7, Codec<P7> codec7, Function<? super R, ? extends P7> getter7,
+            String name8, Codec<P8> codec8, Function<? super R, ? extends P8> getter8,
+            String name9, Codec<P9> codec9, Function<? super R, ? extends P9> getter9,
+            F9<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? extends R> ctor
     ) {
         Objects.requireNonNull(name1, "name1");
         Objects.requireNonNull(codec1, "codec1");
@@ -1025,17 +1025,17 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new {@link StructCodec} template.
      */
     static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object> StructCodec<R> struct(
-            String name1, Codec<P1> codec1, Function<R, P1> getter1,
-            String name2, Codec<P2> codec2, Function<R, P2> getter2,
-            String name3, Codec<P3> codec3, Function<R, P3> getter3,
-            String name4, Codec<P4> codec4, Function<R, P4> getter4,
-            String name5, Codec<P5> codec5, Function<R, P5> getter5,
-            String name6, Codec<P6> codec6, Function<R, P6> getter6,
-            String name7, Codec<P7> codec7, Function<R, P7> getter7,
-            String name8, Codec<P8> codec8, Function<R, P8> getter8,
-            String name9, Codec<P9> codec9, Function<R, P9> getter9,
-            String name10, Codec<P10> codec10, Function<R, P10> getter10,
-            F10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R> ctor
+            String name1, Codec<P1> codec1, Function<? super R, ? extends P1> getter1,
+            String name2, Codec<P2> codec2, Function<? super R, ? extends P2> getter2,
+            String name3, Codec<P3> codec3, Function<? super R, ? extends P3> getter3,
+            String name4, Codec<P4> codec4, Function<? super R, ? extends P4> getter4,
+            String name5, Codec<P5> codec5, Function<? super R, ? extends P5> getter5,
+            String name6, Codec<P6> codec6, Function<? super R, ? extends P6> getter6,
+            String name7, Codec<P7> codec7, Function<? super R, ? extends P7> getter7,
+            String name8, Codec<P8> codec8, Function<? super R, ? extends P8> getter8,
+            String name9, Codec<P9> codec9, Function<? super R, ? extends P9> getter9,
+            String name10, Codec<P10> codec10, Function<? super R, ? extends P10> getter10,
+            F10<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? extends R> ctor
     ) {
         Objects.requireNonNull(name1, "name1");
         Objects.requireNonNull(codec1, "codec1");
@@ -1183,18 +1183,18 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new {@link StructCodec} template.
      */
     static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object> StructCodec<R> struct(
-            String name1, Codec<P1> codec1, Function<R, P1> getter1,
-            String name2, Codec<P2> codec2, Function<R, P2> getter2,
-            String name3, Codec<P3> codec3, Function<R, P3> getter3,
-            String name4, Codec<P4> codec4, Function<R, P4> getter4,
-            String name5, Codec<P5> codec5, Function<R, P5> getter5,
-            String name6, Codec<P6> codec6, Function<R, P6> getter6,
-            String name7, Codec<P7> codec7, Function<R, P7> getter7,
-            String name8, Codec<P8> codec8, Function<R, P8> getter8,
-            String name9, Codec<P9> codec9, Function<R, P9> getter9,
-            String name10, Codec<P10> codec10, Function<R, P10> getter10,
-            String name11, Codec<P11> codec11, Function<R, P11> getter11,
-            F11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, R> ctor
+            String name1, Codec<P1> codec1, Function<? super R, ? extends P1> getter1,
+            String name2, Codec<P2> codec2, Function<? super R, ? extends P2> getter2,
+            String name3, Codec<P3> codec3, Function<? super R, ? extends P3> getter3,
+            String name4, Codec<P4> codec4, Function<? super R, ? extends P4> getter4,
+            String name5, Codec<P5> codec5, Function<? super R, ? extends P5> getter5,
+            String name6, Codec<P6> codec6, Function<? super R, ? extends P6> getter6,
+            String name7, Codec<P7> codec7, Function<? super R, ? extends P7> getter7,
+            String name8, Codec<P8> codec8, Function<? super R, ? extends P8> getter8,
+            String name9, Codec<P9> codec9, Function<? super R, ? extends P9> getter9,
+            String name10, Codec<P10> codec10, Function<? super R, ? extends P10> getter10,
+            String name11, Codec<P11> codec11, Function<? super R, ? extends P11> getter11,
+            F11<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? super P11, ? extends R> ctor
     ) {
         Objects.requireNonNull(name1, "name1");
         Objects.requireNonNull(codec1, "codec1");
@@ -1355,19 +1355,19 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new {@link StructCodec} template.
      */
     static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object> StructCodec<R> struct(
-            String name1, Codec<P1> codec1, Function<R, P1> getter1,
-            String name2, Codec<P2> codec2, Function<R, P2> getter2,
-            String name3, Codec<P3> codec3, Function<R, P3> getter3,
-            String name4, Codec<P4> codec4, Function<R, P4> getter4,
-            String name5, Codec<P5> codec5, Function<R, P5> getter5,
-            String name6, Codec<P6> codec6, Function<R, P6> getter6,
-            String name7, Codec<P7> codec7, Function<R, P7> getter7,
-            String name8, Codec<P8> codec8, Function<R, P8> getter8,
-            String name9, Codec<P9> codec9, Function<R, P9> getter9,
-            String name10, Codec<P10> codec10, Function<R, P10> getter10,
-            String name11, Codec<P11> codec11, Function<R, P11> getter11,
-            String name12, Codec<P12> codec12, Function<R, P12> getter12,
-            F12<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R> ctor
+            String name1, Codec<P1> codec1, Function<? super R, ? extends P1> getter1,
+            String name2, Codec<P2> codec2, Function<? super R, ? extends P2> getter2,
+            String name3, Codec<P3> codec3, Function<? super R, ? extends P3> getter3,
+            String name4, Codec<P4> codec4, Function<? super R, ? extends P4> getter4,
+            String name5, Codec<P5> codec5, Function<? super R, ? extends P5> getter5,
+            String name6, Codec<P6> codec6, Function<? super R, ? extends P6> getter6,
+            String name7, Codec<P7> codec7, Function<? super R, ? extends P7> getter7,
+            String name8, Codec<P8> codec8, Function<? super R, ? extends P8> getter8,
+            String name9, Codec<P9> codec9, Function<? super R, ? extends P9> getter9,
+            String name10, Codec<P10> codec10, Function<? super R, ? extends P10> getter10,
+            String name11, Codec<P11> codec11, Function<? super R, ? extends P11> getter11,
+            String name12, Codec<P12> codec12, Function<? super R, ? extends P12> getter12,
+            F12<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? super P11, ? super P12, ? extends R> ctor
     ) {
         Objects.requireNonNull(name1, "name1");
         Objects.requireNonNull(codec1, "codec1");
@@ -1539,20 +1539,20 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new {@link StructCodec} template.
      */
     static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object> StructCodec<R> struct(
-            String name1, Codec<P1> codec1, Function<R, P1> getter1,
-            String name2, Codec<P2> codec2, Function<R, P2> getter2,
-            String name3, Codec<P3> codec3, Function<R, P3> getter3,
-            String name4, Codec<P4> codec4, Function<R, P4> getter4,
-            String name5, Codec<P5> codec5, Function<R, P5> getter5,
-            String name6, Codec<P6> codec6, Function<R, P6> getter6,
-            String name7, Codec<P7> codec7, Function<R, P7> getter7,
-            String name8, Codec<P8> codec8, Function<R, P8> getter8,
-            String name9, Codec<P9> codec9, Function<R, P9> getter9,
-            String name10, Codec<P10> codec10, Function<R, P10> getter10,
-            String name11, Codec<P11> codec11, Function<R, P11> getter11,
-            String name12, Codec<P12> codec12, Function<R, P12> getter12,
-            String name13, Codec<P13> codec13, Function<R, P13> getter13,
-            F13<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, R> ctor
+            String name1, Codec<P1> codec1, Function<? super R, ? extends P1> getter1,
+            String name2, Codec<P2> codec2, Function<? super R, ? extends P2> getter2,
+            String name3, Codec<P3> codec3, Function<? super R, ? extends P3> getter3,
+            String name4, Codec<P4> codec4, Function<? super R, ? extends P4> getter4,
+            String name5, Codec<P5> codec5, Function<? super R, ? extends P5> getter5,
+            String name6, Codec<P6> codec6, Function<? super R, ? extends P6> getter6,
+            String name7, Codec<P7> codec7, Function<? super R, ? extends P7> getter7,
+            String name8, Codec<P8> codec8, Function<? super R, ? extends P8> getter8,
+            String name9, Codec<P9> codec9, Function<? super R, ? extends P9> getter9,
+            String name10, Codec<P10> codec10, Function<? super R, ? extends P10> getter10,
+            String name11, Codec<P11> codec11, Function<? super R, ? extends P11> getter11,
+            String name12, Codec<P12> codec12, Function<? super R, ? extends P12> getter12,
+            String name13, Codec<P13> codec13, Function<? super R, ? extends P13> getter13,
+            F13<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? super P11, ? super P12, ? super P13, ? extends R> ctor
     ) {
         Objects.requireNonNull(name1, "name1");
         Objects.requireNonNull(codec1, "codec1");
@@ -1736,21 +1736,21 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new {@link StructCodec} template.
      */
     static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object> StructCodec<R> struct(
-            String name1, Codec<P1> codec1, Function<R, P1> getter1,
-            String name2, Codec<P2> codec2, Function<R, P2> getter2,
-            String name3, Codec<P3> codec3, Function<R, P3> getter3,
-            String name4, Codec<P4> codec4, Function<R, P4> getter4,
-            String name5, Codec<P5> codec5, Function<R, P5> getter5,
-            String name6, Codec<P6> codec6, Function<R, P6> getter6,
-            String name7, Codec<P7> codec7, Function<R, P7> getter7,
-            String name8, Codec<P8> codec8, Function<R, P8> getter8,
-            String name9, Codec<P9> codec9, Function<R, P9> getter9,
-            String name10, Codec<P10> codec10, Function<R, P10> getter10,
-            String name11, Codec<P11> codec11, Function<R, P11> getter11,
-            String name12, Codec<P12> codec12, Function<R, P12> getter12,
-            String name13, Codec<P13> codec13, Function<R, P13> getter13,
-            String name14, Codec<P14> codec14, Function<R, P14> getter14,
-            F14<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, R> ctor
+            String name1, Codec<P1> codec1, Function<? super R, ? extends P1> getter1,
+            String name2, Codec<P2> codec2, Function<? super R, ? extends P2> getter2,
+            String name3, Codec<P3> codec3, Function<? super R, ? extends P3> getter3,
+            String name4, Codec<P4> codec4, Function<? super R, ? extends P4> getter4,
+            String name5, Codec<P5> codec5, Function<? super R, ? extends P5> getter5,
+            String name6, Codec<P6> codec6, Function<? super R, ? extends P6> getter6,
+            String name7, Codec<P7> codec7, Function<? super R, ? extends P7> getter7,
+            String name8, Codec<P8> codec8, Function<? super R, ? extends P8> getter8,
+            String name9, Codec<P9> codec9, Function<? super R, ? extends P9> getter9,
+            String name10, Codec<P10> codec10, Function<? super R, ? extends P10> getter10,
+            String name11, Codec<P11> codec11, Function<? super R, ? extends P11> getter11,
+            String name12, Codec<P12> codec12, Function<? super R, ? extends P12> getter12,
+            String name13, Codec<P13> codec13, Function<? super R, ? extends P13> getter13,
+            String name14, Codec<P14> codec14, Function<? super R, ? extends P14> getter14,
+            F14<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? super P11, ? super P12, ? super P13, ? super P14, ? extends R> ctor
     ) {
         Objects.requireNonNull(name1, "name1");
         Objects.requireNonNull(codec1, "codec1");
@@ -1946,22 +1946,22 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new {@link StructCodec} template.
      */
     static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object> StructCodec<R> struct(
-            String name1, Codec<P1> codec1, Function<R, P1> getter1,
-            String name2, Codec<P2> codec2, Function<R, P2> getter2,
-            String name3, Codec<P3> codec3, Function<R, P3> getter3,
-            String name4, Codec<P4> codec4, Function<R, P4> getter4,
-            String name5, Codec<P5> codec5, Function<R, P5> getter5,
-            String name6, Codec<P6> codec6, Function<R, P6> getter6,
-            String name7, Codec<P7> codec7, Function<R, P7> getter7,
-            String name8, Codec<P8> codec8, Function<R, P8> getter8,
-            String name9, Codec<P9> codec9, Function<R, P9> getter9,
-            String name10, Codec<P10> codec10, Function<R, P10> getter10,
-            String name11, Codec<P11> codec11, Function<R, P11> getter11,
-            String name12, Codec<P12> codec12, Function<R, P12> getter12,
-            String name13, Codec<P13> codec13, Function<R, P13> getter13,
-            String name14, Codec<P14> codec14, Function<R, P14> getter14,
-            String name15, Codec<P15> codec15, Function<R, P15> getter15,
-            F15<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, R> ctor
+            String name1, Codec<P1> codec1, Function<? super R, ? extends P1> getter1,
+            String name2, Codec<P2> codec2, Function<? super R, ? extends P2> getter2,
+            String name3, Codec<P3> codec3, Function<? super R, ? extends P3> getter3,
+            String name4, Codec<P4> codec4, Function<? super R, ? extends P4> getter4,
+            String name5, Codec<P5> codec5, Function<? super R, ? extends P5> getter5,
+            String name6, Codec<P6> codec6, Function<? super R, ? extends P6> getter6,
+            String name7, Codec<P7> codec7, Function<? super R, ? extends P7> getter7,
+            String name8, Codec<P8> codec8, Function<? super R, ? extends P8> getter8,
+            String name9, Codec<P9> codec9, Function<? super R, ? extends P9> getter9,
+            String name10, Codec<P10> codec10, Function<? super R, ? extends P10> getter10,
+            String name11, Codec<P11> codec11, Function<? super R, ? extends P11> getter11,
+            String name12, Codec<P12> codec12, Function<? super R, ? extends P12> getter12,
+            String name13, Codec<P13> codec13, Function<? super R, ? extends P13> getter13,
+            String name14, Codec<P14> codec14, Function<? super R, ? extends P14> getter14,
+            String name15, Codec<P15> codec15, Function<? super R, ? extends P15> getter15,
+            F15<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? super P11, ? super P12, ? super P13, ? super P14, ? super P15, ? extends R> ctor
     ) {
         Objects.requireNonNull(name1, "name1");
         Objects.requireNonNull(codec1, "codec1");
@@ -2169,23 +2169,23 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new {@link StructCodec} template.
      */
     static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object> StructCodec<R> struct(
-            String name1, Codec<P1> codec1, Function<R, P1> getter1,
-            String name2, Codec<P2> codec2, Function<R, P2> getter2,
-            String name3, Codec<P3> codec3, Function<R, P3> getter3,
-            String name4, Codec<P4> codec4, Function<R, P4> getter4,
-            String name5, Codec<P5> codec5, Function<R, P5> getter5,
-            String name6, Codec<P6> codec6, Function<R, P6> getter6,
-            String name7, Codec<P7> codec7, Function<R, P7> getter7,
-            String name8, Codec<P8> codec8, Function<R, P8> getter8,
-            String name9, Codec<P9> codec9, Function<R, P9> getter9,
-            String name10, Codec<P10> codec10, Function<R, P10> getter10,
-            String name11, Codec<P11> codec11, Function<R, P11> getter11,
-            String name12, Codec<P12> codec12, Function<R, P12> getter12,
-            String name13, Codec<P13> codec13, Function<R, P13> getter13,
-            String name14, Codec<P14> codec14, Function<R, P14> getter14,
-            String name15, Codec<P15> codec15, Function<R, P15> getter15,
-            String name16, Codec<P16> codec16, Function<R, P16> getter16,
-            F16<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, R> ctor
+            String name1, Codec<P1> codec1, Function<? super R, ? extends P1> getter1,
+            String name2, Codec<P2> codec2, Function<? super R, ? extends P2> getter2,
+            String name3, Codec<P3> codec3, Function<? super R, ? extends P3> getter3,
+            String name4, Codec<P4> codec4, Function<? super R, ? extends P4> getter4,
+            String name5, Codec<P5> codec5, Function<? super R, ? extends P5> getter5,
+            String name6, Codec<P6> codec6, Function<? super R, ? extends P6> getter6,
+            String name7, Codec<P7> codec7, Function<? super R, ? extends P7> getter7,
+            String name8, Codec<P8> codec8, Function<? super R, ? extends P8> getter8,
+            String name9, Codec<P9> codec9, Function<? super R, ? extends P9> getter9,
+            String name10, Codec<P10> codec10, Function<? super R, ? extends P10> getter10,
+            String name11, Codec<P11> codec11, Function<? super R, ? extends P11> getter11,
+            String name12, Codec<P12> codec12, Function<? super R, ? extends P12> getter12,
+            String name13, Codec<P13> codec13, Function<? super R, ? extends P13> getter13,
+            String name14, Codec<P14> codec14, Function<? super R, ? extends P14> getter14,
+            String name15, Codec<P15> codec15, Function<? super R, ? extends P15> getter15,
+            String name16, Codec<P16> codec16, Function<? super R, ? extends P16> getter16,
+            F16<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? super P11, ? super P12, ? super P13, ? super P14, ? super P15, ? super P16, ? extends R> ctor
     ) {
         Objects.requireNonNull(name1, "name1");
         Objects.requireNonNull(codec1, "codec1");
@@ -2405,24 +2405,24 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new {@link StructCodec} template.
      */
     static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object> StructCodec<R> struct(
-            String name1, Codec<P1> codec1, Function<R, P1> getter1,
-            String name2, Codec<P2> codec2, Function<R, P2> getter2,
-            String name3, Codec<P3> codec3, Function<R, P3> getter3,
-            String name4, Codec<P4> codec4, Function<R, P4> getter4,
-            String name5, Codec<P5> codec5, Function<R, P5> getter5,
-            String name6, Codec<P6> codec6, Function<R, P6> getter6,
-            String name7, Codec<P7> codec7, Function<R, P7> getter7,
-            String name8, Codec<P8> codec8, Function<R, P8> getter8,
-            String name9, Codec<P9> codec9, Function<R, P9> getter9,
-            String name10, Codec<P10> codec10, Function<R, P10> getter10,
-            String name11, Codec<P11> codec11, Function<R, P11> getter11,
-            String name12, Codec<P12> codec12, Function<R, P12> getter12,
-            String name13, Codec<P13> codec13, Function<R, P13> getter13,
-            String name14, Codec<P14> codec14, Function<R, P14> getter14,
-            String name15, Codec<P15> codec15, Function<R, P15> getter15,
-            String name16, Codec<P16> codec16, Function<R, P16> getter16,
-            String name17, Codec<P17> codec17, Function<R, P17> getter17,
-            F17<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, R> ctor
+            String name1, Codec<P1> codec1, Function<? super R, ? extends P1> getter1,
+            String name2, Codec<P2> codec2, Function<? super R, ? extends P2> getter2,
+            String name3, Codec<P3> codec3, Function<? super R, ? extends P3> getter3,
+            String name4, Codec<P4> codec4, Function<? super R, ? extends P4> getter4,
+            String name5, Codec<P5> codec5, Function<? super R, ? extends P5> getter5,
+            String name6, Codec<P6> codec6, Function<? super R, ? extends P6> getter6,
+            String name7, Codec<P7> codec7, Function<? super R, ? extends P7> getter7,
+            String name8, Codec<P8> codec8, Function<? super R, ? extends P8> getter8,
+            String name9, Codec<P9> codec9, Function<? super R, ? extends P9> getter9,
+            String name10, Codec<P10> codec10, Function<? super R, ? extends P10> getter10,
+            String name11, Codec<P11> codec11, Function<? super R, ? extends P11> getter11,
+            String name12, Codec<P12> codec12, Function<? super R, ? extends P12> getter12,
+            String name13, Codec<P13> codec13, Function<? super R, ? extends P13> getter13,
+            String name14, Codec<P14> codec14, Function<? super R, ? extends P14> getter14,
+            String name15, Codec<P15> codec15, Function<? super R, ? extends P15> getter15,
+            String name16, Codec<P16> codec16, Function<? super R, ? extends P16> getter16,
+            String name17, Codec<P17> codec17, Function<? super R, ? extends P17> getter17,
+            F17<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? super P11, ? super P12, ? super P13, ? super P14, ? super P15, ? super P16, ? super P17, ? extends R> ctor
     ) {
         Objects.requireNonNull(name1, "name1");
         Objects.requireNonNull(codec1, "codec1");
@@ -2654,25 +2654,25 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new {@link StructCodec} template.
      */
     static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, P18 extends @UnknownNullability Object> StructCodec<R> struct(
-            String name1, Codec<P1> codec1, Function<R, P1> getter1,
-            String name2, Codec<P2> codec2, Function<R, P2> getter2,
-            String name3, Codec<P3> codec3, Function<R, P3> getter3,
-            String name4, Codec<P4> codec4, Function<R, P4> getter4,
-            String name5, Codec<P5> codec5, Function<R, P5> getter5,
-            String name6, Codec<P6> codec6, Function<R, P6> getter6,
-            String name7, Codec<P7> codec7, Function<R, P7> getter7,
-            String name8, Codec<P8> codec8, Function<R, P8> getter8,
-            String name9, Codec<P9> codec9, Function<R, P9> getter9,
-            String name10, Codec<P10> codec10, Function<R, P10> getter10,
-            String name11, Codec<P11> codec11, Function<R, P11> getter11,
-            String name12, Codec<P12> codec12, Function<R, P12> getter12,
-            String name13, Codec<P13> codec13, Function<R, P13> getter13,
-            String name14, Codec<P14> codec14, Function<R, P14> getter14,
-            String name15, Codec<P15> codec15, Function<R, P15> getter15,
-            String name16, Codec<P16> codec16, Function<R, P16> getter16,
-            String name17, Codec<P17> codec17, Function<R, P17> getter17,
-            String name18, Codec<P18> codec18, Function<R, P18> getter18,
-            F18<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, R> ctor
+            String name1, Codec<P1> codec1, Function<? super R, ? extends P1> getter1,
+            String name2, Codec<P2> codec2, Function<? super R, ? extends P2> getter2,
+            String name3, Codec<P3> codec3, Function<? super R, ? extends P3> getter3,
+            String name4, Codec<P4> codec4, Function<? super R, ? extends P4> getter4,
+            String name5, Codec<P5> codec5, Function<? super R, ? extends P5> getter5,
+            String name6, Codec<P6> codec6, Function<? super R, ? extends P6> getter6,
+            String name7, Codec<P7> codec7, Function<? super R, ? extends P7> getter7,
+            String name8, Codec<P8> codec8, Function<? super R, ? extends P8> getter8,
+            String name9, Codec<P9> codec9, Function<? super R, ? extends P9> getter9,
+            String name10, Codec<P10> codec10, Function<? super R, ? extends P10> getter10,
+            String name11, Codec<P11> codec11, Function<? super R, ? extends P11> getter11,
+            String name12, Codec<P12> codec12, Function<? super R, ? extends P12> getter12,
+            String name13, Codec<P13> codec13, Function<? super R, ? extends P13> getter13,
+            String name14, Codec<P14> codec14, Function<? super R, ? extends P14> getter14,
+            String name15, Codec<P15> codec15, Function<? super R, ? extends P15> getter15,
+            String name16, Codec<P16> codec16, Function<? super R, ? extends P16> getter16,
+            String name17, Codec<P17> codec17, Function<? super R, ? extends P17> getter17,
+            String name18, Codec<P18> codec18, Function<? super R, ? extends P18> getter18,
+            F18<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? super P11, ? super P12, ? super P13, ? super P14, ? super P15, ? super P16, ? super P17, ? super P18, ? extends R> ctor
     ) {
         Objects.requireNonNull(name1, "name1");
         Objects.requireNonNull(codec1, "codec1");
@@ -2916,26 +2916,26 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new {@link StructCodec} template.
      */
     static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, P18 extends @UnknownNullability Object, P19 extends @UnknownNullability Object> StructCodec<R> struct(
-            String name1, Codec<P1> codec1, Function<R, P1> getter1,
-            String name2, Codec<P2> codec2, Function<R, P2> getter2,
-            String name3, Codec<P3> codec3, Function<R, P3> getter3,
-            String name4, Codec<P4> codec4, Function<R, P4> getter4,
-            String name5, Codec<P5> codec5, Function<R, P5> getter5,
-            String name6, Codec<P6> codec6, Function<R, P6> getter6,
-            String name7, Codec<P7> codec7, Function<R, P7> getter7,
-            String name8, Codec<P8> codec8, Function<R, P8> getter8,
-            String name9, Codec<P9> codec9, Function<R, P9> getter9,
-            String name10, Codec<P10> codec10, Function<R, P10> getter10,
-            String name11, Codec<P11> codec11, Function<R, P11> getter11,
-            String name12, Codec<P12> codec12, Function<R, P12> getter12,
-            String name13, Codec<P13> codec13, Function<R, P13> getter13,
-            String name14, Codec<P14> codec14, Function<R, P14> getter14,
-            String name15, Codec<P15> codec15, Function<R, P15> getter15,
-            String name16, Codec<P16> codec16, Function<R, P16> getter16,
-            String name17, Codec<P17> codec17, Function<R, P17> getter17,
-            String name18, Codec<P18> codec18, Function<R, P18> getter18,
-            String name19, Codec<P19> codec19, Function<R, P19> getter19,
-            F19<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, R> ctor
+            String name1, Codec<P1> codec1, Function<? super R, ? extends P1> getter1,
+            String name2, Codec<P2> codec2, Function<? super R, ? extends P2> getter2,
+            String name3, Codec<P3> codec3, Function<? super R, ? extends P3> getter3,
+            String name4, Codec<P4> codec4, Function<? super R, ? extends P4> getter4,
+            String name5, Codec<P5> codec5, Function<? super R, ? extends P5> getter5,
+            String name6, Codec<P6> codec6, Function<? super R, ? extends P6> getter6,
+            String name7, Codec<P7> codec7, Function<? super R, ? extends P7> getter7,
+            String name8, Codec<P8> codec8, Function<? super R, ? extends P8> getter8,
+            String name9, Codec<P9> codec9, Function<? super R, ? extends P9> getter9,
+            String name10, Codec<P10> codec10, Function<? super R, ? extends P10> getter10,
+            String name11, Codec<P11> codec11, Function<? super R, ? extends P11> getter11,
+            String name12, Codec<P12> codec12, Function<? super R, ? extends P12> getter12,
+            String name13, Codec<P13> codec13, Function<? super R, ? extends P13> getter13,
+            String name14, Codec<P14> codec14, Function<? super R, ? extends P14> getter14,
+            String name15, Codec<P15> codec15, Function<? super R, ? extends P15> getter15,
+            String name16, Codec<P16> codec16, Function<? super R, ? extends P16> getter16,
+            String name17, Codec<P17> codec17, Function<? super R, ? extends P17> getter17,
+            String name18, Codec<P18> codec18, Function<? super R, ? extends P18> getter18,
+            String name19, Codec<P19> codec19, Function<? super R, ? extends P19> getter19,
+            F19<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? super P11, ? super P12, ? super P13, ? super P14, ? super P15, ? super P16, ? super P17, ? super P18, ? super P19, ? extends R> ctor
     ) {
         Objects.requireNonNull(name1, "name1");
         Objects.requireNonNull(codec1, "codec1");
@@ -3191,27 +3191,27 @@ public interface StructCodec<R> extends Codec<R> {
      * @return the new {@link StructCodec} template.
      */
     static <R, P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, P18 extends @UnknownNullability Object, P19 extends @UnknownNullability Object, P20 extends @UnknownNullability Object> StructCodec<R> struct(
-            String name1, Codec<P1> codec1, Function<R, P1> getter1,
-            String name2, Codec<P2> codec2, Function<R, P2> getter2,
-            String name3, Codec<P3> codec3, Function<R, P3> getter3,
-            String name4, Codec<P4> codec4, Function<R, P4> getter4,
-            String name5, Codec<P5> codec5, Function<R, P5> getter5,
-            String name6, Codec<P6> codec6, Function<R, P6> getter6,
-            String name7, Codec<P7> codec7, Function<R, P7> getter7,
-            String name8, Codec<P8> codec8, Function<R, P8> getter8,
-            String name9, Codec<P9> codec9, Function<R, P9> getter9,
-            String name10, Codec<P10> codec10, Function<R, P10> getter10,
-            String name11, Codec<P11> codec11, Function<R, P11> getter11,
-            String name12, Codec<P12> codec12, Function<R, P12> getter12,
-            String name13, Codec<P13> codec13, Function<R, P13> getter13,
-            String name14, Codec<P14> codec14, Function<R, P14> getter14,
-            String name15, Codec<P15> codec15, Function<R, P15> getter15,
-            String name16, Codec<P16> codec16, Function<R, P16> getter16,
-            String name17, Codec<P17> codec17, Function<R, P17> getter17,
-            String name18, Codec<P18> codec18, Function<R, P18> getter18,
-            String name19, Codec<P19> codec19, Function<R, P19> getter19,
-            String name20, Codec<P20> codec20, Function<R, P20> getter20,
-            F20<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, R> ctor
+            String name1, Codec<P1> codec1, Function<? super R, ? extends P1> getter1,
+            String name2, Codec<P2> codec2, Function<? super R, ? extends P2> getter2,
+            String name3, Codec<P3> codec3, Function<? super R, ? extends P3> getter3,
+            String name4, Codec<P4> codec4, Function<? super R, ? extends P4> getter4,
+            String name5, Codec<P5> codec5, Function<? super R, ? extends P5> getter5,
+            String name6, Codec<P6> codec6, Function<? super R, ? extends P6> getter6,
+            String name7, Codec<P7> codec7, Function<? super R, ? extends P7> getter7,
+            String name8, Codec<P8> codec8, Function<? super R, ? extends P8> getter8,
+            String name9, Codec<P9> codec9, Function<? super R, ? extends P9> getter9,
+            String name10, Codec<P10> codec10, Function<? super R, ? extends P10> getter10,
+            String name11, Codec<P11> codec11, Function<? super R, ? extends P11> getter11,
+            String name12, Codec<P12> codec12, Function<? super R, ? extends P12> getter12,
+            String name13, Codec<P13> codec13, Function<? super R, ? extends P13> getter13,
+            String name14, Codec<P14> codec14, Function<? super R, ? extends P14> getter14,
+            String name15, Codec<P15> codec15, Function<? super R, ? extends P15> getter15,
+            String name16, Codec<P16> codec16, Function<? super R, ? extends P16> getter16,
+            String name17, Codec<P17> codec17, Function<? super R, ? extends P17> getter17,
+            String name18, Codec<P18> codec18, Function<? super R, ? extends P18> getter18,
+            String name19, Codec<P19> codec19, Function<? super R, ? extends P19> getter19,
+            String name20, Codec<P20> codec20, Function<? super R, ? extends P20> getter20,
+            F20<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? super P11, ? super P12, ? super P13, ? super P14, ? super P15, ? super P16, ? super P17, ? super P18, ? super P19, ? super P20, ? extends R> ctor
     ) {
         Objects.requireNonNull(name1, "name1");
         Objects.requireNonNull(codec1, "codec1");

--- a/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentItemStack.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentItemStack.java
@@ -2,7 +2,6 @@ package net.minestom.server.command.builder.arguments.minecraft;
 
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.BinaryTag;
-import net.kyori.adventure.nbt.CompoundBinaryTag;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.adventure.MinestomAdventure;
 import net.minestom.server.codec.Result;
@@ -13,11 +12,10 @@ import net.minestom.server.command.builder.arguments.Argument;
 import net.minestom.server.command.builder.exception.ArgumentSyntaxException;
 import net.minestom.server.component.DataComponent;
 import net.minestom.server.component.DataComponentMap;
-import net.minestom.server.component.DataComponents;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
-import net.minestom.server.item.component.CustomData;
 import net.minestom.server.registry.RegistryTranscoder;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 
@@ -26,14 +24,13 @@ import java.io.IOException;
  * <p>
  * It is the same type as the one used in the /give command.
  * <p>
- * Example: diamond_sword{display:{Name:"{\"text\":\"Sword of Power\"}"}}
+ * Example: diamond_sword[minecraft:custom_name={text:"Sword of Power"}]
  */
 public class ArgumentItemStack extends Argument<ItemStack> {
 
-    public static final int NO_MATERIAL = 1;
-    public static final int INVALID_NBT = 2;
-    public static final int INVALID_MATERIAL = 3;
-    public static final int INVALID_COMPONENT = 4;
+    public static final int INVALID_NBT = 1;
+    public static final int INVALID_MATERIAL = 2;
+    public static final int INVALID_COMPONENT = 3;
 
     public ArgumentItemStack(String id) {
         super(id, true);
@@ -56,47 +53,43 @@ public class ArgumentItemStack extends Argument<ItemStack> {
     public static ItemStack staticParse(String input) throws ArgumentSyntaxException {
         var reader = new StringReader(input);
 
-        final Material material = Material.fromKey(reader.readKey());
+        Key materialKey = reader.readKey();
+        final Material material = materialKey == null ? null : Material.fromKey(materialKey);
         if (material == null)
             throw new ArgumentSyntaxException("Material is invalid", input, INVALID_MATERIAL);
         if (!reader.hasMore()) {
             return ItemStack.of(material); // Nothing else, we have our item
         }
 
-        DataComponentMap.Builder components = DataComponentMap.builder();
+        DataComponentMap.PatchBuilder components = DataComponentMap.patchBuilder();
 
         // Parse the declared components
         if (reader.peek() == '[') {
             reader.consume('[');
             final Transcoder<BinaryTag> coder = new RegistryTranscoder<>(Transcoder.NBT, MinecraftServer.process());
             do {
+                final boolean remove = reader.peek() == '!';
+                if (remove)
+                    reader.consume('!');
                 final Key componentId = reader.readKey();
                 final DataComponent<?> component = DataComponent.fromKey(componentId);
                 if (component == null)
                     throw new ArgumentSyntaxException("Unknown item component", input, INVALID_COMPONENT);
+                if (components.has(component))
+                    throw new ArgumentSyntaxException("Repeated item component", input, INVALID_COMPONENT);
 
-                reader.consume('=');
-
-                final Result<Object> componentValueResult = (Result<Object>) component.decode(coder, reader.readTag());
-                components.set((DataComponent<Object>) component, componentValueResult.orElseThrow());
+                if (remove)
+                    components.remove(component);
+                else {
+                    reader.consume('=');
+                    final Result<Object> componentValueResult = (Result<Object>) component.decode(coder, reader.readTag());
+                    components.set((DataComponent<Object>) component, componentValueResult.orElseThrow());
+                }
 
                 if (reader.peek() != ']')
                     reader.consume(',');
             } while (reader.peek() != ']');
             reader.consume(']');
-        }
-
-        // Parse the NBT
-        if (reader.hasMore() && reader.peek() == '{') {
-            final BinaryTag nbt = reader.readTag();
-            if (!(nbt instanceof CompoundBinaryTag compound))
-                throw new ArgumentSyntaxException("Item NBT must be compound", input, INVALID_NBT);
-
-            final CompoundBinaryTag customData = CompoundBinaryTag.builder()
-                    .put(components.get(DataComponents.CUSTOM_DATA, CustomData.EMPTY).nbt())
-                    .put(compound)
-                    .build();
-            components.set(DataComponents.CUSTOM_DATA, new CustomData(customData));
         }
 
         if (reader.hasMore())
@@ -138,13 +131,15 @@ public class ArgumentItemStack extends Argument<ItemStack> {
             index++;
         }
 
-        public Key readKey() {
+        public @Nullable Key readKey() {
             char c;
             int start = index;
-            while (hasMore() && (c = peek()) != '{' && c != '[' && c != '=') {
+            while (hasMore() && (c = peek()) != '{' && c != '[' && c != '=' && c != ',' && c != ']') {
                 index++;
             }
-            return Key.key(input.substring(start, index));
+            String key = input.substring(start, index);
+            if (!Key.parseable(key)) return null;
+            return Key.key(key);
         }
 
         public BinaryTag readTag() {

--- a/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentItemStack.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentItemStack.java
@@ -24,7 +24,7 @@ import java.io.IOException;
  * <p>
  * It is the same type as the one used in the /give command.
  * <p>
- * Example: diamond_sword{display:{Name:"{\"text\":\"Sword of Power\"}"}}
+ * Example: diamond_sword[custom_name={text:"Sword of Power"}]
  */
 public class ArgumentItemStack extends Argument<ItemStack> {
 

--- a/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentItemStack.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentItemStack.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 
 /**
- * Argument which can be used to retrieve an {@link ItemStack} from its material and with NBT data.
+ * Argument which can be used to retrieve an {@link ItemStack} from its material and with component data.
  * <p>
  * It is the same type as the one used in the /give command.
  * <p>

--- a/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentItemStack.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentItemStack.java
@@ -24,7 +24,7 @@ import java.io.IOException;
  * <p>
  * It is the same type as the one used in the /give command.
  * <p>
- * Example: diamond_sword[minecraft:custom_name={text:"Sword of Power"}]
+ * Example: diamond_sword{display:{Name:"{\"text\":\"Sword of Power\"}"}}
  */
 public class ArgumentItemStack extends Argument<ItemStack> {
 
@@ -38,19 +38,6 @@ public class ArgumentItemStack extends Argument<ItemStack> {
 
     @Override
     public ItemStack parse(CommandSender sender, String input) throws ArgumentSyntaxException {
-        return staticParse(input);
-    }
-
-    @Override
-    public ArgumentParserType parser() {
-        return ArgumentParserType.ITEM_STACK;
-    }
-
-    /**
-     * @deprecated use {@link Argument#parse(CommandSender, Argument)}
-     */
-    @SuppressWarnings("unchecked") @Deprecated
-    public static ItemStack staticParse(String input) throws ArgumentSyntaxException {
         var reader = new StringReader(input);
 
         Key materialKey = reader.readKey();
@@ -96,6 +83,11 @@ public class ArgumentItemStack extends Argument<ItemStack> {
             throw new ArgumentSyntaxException("Unexpected remaining input", input, INVALID_NBT);
 
         return ItemStack.of(material, components.build());
+    }
+
+    @Override
+    public ArgumentParserType parser() {
+        return ArgumentParserType.ITEM_STACK;
     }
 
     @Override

--- a/src/main/java/net/minestom/server/coordinate/BlockVec.java
+++ b/src/main/java/net/minestom/server/coordinate/BlockVec.java
@@ -5,282 +5,663 @@ import net.minestom.server.utils.Direction;
 import org.jetbrains.annotations.Contract;
 
 import java.util.function.DoubleUnaryOperator;
+import java.util.function.IntUnaryOperator;
 
-import static net.minestom.server.coordinate.CoordConversion.SECTION_SIZE;
 import static net.minestom.server.coordinate.CoordConversion.globalToBlock;
 
 /**
- * Represents an immutable block position.
+ * Represents a 3D vector with block-aligned coordinates.
  * <p>
- * Usage note: If you accept a block position as an argument to a method,
- * it's usually better to accept a Point rather than a BlockVec to avoid
- * callers continually having to convert.
+ * Using 12 bytes compared to 24 bytes for {@link Vec}.
+ * Ideal for block positions, chunk coordinates, and anything on a grid.
+ * <p>
+ * Conversion: When constructed from {@code double} values,
+ * coordinates are floored to the nearest integer block position.
+ * <p>
+ * Instances are immutable. All operations return new instances
+ * (either {@link BlockVec} for integer results or {@link Vec} where doubles are used).
+ *
+ * @param blockX the block X coordinate
+ * @param blockY the block Y coordinate
+ * @param blockZ the block Z coordinate
  */
 public record BlockVec(int blockX, int blockY, int blockZ) implements Point {
     public static final BlockVec ZERO = new BlockVec(0);
     public static final BlockVec ONE = new BlockVec(1);
     public static final BlockVec SECTION = new BlockVec(SECTION_SIZE);
+    public static final BlockVec CHUNK = new BlockVec(SECTION_SIZE, SECTION_SIZE);
+    public static final BlockVec REGION = new BlockVec(REGION_SIZE, REGION_SIZE);
 
+    /**
+     * Narrows an assumed global coordinate to a block coordinate by flooring the value.
+     * <br>
+     * Developer Note: Minestom should not call this constructor without explicit warnings.
+     *
+     * @param x the global x coordinate
+     * @param y the global y coordinate
+     * @param z the global z coordinate
+     */
     public BlockVec(double x, double y, double z) {
         this(globalToBlock(x), globalToBlock(y), globalToBlock(z));
     }
 
-    public BlockVec(Point point) {
-        this(point.blockX(), point.blockY(), point.blockZ());
-    }
-
-    public BlockVec(int value) {
-        this(value, value, value);
-    }
-
+    /**
+     * Creates a block vector with the given value for all coordinates.
+     * See {@link #BlockVec(double, double, double)} for side effects.
+     *
+     * @param value the value
+     */
     public BlockVec(double value) {
         this(value, value, value);
     }
 
+    /**
+     * Creates a block vector from a point.
+     *
+     * @param point the point
+     * @deprecated Use {@link Point#asBlockVec()} instead
+     */
+    @Deprecated(forRemoval = true)
+    public BlockVec(Point point) {
+        this(point.blockX(), point.blockY(), point.blockZ());
+    }
+
+    /**
+     * Creates a BlockVec with the blockX and blockZ, with blockY being zero.
+     *
+     * @param blockX the blockX
+     * @param blockZ the blockZ
+     */
+    public BlockVec(int blockX, int blockZ) {
+        this(blockX, 0, blockZ);
+    }
+
+    /**
+     * Creates a block vector with the given value for all coordinates (x/y/z).
+     *
+     * @param value the value
+     */
+    public BlockVec(int value) {
+        this(value, value, value);
+    }
+
     @Override
+    @Contract(pure = true)
     public double x() {
         return blockX;
     }
 
     @Override
+    @Contract(pure = true)
     public double y() {
         return blockY;
     }
 
     @Override
+    @Contract(pure = true)
     public double z() {
         return blockZ;
     }
 
+    /**
+     * Applies the given operator to this block vector.
+     *
+     * @param operator the operator to apply
+     * @return the resulting block vector
+     */
+    public BlockVec apply(Operator operator) {
+        return operator.apply(blockX, blockY, blockZ);
+    }
+
     @Override
-    public Point withX(DoubleUnaryOperator operator) {
+    @Contract("_ -> new")
+    public Vec withX(DoubleUnaryOperator operator) {
         return new Vec(operator.applyAsDouble(blockX), blockY, blockZ);
     }
 
     @Override
-    public Point withX(double x) {
+    @Contract(pure = true, value = "_ -> new")
+    public Vec withX(double x) {
         return new Vec(x, blockY, blockZ);
     }
 
-    @Contract(pure = true)
-    public BlockVec withBlockX(int x) {
-        return new BlockVec(x, blockY, blockZ);
+    /**
+     * Sets the block X coordinate to the given value.
+     *
+     * @param blockX the block X coordinate
+     * @return the resulting block vector
+     */
+    @Contract(pure = true, value = "_ -> new")
+    public BlockVec withBlockX(int blockX) {
+        return new BlockVec(blockX, blockY, blockZ);
+    }
+
+    /**
+     * Applies the given operator to the block X coordinate.
+     *
+     * @param operator the operator to apply
+     * @return the resulting block vector
+     */
+    @Contract("_ -> new")
+    public BlockVec withBlockX(IntUnaryOperator operator) {
+        return new BlockVec(operator.applyAsInt(blockX), blockY, blockZ);
     }
 
     @Override
-    public Point withY(DoubleUnaryOperator operator) {
+    @Contract("_ -> new")
+    public Vec withY(DoubleUnaryOperator operator) {
         return new Vec(blockX, operator.applyAsDouble(blockY), blockZ);
     }
 
     @Override
-    public Point withY(double y) {
+    @Contract(pure = true, value = "_ -> new")
+    public Vec withY(double y) {
         return new Vec(blockX, y, blockZ);
     }
 
-    @Contract(pure = true)
-    public BlockVec withBlockY(int y) {
-        return new BlockVec(blockX, y, blockZ);
+    /**
+     * Sets the block Y coordinate to the given value.
+     *
+     * @param blockY the block Y coordinate
+     * @return the resulting block vector
+     */
+    @Contract(pure = true, value = "_ -> new")
+    public BlockVec withBlockY(int blockY) {
+        return new BlockVec(blockX, blockY, blockZ);
+    }
+
+    /**
+     * Applies the given operator to the block Y coordinate.
+     *
+     * @param operator the operator to apply
+     * @return the resulting block vector
+     */
+    @Contract("_ -> new")
+    public BlockVec withBlockY(IntUnaryOperator operator) {
+        return new BlockVec(blockX, operator.applyAsInt(blockY), blockZ);
     }
 
     @Override
-    public Point withZ(DoubleUnaryOperator operator) {
+    @Contract("_ -> new")
+    public Vec withZ(DoubleUnaryOperator operator) {
         return new Vec(blockX, blockY, operator.applyAsDouble(blockZ));
     }
 
     @Override
-    public Point withZ(double z) {
+    @Contract(pure = true, value = "_ -> new")
+    public Vec withZ(double z) {
         return new Vec(blockX, blockY, z);
     }
 
-    @Contract(pure = true)
-    public BlockVec withBlockZ(int z) {
-        return new BlockVec(blockX, blockY, z);
+    /**
+     * Sets the block Z coordinate to the given value.
+     *
+     * @param blockZ the block Z coordinate
+     * @return the resulting block vector
+     */
+    @Contract(pure = true, value = "_ -> new")
+    public BlockVec withBlockZ(int blockZ) {
+        return new BlockVec(blockX, blockY, blockZ);
+    }
+
+    /**
+     * Applies the given operator to the block Z coordinate.
+     *
+     * @param operator the operator to apply
+     * @return the resulting block vector
+     */
+    @Contract("_ -> new")
+    public BlockVec withBlockZ(IntUnaryOperator operator) {
+        return new BlockVec(blockX, blockY, operator.applyAsInt(blockZ));
     }
 
     @Override
-    public Point add(double x, double y, double z) {
+    @Contract(pure = true, value = "_, _, _ -> new")
+    public Vec add(double x, double y, double z) {
         return new Vec(blockX + x, blockY + y, blockZ + z);
     }
 
-    @Contract(pure = true)
-    public BlockVec add(int x, int y, int z) {
-        return new BlockVec(blockX + x, blockY + y, blockZ + z);
+    /**
+     * Adds the given block XYZ to this block vector.
+     *
+     * @param blockX the block X to add
+     * @param blockY the block Y to add
+     * @param blockZ the block Z to add
+     * @return the resulting block vector
+     */
+    @Contract(pure = true, value = "_, _, _ -> new")
+    public BlockVec add(int blockX, int blockY, int blockZ) {
+        return new BlockVec(this.blockX + blockX, this.blockY + blockY, this.blockZ + blockZ);
     }
 
     @Override
-    public Point add(Point point) {
+    @Contract(pure = true, value = "_ -> new")
+    public Vec add(Point point) {
         return new Vec(blockX + point.x(), blockY + point.y(), blockZ + point.z());
     }
 
-    @Contract(pure = true)
+    /**
+     * Adds the given block vector to this block vector.
+     *
+     * @param blockVec the block vector to add
+     * @return the resulting block vector
+     */
+    @Contract(pure = true, value = "_ -> new")
     public BlockVec add(BlockVec blockVec) {
         return new BlockVec(blockX + blockVec.blockX, blockY + blockVec.blockY, blockZ + blockVec.blockZ);
     }
 
     @Override
-    public Point add(double value) {
+    @Contract(pure = true, value = "_ -> new")
+    public Vec add(double value) {
         return add(value, value, value);
     }
 
-    @Contract(pure = true)
+    /**
+     * Adds the given integer value to all coordinates of this block vector.
+     *
+     * @param value the value to add
+     * @return the resulting block vector
+     */
+    @Contract(pure = true, value = "_ -> new")
     public BlockVec add(int value) {
         return new BlockVec(blockX + value, blockY + value, blockZ + value);
     }
 
     @Override
-    public Point sub(double x, double y, double z) {
+    @Contract(pure = true, value = "_, _, _ -> new")
+    public Vec sub(double x, double y, double z) {
         return new Vec(blockX - x, blockY - y, blockZ - z);
     }
 
-    @Contract(pure = true)
-    public BlockVec sub(int x, int y, int z) {
-        return new BlockVec(blockX - x, blockY - y, blockZ - z);
+    /**
+     * Subtracts the given block XYZ from this block vector.
+     *
+     * @param blockX the block X to subtract
+     * @param blockY the block Y to subtract
+     * @param blockZ the block Z to subtract
+     * @return the resulting block vector
+     */
+    @Contract(pure = true, value = "_, _, _ -> new")
+    public BlockVec sub(int blockX, int blockY, int blockZ) {
+        return new BlockVec(this.blockX - blockX, this.blockY - blockY, this.blockZ - blockZ);
     }
 
     @Override
-    public Point sub(Point point) {
+    @Contract(pure = true, value = "_ -> new")
+    public Vec sub(Point point) {
         return sub(point.x(), point.y(), point.z());
     }
 
-    @Contract(pure = true)
+    /**
+     * Subtracts the given block vector from this block vector.
+     *
+     * @param blockVec the block vector to subtract
+     * @return the resulting block vector
+     */
+    @Contract(pure = true, value = "_ -> new")
     public BlockVec sub(BlockVec blockVec) {
         return new BlockVec(blockX - blockVec.blockX, blockY - blockVec.blockY, blockZ - blockVec.blockZ);
     }
 
     @Override
-    public Point sub(double value) {
+    @Contract(pure = true, value = "_ -> new")
+    public Vec sub(double value) {
         return sub(value, value, value);
     }
 
-    @Contract(pure = true)
+    /**
+     * Subtracts the given integer value from all coordinates of this block vector.
+     *
+     * @param value the value to subtract
+     * @return the resulting block vector
+     */
+    @Contract(pure = true, value = "_ -> new")
     public BlockVec sub(int value) {
         return new BlockVec(blockX - value, blockY - value, blockZ - value);
     }
 
     @Override
-    public Point mul(double x, double y, double z) {
+    @Contract(pure = true, value = "_, _, _ -> new")
+    public Vec mul(double x, double y, double z) {
         return new Vec(blockX * x, blockY * y, blockZ * z);
     }
 
-    @Contract(pure = true)
-    public BlockVec mul(int x, int y, int z) {
-        return new BlockVec(blockX * x, blockY * y, blockZ * z);
+    /**
+     * Multiplies this block vector by the given integer values.
+     *
+     * @param blockX the block x to multiply by
+     * @param blockY the block y to multiply by
+     * @param blockZ the block z to multiply by
+     * @return the resulting block vector
+     */
+    @Contract(pure = true, value = "_, _, _ -> new")
+    public BlockVec mul(int blockX, int blockY, int blockZ) {
+        return new BlockVec(this.blockX * blockX, this.blockY * blockY, this.blockZ * blockZ);
     }
 
     @Override
-    public Point mul(Point point) {
+    @Contract(pure = true, value = "_ -> new")
+    public Vec mul(Point point) {
         return mul(point.x(), point.y(), point.z());
     }
 
-    @Contract(pure = true)
+    /**
+     * Multiplies this block vector by another block vector.
+     *
+     * @param blockVec the block vector to multiply by
+     * @return the resulting block vector
+     */
+    @Contract(pure = true, value = "_ -> new")
     public BlockVec mul(BlockVec blockVec) {
         return new BlockVec(blockX * blockVec.blockX, blockY * blockVec.blockY, blockZ * blockVec.blockZ);
     }
 
     @Override
-    public Point mul(double value) {
+    @Contract(pure = true, value = "_ -> new")
+    public Vec mul(double value) {
         return mul(value, value, value);
     }
 
-    @Contract(pure = true)
+    /**
+     * Multiplies this block vector by the given integer value.
+     *
+     * @param value the value to multiply by
+     * @return the resulting block vector
+     */
+    @Contract(pure = true, value = "_ -> new")
     public BlockVec mul(int value) {
         return mul(value, value, value);
     }
 
     @Override
-    public Point div(double x, double y, double z) {
+    @Contract(pure = true, value = "_, _, _ -> new")
+    public Vec div(double x, double y, double z) {
         return new Vec(blockX / x, blockY / y, blockZ / z);
     }
 
-    @Contract(pure = true)
-    public BlockVec div(int x, int y, int z) {
-        return new BlockVec(blockX / x, blockY / y, blockZ / z);
+    /**
+     * Divides this block vector by the given integer values.
+     *
+     * @param blockX the x divisor
+     * @param blockY the y divisor
+     * @param blockZ the z divisor
+     * @return the resulting block vector
+     * @throws ArithmeticException if any of the divisors is zero
+     */
+    @Contract(pure = true, value = "_, _, _ -> new")
+    public BlockVec div(int blockX, int blockY, int blockZ) {
+        return new BlockVec(this.blockX / blockX, this.blockY / blockY, this.blockZ / blockZ);
     }
 
     @Override
-    public Point div(Point point) {
+    @Contract(pure = true, value = "_ -> new")
+    public Vec div(Point point) {
         return div(point.x(), point.y(), point.z());
     }
 
-    @Contract(pure = true)
+    /**
+     * Divides this block vector by another block vector.
+     *
+     * @param blockVec the block vector divisor
+     * @return the resulting block vector
+     * @throws ArithmeticException if any component of the divisor is zero
+     */
+    @Contract(pure = true, value = "_ -> new")
     public BlockVec div(BlockVec blockVec) {
         return new BlockVec(blockX / blockVec.blockX, blockY / blockVec.blockY, blockZ / blockVec.blockZ);
     }
 
     @Override
-    public Point div(double value) {
+    @Contract(pure = true, value = "_ -> new")
+    public Vec div(double value) {
         return div(value, value, value);
     }
 
-    @Contract(pure = true)
+    /**
+     * Divides this block vector by the given integer value.
+     *
+     * @param value the divisor
+     * @return the resulting block vector
+     * @throws ArithmeticException if the divisor is zero
+     */
+    @Contract(pure = true, value = "_ -> new")
     public BlockVec div(int value) {
         return div(value, value, value);
     }
 
     @Override
-    @Contract(pure = true)
+    @Contract(pure = true, value = "_ -> new")
     public BlockVec relative(BlockFace face) {
+        // Cant use super because of return type of #add(double, double, double), use #add(int, int, int) instead
         final Direction direction = face.toDirection();
         return add(direction.normalX(), direction.normalY(), direction.normalZ());
     }
 
-    @Contract(pure = true)
+    @Override
+    @Contract(pure = true, value = "-> new")
     public BlockVec neg() {
         return new BlockVec(-blockX, -blockY, -blockZ);
     }
 
-    @Contract(pure = true)
+    @Override
+    @Contract(pure = true, value = "-> new")
     public BlockVec abs() {
         return new BlockVec(Math.abs(blockX), Math.abs(blockY), Math.abs(blockZ));
     }
 
-    @Contract(pure = true)
-    public Point min(Point point) {
+    @Override
+    @Contract(pure = true, value = "_ -> new")
+    public Vec min(Point point) {
         return new Vec(Math.min(blockX, point.x()), Math.min(blockY, point.y()), Math.min(blockZ, point.z()));
     }
 
-    @Contract(pure = true)
+    @Override
+    @Contract(pure = true, value = "_, _, _ -> new")
+    public Vec min(double x, double y, double z) {
+        return new Vec(Math.min(blockX, x), Math.min(blockY, y), Math.min(blockZ, z));
+    }
+
+    @Override
+    @Contract(pure = true, value = "_ -> new")
+    public Vec min(double value) {
+        return new Vec(Math.min(blockX, value), Math.min(blockY, value), Math.min(blockZ, value));
+    }
+
+    /**
+     * Calculates the minimum between this block vector and another block vector.
+     *
+     * @param point the other block vector
+     * @return the resulting block vector
+     */
+    @Contract(pure = true, value = "_ -> new")
     public BlockVec min(BlockVec point) {
         return new BlockVec(Math.min(blockX, point.blockX()), Math.min(blockY, point.blockY()), Math.min(blockZ, point.blockZ()));
     }
 
-    @Contract(pure = true)
-    public BlockVec min(int x, int y, int z) {
-        return new BlockVec(Math.min(blockX, x), Math.min(blockY, y), Math.min(blockZ, z));
+    /**
+     * Calculates the minimum between this block vector and the given block coordinates.
+     *
+     * @param blockX the blockX
+     * @param blockY the blockY
+     * @param blockZ the blockZ
+     * @return the resulting block vector
+     */
+    @Contract(pure = true, value = "_, _, _ -> new")
+    public BlockVec min(int blockX, int blockY, int blockZ) {
+        return new BlockVec(Math.min(this.blockX, blockX), Math.min(this.blockY, blockY), Math.min(this.blockZ, blockZ));
     }
 
-    @Contract(pure = true)
+    /**
+     * Calculates the minimum between this block vector and the given integer value.
+     *
+     * @param value the value
+     * @return the resulting block vector
+     */
+    @Contract(pure = true, value = "_ -> new")
     public BlockVec min(int value) {
         return new BlockVec(Math.min(blockX, value), Math.min(blockY, value), Math.min(blockZ, value));
     }
 
-    @Contract(pure = true)
-    public Point max(Point point) {
+    @Override
+    @Contract(pure = true, value = "_ -> new")
+    public Vec max(Point point) {
         return new Vec(Math.max(blockX, point.x()), Math.max(blockY, point.y()), Math.max(blockZ, point.z()));
     }
 
-    @Contract(pure = true)
+    @Override
+    @Contract(pure = true, value = "_, _, _ -> new")
+    public Vec max(double x, double y, double z) {
+        return new Vec(Math.max(blockX, x), Math.max(blockY, y), Math.max(blockZ, z));
+    }
+
+    @Override
+    @Contract(pure = true, value = "_ -> new")
+    public Vec max(double value) {
+        return new Vec(Math.max(blockX, value), Math.max(blockY, value), Math.max(blockZ, value));
+    }
+
+    @Override
+    @Contract(pure = true, value = "-> new")
+    public Vec normalize() {
+        final double length = length();
+        return new Vec(blockX / length, blockY / length, blockZ / length);
+    }
+
+    @Override
+    @Contract(pure = true, value = "_ -> new")
+    public Vec cross(Point point) {
+        return new Vec(blockY * point.z() - blockZ * point.y(),
+                blockZ * point.x() - blockX * point.z(),
+                blockX * point.y() - blockY * point.x());
+    }
+
+    /**
+     * Calculates the cross product of this point with another. The cross
+     * product is defined as:
+     * <ul>
+     * <li>x = y1 * z2 - y2 * z1
+     * <li>y = z1 * x2 - z2 * x1
+     * <li>z = x1 * y2 - x2 * y1
+     * </ul>
+     *
+     * @param point the other point
+     * @return the cross product point
+     */
+    @Contract(pure = true, value = "_ -> new")
+    public BlockVec cross(BlockVec point) {
+        return new BlockVec(blockY * point.blockZ - blockZ * point.blockY,
+                blockZ * point.blockX - blockX * point.blockZ,
+                blockX * point.blockY - blockY * point.blockX);
+    }
+
+    @Override
+    @Contract(pure = true, value = "_, _ -> new")
+    public Vec lerp(Point point, double alpha) {
+        return new Vec(blockX + (alpha * (point.x() - blockX)),
+                blockY + (alpha * (point.y() - blockY)),
+                blockZ + (alpha * (point.z() - blockZ)));
+    }
+
+    /**
+     * Calculates the maximum between this block vector and another block vector.
+     *
+     * @param point the other block vector
+     * @return the resulting block vector
+     */
+    @Contract(pure = true, value = "_ -> new")
     public BlockVec max(BlockVec point) {
         return new BlockVec(Math.max(blockX, point.blockX()), Math.max(blockY, point.blockY()), Math.max(blockZ, point.blockZ()));
     }
 
-    @Contract(pure = true)
-    public BlockVec max(int x, int y, int z) {
-        return new BlockVec(Math.max(blockX, x), Math.max(blockY, y), Math.max(blockZ, z));
+    /**
+     * Calculates the maximum between this block vector and the given block coordinates (x/y/z).
+     *
+     * @param blockX the block X
+     * @param blockY the block Y
+     * @param blockZ the block Z
+     * @return the resulting block vector
+     */
+    @Contract(pure = true, value = "_, _, _ -> new")
+    public BlockVec max(int blockX, int blockY, int blockZ) {
+        return new BlockVec(Math.max(this.blockX, blockX), Math.max(this.blockY, blockY), Math.max(this.blockZ, blockZ));
     }
 
-    @Contract(pure = true)
+    /**
+     * Calculates the maximum between this block vector and the given integer value.
+     *
+     * @param value the value
+     * @return the resulting block vector
+     */
+    @Contract(pure = true, value = "_ -> new")
     public BlockVec max(int value) {
         return new BlockVec(Math.max(blockX, value), Math.max(blockY, value), Math.max(blockZ, value));
     }
 
+    /**
+     * Checks if two block positions have the same coordinates (x/y/z).
+     *
+     * @param blockX the block X coordinate
+     * @param blockY the block Y coordinate
+     * @param blockZ the block Z coordinate
+     * @return true if the coordinates are the same
+     */
     @Contract(pure = true)
-    public boolean samePoint(int x, int y, int z) {
-        return blockX == x && blockY == y && blockZ == z;
+    public boolean samePoint(int blockX, int blockY, int blockZ) {
+        return this.blockX == blockX && this.blockY == blockY && this.blockZ == blockZ;
     }
 
+    /**
+     * Checks if two block vectors have the same coordinates (x/y/z).
+     *
+     * @param blockVec the other block vector
+     * @return true if the coordinates are the same
+     */
     @Contract(pure = true)
     public boolean samePoint(BlockVec blockVec) {
         return blockX == blockVec.blockX && blockY == blockVec.blockY && blockZ == blockVec.blockZ;
+    }
+
+    /**
+     * Does nothing as this is already a {@link BlockVec}.
+     * <p>
+     * Marked as deprecated to warn against redundant usage.
+     *
+     * @return this block vector
+     */
+    @Deprecated
+    @Override
+    @Contract(pure = true, value = "-> this")
+    public BlockVec asBlockVec() {
+        return this;
+    }
+
+    /**
+     * A functional interface representing an operation on the components of a {@link BlockVec}.
+     */
+    @FunctionalInterface
+    public interface Operator {
+        /**
+         * Creates an operator from the given {@link IntUnaryOperator}.
+         *
+         * @param operator the operator to convert
+         * @return the resulting operator
+         */
+        static Operator operator(IntUnaryOperator operator) {
+            return (blockX, blockY, blockZ) -> new BlockVec(
+                    operator.applyAsInt(blockX),
+                    operator.applyAsInt(blockY),
+                    operator.applyAsInt(blockZ));
+        }
+
+        /**
+         * Applies this operator to the given block coordinates.
+         *
+         * @param blockX the blockX component
+         * @param blockY the blockY component
+         * @param blockZ the blockZ component
+         * @return the resulting block vector
+         */
+        BlockVec apply(int blockX, int blockY, int blockZ);
     }
 }

--- a/src/main/java/net/minestom/server/coordinate/Point.java
+++ b/src/main/java/net/minestom/server/coordinate/Point.java
@@ -2,7 +2,6 @@ package net.minestom.server.coordinate;
 
 import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.utils.Direction;
-import net.minestom.server.utils.MathUtils;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.Contract;
 
@@ -11,9 +10,67 @@ import java.util.function.DoubleUnaryOperator;
 import static net.minestom.server.coordinate.CoordConversion.*;
 
 /**
- * Represents a 3D point.
+ * Represents a 3D point in coordinate space.
+ * <p>
+ * This interface has three main implementations:
+ * <ul>
+ *   <li>{@link Vec} - Double-precision coordinates (x, y, z)</li>
+ *   <li>{@link Pos} - Double-precision coordinates with view angles (yaw, pitch)</li>
+ *   <li>{@link BlockVec} - Integer block-aligned coordinates</li>
+ * </ul>
+ * <p>
+ * <b>Coordinate Scale:</b>
+ * <ul>
+ *   <li>Block: Individual voxel position (1 block)</li>
+ *   <li>Section: 16 blocks ({@link #SECTION_SIZE})</li>
+ *   <li>Chunk: Same as a section in X and Z axis ({@link #SECTION_SIZE})</li>
+ *   <li>Region: 512 blocks or 32 sections ({@link #REGION_SIZE})</li>
+ * </ul>
+ * <p>
+ * <b>Coordinate Conventions:</b>
+ * <ul>
+ *   <li>Three {@code double} values represent global coordinates</li>
+ *   <li>Three {@code double} values following two {@code float} values represent global position coordinates</li>
+ *   <li>Three {@code int} values represent global block coordinates</li>
+ * </ul>
+ * <p>
+ * <b>Directionality:</b>
+ * <ul>
+ *     <li>X increases towards East, decreases towards West</li>
+ *     <li>Y increases upwards, decreases downwards</li>
+ *     <li>Z increases towards South, decreases towards North</li>
+ * </ul>
+ * <p>
+ * Avoid relying on {@link Object#equals(Object)} for direct Point comparison, as different implementations
+ * may represent the same 3D coordinates but be different instances. Use {@link #samePoint(Point)}
+ * or {@link #samePoint(Point, double)} instead. You can also ensure both points are of the same implementation, but this is fragile.
+ * <p>
+ * Usage: Prefer accepting {@link Point} in method parameters when only
+ * coordinate access (x/y/z) is needed. This avoids forcing callers to convert
+ * between specific implementations.
+ * <p>
+ * All implementations are immutable and subject to become value types. Type conversions are also explicit to avoid precision loss.
  */
 public sealed interface Point permits Vec, Pos, BlockVec {
+    /**
+     * The smallest difference between two double values to consider them equal if applicable.
+     */
+    double EPSILON = 1e-6;
+
+    /**
+     * Represents the size of a section (16 blocks).
+     * <p>
+     * Also known as chunk in X and Z axis.
+     */
+    int SECTION_SIZE = 16;
+
+    /**
+     * Represents the size of a region (32 sections) or (512 blocks).
+     * Used in Anvil (.mca) region files.
+     * <p>
+     * Regions do not normally have a Y component.
+     */
+    int REGION_SIZE = 32 * SECTION_SIZE;
 
     /**
      * Gets the X coordinate.
@@ -69,36 +126,71 @@ public sealed interface Point permits Vec, Pos, BlockVec {
         return globalToBlock(z());
     }
 
+    /**
+     * The section x coordinate of {@link #blockX()}, determined by {@link #SECTION_SIZE}
+     *
+     * @return the section x coordinate
+     */
     @Contract(pure = true)
     default int sectionX() {
         return globalToSection(blockX());
     }
 
+    /**
+     * The section y coordinate of {@link #blockY()}, determined by {@link #SECTION_SIZE}
+     *
+     * @return the section y coordinate
+     */
     @Contract(pure = true)
     default int sectionY() {
         return globalToSection(blockY());
     }
 
+    /**
+     * The section z coordinate of {@link #blockZ()}, determined by {@link #SECTION_SIZE}
+     *
+     * @return the section z coordinate
+     */
     @Contract(pure = true)
     default int sectionZ() {
         return globalToSection(blockZ());
     }
 
+    /**
+     * The chunk X coordinate of {@link #blockX()}, also known as the section X {@link #sectionX()}
+     *
+     * @return the chunk X coordinate
+     */
     @Contract(pure = true)
     default int chunkX() {
         return sectionX();
     }
 
+    /**
+     * The chunk Z coordinate of {@link #blockZ()}, also known as the section Z {@link #sectionZ()}
+     *
+     * @return the chunk Z coordinate
+     */
     @Contract(pure = true)
     default int chunkZ() {
         return sectionZ();
     }
 
+    /**
+     * The region x coordinate of {@link #blockX()}, determined by {@link #REGION_SIZE}
+     *
+     * @return the region x coordinate
+     */
     @Contract(pure = true)
     default int regionX() {
         return globalToRegion(blockX());
     }
 
+    /**
+     * The region z coordinate of {@link #blockZ()}, determined by {@link #REGION_SIZE}
+     *
+     * @return the region z coordinate
+     */
     @Contract(pure = true)
     default int regionZ() {
         return globalToRegion(blockZ());
@@ -119,7 +211,7 @@ public sealed interface Point permits Vec, Pos, BlockVec {
      * @param operator the operator providing the current X coordinate and returning the new
      * @return a new point
      */
-    @Contract(pure = true)
+    @Contract("_ -> new")
     Point withX(DoubleUnaryOperator operator);
 
     /**
@@ -128,7 +220,7 @@ public sealed interface Point permits Vec, Pos, BlockVec {
      * @param x the new X coordinate
      * @return a new point
      */
-    @Contract(pure = true)
+    @Contract(pure = true, value = "_ -> new")
     Point withX(double x);
 
     /**
@@ -137,7 +229,7 @@ public sealed interface Point permits Vec, Pos, BlockVec {
      * @param operator the operator providing the current Y coordinate and returning the new
      * @return a new point
      */
-    @Contract(pure = true)
+    @Contract("_ -> new")
     Point withY(DoubleUnaryOperator operator);
 
     /**
@@ -146,7 +238,7 @@ public sealed interface Point permits Vec, Pos, BlockVec {
      * @param y the new Y coordinate
      * @return a new point
      */
-    @Contract(pure = true)
+    @Contract(pure = true, value = "_ -> new")
     Point withY(double y);
 
     /**
@@ -155,7 +247,7 @@ public sealed interface Point permits Vec, Pos, BlockVec {
      * @param operator the operator providing the current Z coordinate and returning the new
      * @return a new point
      */
-    @Contract(pure = true)
+    @Contract("_ -> new")
     Point withZ(DoubleUnaryOperator operator);
 
     /**
@@ -164,60 +256,161 @@ public sealed interface Point permits Vec, Pos, BlockVec {
      * @param z the new Z coordinate
      * @return a new point
      */
-    @Contract(pure = true)
+    @Contract(pure = true, value = "_ -> new")
     Point withZ(double z);
 
-    @Contract(pure = true)
+    /**
+     * Creates a new point by adding the provided values to this point coordinates.
+     *
+     * @param x the x to add
+     * @param y the y to add
+     * @param z the z to add
+     * @return the new point
+     */
+    @Contract(pure = true, value = "_, _, _ -> new")
     Point add(double x, double y, double z);
 
-    @Contract(pure = true)
+    /**
+     * Creates a new point by adding another point coordinates to this point coordinates.
+     *
+     * @param point the point decomposed by {@link #x()}, {@link #y()} and {@link #z()}
+     * @return the new point
+     */
+    @Contract(pure = true, value = "_ -> new")
     Point add(Point point);
 
-    @Contract(pure = true)
+    /**
+     * Creates a new point by adding the provided value to this point coordinates for all XYZ.
+     *
+     * @param value the value to add
+     * @return the new point
+     */
+    @Contract(pure = true, value = "_ -> new")
     Point add(double value);
 
-    @Contract(pure = true)
+    /**
+     * Creates a new point by subtracting the provided values to this point coordinates.
+     *
+     * @param x the x to subtract
+     * @param y the y to subtract
+     * @param z the z to subtract
+     * @return the new point
+     */
+    @Contract(pure = true, value = "_, _, _ -> new")
     Point sub(double x, double y, double z);
 
-    @Contract(pure = true)
+    /**
+     * Creates a new point by subtracting another point coordinates to this point coordinates.
+     *
+     * @param point the point decomposed by {@link #x()}, {@link #y()} and {@link #z()}
+     * @return the new point
+     */
+    @Contract(pure = true, value = "_ -> new")
     Point sub(Point point);
 
-    @Contract(pure = true)
+    /**
+     * Creates a new point by subtracting the provided value to this point coordinates for all XYZ.
+     *
+     * @param value the value to subtract
+     * @return the new point
+     */
+    @Contract(pure = true, value = "_ -> new")
     Point sub(double value);
 
-    @Contract(pure = true)
+    /**
+     * Creates a new point by multiplying the provided values to this point coordinates.
+     *
+     * @param x the x to multiply
+     * @param y the y to multiply
+     * @param z the z to multiply
+     * @return the new point
+     */
+    @Contract(pure = true, value = "_, _, _ -> new")
     Point mul(double x, double y, double z);
 
-    @Contract(pure = true)
+    /**
+     * Creates a new point by multiplying another point coordinates to this point coordinates.
+     *
+     * @param point the point decomposed by {@link #x()}, {@link #y()} and {@link #z()}
+     * @return the new point
+     */
+    @Contract(pure = true, value = "_ -> new")
     Point mul(Point point);
 
-    @Contract(pure = true)
+    /**
+     * Creates a new point by multiplying the provided value to this point coordinates for all XYZ.
+     *
+     * @param value the value to multiply
+     * @return the new point
+     */
+    @Contract(pure = true, value = "_ -> new")
     Point mul(double value);
 
-    @Contract(pure = true)
+    /**
+     * Creates a new point by dividing the provided values to this point coordinates.
+     * <p>
+     * Warning: division by zero will not error.
+     *
+     * @param x the x to divide
+     * @param y the y to divide
+     * @param z the z to divide
+     * @return the new point
+     */
+    @Contract(pure = true, value = "_, _, _ -> new")
     Point div(double x, double y, double z);
 
-    @Contract(pure = true)
+    /**
+     * Creates a new point by dividing another point coordinates to this point coordinates.
+     * <p>
+     * Warning: division by zero will not error.
+     *
+     * @param point the point decomposed by {@link #x()}, {@link #y()} and {@link #z()}
+     * @return the new point
+     */
+    @Contract(pure = true, value = "_ -> new")
     Point div(Point point);
 
-    @Contract(pure = true)
+    /**
+     * Creates a new point by dividing the provided value to this point coordinates for all XYZ.
+     * <p>
+     * Warning: division by zero will not error.
+     *
+     * @param value the value to divide
+     * @return the new point
+     */
+    @Contract(pure = true, value = "_ -> new")
     Point div(double value);
 
-    @Contract(pure = true)
+    /**
+     * Creates a new point relative to this point based on the provided block face.
+     *
+     * @param face the face
+     * @return the new point
+     */
+    @Contract(pure = true, value = "_ -> new")
     default Point relative(BlockFace face) {
         final Direction direction = face.toDirection();
         return add(direction.normalX(), direction.normalY(), direction.normalZ());
     }
 
+    /**
+     * Gets the squared distance between this point and the provided coordinates.
+     *
+     * @param x the x coordinate
+     * @param y the y coordinate
+     * @param z the z coordinate
+     * @return the squared distance
+     */
     @Contract(pure = true)
     default double distanceSquared(double x, double y, double z) {
-        return MathUtils.square(x() - x) + MathUtils.square(y() - y) + MathUtils.square(z() - z);
+        final double xDiff = x() - x, yDiff = y() - y, zDiff = z() - z;
+        return (xDiff * xDiff) + (yDiff * yDiff) + (zDiff * zDiff);
     }
 
     /**
      * Gets the squared distance between this point and another.
      *
-     * @param point the other point
+     * @param point the other point, decomposed by {@link #x()}, {@link #y()} and {@link #z()}
      * @return the squared distance
      */
     @Contract(pure = true)
@@ -225,6 +418,14 @@ public sealed interface Point permits Vec, Pos, BlockVec {
         return distanceSquared(point.x(), point.y(), point.z());
     }
 
+    /**
+     * Gets the distance between this point and the provided coordinates.
+     *
+     * @param x the x coordinate
+     * @param y the y coordinate
+     * @param z the z coordinate
+     * @return the distance
+     */
     @Contract(pure = true)
     default double distance(double x, double y, double z) {
         return Math.sqrt(distanceSquared(x, y, z));
@@ -233,7 +434,7 @@ public sealed interface Point permits Vec, Pos, BlockVec {
     /**
      * Gets the distance between this point and another. The value of this
      * method is not cached and uses a costly square-root function, so do not
-     * repeatedly call this method to get the vector's magnitude. NaN will be
+     * repeatedly call this method to get the point's magnitude. NaN will be
      * returned if the inner result of the sqrt() function overflows, which
      * will be caused if the distance is too long.
      *
@@ -245,16 +446,26 @@ public sealed interface Point permits Vec, Pos, BlockVec {
         return distance(point.x(), point.y(), point.z());
     }
 
+    /**
+     * Checks if two points have similar (x/y/z).
+     *
+     * @param x the x coordinate
+     * @param y the y coordinate
+     * @param z the z coordinate
+     * @return true if the two positions are similar
+     */
+    @Contract(pure = true)
     default boolean samePoint(double x, double y, double z) {
         return x == x() && y == y() && z == z();
     }
 
     /**
-     * Checks it two points have similar (x/y/z).
+     * Checks if two points have similar (x/y/z).
      *
-     * @param point the point to compare
+     * @param point the point to compare, decomposed by {@link #x()}, {@link #y()} and {@link #z()}
      * @return true if the two positions are similar
      */
+    @Contract(pure = true)
     default boolean samePoint(Point point) {
         return samePoint(point.x(), point.y(), point.z());
     }
@@ -269,6 +480,7 @@ public sealed interface Point permits Vec, Pos, BlockVec {
      * @return true if the two positions are similar within the epsilon
      * @throws IllegalArgumentException if epsilon is less than or equal to 0
      */
+    @Contract(pure = true)
     default boolean samePoint(double x, double y, double z, double epsilon) {
         Check.argCondition(epsilon <= 0, "Epsilon must be greater than 0 but found {0}", epsilon);
         return Math.abs(x - x()) < epsilon && Math.abs(y - y()) < epsilon && Math.abs(z - z()) < epsilon;
@@ -282,8 +494,33 @@ public sealed interface Point permits Vec, Pos, BlockVec {
      * @return true if the two positions are similar within the epsilon
      * @throws IllegalArgumentException if epsilon is less than or equal to 0
      */
+    @Contract(pure = true)
     default boolean samePoint(Point point, double epsilon) {
         return samePoint(point.x(), point.y(), point.z(), epsilon);
+    }
+
+    /**
+     * Checks it two points have similar (x/y/z) coordinates within {@link #EPSILON}.
+     *
+     * @param x the x coordinate
+     * @param y the y coordinate
+     * @param z the z coordinate
+     * @return true if the two positions are similar within {@link #EPSILON}
+     */
+    @Contract(pure = true)
+    default boolean similarPoint(double x, double y, double z) {
+        return samePoint(x, y, z, EPSILON);
+    }
+
+    /**
+     * Checks it two points have similar (x/y/z) coordinates within {@link #EPSILON}.
+     *
+     * @param point the point to compare
+     * @return true if the two positions are similar within {@link #EPSILON}
+     */
+    @Contract(pure = true)
+    default boolean similarPoint(Point point) {
+        return samePoint(point, EPSILON);
     }
 
     /**
@@ -292,6 +529,7 @@ public sealed interface Point permits Vec, Pos, BlockVec {
      *
      * @return true if the three coordinates are zero
      */
+    @Contract(pure = true)
     default boolean isZero() {
         return x() == 0 && y() == 0 && z() == 0;
     }
@@ -302,10 +540,21 @@ public sealed interface Point permits Vec, Pos, BlockVec {
      * @param point the point to compare to
      * @return true if 'this' is in the same chunk as {@code point}
      */
+    @Contract(pure = true)
     default boolean sameChunk(Point point) {
         return chunkX() == point.chunkX() && chunkZ() == point.chunkZ();
     }
 
+    /**
+     * Checks if the three {@link #blockX()}, {@link #blockY()}, {@link #blockZ()},
+     * are equal to the provided ones.
+     *
+     * @param blockX the block x
+     * @param blockY the block y
+     * @param blockZ the block z
+     * @return true if 'this' is in the same block as the provided coordinates
+     */
+    @Contract(pure = true)
     default boolean sameBlock(int blockX, int blockY, int blockZ) {
         return blockX() == blockX && blockY() == blockY && blockZ() == blockZ;
     }
@@ -316,34 +565,210 @@ public sealed interface Point permits Vec, Pos, BlockVec {
      * @param point the point to compare to
      * @return true if 'this' is in the same block as {@code point}
      */
+    @Contract(pure = true)
     default boolean sameBlock(Point point) {
         return sameBlock(point.blockX(), point.blockY(), point.blockZ());
     }
 
+    /**
+     * Gets the magnitude of the point squared.
+     *
+     * @return the magnitude
+     */
     @Contract(pure = true)
+    default double lengthSquared() {
+        final double x = x(), y = y(), z = z();
+        return (x * x) + (y * y) + (z * z);
+    }
+
+    /**
+     * Gets the magnitude of the point, defined as sqrt(x^2+y^2+z^2). The
+     * value of this method is not cached and uses a costly square-root
+     * function, so do not repeatedly call this method to get the point's
+     * magnitude. NaN will be returned if the inner result of the sqrt()
+     * function overflows, which will be caused if the length is too long.
+     *
+     * @return the magnitude
+     */
+    @Contract(pure = true)
+    default double length() {
+        return Math.sqrt(lengthSquared());
+    }
+
+    /**
+     * Returns if a point is normalized
+     *
+     * @return whether the point is normalized
+     */
+    @Contract(pure = true)
+    default boolean isNormalized() {
+        return Math.abs(lengthSquared() - 1) < EPSILON;
+    }
+
+    /**
+     * Gets the angle between this point and another in radians.
+     *
+     * @param point the other point
+     * @return angle in radians
+     */
+    @Contract(pure = true)
+    default double angle(Point point) {
+        final double dot = Math.clamp(dot(point) / (length() * point.length()), -1.0, 1.0);
+        return Math.acos(dot);
+    }
+
+    /**
+     * Calculates the dot product of this point with another. The dot product
+     * is defined as x1*x2+y1*y2+z1*z2. The returned value is a scalar.
+     *
+     * @param point the other point
+     * @return dot product
+     */
+    @Contract(pure = true)
+    default double dot(Point point) {
+        return x() * point.x() + y() * point.y() + z() * point.z();
+    }
+
+    /**
+     * Represents this point with all coordinates negated.
+     * For example, {@code (x, y, z)} becomes {@code (-x, -y, -z)}.
+     *
+     * @return the negated point
+     */
+    @Contract(pure = true, value = "-> new")
+    Point neg();
+
+    /**
+     * Represents this point with all coordinates as their absolute values.
+     * For example, {@code (x, y, z)} becomes {@code (|x|, |y|, |z|)}.
+     *
+     * @return the absolute point
+     */
+    @Contract(pure = true, value = "-> new")
+    Point abs();
+
+    /**
+     * Gets a point representing the minimum values between this point and the provided one (x/y/z).
+     *
+     * @param point the other point
+     * @return the minimum point
+     */
+    @Contract(pure = true, value = "_ -> new")
+    Point min(Point point);
+
+    /**
+     * Gets a point representing the minimum values between this point and the provided coordinates (x/y/z).
+     *
+     * @param x the x coordinate
+     * @param y the y coordinate
+     * @param z the z coordinate
+     * @return the minimum point
+     */
+    @Contract(pure = true, value = "_, _, _ -> new")
+    Point min(double x, double y, double z);
+
+    /**
+     * Gets a point representing the minimum values between this point and the provided value for all coordinates.
+     *
+     * @param value the value
+     * @return the minimum point
+     */
+    @Contract(pure = true, value = "_ -> new")
+    Point min(double value);
+
+    /**
+     * Gets a point representing the maximum values between this point and the provided one (x/y/z).
+     *
+     * @param point the other point
+     * @return the maximum point
+     */
+    @Contract(pure = true, value = "_ -> new")
+    Point max(Point point);
+
+    /**
+     * Gets a point representing the maximum values between this point and the provided coordinates (x/y/z).
+     *
+     * @param x the x coordinate
+     * @param y the y coordinate
+     * @param z the z coordinate
+     * @return the maximum point
+     */
+    @Contract(pure = true, value = "_, _, _ -> new")
+    Point max(double x, double y, double z);
+
+    /**
+     * Gets a point representing the maximum values between this point and the provided value for all coordinates.
+     *
+     * @param value the value
+     * @return the maximum point
+     */
+    @Contract(pure = true, value = "_ -> new")
+    Point max(double value);
+
+    /**
+     * Converts this point to a unit point (a point with length of 1).
+     *
+     * @return the same point
+     */
+    @Contract(pure = true, value = "-> new")
+    Point normalize();
+
+    /**
+     * Calculates the cross product of this point with another. The cross
+     * product is defined as:
+     * <ul>
+     * <li>x = y1 * z2 - y2 * z1
+     * <li>y = z1 * x2 - z2 * x1
+     * <li>z = x1 * y2 - x2 * y1
+     * </ul>
+     *
+     * @param point the other point
+     * @return the cross product point
+     */
+    @Contract(pure = true, value = "_ -> new")
+    Point cross(Point point);
+
+    /**
+     * Calculates a linear interpolation between this point with another
+     * point (x/y/z).
+     *
+     * @param point the other point
+     * @param alpha The alpha value, must be between 0.0 and 1.0
+     * @return Linear interpolated point
+     */
+    @Contract(pure = true, value = "_, _ -> new")
+    Point lerp(Point point, double alpha);
+
+    /**
+     * Converts this point to a {@link Pos}.
+     *
+     * @return the converted position or this if already a {@link Pos}
+     */
+    @Contract(pure = true, value = "-> new")
     default Pos asPos() {
-        return switch (this) {
-            case Pos pos -> pos;
-            case Vec vec -> new Pos(vec.x(), vec.y(), vec.z());
-            case BlockVec blockVec -> new Pos(blockVec.blockX(), blockVec.blockY(), blockVec.blockZ());
-        };
+        assert !(this instanceof Pos) : "Should be overridden";
+        return new Pos(x(), y(), z());
     }
 
-    @Contract(pure = true)
+    /**
+     * Converts this point to a {@link Vec}.
+     *
+     * @return the converted point or this if already a {@link Vec}
+     */
+    @Contract(pure = true, value = "-> new")
     default Vec asVec() {
-        return switch (this) {
-            case Vec vec -> vec;
-            case Pos pos -> new Vec(pos.x(), pos.y(), pos.z());
-            case BlockVec blockVec -> new Vec(blockVec.blockX(), blockVec.blockY(), blockVec.blockZ());
-        };
+        assert !(this instanceof Vec) : "Should be overridden";
+        return new Vec(x(), y(), z());
     }
 
-    @Contract(pure = true)
+    /**
+     * Converts this point to a {@link BlockVec}. Likely flooring as needed.
+     *
+     * @return the converted block point or this if already a {@link BlockVec}
+     */
+    @Contract(pure = true, value = "-> new")
     default BlockVec asBlockVec() {
-        return switch (this) {
-            case BlockVec blockVec -> blockVec;
-            case Pos pos -> new BlockVec(pos.blockX(), pos.blockY(), pos.blockZ());
-            case Vec vec -> new BlockVec(vec.blockX(), vec.blockY(), vec.blockZ());
-        };
+        assert !(this instanceof BlockVec) : "Should be overridden";
+        return new BlockVec(blockX(), blockY(), blockZ());
     }
 }

--- a/src/main/java/net/minestom/server/coordinate/Pos.java
+++ b/src/main/java/net/minestom/server/coordinate/Pos.java
@@ -2,32 +2,69 @@ package net.minestom.server.coordinate;
 
 import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.utils.Direction;
-import net.minestom.server.utils.MathUtils;
 import net.minestom.server.utils.position.PositionUtils;
 import org.jetbrains.annotations.Contract;
 
 import java.util.function.DoubleUnaryOperator;
 
 /**
- * Represents a position containing coordinates and a view.
+ * Represents a 3D position with double-precision coordinates and viewing direction.
  * <p>
- * To become a value then primitive type.
+ * Combines {@link Vec} with yaw and pitch angles, making it suitable for entities
+ * and cameras that need both location and orientation.
+ * <p>
+ * View angles are automatically normalized.
+ *
+ * @param x     the X coordinate
+ * @param y     the Y coordinate
+ * @param z     the Z coordinate
+ * @param yaw   the yaw (rotation around vertical axis) in degrees (-180, 180]
+ * @param pitch the pitch (rotation around lateral axis) in degrees [-90, 90]
  */
 public record Pos(double x, double y, double z, float yaw, float pitch) implements Point {
     public static final Pos ZERO = new Pos(0, 0, 0);
 
+    /**
+     * The epsilon used to compare two views (yaw/pitch) if applicable.
+     */
+    public static final float VIEW_EPSILON = 1e-4f;
+
     public Pos {
         yaw = fixYaw(yaw);
+        pitch = fixPitch(pitch);
     }
 
+    /**
+     * Creates a position with the given coordinates (x/y/z) and default view (yaw/pitch = 0).
+     *
+     * @param x the X coordinate
+     * @param y the Y coordinate
+     * @param z the Z coordinate
+     */
     public Pos(double x, double y, double z) {
         this(x, y, z, 0, 0);
     }
 
+    /**
+     * Creates a position from a point with the given view (yaw/pitch).
+     *
+     * @param point the point containing the coordinates (x/y/z)
+     * @param yaw   the yaw
+     * @param pitch the pitch
+     * @deprecated Use {@link Point#asPos()} instead with {@link #withView(float, float)}
+     */
+    @Deprecated
     public Pos(Point point, float yaw, float pitch) {
         this(point.x(), point.y(), point.z(), yaw, pitch);
     }
 
+    /**
+     * Creates a position from a point with the default view (yaw/pitch = 0).
+     *
+     * @param point the point containing the coordinates (x/y/z)
+     * @deprecated Use {@link Point#asPos()} instead
+     */
+    @Deprecated
     public Pos(Point point) {
         this(point, 0, 0);
     }
@@ -40,14 +77,37 @@ public record Pos(double x, double y, double z, float yaw, float pitch) implemen
      * @return the converted position
      * @deprecated use {@link Point#asPos()} instead
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public static Pos fromPoint(Point point) {
         if (point instanceof Pos pos) return pos;
         return new Pos(point.x(), point.y(), point.z());
     }
 
     /**
-     * Changes the 3 coordinates of this position.
+     * Fixes a pitch value that is not between -90.0f and 90.0f
+     * So for example, -135.0f becomes -90.0f and 225.0f becomes 90.0f
+     *
+     * @param pitch The possible "wrong" pitch
+     * @return a fixed pitch in the range [-90.0f, 90.0f]
+     */
+    public static float fixPitch(float pitch) {
+        return Math.clamp(pitch, -90.0f, 90.0f);
+    }
+
+    /**
+     * Fixes a yaw value that is not between -180.0f (exclusive) and 180.0f (inclusive).
+     * Wraps the yaw to the nearest equivalent angle in this range.
+     * For example, -1355.0f becomes 85.0f and 225.0f becomes -135.0f.
+     *
+     * @param yaw The possible "wrong" yaw
+     * @return a fixed yaw in the range (-180.0f, 180.0f]
+     */
+    public static float fixYaw(float yaw) {
+        return yaw - 360.0f * (float) Math.ceil((yaw - 180.0f) / 360.0f);
+    }
+
+    /**
+     * Changes the 3 coordinates of this position (x/y/z).
      *
      * @param x the X coordinate
      * @param y the Y coordinate
@@ -59,16 +119,35 @@ public record Pos(double x, double y, double z, float yaw, float pitch) implemen
         return new Pos(x, y, z, yaw, pitch);
     }
 
+    /**
+     * Changes the coordinates to match the provided point.
+     *
+     * @param point the point to use for coordinates (x/y/z)
+     * @return a new position
+     */
     @Contract(pure = true)
     public Pos withCoord(Point point) {
         return withCoord(point.x(), point.y(), point.z());
     }
 
+    /**
+     * Changes the view of this position (yaw/pitch).
+     *
+     * @param yaw   the yaw
+     * @param pitch the pitch
+     * @return a new position
+     */
     @Contract(pure = true)
     public Pos withView(float yaw, float pitch) {
         return new Pos(x, y, z, yaw, pitch);
     }
 
+    /**
+     * Changes the view to match the provided position.
+     *
+     * @param pos the position to use for the view (yaw/pitch)
+     * @return a new position
+     */
     @Contract(pure = true)
     public Pos withView(Pos pos) {
         return withView(pos.yaw(), pos.pitch());
@@ -77,8 +156,11 @@ public record Pos(double x, double y, double z, float yaw, float pitch) implemen
     /**
      * Sets the yaw and pitch to point
      * in the direction of the point.
+     *
+     * @param point the point to look at
+     * @return a new position
      */
-    @Contract(pure = true)
+    @Contract(pure = true, value = "_ -> new")
     public Pos withDirection(Point point) {
         /*
          * Sin = Opp / Hyp
@@ -94,27 +176,51 @@ public record Pos(double x, double y, double z, float yaw, float pitch) implemen
             return withPitch(point.y() > 0 ? -90f : 90f);
         }
         final double theta = Math.atan2(-x, z);
-        final double xz = Math.sqrt(MathUtils.square(x) + MathUtils.square(z));
+        final double xz = Math.sqrt((x * x) + (z * z));
         final double _2PI = 2 * Math.PI;
         return withView((float) Math.toDegrees((theta + _2PI) % _2PI),
                 (float) Math.toDegrees(Math.atan(-point.y() / xz)));
     }
 
+    /**
+     * Changes the yaw of this position.
+     *
+     * @param yaw the new yaw
+     * @return a new position
+     */
     @Contract(pure = true)
     public Pos withYaw(float yaw) {
         return new Pos(x, y, z, yaw, pitch);
     }
 
+    /**
+     * Applies an operator to the yaw of this position.
+     *
+     * @param operator the operator to apply to the yaw
+     * @return a new position
+     */
     @Contract(pure = true)
     public Pos withYaw(DoubleUnaryOperator operator) {
         return withYaw((float) operator.applyAsDouble(yaw));
     }
 
+    /**
+     * Changes the pitch of this position.
+     *
+     * @param pitch the new pitch
+     * @return a new position
+     */
     @Contract(pure = true)
     public Pos withPitch(float pitch) {
         return new Pos(x, y, z, yaw, pitch);
     }
 
+    /**
+     * Changes the view to look at a specific point.
+     *
+     * @param point the point to look at
+     * @return a new position
+     */
     @Contract(pure = true)
     public Pos withLookAt(Point point) {
         if (samePoint(point)) return this;
@@ -123,6 +229,12 @@ public record Pos(double x, double y, double z, float yaw, float pitch) implemen
                 PositionUtils.getLookPitch(delta.x(), delta.y(), delta.z()));
     }
 
+    /**
+     * Applies an operator to the pitch of this position.
+     *
+     * @param operator the operator to apply to the pitch
+     * @return a new position
+     */
     @Contract(pure = true)
     public Pos withPitch(DoubleUnaryOperator operator) {
         return withPitch((float) operator.applyAsDouble(pitch));
@@ -138,9 +250,65 @@ public record Pos(double x, double y, double z, float yaw, float pitch) implemen
         return sameView(position.yaw(), position.pitch());
     }
 
+    /**
+     * Checks if the yaw and pitch are the same as the given ones.
+     *
+     * @param yaw   the yaw
+     * @param pitch the pitch
+     * @return true if the yaw and pitch are the same
+     */
     public boolean sameView(float yaw, float pitch) {
         return Float.compare(this.yaw, yaw) == 0 &&
                 Float.compare(this.pitch, pitch) == 0;
+    }
+
+    /**
+     * Checks if the yaw and pitch are approximately the same as the given ones.
+     *
+     * @param yaw     the yaw
+     * @param pitch   the pitch
+     * @param epsilon the maximum difference to consider the values equal
+     * @return true if the yaw and pitch are approximately the same
+     */
+    public boolean similarView(float yaw, float pitch, float epsilon) {
+        return Math.abs(this.yaw - yaw) < epsilon &&
+                Math.abs(this.pitch - pitch) < epsilon;
+    }
+
+    /**
+     * Checks if two positions have approximately similar views (yaw/pitch).
+     *
+     * @param position the position to compare
+     * @param epsilon  the maximum difference to consider the values equal
+     * @return true if the two positions have a similar view
+     */
+    public boolean similarView(Pos position, float epsilon) {
+        return similarView(position.yaw(), position.pitch(), epsilon);
+    }
+
+    /**
+     * Checks if two positions have approximately similar views (yaw/pitch).
+     * <p>
+     * Uses {@link #VIEW_EPSILON} as epsilon.
+     *
+     * @param position the position to compare
+     * @return true if the two positions have a similar view
+     */
+    public boolean similarView(Pos position) {
+        return similarView(position.yaw(), position.pitch(), VIEW_EPSILON);
+    }
+
+    /**
+     * Checks if the yaw and pitch are approximately the same as the given ones.
+     * <p>
+     * Uses {@link #VIEW_EPSILON} as epsilon.
+     *
+     * @param yaw   the yaw
+     * @param pitch the pitch
+     * @return true if the yaw and pitch are approximately the same
+     */
+    public boolean similarView(float yaw, float pitch) {
+        return similarView(yaw, pitch, VIEW_EPSILON);
     }
 
     /**
@@ -160,7 +328,9 @@ public record Pos(double x, double y, double z, float yaw, float pitch) implemen
     }
 
     /**
-     * @return The closest direction {@link #yaw() yaw} and {@link #pitch() pitch} are facing to.
+     * Gets the closest direction {@link #yaw()} and {@link #pitch()} are facing to.
+     *
+     * @return the direction this position is facing
      */
     public Direction facing() {
         if (pitch < -45) return Direction.UP;
@@ -178,131 +348,271 @@ public record Pos(double x, double y, double z, float yaw, float pitch) implemen
      * @param operator the operator deconstructing this object and providing a new position
      * @return the new position
      */
-    @Contract(pure = true)
     public Pos apply(Operator operator) {
         return operator.apply(x, y, z, yaw, pitch);
     }
 
     @Override
-    @Contract(pure = true)
+    @Contract("_ -> new")
     public Pos withX(DoubleUnaryOperator operator) {
         return new Pos(operator.applyAsDouble(x), y, z, yaw, pitch);
     }
 
     @Override
-    @Contract(pure = true)
+    @Contract(pure = true, value = "_ -> new")
     public Pos withX(double x) {
         return new Pos(x, y, z, yaw, pitch);
     }
 
     @Override
-    @Contract(pure = true)
+    @Contract("_ -> new")
     public Pos withY(DoubleUnaryOperator operator) {
         return new Pos(x, operator.applyAsDouble(y), z, yaw, pitch);
     }
 
     @Override
-    @Contract(pure = true)
+    @Contract(pure = true, value = "_ -> new")
     public Pos withY(double y) {
         return new Pos(x, y, z, yaw, pitch);
     }
 
     @Override
-    @Contract(pure = true)
+    @Contract("_ -> new")
     public Pos withZ(DoubleUnaryOperator operator) {
         return new Pos(x, y, operator.applyAsDouble(z), yaw, pitch);
     }
 
     @Override
-    @Contract(pure = true)
+    @Contract(pure = true, value = "_ -> new")
     public Pos withZ(double z) {
         return new Pos(x, y, z, yaw, pitch);
     }
 
     @Override
+    @Contract(pure = true, value = "_, _, _ -> new")
     public Pos add(double x, double y, double z) {
         return new Pos(this.x + x, this.y + y, this.z + z, yaw, pitch);
     }
 
     @Override
+    @Contract(pure = true, value = "_ -> new")
     public Pos add(Point point) {
         return add(point.x(), point.y(), point.z());
     }
 
     @Override
+    @Contract(pure = true, value = "_ -> new")
     public Pos add(double value) {
         return add(value, value, value);
     }
 
     @Override
+    @Contract(pure = true, value = "_, _, _ -> new")
     public Pos sub(double x, double y, double z) {
         return new Pos(this.x - x, this.y - y, this.z - z, yaw, pitch);
     }
 
     @Override
+    @Contract(pure = true, value = "_ -> new")
     public Pos sub(Point point) {
         return sub(point.x(), point.y(), point.z());
     }
 
     @Override
+    @Contract(pure = true, value = "_ -> new")
     public Pos sub(double value) {
         return sub(value, value, value);
     }
 
     @Override
+    @Contract(pure = true, value = "_, _, _ -> new")
     public Pos mul(double x, double y, double z) {
         return new Pos(this.x * x, this.y * y, this.z * z, yaw, pitch);
     }
 
     @Override
+    @Contract(pure = true, value = "_ -> new")
     public Pos mul(Point point) {
         return mul(point.x(), point.y(), point.z());
     }
 
     @Override
+    @Contract(pure = true, value = "_ -> new")
     public Pos mul(double value) {
         return mul(value, value, value);
     }
 
     @Override
+    @Contract(pure = true, value = "_, _, _ -> new")
     public Pos div(double x, double y, double z) {
         return new Pos(this.x / x, this.y / y, this.z / z, yaw, pitch);
     }
 
     @Override
+    @Contract(pure = true, value = "_ -> new")
     public Pos div(Point point) {
         return div(point.x(), point.y(), point.z());
     }
 
     @Override
+    @Contract(pure = true, value = "_ -> new")
     public Pos div(double value) {
         return div(value, value, value);
     }
 
     @Override
+    @Contract(pure = true, value = "_ -> new")
     public Pos relative(BlockFace face) {
         return (Pos) Point.super.relative(face);
     }
 
-    @FunctionalInterface
-    public interface Operator {
-        Pos apply(double x, double y, double z, float yaw, float pitch);
+    /**
+     * Does nothing as this is already a {@link Pos}.
+     * <p>
+     * Marked as deprecated to warn against redundant usage.
+     *
+     * @return this position
+     */
+    @Deprecated
+    @Override
+    @Contract(pure = true, value = "-> this")
+    public Pos asPos() {
+        return this;
+    }
+
+    @Override
+    @Contract(pure = true, value = "-> new")
+    public Pos normalize() {
+        final double length = length();
+        return new Pos(x / length, y / length, z / length, yaw, pitch);
+    }
+
+    @Override
+    @Contract(pure = true, value = "_ -> new")
+    public Pos cross(Point point) {
+        return new Pos(y * point.z() - point.y() * z,
+                z * point.x() - point.z() * x,
+                x * point.y() - point.x() * y,
+                yaw, pitch);
+    }
+
+    @Override
+    @Contract(pure = true, value = "_, _ -> new")
+    public Pos lerp(Point point, double alpha) {
+        return new Pos(x + (alpha * (point.x() - x)),
+                y + (alpha * (point.y() - y)),
+                z + (alpha * (point.z() - z)),
+                yaw, pitch);
     }
 
     /**
-     * Fixes a yaw value that is not between -180.0F and 180.0F
-     * So for example -1355.0F becomes 85.0F and 225.0F becomes -135.0F
+     * Calculates a linear interpolation between this position's view and another position's view (yaw/pitch).
+     * The coordinates (x/y/z) remain unchanged.
      *
-     * @param yaw The possible "wrong" yaw
-     * @return a fixed yaw
+     * @param pos   the other position
+     * @param alpha the alpha value, must be between 0.0 and 1.0
+     * @return a new position with interpolated view
      */
-    public static float fixYaw(float yaw) {
-        yaw = yaw % 360;
-        if (yaw < -180.0F) {
-            yaw += 360.0F;
-        } else if (yaw > 180.0F) {
-            yaw -= 360.0F;
+    @Contract(pure = true, value = "_, _ -> new")
+    public Pos lerpView(Pos pos, float alpha) {
+        return new Pos(x, y, z,
+                yaw + (alpha * (pos.yaw() - yaw)),
+                pitch + (alpha * (pos.pitch() - pitch)));
+    }
+
+    @Override
+    @Contract(pure = true, value = "-> new")
+    public Pos neg() {
+        return new Pos(-x, -y, -z, yaw, pitch);
+    }
+
+    /**
+     * Negates the view (yaw/pitch) of this position.
+     *
+     * @return a new position
+     */
+    @Contract(pure = true, value = "-> new")
+    public Pos negView() {
+        return new Pos(x, y, z, -yaw, -pitch);
+    }
+
+    @Override
+    @Contract(pure = true, value = "-> new")
+    public Pos abs() {
+        return new Pos(Math.abs(x), Math.abs(y), Math.abs(z), yaw, pitch);
+    }
+
+    /**
+     * Returns the absolute value of the view (yaw/pitch).
+     *
+     * @return a new position
+     */
+    @Contract(pure = true, value = "-> new")
+    public Pos absView() {
+        return new Pos(x, y, z, Math.abs(yaw), Math.abs(pitch));
+    }
+
+    @Override
+    @Contract(pure = true, value = "_ -> new")
+    public Pos min(Point point) {
+        return new Pos(Math.min(x, point.x()), Math.min(y, point.y()), Math.min(z, point.z()), yaw, pitch);
+    }
+
+    @Override
+    @Contract(pure = true, value = "_, _, _ -> new")
+    public Pos min(double x, double y, double z) {
+        return new Pos(Math.min(this.x, x), Math.min(this.y, y), Math.min(this.z, z), yaw, pitch);
+    }
+
+    @Override
+    @Contract(pure = true, value = "_ -> new")
+    public Pos min(double value) {
+        return new Pos(Math.min(x, value), Math.min(y, value), Math.min(z, value), yaw, pitch);
+    }
+
+    @Override
+    @Contract(pure = true, value = "_ -> new")
+    public Pos max(Point point) {
+        return new Pos(Math.max(x, point.x()), Math.max(y, point.y()), Math.max(z, point.z()), yaw, pitch);
+    }
+
+    @Override
+    @Contract(pure = true, value = "_, _, _ -> new")
+    public Pos max(double x, double y, double z) {
+        return new Pos(Math.max(this.x, x), Math.max(this.y, y), Math.max(this.z, z), yaw, pitch);
+    }
+
+    @Override
+    @Contract(pure = true, value = "_ -> new")
+    public Pos max(double value) {
+        return new Pos(Math.max(x, value), Math.max(y, value), Math.max(z, value), yaw, pitch);
+    }
+
+    /**
+     * A functional interface representing an operation on the components of a {@link Pos}.
+     */
+    @FunctionalInterface
+    public interface Operator {
+        /**
+         * Uses a {@link Vec.Operator} for the position components (x/y/z) for a {@link Operator}.
+         *
+         * @param operator the vector operator
+         * @return the position operator
+         */
+        static Operator operator(Vec.Operator operator) {
+            return (x, y, z, yaw, pitch) -> operator.apply(x, y, z).asPos().withView(yaw, pitch);
         }
-        return yaw;
+
+        /**
+         * Applies this operator to the given position components.
+         *
+         * @param x     the x component
+         * @param y     the y component
+         * @param z     the z component
+         * @param yaw   the yaw component
+         * @param pitch the pitch component
+         * @return the resulting position
+         */
+        Pos apply(double x, double y, double z, float yaw, float pitch);
     }
 }

--- a/src/main/java/net/minestom/server/coordinate/Vec.java
+++ b/src/main/java/net/minestom/server/coordinate/Vec.java
@@ -1,25 +1,27 @@
 package net.minestom.server.coordinate;
 
 import net.minestom.server.instance.block.BlockFace;
-import net.minestom.server.utils.Direction;
-import net.minestom.server.utils.MathUtils;
 import org.jetbrains.annotations.Contract;
 
 import java.util.function.DoubleUnaryOperator;
 
-import static net.minestom.server.coordinate.CoordConversion.SECTION_SIZE;
-
 /**
- * Represents an immutable 3D vector.
+ * Represents a 3D vector with double-precision coordinates.
  * <p>
- * To become a value then primitive type.
+ * This is the fundamental coordinate type for precise spatial calculations.
+ * Supports standard vector operations including dot product, cross product,
+ * normalization, and rotation.
+ *
+ * @param x the X coordinate
+ * @param y the Y coordinate
+ * @param z the Z coordinate
  */
 public record Vec(double x, double y, double z) implements Point {
     public static final Vec ZERO = new Vec(0);
     public static final Vec ONE = new Vec(1);
     public static final Vec SECTION = new Vec(SECTION_SIZE);
-
-    public static final double EPSILON = 0.000001;
+    public static final Vec CHUNK = new Vec(SECTION_SIZE, SECTION_SIZE);
+    public static final Vec REGION = new Vec(REGION_SIZE, REGION_SIZE);
 
     /**
      * Creates a new vec with the [x;z] coordinates set. Y is set to 0.
@@ -48,161 +50,180 @@ public record Vec(double x, double y, double z) implements Point {
      * @return the converted vector
      * @deprecated use {@link Point#asVec()} instead
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public static Vec fromPoint(Point point) {
         if (point instanceof Vec vec) return vec;
         return new Vec(point.x(), point.y(), point.z());
     }
 
     /**
-     * Creates a new point with coordinated depending on {@code this}.
+     * Applies the given operator to this vector's coordinates (x/y/z).
      *
-     * @param operator the operator
-     * @return the created point
+     * @param operator the operator to apply
+     * @return the resulting vector
      */
-    @Contract(pure = true)
     public Vec apply(Operator operator) {
         return operator.apply(x, y, z);
     }
 
     @Override
-    @Contract(pure = true)
+    @Contract("_ -> new")
     public Vec withX(DoubleUnaryOperator operator) {
         return new Vec(operator.applyAsDouble(x), y, z);
     }
 
     @Override
-    @Contract(pure = true)
+    @Contract(pure = true, value = "_ -> new")
     public Vec withX(double x) {
         return new Vec(x, y, z);
     }
 
     @Override
-    @Contract(pure = true)
+    @Contract("_ -> new")
     public Vec withY(DoubleUnaryOperator operator) {
         return new Vec(x, operator.applyAsDouble(y), z);
     }
 
     @Override
-    @Contract(pure = true)
+    @Contract(pure = true, value = "_ -> new")
     public Vec withY(double y) {
         return new Vec(x, y, z);
     }
 
     @Override
-    @Contract(pure = true)
+    @Contract("_ -> new")
     public Vec withZ(DoubleUnaryOperator operator) {
         return new Vec(x, y, operator.applyAsDouble(z));
     }
 
     @Override
-    @Contract(pure = true)
+    @Contract(pure = true, value = "_ -> new")
     public Vec withZ(double z) {
         return new Vec(x, y, z);
     }
 
     @Override
+    @Contract(pure = true, value = "_, _, _ -> new")
     public Vec add(double x, double y, double z) {
         return new Vec(this.x + x, this.y + y, this.z + z);
     }
 
     @Override
+    @Contract(pure = true, value = "_ -> new")
     public Vec add(Point point) {
         return add(point.x(), point.y(), point.z());
     }
 
     @Override
+    @Contract(pure = true, value = "_ -> new")
     public Vec add(double value) {
         return add(value, value, value);
     }
 
     @Override
+    @Contract(pure = true, value = "_, _, _ -> new")
     public Vec sub(double x, double y, double z) {
         return new Vec(this.x - x, this.y - y, this.z - z);
     }
 
     @Override
+    @Contract(pure = true, value = "_ -> new")
     public Vec sub(Point point) {
         return sub(point.x(), point.y(), point.z());
     }
 
     @Override
+    @Contract(pure = true, value = "_ -> new")
     public Vec sub(double value) {
         return sub(value, value, value);
     }
 
     @Override
+    @Contract(pure = true, value = "_, _, _ -> new")
     public Vec mul(double x, double y, double z) {
         return new Vec(this.x * x, this.y * y, this.z * z);
     }
 
     @Override
+    @Contract(pure = true, value = "_ -> new")
     public Vec mul(Point point) {
         return mul(point.x(), point.y(), point.z());
     }
 
     @Override
+    @Contract(pure = true, value = "_ -> new")
     public Vec mul(double value) {
         return mul(value, value, value);
     }
 
     @Override
+    @Contract(pure = true, value = "_, _, _ -> new")
     public Vec div(double x, double y, double z) {
         return new Vec(this.x / x, this.y / y, this.z / z);
     }
 
     @Override
+    @Contract(pure = true, value = "_ -> new")
     public Vec div(Point point) {
         return div(point.x(), point.y(), point.z());
     }
 
     @Override
+    @Contract(pure = true, value = "_ -> new")
     public Vec div(double value) {
         return div(value, value, value);
     }
 
     @Override
+    @Contract(pure = true, value = "_ -> new")
     public Vec relative(BlockFace face) {
-        final Direction direction = face.toDirection();
-        return add(direction.normalX(), direction.normalY(), direction.normalZ());
+        return (Vec) Point.super.relative(face);
     }
 
-    @Contract(pure = true)
+    @Override
+    @Contract(pure = true, value = "-> new")
     public Vec neg() {
         return new Vec(-x, -y, -z);
     }
 
-    @Contract(pure = true)
+    @Override
+    @Contract(pure = true, value = "-> new")
     public Vec abs() {
         return new Vec(Math.abs(x), Math.abs(y), Math.abs(z));
     }
 
-    @Contract(pure = true)
+    @Override
+    @Contract(pure = true, value = "_ -> new")
     public Vec min(Point point) {
         return new Vec(Math.min(x, point.x()), Math.min(y, point.y()), Math.min(z, point.z()));
     }
 
-    @Contract(pure = true)
+    @Override
+    @Contract(pure = true, value = "_, _, _ -> new")
     public Vec min(double x, double y, double z) {
         return new Vec(Math.min(this.x, x), Math.min(this.y, y), Math.min(this.z, z));
     }
 
-    @Contract(pure = true)
+    @Override
+    @Contract(pure = true, value = "_ -> new")
     public Vec min(double value) {
         return new Vec(Math.min(x, value), Math.min(y, value), Math.min(z, value));
     }
 
-    @Contract(pure = true)
+    @Override
+    @Contract(pure = true, value = "_ -> new")
     public Vec max(Point point) {
         return new Vec(Math.max(x, point.x()), Math.max(y, point.y()), Math.max(z, point.z()));
     }
 
-    @Contract(pure = true)
+    @Override
+    @Contract(pure = true, value = "_, _, _ -> new")
     public Vec max(double x, double y, double z) {
         return new Vec(Math.max(this.x, x), Math.max(this.y, y), Math.max(this.z, z));
     }
 
-    @Contract(pure = true)
+    @Override
+    @Contract(pure = true, value = "_ -> new")
     public Vec max(double value) {
         return new Vec(Math.max(x, value), Math.max(y, value), Math.max(z, value));
     }
@@ -210,97 +231,25 @@ public record Vec(double x, double y, double z) implements Point {
     /**
      * @deprecated use {@link Point#asPos()} instead.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     @Contract(pure = true)
     public Pos asPosition() {
         return new Pos(x, y, z);
     }
 
-    /**
-     * Gets the magnitude of the vector squared.
-     *
-     * @return the magnitude
-     */
-    @Contract(pure = true)
-    public double lengthSquared() {
-        return MathUtils.square(x) + MathUtils.square(y) + MathUtils.square(z);
-    }
-
-    /**
-     * Gets the magnitude of the vector, defined as sqrt(x^2+y^2+z^2). The
-     * value of this method is not cached and uses a costly square-root
-     * function, so do not repeatedly call this method to get the vector's
-     * magnitude. NaN will be returned if the inner result of the sqrt()
-     * function overflows, which will be caused if the length is too long.
-     *
-     * @return the magnitude
-     */
-    @Contract(pure = true)
-    public double length() {
-        return Math.sqrt(lengthSquared());
-    }
-
-    /**
-     * Converts this vector to a unit vector (a vector with length of 1).
-     *
-     * @return the same vector
-     */
-    @Contract(pure = true)
+    @Override
+    @Contract(pure = true, value = "-> new")
     public Vec normalize() {
         final double length = length();
         return new Vec(x / length, y / length, z / length);
     }
 
-    /**
-     * Returns if a vector is normalized
-     *
-     * @return whether the vector is normalised
-     */
-    public boolean isNormalized() {
-        return Math.abs(lengthSquared() - 1) < EPSILON;
-    }
-
-    /**
-     * Gets the angle between this vector and another in radians.
-     *
-     * @param vec the other vector
-     * @return angle in radians
-     */
-    @Contract(pure = true)
-    public double angle(Vec vec) {
-        final double dot = MathUtils.clamp(dot(vec) / (length() * vec.length()), -1.0, 1.0);
-        return Math.acos(dot);
-    }
-
-    /**
-     * Calculates the dot product of this vector with another. The dot product
-     * is defined as x1*x2+y1*y2+z1*z2. The returned value is a scalar.
-     *
-     * @param vec the other vector
-     * @return dot product
-     */
-    @Contract(pure = true)
-    public double dot(Vec vec) {
-        return x * vec.x + y * vec.y + z * vec.z;
-    }
-
-    /**
-     * Calculates the cross product of this vector with another. The cross
-     * product is defined as:
-     * <ul>
-     * <li>x = y1 * z2 - y2 * z1
-     * <li>y = z1 * x2 - z2 * x1
-     * <li>z = x1 * y2 - x2 * y1
-     * </ul>
-     *
-     * @param o the other vector
-     * @return the same vector
-     */
-    @Contract(pure = true)
-    public Vec cross(Vec o) {
-        return new Vec(y * o.z - o.y * z,
-                z * o.x - o.z * x,
-                x * o.y - o.x * y);
+    @Override
+    @Contract(pure = true, value = "_ -> new")
+    public Vec cross(Point point) {
+        return new Vec(y * point.z() - point.y() * z,
+                z * point.x() - point.z() * x,
+                x * point.y() - point.x() * y);
     }
 
     /**
@@ -315,7 +264,7 @@ public record Vec(double x, double y, double z) implements Point {
      *              in radians
      * @return a new, rotated vector
      */
-    @Contract(pure = true)
+    @Contract(pure = true, value = "_ -> new")
     public Vec rotateAroundX(double angle) {
         double angleCos = Math.cos(angle);
         double angleSin = Math.sin(angle);
@@ -337,7 +286,7 @@ public record Vec(double x, double y, double z) implements Point {
      *              in radians
      * @return a new, rotated vector
      */
-    @Contract(pure = true)
+    @Contract(pure = true, value = "_ -> new")
     public Vec rotateAroundY(double angle) {
         final double angleCos = Math.cos(angle);
         final double angleSin = Math.sin(angle);
@@ -359,7 +308,7 @@ public record Vec(double x, double y, double z) implements Point {
      *              in radians
      * @return a new, rotated vector
      */
-    @Contract(pure = true)
+    @Contract(pure = true, value = "_ -> new")
     public Vec rotateAroundZ(double angle) {
         final double angleCos = Math.cos(angle);
         final double angleSin = Math.sin(angle);
@@ -369,12 +318,27 @@ public record Vec(double x, double y, double z) implements Point {
         return new Vec(newX, newY, z);
     }
 
-    @Contract(pure = true)
+    /**
+     * Rotates the vector around the x, y, and z axes.
+     *
+     * @param angleX the angle to rotate around the x-axis in radians
+     * @param angleY the angle to rotate around the y-axis in radians
+     * @param angleZ the angle to rotate around the z-axis in radians
+     * @return a new, rotated vector
+     */
+    @Contract(pure = true, value = "_, _, _ -> new")
     public Vec rotate(double angleX, double angleY, double angleZ) {
         return rotateAroundX(angleX).rotateAroundY(angleY).rotateAroundZ(angleZ);
     }
 
-    @Contract(pure = true)
+    /**
+     * Rotates the vector from a given yaw and pitch.
+     *
+     * @param yawDegrees   the yaw in degrees
+     * @param pitchDegrees the pitch in degrees
+     * @return a new, rotated vector
+     */
+    @Contract(pure = true, value = "_, _ -> new")
     public Vec rotateFromView(float yawDegrees, float pitchDegrees) {
         final double yaw = Math.toRadians(-1 * (yawDegrees + 90));
         final double pitch = Math.toRadians(-pitchDegrees);
@@ -402,7 +366,13 @@ public record Vec(double x, double y, double z) implements Point {
         return new Vec(x, y, z);
     }
 
-    @Contract(pure = true)
+    /**
+     * Rotates the vector from a position's view (yaw/pitch).
+     *
+     * @param pos the position containing the view
+     * @return a new, rotated vector
+     */
+    @Contract(pure = true, value = "_ -> new")
     public Vec rotateFromView(Pos pos) {
         return rotateFromView(pos.yaw(), pos.pitch());
     }
@@ -426,7 +396,7 @@ public record Vec(double x, double y, double z) implements Point {
      * @param angle the angle to rotate the vector around the axis
      * @return a new vector
      */
-    @Contract(pure = true)
+    @Contract(pure = true, value = "_, _ -> new")
     public Vec rotateAroundAxis(Vec axis, double angle) throws IllegalArgumentException {
         return rotateAroundNonUnitAxis(axis.isNormalized() ? axis : axis.normalize(), angle);
     }
@@ -449,7 +419,7 @@ public record Vec(double x, double y, double z) implements Point {
      * @param angle the angle to rotate the vector around the axis
      * @return a new vector
      */
-    @Contract(pure = true)
+    @Contract(pure = true, value = "_, _ -> new")
     public Vec rotateAroundNonUnitAxis(Vec axis, double angle) throws IllegalArgumentException {
         final double x = x(), y = y(), z = z();
         final double x2 = axis.x(), y2 = axis.y(), z2 = axis.z();
@@ -470,47 +440,84 @@ public record Vec(double x, double y, double z) implements Point {
         return new Vec(newX, newY, newZ);
     }
 
-    /**
-     * Calculates a linear interpolation between this vector with another
-     * vector.
-     *
-     * @param vec   the other vector
-     * @param alpha The alpha value, must be between 0.0 and 1.0
-     * @return Linear interpolated vector
-     */
-    @Contract(pure = true)
-    public Vec lerp(Vec vec, double alpha) {
-        return new Vec(x + (alpha * (vec.x - x)),
-                y + (alpha * (vec.y - y)),
-                z + (alpha * (vec.z - z)));
+    @Override
+    @Contract(pure = true, value = "_, _ -> new")
+    public Vec lerp(Point point, double alpha) {
+        return new Vec(x + (alpha * (point.x() - x)),
+                y + (alpha * (point.y() - y)),
+                z + (alpha * (point.z() - z)));
     }
 
+    /**
+     * Calculates an interpolation between this vector and a target vector.
+     *
+     * @param target        the target vector
+     * @param alpha         the alpha value, must be between 0.0 and 1.0
+     * @param interpolation the interpolation function to use
+     * @return the interpolated vector
+     * @deprecated use {@link Point#lerp(Point, double)} with a {@link net.minestom.server.utils.EaseFunction} instead
+     */
+    @Deprecated(forRemoval = true)
     @Contract(pure = true)
     public Vec interpolate(Vec target, double alpha, Interpolation interpolation) {
         return lerp(target, interpolation.apply(alpha));
     }
 
+    /**
+     * Does nothing as this is already a {@link Vec}.
+     * <p>
+     * Marked as deprecated to warn against redundant usage.
+     *
+     * @return this vector
+     */
+    @Deprecated
+    @Override
+    @Contract(pure = true, value = "-> this")
+    public Vec asVec() {
+        return this;
+    }
+
+    /**
+     * A functional interface representing an operation on the components of a {@link Vec}.
+     */
     @FunctionalInterface
     public interface Operator {
         Operator EPSILON = operator(v -> Math.abs(v) < Vec.EPSILON ? 0 : v);
         Operator FLOOR = operator(Math::floor);
         Operator SIGNUM = operator(Math::signum);
-        Operator ABS = operator(Math::abs);
-        Operator NEG = operator(v -> -v);
         Operator CEIL = operator(Math::ceil);
+        Operator ROUND = operator(Math::round);
 
+        /**
+         * Shortcut utility to apply the operator on all 3 components.
+         *
+         * @param operator the unary operator to use
+         * @return the vector operator
+         */
         static Operator operator(DoubleUnaryOperator operator) {
             return (x, y, z) -> new Vec(operator.applyAsDouble(x), operator.applyAsDouble(y), operator.applyAsDouble(z));
         }
 
+        /**
+         * Applies the operator to the given x, y, z components.
+         *
+         * @param x the x component
+         * @param y the y component
+         * @param z the z component
+         * @return the resulting vector
+         */
         Vec apply(double x, double y, double z);
     }
 
+    /**
+     * @deprecated use {@link net.minestom.server.utils.EaseFunction} instead with {@link #lerp(Point, double)}
+     */
+    @Deprecated(forRemoval = true)
     @FunctionalInterface
     public interface Interpolation {
         Interpolation LINEAR = a -> a;
         Interpolation SMOOTH = a -> a * a * (3 - 2 * a);
 
-        double apply(double a);
+        double apply(double alpha);
     }
 }

--- a/src/main/java/net/minestom/server/coordinate/package-info.java
+++ b/src/main/java/net/minestom/server/coordinate/package-info.java
@@ -1,3 +1,9 @@
+/**
+ * 3D coordinate classes and utilities.
+ * <p>
+ * See {@link net.minestom.server.coordinate.Point} for more details about 3D coordinates (x/y/z).
+ * See {@link net.minestom.server.coordinate.Area} to work with 3D areas.
+ */
 @NotNullByDefault
 package net.minestom.server.coordinate;
 

--- a/src/main/java/net/minestom/server/dialog/Dialog.java
+++ b/src/main/java/net/minestom/server/dialog/Dialog.java
@@ -21,7 +21,7 @@ public sealed interface Dialog extends Holder.Direct<Dialog>, DialogLike {
             Map.entry(Key.key("dialog_list"), DialogList.CODEC),
             Map.entry(Key.key("multi_action"), MultiAction.CODEC),
             Map.entry(Key.key("confirmation"), Confirmation.CODEC));
-    Codec<Dialog> REGISTRY_CODEC = Codec.RegistryTaggedUnion(REGISTRY, Dialog::codec);
+    StructCodec<Dialog> REGISTRY_CODEC = Codec.RegistryTaggedUnion(REGISTRY, Dialog::codec);
     NetworkBuffer.Type<Dialog> REGISTRY_NETWORK_TYPE = NetworkBuffer.TypedNBT(REGISTRY_CODEC);
 
     NetworkBuffer.Type<Holder<Dialog>> NETWORK_TYPE = Holder.networkType(Registries::dialog, REGISTRY_NETWORK_TYPE);
@@ -77,7 +77,7 @@ public sealed interface Dialog extends Holder.Direct<Dialog>, DialogLike {
                 Notice::new);
 
         @Override
-        public StructCodec<? extends Dialog> codec() {
+        public StructCodec<Notice> codec() {
             return CODEC;
         }
     }
@@ -95,7 +95,7 @@ public sealed interface Dialog extends Holder.Direct<Dialog>, DialogLike {
                 ServerLinks::new);
 
         @Override
-        public StructCodec<? extends Dialog> codec() {
+        public StructCodec<ServerLinks> codec() {
             return CODEC;
         }
     }
@@ -115,7 +115,7 @@ public sealed interface Dialog extends Holder.Direct<Dialog>, DialogLike {
                 DialogList::new);
 
         @Override
-        public StructCodec<? extends Dialog> codec() {
+        public StructCodec<DialogList> codec() {
             return CODEC;
         }
     }
@@ -134,7 +134,7 @@ public sealed interface Dialog extends Holder.Direct<Dialog>, DialogLike {
                 MultiAction::new);
 
         @Override
-        public StructCodec<? extends Dialog> codec() {
+        public StructCodec<MultiAction> codec() {
             return CODEC;
         }
     }
@@ -151,13 +151,14 @@ public sealed interface Dialog extends Holder.Direct<Dialog>, DialogLike {
                 Confirmation::new);
 
         @Override
-        public StructCodec<? extends Dialog> codec() {
+        public StructCodec<Confirmation> codec() {
             return CODEC;
         }
     }
 
     DialogMetadata metadata();
 
+    @ApiStatus.OverrideOnly
     StructCodec<? extends Dialog> codec();
 
 }

--- a/src/main/java/net/minestom/server/dialog/DialogAction.java
+++ b/src/main/java/net/minestom/server/dialog/DialogAction.java
@@ -9,6 +9,7 @@ import net.minestom.server.registry.DynamicRegistry;
 import net.minestom.server.registry.Holder;
 import net.minestom.server.registry.Registries;
 import net.minestom.server.registry.Registry;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
@@ -39,7 +40,7 @@ public sealed interface DialogAction {
                 OpenUrl::new);
 
         @Override
-        public StructCodec<? extends DialogAction> codec() {
+        public StructCodec<OpenUrl> codec() {
             return CODEC;
         }
     }
@@ -50,7 +51,7 @@ public sealed interface DialogAction {
                 RunCommand::new);
 
         @Override
-        public StructCodec<? extends DialogAction> codec() {
+        public StructCodec<RunCommand> codec() {
             return CODEC;
         }
     }
@@ -61,7 +62,7 @@ public sealed interface DialogAction {
                 SuggestCommand::new);
 
         @Override
-        public StructCodec<? extends DialogAction> codec() {
+        public StructCodec<SuggestCommand> codec() {
             return CODEC;
         }
     }
@@ -72,7 +73,7 @@ public sealed interface DialogAction {
                 ShowDialog::new);
 
         @Override
-        public StructCodec<? extends DialogAction> codec() {
+        public StructCodec<ShowDialog> codec() {
             return CODEC;
         }
     }
@@ -83,7 +84,7 @@ public sealed interface DialogAction {
                 ChangePage::new);
 
         @Override
-        public StructCodec<? extends DialogAction> codec() {
+        public StructCodec<ChangePage> codec() {
             return CODEC;
         }
     }
@@ -94,7 +95,7 @@ public sealed interface DialogAction {
                 CopyToClipboard::new);
 
         @Override
-        public StructCodec<? extends DialogAction> codec() {
+        public StructCodec<CopyToClipboard> codec() {
             return CODEC;
         }
     }
@@ -106,7 +107,7 @@ public sealed interface DialogAction {
                 Custom::new);
 
         @Override
-        public StructCodec<? extends DialogAction> codec() {
+        public StructCodec<Custom> codec() {
             return CODEC;
         }
     }
@@ -117,7 +118,7 @@ public sealed interface DialogAction {
                 DynamicRunCommand::new);
 
         @Override
-        public StructCodec<? extends DialogAction> codec() {
+        public StructCodec<DynamicRunCommand> codec() {
             return CODEC;
         }
     }
@@ -129,10 +130,11 @@ public sealed interface DialogAction {
                 DynamicCustom::new);
 
         @Override
-        public StructCodec<? extends DialogAction> codec() {
+        public StructCodec<DynamicCustom> codec() {
             return CODEC;
         }
     }
 
+    @ApiStatus.OverrideOnly
     StructCodec<? extends DialogAction> codec();
 }

--- a/src/main/java/net/minestom/server/dialog/DialogBody.java
+++ b/src/main/java/net/minestom/server/dialog/DialogBody.java
@@ -7,6 +7,7 @@ import net.minestom.server.codec.StructCodec;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.registry.DynamicRegistry;
 import net.minestom.server.registry.Registry;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
@@ -35,7 +36,7 @@ public sealed interface DialogBody {
                 Item::new);
 
         @Override
-        public StructCodec<? extends DialogBody> codec() {
+        public StructCodec<Item> codec() {
             return CODEC;
         }
     }
@@ -52,11 +53,12 @@ public sealed interface DialogBody {
                 PlainMessage::new).orElseStruct(COMPONENT_CODEC);
 
         @Override
-        public StructCodec<? extends DialogBody> codec() {
+        public StructCodec<PlainMessage> codec() {
             return CODEC;
         }
     }
 
+    @ApiStatus.OverrideOnly
     StructCodec<? extends DialogBody> codec();
 
 }

--- a/src/main/java/net/minestom/server/dialog/DialogInput.java
+++ b/src/main/java/net/minestom/server/dialog/DialogInput.java
@@ -7,6 +7,7 @@ import net.minestom.server.codec.StructCodec;
 import net.minestom.server.registry.DynamicRegistry;
 import net.minestom.server.registry.Registry;
 import net.minestom.server.utils.validate.Check;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import java.text.MessageFormat;
@@ -51,7 +52,7 @@ public sealed interface DialogInput {
         }
 
         @Override
-        public StructCodec<? extends DialogInput> codec() {
+        public StructCodec<Boolean> codec() {
             return CODEC;
         }
     }
@@ -81,7 +82,7 @@ public sealed interface DialogInput {
         }
 
         @Override
-        public StructCodec<? extends DialogInput> codec() {
+        public StructCodec<NumberRange> codec() {
             return CODEC;
         }
     }
@@ -111,7 +112,7 @@ public sealed interface DialogInput {
         }
 
         @Override
-        public StructCodec<? extends DialogInput> codec() {
+        public StructCodec<SingleOption> codec() {
             return CODEC;
         }
 
@@ -147,7 +148,7 @@ public sealed interface DialogInput {
         }
 
         @Override
-        public StructCodec<? extends DialogInput> codec() {
+        public StructCodec<Text> codec() {
             return CODEC;
         }
 
@@ -159,6 +160,7 @@ public sealed interface DialogInput {
         }
     }
 
+    @ApiStatus.OverrideOnly
     StructCodec<? extends DialogInput> codec();
 
 }

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -248,7 +248,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
      *
      * @param callback the task to execute during the next entity tick
      */
-    public void scheduleNextTick(Consumer<Entity> callback) {
+    public void scheduleNextTick(Consumer<? super Entity> callback) {
         this.scheduler.scheduleNextTick(() -> callback.accept(this));
     }
 
@@ -476,7 +476,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         this.viewEngine.viewableOption.updateAuto(autoViewable);
     }
 
-    public void updateViewableRule(@Nullable Predicate<Player> predicate) {
+    public void updateViewableRule(@Nullable Predicate<? super Player> predicate) {
         this.viewEngine.viewableOption.updateRule(predicate);
     }
 
@@ -503,7 +503,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         this.viewEngine.viewerOption.updateAuto(autoViewer);
     }
 
-    public void updateViewerRule(@Nullable Predicate<Entity> predicate) {
+    public void updateViewerRule(@Nullable Predicate<? super Entity> predicate) {
         this.viewEngine.viewerOption.updateRule(predicate);
     }
 
@@ -565,7 +565,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     }
 
     @Override
-    public Set<Player> getViewers() {
+    public Set<? extends Player> getViewers() {
         return viewers;
     }
 
@@ -1815,7 +1815,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
      * @param predicate optional predicate
      * @return resulting entity whether there're any, null otherwise.
      */
-    public @Nullable Entity getLineOfSightEntity(double range, Predicate<Entity> predicate) {
+    public @Nullable Entity getLineOfSightEntity(double range, Predicate<? super Entity> predicate) {
         Instance instance = getInstance();
         if (instance == null) {
             return null;

--- a/src/main/java/net/minestom/server/entity/EntityType.java
+++ b/src/main/java/net/minestom/server/entity/EntityType.java
@@ -3,6 +3,7 @@ package net.minestom.server.entity;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.KeyPattern;
 import net.minestom.server.codec.Codec;
+import net.minestom.server.entity.attribute.Attribute;
 import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.registry.Registry;
 import net.minestom.server.registry.RegistryData;
@@ -11,6 +12,7 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
+import java.util.Map;
 
 public sealed interface EntityType extends StaticProtocolObject<EntityType>, EntityTypes permits EntityTypeImpl {
     NetworkBuffer.Type<EntityType> NETWORK_TYPE = NetworkBuffer.VAR_INT.transform(EntityType::fromId, EntityType::id);
@@ -40,6 +42,10 @@ public sealed interface EntityType extends StaticProtocolObject<EntityType>, Ent
 
     default double height() {
         return registry().height();
+    }
+
+    default Map<Attribute, Double> defaultAttributes() {
+        return registry().defaultAttributes();
     }
 
     static Collection<EntityType> values() {

--- a/src/main/java/net/minestom/server/entity/EntityView.java
+++ b/src/main/java/net/minestom/server/entity/EntityView.java
@@ -28,7 +28,7 @@ final class EntityView {
     final Set<Player> set = new SetImpl();
     private final Object mutex = this;
 
-    private volatile TrackedLocation trackedLocation;
+    private volatile @Nullable TrackedLocation trackedLocation;
 
     public EntityView(Entity entity) {
         this.entity = entity;
@@ -134,7 +134,7 @@ final class EntityView {
         }
     }
 
-    public void forManuals(Consumer<Player> consumer) {
+    public void forManuals(Consumer<? super Player> consumer) {
         synchronized (mutex) {
             Set<Player> manualViewersCopy = Set.copyOf(this.manualViewers);
             manualViewersCopy.forEach(consumer);
@@ -156,7 +156,7 @@ final class EntityView {
         handleAutoView(entity, viewerOption.removal, viewableOption.removal);
     }
 
-    private void handleAutoView(Entity entity, Consumer<Entity> viewer, Consumer<Player> viewable) {
+    private void handleAutoView(Entity entity, @Nullable Consumer<Entity> viewer, @Nullable Consumer<Player> viewable) {
         if (this.entity instanceof Player && viewerOption.isAuto() && entity.isAutoViewable()) {
             if (viewer != null) viewer.accept(entity); // Send packet to this player
         }
@@ -180,7 +180,7 @@ final class EntityView {
         private volatile int auto = 1;
         // The custom rule used to determine if an entity is viewable.
         // null if auto-viewable
-        private Predicate<T> predicate = null;
+        private @Nullable Predicate<? super T> predicate = null;
 
         public Option(EntityTracker.Target<T> target, Predicate<T> loopPredicate,
                       Consumer<T> addition, Consumer<T> removal) {
@@ -195,7 +195,7 @@ final class EntityView {
         }
 
         public boolean predicate(T entity) {
-            final Predicate<T> predicate = this.predicate;
+            final Predicate<? super T> predicate = this.predicate;
             return predicate == null || predicate.test(entity);
         }
 
@@ -222,7 +222,7 @@ final class EntityView {
             }
         }
 
-        public void updateRule(Predicate<T> predicate) {
+        public void updateRule(@Nullable Predicate<? super T> predicate) {
             synchronized (mutex) {
                 this.predicate = predicate;
                 updateRule0(predicate);
@@ -235,7 +235,7 @@ final class EntityView {
             }
         }
 
-        void updateRule0(Predicate<T> predicate) {
+        void updateRule0(@Nullable Predicate<? super T> predicate) {
             if (predicate == null) {
                 update(loopPredicate, entity -> {
                     if (!isRegistered(entity)) addition.accept(entity);
@@ -251,7 +251,7 @@ final class EntityView {
             }
         }
 
-        private void update(Predicate<T> visibilityPredicate,
+        private void update(Predicate<? super T> visibilityPredicate,
                             Consumer<T> action) {
             references().forEach(entity -> {
                 if (entity == EntityView.this.entity || !visibilityPredicate.test(entity)) return;

--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -450,7 +450,10 @@ public class LivingEntity extends Entity implements EquipmentHandler {
      */
     public AttributeInstance getAttribute(Attribute attribute) {
         return attributeModifiers.computeIfAbsent(attribute.name(),
-                s -> new AttributeInstance(attribute, this::onAttributeChanged));
+                s -> {
+                    double defaultValue = entityType.registry().defaultAttributes().getOrDefault(attribute, attribute.defaultValue());
+                    return new AttributeInstance(attribute, defaultValue, new ArrayList<>(), this::onAttributeChanged);
+                });
     }
 
     /**
@@ -497,7 +500,8 @@ public class LivingEntity extends Entity implements EquipmentHandler {
      */
     public double getAttributeValue(Attribute attribute) {
         AttributeInstance instance = attributeModifiers.get(attribute.name());
-        return (instance != null) ? instance.getValue() : attribute.defaultValue();
+        if (instance != null) return instance.getValue();
+        return entityType.registry().defaultAttributes().getOrDefault(attribute, attribute.defaultValue());
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -33,7 +33,6 @@ import net.minestom.server.command.CommandSender;
 import net.minestom.server.component.DataComponents;
 import net.minestom.server.coordinate.*;
 import net.minestom.server.dialog.Dialog;
-import net.minestom.server.entity.attribute.Attribute;
 import net.minestom.server.entity.metadata.LivingEntityMeta;
 import net.minestom.server.entity.metadata.avatar.PlayerMeta;
 import net.minestom.server.entity.vehicle.PlayerInputs;
@@ -254,7 +253,6 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
         this.gameMode = GameMode.SURVIVAL;
         this.dimensionTypeId = DIMENSION_TYPE_REGISTRY.getId(DimensionType.OVERWORLD); // Default dimension
         this.levelFlat = true;
-        getAttribute(Attribute.MOVEMENT_SPEED).setBaseValue(0.1);
 
         // FakePlayer init its connection there
         playerConnectionInit();

--- a/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/EntityMeta.java
@@ -160,7 +160,7 @@ public class EntityMeta {
         metadata.set(MetadataDef.TICKS_FROZEN, tickFrozen);
     }
 
-    protected void consumeEntity(Consumer<Entity> consumer) {
+    protected void consumeEntity(Consumer<? super Entity> consumer) {
         Entity entity = this.entityRef.get();
         if (entity != null) {
             consumer.accept(entity);

--- a/src/main/java/net/minestom/server/event/instance/InstanceBlockUpdateEvent.java
+++ b/src/main/java/net/minestom/server/event/instance/InstanceBlockUpdateEvent.java
@@ -2,7 +2,6 @@ package net.minestom.server.event.instance;
 
 import net.minestom.server.coordinate.BlockVec;
 import net.minestom.server.event.trait.BlockEvent;
-import net.minestom.server.event.trait.InstanceEvent;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
 
@@ -12,7 +11,7 @@ import net.minestom.server.instance.block.Block;
  * This event is triggered when a block's state changes from its instance.
  * If you wish to listen to all block updates, must be used in conjunction with {@link InstanceSectionInvalidateEvent}
  */
-public class InstanceBlockUpdateEvent implements InstanceEvent, BlockEvent {
+public class InstanceBlockUpdateEvent implements BlockEvent {
     private final Instance instance;
     private final BlockVec blockPosition;
     private final Block block;

--- a/src/main/java/net/minestom/server/event/player/PlayerBlockBreakEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerBlockBreakEvent.java
@@ -2,15 +2,15 @@ package net.minestom.server.event.player;
 
 import net.minestom.server.coordinate.BlockVec;
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.BlockEvent;
-import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.PlayerInstanceEvent;
+import net.minestom.server.event.trait.*;
+import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockFace;
 
 public class PlayerBlockBreakEvent implements PlayerInstanceEvent, BlockEvent, CancellableEvent {
 
     private final Player player;
+    private final Instance instance;
     private final Block block;
     private Block resultBlock;
     private final BlockVec blockPosition;
@@ -18,15 +18,20 @@ public class PlayerBlockBreakEvent implements PlayerInstanceEvent, BlockEvent, C
 
     private boolean cancelled;
 
-    public PlayerBlockBreakEvent(Player player,
+    public PlayerBlockBreakEvent(Player player, Instance instance,
                                  Block block, Block resultBlock, BlockVec blockPosition,
                                  BlockFace blockFace) {
         this.player = player;
-
+        this.instance = instance;
         this.block = block;
         this.resultBlock = resultBlock;
         this.blockPosition = blockPosition;
         this.blockFace = blockFace;
+    }
+
+    @Override
+    public Instance getInstance() {
+        return instance;
     }
 
     /**

--- a/src/main/java/net/minestom/server/event/player/PlayerBlockInteractEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerBlockInteractEvent.java
@@ -4,9 +4,8 @@ import net.minestom.server.coordinate.BlockVec;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Player;
 import net.minestom.server.entity.PlayerHand;
-import net.minestom.server.event.trait.BlockEvent;
-import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.PlayerInstanceEvent;
+import net.minestom.server.event.trait.*;
+import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockFace;
 
@@ -18,6 +17,7 @@ public class PlayerBlockInteractEvent implements PlayerInstanceEvent, BlockEvent
 
     private final Player player;
     private final PlayerHand hand;
+    private final Instance instance;
     private final Block block;
     private final BlockVec blockPosition;
     private final Point cursorPosition;
@@ -31,11 +31,12 @@ public class PlayerBlockInteractEvent implements PlayerInstanceEvent, BlockEvent
 
     private boolean cancelled;
 
-    public PlayerBlockInteractEvent(Player player, PlayerHand hand,
+    public PlayerBlockInteractEvent(Player player, PlayerHand hand, Instance instance,
                                     Block block, BlockVec blockPosition, Point cursorPosition,
                                     BlockFace blockFace) {
         this.player = player;
         this.hand = hand;
+        this.instance = instance;
         this.block = block;
         this.blockPosition = blockPosition;
         this.cursorPosition = cursorPosition;
@@ -58,6 +59,11 @@ public class PlayerBlockInteractEvent implements PlayerInstanceEvent, BlockEvent
      */
     public void setBlockingItemUse(boolean blocks) {
         this.blocksItemUse = blocks;
+    }
+
+    @Override
+    public Instance getInstance() {
+        return instance;
     }
 
     @Override

--- a/src/main/java/net/minestom/server/event/player/PlayerBlockPlaceEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerBlockPlaceEvent.java
@@ -4,9 +4,8 @@ import net.minestom.server.coordinate.BlockVec;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Player;
 import net.minestom.server.entity.PlayerHand;
-import net.minestom.server.event.trait.BlockEvent;
-import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.PlayerInstanceEvent;
+import net.minestom.server.event.trait.*;
+import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockFace;
 
@@ -16,6 +15,7 @@ import net.minestom.server.instance.block.BlockFace;
 public class PlayerBlockPlaceEvent implements PlayerInstanceEvent, BlockEvent, CancellableEvent {
 
     private final Player player;
+    private final Instance instance;
     private Block block;
     private final BlockFace blockFace;
     private final BlockVec blockPosition;
@@ -27,10 +27,11 @@ public class PlayerBlockPlaceEvent implements PlayerInstanceEvent, BlockEvent, C
 
     private boolean cancelled;
 
-    public PlayerBlockPlaceEvent(Player player, Block block,
+    public PlayerBlockPlaceEvent(Player player, Instance instance, Block block,
                                  BlockFace blockFace, BlockVec blockPosition,
                                  Point cursorPosition, PlayerHand hand) {
         this.player = player;
+        this.instance = instance;
         this.block = block;
         this.blockFace = blockFace;
         this.blockPosition = blockPosition;
@@ -38,6 +39,11 @@ public class PlayerBlockPlaceEvent implements PlayerInstanceEvent, BlockEvent, C
         this.hand = hand;
         this.consumeBlock = true;
         this.doBlockUpdates = true;
+    }
+
+    @Override
+    public Instance getInstance() {
+        return instance;
     }
 
     /**

--- a/src/main/java/net/minestom/server/event/player/PlayerCancelDiggingEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerCancelDiggingEvent.java
@@ -4,6 +4,7 @@ import net.minestom.server.coordinate.BlockVec;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.BlockEvent;
 import net.minestom.server.event.trait.PlayerInstanceEvent;
+import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
 
 /**
@@ -11,13 +12,20 @@ import net.minestom.server.instance.block.Block;
  */
 public class PlayerCancelDiggingEvent implements PlayerInstanceEvent, BlockEvent {
     private final Player player;
+    private final Instance instance;
     private final Block block;
     private final BlockVec blockPosition;
 
-    public PlayerCancelDiggingEvent(Player player, Block block, BlockVec blockPosition) {
+    public PlayerCancelDiggingEvent(Player player, Instance instance, Block block, BlockVec blockPosition) {
         this.player = player;
+        this.instance = instance;
         this.block = block;
         this.blockPosition = blockPosition;
+    }
+
+    @Override
+    public Instance getInstance() {
+        return instance;
     }
 
     /**

--- a/src/main/java/net/minestom/server/event/player/PlayerEditSignEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerEditSignEvent.java
@@ -4,23 +4,31 @@ import net.minestom.server.coordinate.BlockVec;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.BlockEvent;
 import net.minestom.server.event.trait.PlayerInstanceEvent;
+import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
 
 import java.util.List;
 
 public class PlayerEditSignEvent implements PlayerInstanceEvent, BlockEvent {
     private final Player player;
+    private final Instance instance;
     private final Block block;
     private final BlockVec blockPosition;
     private final List<String> lines;
     private final boolean isFrontText;
 
-    public PlayerEditSignEvent(Player player, Block block, BlockVec blockPosition, List<String> lines, boolean isFrontText) {
+    public PlayerEditSignEvent(Player player, Instance instance, Block block, BlockVec blockPosition, List<String> lines, boolean isFrontText) {
         this.player = player;
+        this.instance = instance;
         this.block = block;
         this.blockPosition = blockPosition;
         this.lines = lines;
         this.isFrontText = isFrontText;
+    }
+
+    @Override
+    public Instance getInstance() {
+        return instance;
     }
 
     @Override

--- a/src/main/java/net/minestom/server/event/player/PlayerFinishDiggingEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerFinishDiggingEvent.java
@@ -4,6 +4,7 @@ import net.minestom.server.coordinate.BlockVec;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.BlockEvent;
 import net.minestom.server.event.trait.PlayerInstanceEvent;
+import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
 
 /**
@@ -11,13 +12,20 @@ import net.minestom.server.instance.block.Block;
  */
 public class PlayerFinishDiggingEvent implements PlayerInstanceEvent, BlockEvent {
     private final Player player;
+    private final Instance instance;
     private Block block;
     private final BlockVec blockPosition;
 
-    public PlayerFinishDiggingEvent(Player player, Block block, BlockVec blockPosition) {
+    public PlayerFinishDiggingEvent(Player player, Instance instance, Block block, BlockVec blockPosition) {
         this.player = player;
+        this.instance = instance;
         this.block = block;
         this.blockPosition = blockPosition;
+    }
+
+    @Override
+    public Instance getInstance() {
+        return instance;
     }
 
     /**

--- a/src/main/java/net/minestom/server/event/player/PlayerPickBlockEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerPickBlockEvent.java
@@ -4,6 +4,7 @@ import net.minestom.server.coordinate.BlockVec;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.trait.BlockEvent;
 import net.minestom.server.event.trait.PlayerInstanceEvent;
+import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
 
 /**
@@ -13,17 +14,23 @@ public class PlayerPickBlockEvent implements PlayerInstanceEvent, BlockEvent {
 
     private final Player player;
 
+    private final Instance instance;
     private final Block block;
     private final BlockVec blockPosition;
     private final boolean includeData;
 
-    public PlayerPickBlockEvent(Player player, Block block,
+    public PlayerPickBlockEvent(Player player, Instance instance, Block block,
                                 BlockVec blockPosition, boolean includeData) {
         this.player = player;
-
+        this.instance = instance;
         this.block = block;
         this.blockPosition = blockPosition;
         this.includeData = includeData;
+    }
+
+    @Override
+    public Instance getInstance() {
+        return instance;
     }
 
     /**

--- a/src/main/java/net/minestom/server/event/player/PlayerStartDiggingEvent.java
+++ b/src/main/java/net/minestom/server/event/player/PlayerStartDiggingEvent.java
@@ -2,9 +2,8 @@ package net.minestom.server.event.player;
 
 import net.minestom.server.coordinate.BlockVec;
 import net.minestom.server.entity.Player;
-import net.minestom.server.event.trait.BlockEvent;
-import net.minestom.server.event.trait.CancellableEvent;
-import net.minestom.server.event.trait.PlayerInstanceEvent;
+import net.minestom.server.event.trait.*;
+import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockFace;
 
@@ -19,18 +18,26 @@ import net.minestom.server.instance.block.BlockFace;
 public class PlayerStartDiggingEvent implements PlayerInstanceEvent, BlockEvent, CancellableEvent {
 
     private final Player player;
+    private final Instance instance;
     private final Block block;
     private final BlockVec blockPosition;
     private final BlockFace blockFace;
 
     private boolean cancelled;
 
-    public PlayerStartDiggingEvent(Player player, Block block, BlockVec blockPosition,
+    public PlayerStartDiggingEvent(Player player, Instance instance, Block block,
+                                   BlockVec blockPosition,
                                    BlockFace blockFace) {
         this.player = player;
+        this.instance = instance;
         this.block = block;
         this.blockPosition = blockPosition;
         this.blockFace = blockFace;
+    }
+
+    @Override
+    public Instance getInstance() {
+        return instance;
     }
 
     /**

--- a/src/main/java/net/minestom/server/event/trait/BlockEvent.java
+++ b/src/main/java/net/minestom/server/event/trait/BlockEvent.java
@@ -1,10 +1,14 @@
 package net.minestom.server.event.trait;
 
 import net.minestom.server.coordinate.BlockVec;
-import net.minestom.server.event.Event;
+import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
+import org.jetbrains.annotations.ApiStatus;
 
-public interface BlockEvent extends Event {
+/**
+ * Represents an event related to a {@link Block} happening in an {@link Instance}.
+ */
+public interface BlockEvent extends InstanceEvent {
     Block getBlock();
 
     BlockVec getBlockPosition();

--- a/src/main/java/net/minestom/server/instance/Chunk.java
+++ b/src/main/java/net/minestom/server/instance/Chunk.java
@@ -24,6 +24,8 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Supplier;
 
 // TODO light data & API
 
@@ -44,6 +46,7 @@ public abstract class Chunk implements Block.Getter, Block.Setter, Biome.Getter,
     public static final int CHUNK_SECTION_SIZE = 16;
 
     private final UUID identifier;
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
     protected Instance instance;
     protected final int chunkX, chunkZ;
@@ -80,7 +83,7 @@ public abstract class Chunk implements Block.Getter, Block.Setter, Biome.Getter,
      * <p>
      * WARNING: this method is not thread-safe (in order to bring performance improvement with {@link net.minestom.server.instance.batch.Batch batches})
      * The thread-safe version is {@link Instance#setBlock(int, int, int, Block)} (or any similar instance methods)
-     * Otherwise, you can simply do not forget to have this chunk synchronized when this is called.
+     * Otherwise, remember to have this chunk {@link #lockWriteLock() locked} when this is called.
      *
      * @param x     the block X
      * @param y     the block Y
@@ -89,6 +92,7 @@ public abstract class Chunk implements Block.Getter, Block.Setter, Biome.Getter,
      */
     @Override
     public void setBlock(int x, int y, int z, Block block) {
+        assertWriteLock();
         setBlock(x, y, z, block, null, null);
     }
 
@@ -250,6 +254,7 @@ public abstract class Chunk implements Block.Getter, Block.Setter, Biome.Getter,
      * @param readOnly true to make the chunk read-only, false otherwise
      */
     public void setReadOnly(boolean readOnly) {
+        assertWriteLock();
         this.readOnly = readOnly;
     }
 
@@ -308,4 +313,50 @@ public abstract class Chunk implements Block.Getter, Block.Setter, Biome.Getter,
      * Invalidate the chunk caches
      */
     public abstract void invalidate();
+
+    @ApiStatus.Internal
+    protected final void assertWriteLock() {
+        assert holdsWriteLock() : "Not holding write-lock for chunk " + chunkX + "," + chunkZ;
+    }
+
+    @ApiStatus.Internal
+    protected final void assertReadLock() {
+        assert holdsReadLock() : "Not holding read-lock for chunk " + chunkX + "," + chunkZ;
+    }
+
+    @ApiStatus.Experimental
+    public final void lockWriteLock() {
+        lock.writeLock().lock();
+    }
+
+    @ApiStatus.Experimental
+    public final void unlockWriteLock() {
+        lock.writeLock().unlock();
+    }
+
+    @ApiStatus.Experimental
+    public final void lockReadLock() {
+        lock.readLock().lock();
+    }
+
+    @ApiStatus.Experimental
+    public final void unlockReadLock() {
+        lock.readLock().unlock();
+    }
+
+    /**
+     * @return whether the calling thread holds the chunk write-lock
+     */
+    @ApiStatus.Experimental
+    public final boolean holdsWriteLock() {
+        return lock.isWriteLockedByCurrentThread();
+    }
+
+    /**
+     * @return whether the calling thread holds the chunk read-lock
+     */
+    @ApiStatus.Experimental
+    public final boolean holdsReadLock() {
+        return holdsWriteLock() || lock.getReadHoldCount() > 0;
+    }
 }

--- a/src/main/java/net/minestom/server/instance/Chunk.java
+++ b/src/main/java/net/minestom/server/instance/Chunk.java
@@ -293,7 +293,7 @@ public abstract class Chunk implements Block.Getter, Block.Setter, Biome.Getter,
     }
 
     @Override
-    public Set<Player> getViewers() {
+    public Set<? extends Player> getViewers() {
         return viewable.getViewers();
     }
 

--- a/src/main/java/net/minestom/server/instance/EntityTrackerImpl.java
+++ b/src/main/java/net/minestom/server/instance/EntityTrackerImpl.java
@@ -313,7 +313,7 @@ final class EntityTrackerImpl implements EntityTracker {
         }
 
         @Override
-        public Set<Player> getViewers() {
+        public Set<? extends Player> getViewers() {
             return set;
         }
 

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -196,8 +196,11 @@ public abstract class Instance implements Block.Getter, Block.Setter, Biome.Gett
     public void setBiome(int x, int y, int z, RegistryKey<Biome> biome) {
         Chunk chunk = getChunk(CoordConversion.globalToChunk(x), CoordConversion.globalToChunk(z));
         if (chunk == null) return;
-        synchronized (chunk) {
+        chunk.lockWriteLock();
+        try {
             chunk.setBiome(x, y, z, biome);
+        } finally {
+            chunk.unlockWriteLock();
         }
     }
 
@@ -755,8 +758,11 @@ public abstract class Instance implements Block.Getter, Block.Setter, Biome.Gett
     public RegistryKey<Biome> getBiome(int x, int y, int z) {
         Chunk chunk = getChunk(CoordConversion.globalToChunk(x), CoordConversion.globalToChunk(z));
         Objects.requireNonNull(chunk);
-        synchronized (chunk) {
+        chunk.lockReadLock();
+        try {
             return chunk.getBiome(x, y, z);
+        } finally {
+            chunk.unlockReadLock();
         }
     }
 

--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -239,7 +239,7 @@ public class InstanceContainer extends Instance {
             chunk.sendChunk(player);
             return false;
         }
-        PlayerBlockBreakEvent blockBreakEvent = new PlayerBlockBreakEvent(player, block, Block.AIR, new BlockVec(blockPosition), blockFace);
+        PlayerBlockBreakEvent blockBreakEvent = new PlayerBlockBreakEvent(player, this, block, Block.AIR, new BlockVec(blockPosition), blockFace);
         EventDispatcher.call(blockBreakEvent);
         final boolean allowed = !blockBreakEvent.isCancelled();
         if (allowed) {

--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -156,7 +156,8 @@ public class InstanceContainer extends Instance {
             return;
         }
 
-        synchronized (chunk) {
+        chunk.lockWriteLock();
+        try {
             // Refresh the last block change time
             this.lastBlockChangeTime = System.nanoTime();
             final BlockVec blockPosition = new BlockVec(x, y, z);
@@ -209,6 +210,8 @@ public class InstanceContainer extends Instance {
                 }
             }
             EventDispatcher.call(new InstanceBlockUpdateEvent(this, blockPosition, block));
+        } finally {
+            chunk.unlockWriteLock();
         }
     }
 
@@ -459,12 +462,15 @@ public class InstanceContainer extends Instance {
     }
 
     private void applyFork(Chunk chunk, GeneratorImpl.SectionModifierImpl sectionModifier) {
-        synchronized (chunk) {
+        chunk.lockWriteLock();
+        try {
             Section section = chunk.getSectionAt(sectionModifier.start().blockY());
             Palette currentBlocks = section.blockPalette();
             // -1 is necessary because forked units handle explicit changes by changing AIR 0 to 1
             sectionModifier.genSection().blocks().getAllPresent((x, y, z, value) -> currentBlocks.set(x, y, z, value - 1));
             applyGenerationData(chunk, sectionModifier);
+        } finally {
+            chunk.unlockWriteLock();
         }
     }
 
@@ -472,7 +478,8 @@ public class InstanceContainer extends Instance {
         var cache = section.genSection().specials();
         if (cache.isEmpty()) return;
         final int height = section.start().blockY();
-        synchronized (chunk) {
+        chunk.lockWriteLock();
+        try {
             Int2ObjectMaps.fastForEach(cache, blockEntry -> {
                 final int index = blockEntry.getIntKey();
                 final Block block = blockEntry.getValue();
@@ -481,6 +488,8 @@ public class InstanceContainer extends Instance {
                 final int z = CoordConversion.chunkBlockIndexGetZ(index);
                 chunk.setBlock(x, y, z, block);
             });
+        } finally {
+            chunk.unlockWriteLock();
         }
     }
 
@@ -626,9 +635,12 @@ public class InstanceContainer extends Instance {
         CompletableFuture<Void> future = new CompletableFuture<>();
         Thread.startVirtualThread(() -> {
             Chunk chunk = loadChunk(chunkX, chunkZ).join();
-            synchronized (chunk) {
+            chunk.lockWriteLock();
+            try {
                 generateChunk(chunk, generator);
                 chunk.invalidate();
+            } finally {
+                chunk.unlockWriteLock();
             }
             chunk.sendChunk();
             future.complete(null);

--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -15,7 +15,6 @@ import net.minestom.server.event.instance.InstanceBlockUpdateEvent;
 import net.minestom.server.event.instance.InstanceChunkLoadEvent;
 import net.minestom.server.event.instance.InstanceChunkUnloadEvent;
 import net.minestom.server.event.player.PlayerBlockBreakEvent;
-import net.minestom.server.instance.anvil.AnvilLoader;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockEntityType;
 import net.minestom.server.instance.block.BlockFace;
@@ -62,7 +61,7 @@ import static net.minestom.server.utils.chunk.ChunkUtils.isLoaded;
 public class InstanceContainer extends Instance {
     private static final Logger LOGGER = LoggerFactory.getLogger(InstanceContainer.class);
 
-    private static final AnvilLoader DEFAULT_LOADER = new AnvilLoader("world");
+    private static final NoopChunkLoaderImpl DEFAULT_LOADER = NoopChunkLoaderImpl.INSTANCE;
 
     private static final BlockFace[] BLOCK_UPDATE_FACES = new BlockFace[]{
             BlockFace.WEST, BlockFace.EAST, BlockFace.NORTH, BlockFace.SOUTH, BlockFace.BOTTOM, BlockFace.TOP

--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -238,7 +238,7 @@ public class InstanceContainer extends Instance {
             chunk.sendChunk(player);
             return false;
         }
-        PlayerBlockBreakEvent blockBreakEvent = new PlayerBlockBreakEvent(player, this, block, Block.AIR, new BlockVec(blockPosition), blockFace);
+        PlayerBlockBreakEvent blockBreakEvent = new PlayerBlockBreakEvent(player, this, block, Block.AIR, blockPosition.asBlockVec(), blockFace);
         EventDispatcher.call(blockBreakEvent);
         final boolean allowed = !blockBreakEvent.isCancelled();
         if (allowed) {

--- a/src/main/java/net/minestom/server/instance/LightingChunk.java
+++ b/src/main/java/net/minestom/server/instance/LightingChunk.java
@@ -37,12 +37,11 @@ public class LightingChunk extends DynamicChunk {
 
     private static final ExecutorService pool = Executors.newWorkStealingPool();
 
-    private int @Nullable [] occlusionMap;
+    private volatile @Nullable OcclusionData occlusionData;
     final CachedPacket partialLightCache = new CachedPacket(this::createLightPacket);
     private @Nullable LightData partialLightData;
     private @Nullable LightData fullLightData;
 
-    private int highestBlock;
     private boolean freezeInvalidation = false;
 
     private final ReentrantLock packetGenerationLock = new ReentrantLock();
@@ -161,7 +160,7 @@ public class LightingChunk extends DynamicChunk {
                          @Nullable BlockHandler.Placement placement,
                          @Nullable BlockHandler.Destroy destroy) {
         super.setBlock(x, y, z, block, placement, destroy);
-        this.occlusionMap = null;
+        this.occlusionData = null;
 
         // Invalidate neighbor chunks, since they can be updated by this block change
         int coordinate = CoordConversion.globalToChunk(y);
@@ -213,33 +212,41 @@ public class LightingChunk extends DynamicChunk {
         }
     }
 
-    // Lazy compute occlusion map
-    public int[] getOcclusionMap() {
-        if (this.occlusionMap != null) return this.occlusionMap;
-        var occlusionMap = new int[CHUNK_SIZE_X * CHUNK_SIZE_Z];
+    protected OcclusionData getOcclusionData() {
+        assertReadLock();
+        final OcclusionData currentOcclusionData = this.occlusionData;
+        if (currentOcclusionData != null) return currentOcclusionData;
+
+        final int[] occlusionMap = new int[CHUNK_SIZE_X * CHUNK_SIZE_Z];
 
         int minY = instance.getCachedDimensionType().minY();
-        highestBlock = minY - 1;
+        int highestBlock = minY - 1;
 
-        synchronized (this) {
-            int startY = Heightmap.getHighestBlockSection(this);
+        int startY = Heightmap.getHighestBlockSection(this);
 
-            for (int x = 0; x < CHUNK_SIZE_X; x++) {
-                for (int z = 0; z < CHUNK_SIZE_Z; z++) {
-                    int height = startY;
-                    while (height >= minY) {
-                        Block block = getBlock(x, height, z, Condition.TYPE);
-                        if (block != Block.AIR) highestBlock = Math.max(highestBlock, height);
-                        if (checkSkyOcclusion(block)) break;
-                        height--;
-                    }
-                    occlusionMap[z << 4 | x] = (height + 1);
+        for (int x = 0; x < CHUNK_SIZE_X; x++) {
+            for (int z = 0; z < CHUNK_SIZE_Z; z++) {
+                int height = startY;
+                while (height >= minY) {
+                    Block block = getBlock(x, height, z, Condition.TYPE);
+                    if (block != Block.AIR) highestBlock = Math.max(highestBlock, height);
+                    if (checkSkyOcclusion(block)) break;
+                    height--;
                 }
+                occlusionMap[z << 4 | x] = (height + 1);
             }
         }
 
-        this.occlusionMap = occlusionMap;
-        return occlusionMap;
+        var occlusionData = new OcclusionData(highestBlock, occlusionMap);
+        // While we only assert that we are in a read-lock, this should still be OK because even if two threads concurrently
+        // compute the occlusionData, then both results will be the same, and the differing OcclusionData identites are of no concern.
+        this.occlusionData = occlusionData;
+        return occlusionData;
+    }
+
+    // Lazy compute occlusion map
+    public int[] getOcclusionMap() {
+        return getOcclusionData().occlusionMap();
     }
 
     @Override
@@ -271,8 +278,12 @@ public class LightingChunk extends DynamicChunk {
                     if (neighborChunk == null) continue;
 
                     if (neighborChunk instanceof LightingChunk light) {
-                        light.getOcclusionMap();
-                        highestNeighborBlock = Math.max(highestNeighborBlock, light.highestBlock);
+                        light.lockReadLock();
+                        try {
+                            highestNeighborBlock = Math.max(highestNeighborBlock, light.getOcclusionData().highestBlock);
+                        } finally {
+                            light.unlockReadLock();
+                        }
                     }
                 }
             }
@@ -392,15 +403,21 @@ public class LightingChunk extends DynamicChunk {
             final Palette blockPalette = section.blockPalette();
             CompletableFuture<Void> task = CompletableFuture.runAsync(() -> {
                 try {
-                    final Set<Point> toAdd = switch (queueType) {
-                        case INTERNAL -> light.calculateInternal(blockPalette,
-                                chunk.getChunkX(), point.blockY(), chunk.getChunkZ(),
-                                lightingChunk.getOcclusionMap(), chunk.instance.getCachedDimensionType().maxY(),
-                                lightLookup);
-                        case EXTERNAL -> light.calculateExternal(blockPalette,
-                                Light.getNeighbors(chunk, point.blockY()),
-                                lightLookup, paletteLookup);
-                    };
+                    final Set<Point> toAdd;
+                    lightingChunk.lockReadLock();
+                    try {
+                        toAdd = switch (queueType) {
+                            case INTERNAL -> light.calculateInternal(blockPalette,
+                                    chunk.getChunkX(), point.blockY(), chunk.getChunkZ(),
+                                    lightingChunk.getOcclusionMap(), chunk.instance.getCachedDimensionType().maxY(),
+                                    lightLookup);
+                            case EXTERNAL -> light.calculateExternal(blockPalette,
+                                    Light.getNeighbors(chunk, point.blockY()),
+                                    lightLookup, paletteLookup);
+                        };
+                    } finally {
+                        lightingChunk.unlockReadLock();
+                    }
 
                     sections.add(light);
 
@@ -489,9 +506,12 @@ public class LightingChunk extends DynamicChunk {
                 if (chunkCheck == null) continue;
 
                 if (chunkCheck instanceof LightingChunk lighting) {
-                    // Ensure heightmap is calculated before taking values from it
-                    lighting.getOcclusionMap();
-                    highestRegionPoint = Math.max(highestRegionPoint, lighting.highestBlock);
+                    lighting.lockReadLock();
+                    try {
+                        highestRegionPoint = Math.max(highestRegionPoint, lighting.getOcclusionData().highestBlock);
+                    } finally {
+                        lighting.unlockReadLock();
+                    }
                 }
             }
         }
@@ -564,6 +584,7 @@ public class LightingChunk extends DynamicChunk {
 
     @Override
     public Chunk copy(Instance instance, int chunkX, int chunkZ) {
+        assertReadLock();
         var sections = this.sections.stream().map(Section::clone).toList();
         LightingChunk lightingChunk = new LightingChunk(instance, chunkX, chunkZ, sections);
         lightingChunk.entries.putAll(entries);
@@ -573,5 +594,8 @@ public class LightingChunk extends DynamicChunk {
     @Override
     public boolean isLoaded() {
         return super.isLoaded() && doneInit;
+    }
+
+    protected record OcclusionData(int highestBlock, int[] occlusionMap) {
     }
 }

--- a/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
+++ b/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
@@ -105,7 +105,8 @@ public class AnvilLoader implements ChunkLoader {
 
         // Load the chunk data (assuming it is fully generated)
         final Chunk chunk = instance.getChunkSupplier().createChunk(instance, chunkX, chunkZ);
-        synchronized (chunk) { // todo: boo, synchronized
+        chunk.lockWriteLock();
+        try {
             final String status = chunkData.getString("status");
             // TODO: Should we handle other statuses?
             if (status.isEmpty() || "minecraft:full".equals(status)) {
@@ -125,6 +126,8 @@ public class AnvilLoader implements ChunkLoader {
                     .remove("block_entities")
                     .build();
             chunk.tagHandler().updateContent(handlerData);
+        } finally {
+            chunk.unlockWriteLock();
         }
 
         // Cache the index of the loaded chunk
@@ -391,7 +394,8 @@ public class AnvilLoader implements ChunkLoader {
         IntList blockPaletteIndices = new IntArrayList(); // Map block indices by state id to avoid doing a deep comparison on every block tag
         int[] blockIndices = new int[SECTION_BLOCK_COUNT];
 
-        synchronized (chunk) {
+        chunk.lockWriteLock();
+        try {
             for (int sectionY = chunk.getMinSection(); sectionY < chunk.getMaxSection(); sectionY++) {
                 final Section section = chunk.getSection(sectionY);
 
@@ -488,6 +492,8 @@ public class AnvilLoader implements ChunkLoader {
 
                 sections.add(sectionData.build());
             }
+        } finally {
+            chunk.unlockWriteLock();
         }
 
         chunkData.put("sections", sections.build());

--- a/src/main/java/net/minestom/server/instance/batch/ChunkBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/ChunkBatch.java
@@ -181,7 +181,8 @@ public class ChunkBatch implements Batch<ChunkCallback> {
             }
 
             final IntSet sections = new IntArraySet();
-            synchronized (chunk) {
+            chunk.lockWriteLock();
+            try {
                 synchronized (blocks) {
                     for (var entry : blocks.int2ObjectEntrySet()) {
                         final int position = entry.getIntKey();
@@ -190,6 +191,8 @@ public class ChunkBatch implements Batch<ChunkCallback> {
                         sections.add(section);
                     }
                 }
+            } finally {
+                chunk.unlockWriteLock();
             }
 
             if (inverse != null) inverse.readyLatch.countDown();

--- a/src/main/java/net/minestom/server/instance/heightmap/Heightmap.java
+++ b/src/main/java/net/minestom/server/instance/heightmap/Heightmap.java
@@ -48,14 +48,17 @@ public abstract class Heightmap {
 
     public void refresh(int startY) {
         if (!needsRefresh) return;
-        synchronized (chunk) {
+        chunk.lockReadLock();
+        try {
             for (int x = 0; x < CHUNK_SIZE_X; x++) {
                 for (int z = 0; z < CHUNK_SIZE_Z; z++) {
                     refresh(x, z, startY);
                 }
             }
+            needsRefresh = false;
+        } finally {
+            chunk.unlockReadLock();
         }
-        needsRefresh = false;
     }
 
     public void refresh(int x, int z, int startY) {

--- a/src/main/java/net/minestom/server/inventory/AbstractInventory.java
+++ b/src/main/java/net/minestom/server/inventory/AbstractInventory.java
@@ -73,7 +73,7 @@ public sealed abstract class AbstractInventory implements InventoryClickHandler,
     public abstract byte getWindowId();
 
     @Override
-    public Set<Player> getViewers() {
+    public Set<? extends Player> getViewers() {
         return unmodifiableViewers;
     }
 

--- a/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
+++ b/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
@@ -58,7 +58,7 @@ public class BlockPlacementListener {
 
         // Interact at block
         // FIXME: onUseOnBlock
-        PlayerBlockInteractEvent playerBlockInteractEvent = new PlayerBlockInteractEvent(player, hand, interactedBlock, new BlockVec(blockPosition), cursorPosition, blockFace);
+        PlayerBlockInteractEvent playerBlockInteractEvent = new PlayerBlockInteractEvent(player, hand, instance, interactedBlock, new BlockVec(blockPosition), cursorPosition, blockFace);
         EventDispatcher.call(playerBlockInteractEvent);
         boolean blockUse = playerBlockInteractEvent.isBlockingItemUse();
         if (!playerBlockInteractEvent.isCancelled()) {
@@ -157,7 +157,7 @@ public class BlockPlacementListener {
         }
 
         // BlockPlaceEvent check
-        PlayerBlockPlaceEvent playerBlockPlaceEvent = new PlayerBlockPlaceEvent(player, placedBlock, blockFace, new BlockVec(placementPosition), cursorPosition, packet.hand());
+        PlayerBlockPlaceEvent playerBlockPlaceEvent = new PlayerBlockPlaceEvent(player, instance, placedBlock, blockFace, new BlockVec(placementPosition), cursorPosition, packet.hand());
         playerBlockPlaceEvent.consumeBlock(player.getGameMode() != GameMode.CREATIVE);
         playerBlockPlaceEvent.setDoBlockUpdates(blockState.equals(useMaterial.prototype().get(DataComponents.BLOCK_STATE, ItemBlockState.EMPTY)));
         EventDispatcher.call(playerBlockPlaceEvent);

--- a/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
+++ b/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
@@ -58,7 +58,7 @@ public class BlockPlacementListener {
 
         // Interact at block
         // FIXME: onUseOnBlock
-        PlayerBlockInteractEvent playerBlockInteractEvent = new PlayerBlockInteractEvent(player, hand, instance, interactedBlock, new BlockVec(blockPosition), cursorPosition, blockFace);
+        PlayerBlockInteractEvent playerBlockInteractEvent = new PlayerBlockInteractEvent(player, hand, instance, interactedBlock, blockPosition.asBlockVec(), cursorPosition, blockFace);
         EventDispatcher.call(playerBlockInteractEvent);
         boolean blockUse = playerBlockInteractEvent.isBlockingItemUse();
         if (!playerBlockInteractEvent.isCancelled()) {
@@ -157,7 +157,7 @@ public class BlockPlacementListener {
         }
 
         // BlockPlaceEvent check
-        PlayerBlockPlaceEvent playerBlockPlaceEvent = new PlayerBlockPlaceEvent(player, instance, placedBlock, blockFace, new BlockVec(placementPosition), cursorPosition, packet.hand());
+        PlayerBlockPlaceEvent playerBlockPlaceEvent = new PlayerBlockPlaceEvent(player, instance, placedBlock, blockFace, placementPosition.asBlockVec(), cursorPosition, packet.hand());
         playerBlockPlaceEvent.consumeBlock(player.getGameMode() != GameMode.CREATIVE);
         playerBlockPlaceEvent.setDoBlockUpdates(blockState.equals(useMaterial.prototype().get(DataComponents.BLOCK_STATE, ItemBlockState.EMPTY)));
         EventDispatcher.call(playerBlockPlaceEvent);

--- a/src/main/java/net/minestom/server/listener/EditSignListener.java
+++ b/src/main/java/net/minestom/server/listener/EditSignListener.java
@@ -4,15 +4,18 @@ import net.minestom.server.coordinate.BlockVec;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.player.PlayerEditSignEvent;
+import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.network.packet.client.play.ClientUpdateSignPacket;
 
 public class EditSignListener {
     public static void listener(ClientUpdateSignPacket packet, Player player) {
+        Instance instance = player.getInstance();
         BlockVec position = new BlockVec(packet.blockPosition());
-        Block block = player.getInstance().getBlock(position);
+        Block block = instance.getBlock(position);
         EventDispatcher.call(new PlayerEditSignEvent(
                 player,
+                instance,
                 block,
                 position,
                 packet.lines(),

--- a/src/main/java/net/minestom/server/listener/EditSignListener.java
+++ b/src/main/java/net/minestom/server/listener/EditSignListener.java
@@ -11,7 +11,7 @@ import net.minestom.server.network.packet.client.play.ClientUpdateSignPacket;
 public class EditSignListener {
     public static void listener(ClientUpdateSignPacket packet, Player player) {
         Instance instance = player.getInstance();
-        BlockVec position = new BlockVec(packet.blockPosition());
+        BlockVec position = packet.blockPosition().asBlockVec();
         Block block = instance.getBlock(position);
         EventDispatcher.call(new PlayerEditSignEvent(
                 player,

--- a/src/main/java/net/minestom/server/listener/PlayerActionListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerActionListener.java
@@ -77,7 +77,7 @@ public final class PlayerActionListener {
         final int breakTicks = BlockBreakCalculation.breakTicks(block, player);
         final boolean instantBreak = breakTicks == 0;
         if (!instantBreak) {
-            PlayerStartDiggingEvent playerStartDiggingEvent = new PlayerStartDiggingEvent(player, block, new BlockVec(blockPosition), blockFace);
+            PlayerStartDiggingEvent playerStartDiggingEvent = new PlayerStartDiggingEvent(player, instance, block, new BlockVec(blockPosition), blockFace);
             EventDispatcher.call(playerStartDiggingEvent);
             return new DiggingResult(block, !playerStartDiggingEvent.isCancelled());
         }
@@ -88,7 +88,7 @@ public final class PlayerActionListener {
     private static DiggingResult cancelDigging(Player player, Instance instance, Point blockPosition) {
         final Block block = instance.getBlock(blockPosition);
 
-        PlayerCancelDiggingEvent playerCancelDiggingEvent = new PlayerCancelDiggingEvent(player, block, new BlockVec(blockPosition));
+        PlayerCancelDiggingEvent playerCancelDiggingEvent = new PlayerCancelDiggingEvent(player, instance, block, new BlockVec(blockPosition));
         EventDispatcher.call(playerCancelDiggingEvent);
         return new DiggingResult(block, true);
     }
@@ -104,14 +104,14 @@ public final class PlayerActionListener {
         // Realistically shouldn't happen, but a hacked client can send any packet, also illegal ones
         // If the block is unbreakable, prevent a hacked client from breaking it!
         if (breakTicks == BlockBreakCalculation.UNBREAKABLE) {
-            PlayerCancelDiggingEvent playerCancelDiggingEvent = new PlayerCancelDiggingEvent(player, block, new BlockVec(blockPosition));
+            PlayerCancelDiggingEvent playerCancelDiggingEvent = new PlayerCancelDiggingEvent(player, instance, block, new BlockVec(blockPosition));
             EventDispatcher.call(playerCancelDiggingEvent);
             return new DiggingResult(block, false);
         }
         // TODO maybe add a check if the player has spent enough time mining the block.
         //   a hacked client could send START_DIGGING and FINISH_DIGGING to instamine any block
 
-        PlayerFinishDiggingEvent playerFinishDiggingEvent = new PlayerFinishDiggingEvent(player, block, new BlockVec(blockPosition));
+        PlayerFinishDiggingEvent playerFinishDiggingEvent = new PlayerFinishDiggingEvent(player, instance, block, new BlockVec(blockPosition));
         EventDispatcher.call(playerFinishDiggingEvent);
 
         return breakBlock(instance, player, blockPosition, playerFinishDiggingEvent.getBlock(), blockFace);

--- a/src/main/java/net/minestom/server/listener/PlayerActionListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerActionListener.java
@@ -77,7 +77,7 @@ public final class PlayerActionListener {
         final int breakTicks = BlockBreakCalculation.breakTicks(block, player);
         final boolean instantBreak = breakTicks == 0;
         if (!instantBreak) {
-            PlayerStartDiggingEvent playerStartDiggingEvent = new PlayerStartDiggingEvent(player, instance, block, new BlockVec(blockPosition), blockFace);
+            PlayerStartDiggingEvent playerStartDiggingEvent = new PlayerStartDiggingEvent(player, instance, block, blockPosition.asBlockVec(), blockFace);
             EventDispatcher.call(playerStartDiggingEvent);
             return new DiggingResult(block, !playerStartDiggingEvent.isCancelled());
         }
@@ -88,7 +88,7 @@ public final class PlayerActionListener {
     private static DiggingResult cancelDigging(Player player, Instance instance, Point blockPosition) {
         final Block block = instance.getBlock(blockPosition);
 
-        PlayerCancelDiggingEvent playerCancelDiggingEvent = new PlayerCancelDiggingEvent(player, instance, block, new BlockVec(blockPosition));
+        PlayerCancelDiggingEvent playerCancelDiggingEvent = new PlayerCancelDiggingEvent(player, instance, block, blockPosition.asBlockVec());
         EventDispatcher.call(playerCancelDiggingEvent);
         return new DiggingResult(block, true);
     }
@@ -104,14 +104,14 @@ public final class PlayerActionListener {
         // Realistically shouldn't happen, but a hacked client can send any packet, also illegal ones
         // If the block is unbreakable, prevent a hacked client from breaking it!
         if (breakTicks == BlockBreakCalculation.UNBREAKABLE) {
-            PlayerCancelDiggingEvent playerCancelDiggingEvent = new PlayerCancelDiggingEvent(player, instance, block, new BlockVec(blockPosition));
+            PlayerCancelDiggingEvent playerCancelDiggingEvent = new PlayerCancelDiggingEvent(player, instance, block, blockPosition.asBlockVec());
             EventDispatcher.call(playerCancelDiggingEvent);
             return new DiggingResult(block, false);
         }
         // TODO maybe add a check if the player has spent enough time mining the block.
         //   a hacked client could send START_DIGGING and FINISH_DIGGING to instamine any block
 
-        PlayerFinishDiggingEvent playerFinishDiggingEvent = new PlayerFinishDiggingEvent(player, instance, block, new BlockVec(blockPosition));
+        PlayerFinishDiggingEvent playerFinishDiggingEvent = new PlayerFinishDiggingEvent(player, instance, block, blockPosition.asBlockVec());
         EventDispatcher.call(playerFinishDiggingEvent);
 
         return breakBlock(instance, player, blockPosition, playerFinishDiggingEvent.getBlock(), blockFace);

--- a/src/main/java/net/minestom/server/listener/PlayerPickListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerPickListener.java
@@ -19,7 +19,7 @@ public class PlayerPickListener {
         final Block block = instance.getBlock(packet.pos());
         final boolean includeData = packet.includeData();
 
-        PlayerPickBlockEvent playerPickBlockEvent = new PlayerPickBlockEvent(player, block, new BlockVec(packet.pos()), includeData);
+        PlayerPickBlockEvent playerPickBlockEvent = new PlayerPickBlockEvent(player, instance, block, new BlockVec(packet.pos()), includeData);
         EventDispatcher.call(playerPickBlockEvent);
     }
 

--- a/src/main/java/net/minestom/server/listener/PlayerPickListener.java
+++ b/src/main/java/net/minestom/server/listener/PlayerPickListener.java
@@ -1,6 +1,5 @@
 package net.minestom.server.listener;
 
-import net.minestom.server.coordinate.BlockVec;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.EventDispatcher;
@@ -19,7 +18,7 @@ public class PlayerPickListener {
         final Block block = instance.getBlock(packet.pos());
         final boolean includeData = packet.includeData();
 
-        PlayerPickBlockEvent playerPickBlockEvent = new PlayerPickBlockEvent(player, instance, block, new BlockVec(packet.pos()), includeData);
+        PlayerPickBlockEvent playerPickBlockEvent = new PlayerPickBlockEvent(player, instance, block, packet.pos().asBlockVec(), includeData);
         EventDispatcher.call(playerPickBlockEvent);
     }
 

--- a/src/main/java/net/minestom/server/message/Messenger.java
+++ b/src/main/java/net/minestom/server/message/Messenger.java
@@ -47,7 +47,7 @@ public final class Messenger {
      * @param position the position
      * @param uuid     the UUID of the sender, if any
      */
-    public static void sendMessage(Collection<Player> players, Component message,
+    public static void sendMessage(Collection<? extends Player> players, Component message,
                                    ChatPosition position, @Nullable UUID uuid) {
         PacketSendingUtils.sendGroupedPacket(players, new SystemChatPacket(message, false),
                 player -> getChatMessageType(player).accepts(position));

--- a/src/main/java/net/minestom/server/network/NetworkBuffer.java
+++ b/src/main/java/net/minestom/server/network/NetworkBuffer.java
@@ -175,7 +175,7 @@ public sealed interface NetworkBuffer permits NetworkBufferImpl {
 
     @Nullable Registries registries();
 
-    interface Type<T> {
+    interface Type<T extends @UnknownNullability Object> {
         void write(NetworkBuffer buffer, T value);
 
         T read(NetworkBuffer buffer);

--- a/src/main/java/net/minestom/server/network/NetworkBufferTemplate.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferTemplate.java
@@ -3,111 +3,149 @@ package net.minestom.server.network;
 import net.minestom.server.network.NetworkBuffer.Type;
 import org.jetbrains.annotations.UnknownNullability;
 
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+/**
+ * A utility class to create {@link NetworkBuffer.Type} templates
+ * useful for serializing and deserializing objects and ensure the same type written is the same type read.
+ * <pre>{@code
+ * record MyClass(int id, String name) {
+ *         // Using the template utility:
+ *         public static final NetworkBuffer.Type<MyClass> SERIALIZER = NetworkBufferTemplate.template(
+ *                 NetworkBuffer.INT, MyClass::id,
+ *                 NetworkBuffer.STRING, MyClass::name,
+ *                 MyClass::new
+ *         );
+ *         // Compared to writing a custom serializer:
+ *         public static final NetworkBuffer.Type<MyClass> SERIALIZER = new NetworkBufferTypeImpl<>() {
+ *             @Override
+ *             public void write(NetworkBuffer buffer, MyClass value) {
+ *                 buffer.write(NetworkBuffer.INT, value.id());
+ *                 buffer.write(NetworkBuffer.STRING, value.name());
+ *             }
+ *
+ *             @Override
+ *             public MyClass read(NetworkBuffer buffer) {
+ *                 return new MyClass(
+ *                         buffer.read(NetworkBuffer.INT),
+ *                         buffer.read(NetworkBuffer.STRING)
+ *                 );
+ *             }
+ *         };
+ * }
+ * }</pre>
+ */
 public final class NetworkBufferTemplate {
     @FunctionalInterface
-    public interface F1<P1 extends @UnknownNullability Object, R> {
+    public interface F1<P1 extends @UnknownNullability Object, R extends @UnknownNullability Object> {
         R apply(P1 p1);
     }
 
     @FunctionalInterface
-    public interface F2<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, R> {
+    public interface F2<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, R extends @UnknownNullability Object> {
         R apply(P1 p1, P2 p2);
     }
 
     @FunctionalInterface
-    public interface F3<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, R> {
+    public interface F3<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, R extends @UnknownNullability Object> {
         R apply(P1 p1, P2 p2, P3 p3);
     }
 
     @FunctionalInterface
-    public interface F4<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, R> {
+    public interface F4<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, R extends @UnknownNullability Object> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4);
     }
 
     @FunctionalInterface
-    public interface F5<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, R> {
+    public interface F5<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, R extends @UnknownNullability Object> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5);
     }
 
     @FunctionalInterface
-    public interface F6<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, R> {
+    public interface F6<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, R extends @UnknownNullability Object> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6);
     }
 
     @FunctionalInterface
-    public interface F7<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, R> {
+    public interface F7<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, R extends @UnknownNullability Object> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7);
     }
 
     @FunctionalInterface
-    public interface F8<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, R> {
+    public interface F8<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, R extends @UnknownNullability Object> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8);
     }
 
     @FunctionalInterface
-    public interface F9<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, R> {
+    public interface F9<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, R extends @UnknownNullability Object> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9);
     }
 
     @FunctionalInterface
-    public interface F10<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, R> {
+    public interface F10<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, R extends @UnknownNullability Object> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10);
     }
 
     @FunctionalInterface
-    public interface F11<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, R> {
+    public interface F11<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, R extends @UnknownNullability Object> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11);
     }
 
     @FunctionalInterface
-    public interface F12<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, R> {
+    public interface F12<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, R extends @UnknownNullability Object> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12);
     }
 
     @FunctionalInterface
-    public interface F13<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, R> {
+    public interface F13<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, R extends @UnknownNullability Object> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13);
     }
 
     @FunctionalInterface
-    public interface F14<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, R> {
+    public interface F14<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, R extends @UnknownNullability Object> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14);
     }
 
     @FunctionalInterface
-    public interface F15<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, R> {
+    public interface F15<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, R extends @UnknownNullability Object> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15);
     }
 
     @FunctionalInterface
-    public interface F16<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, R> {
+    public interface F16<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, R extends @UnknownNullability Object> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16);
     }
 
     @FunctionalInterface
-    public interface F17<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, R> {
+    public interface F17<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, R extends @UnknownNullability Object> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17);
     }
 
     @FunctionalInterface
-    public interface F18<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, P18 extends @UnknownNullability Object, R> {
+    public interface F18<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, P18 extends @UnknownNullability Object, R extends @UnknownNullability Object> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17, P18 p18);
     }
 
     @FunctionalInterface
-    public interface F19<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, P18 extends @UnknownNullability Object, P19 extends @UnknownNullability Object, R> {
+    public interface F19<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, P18 extends @UnknownNullability Object, P19 extends @UnknownNullability Object, R extends @UnknownNullability Object> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17, P18 p18, P19 p19);
     }
 
     @FunctionalInterface
-    public interface F20<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, P18 extends @UnknownNullability Object, P19 extends @UnknownNullability Object, P20 extends @UnknownNullability Object, R> {
+    public interface F20<P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, P18 extends @UnknownNullability Object, P19 extends @UnknownNullability Object, P20 extends @UnknownNullability Object, R extends @UnknownNullability Object> {
         R apply(P1 p1, P2 p2, P3 p3, P4 p4, P5 p5, P6 p6, P7 p7, P8 p8, P9 p9, P10 p10, P11 p11, P12 p12, P13 p13, P14 p14, P15 p15, P16 p16, P17 p17, P18 p18, P19 p19, P20 p20);
     }
 
-    public static <R> Type<R> template(R value) {
+    /**
+     * Creates a template that always returns {@link R}
+     *
+     * @param value the value to return
+     * @param <R>   the type of the value
+     * @return the new template
+     */
+    public static <R extends @UnknownNullability Object> Type<R> template(R value) {
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -120,7 +158,15 @@ public final class NetworkBufferTemplate {
         };
     }
 
-    public static <R> Type<R> template(Supplier<R> supplier) {
+    /**
+     * Creates a template that uses a supplier to get a value {@link R}
+     *
+     * @param supplier the supplier to get the value
+     * @param <R>      the type of the value
+     * @return the new template
+     */
+    public static <R extends @UnknownNullability Object> Type<R> template(Supplier<? extends R> supplier) {
+        Objects.requireNonNull(supplier, "supplier");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -133,7 +179,20 @@ public final class NetworkBufferTemplate {
         };
     }
 
-    public static <P1, R> Type<R> template(Type<P1> p1, Function<R, P1> g1, F1<P1, R> reader) {
+    /**
+     * Creates a template with one parameter
+     *
+     * @param p1   the first parameter {@link Type}
+     * @param g1   the first parameter getter
+     * @param ctor the constructor for {@link R}
+     * @param <P1> the type of the first parameter
+     * @param <R>  the type of the value
+     * @return the new template
+     */
+    public static <P1 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(Type<P1> p1, Function<? super R, ? extends P1> g1, Function<? super P1, ? extends R> ctor) {
+        Objects.requireNonNull(p1, "p1");
+        Objects.requireNonNull(g1, "g1");
+        Objects.requireNonNull(ctor, "ctor");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -142,15 +201,33 @@ public final class NetworkBufferTemplate {
 
             @Override
             public R read(NetworkBuffer buffer) {
-                return reader.apply(p1.read(buffer));
+                return ctor.apply(p1.read(buffer));
             }
         };
     }
 
-    public static <P1, P2, R> Type<R> template(
-            Type<P1> p1, Function<R, P1> g1, Type<P2> p2, Function<R, P2> g2,
-            F2<P1, P2, R> reader
+    /**
+     * Creates a template with two parameters
+     *
+     * @param p1   the first parameter {@link Type}
+     * @param g1   the first parameter getter
+     * @param p2   the second parameter {@link Type}
+     * @param g2   the second parameter getter
+     * @param ctor the constructor for {@link R}
+     * @param <P1> the type of the first parameter
+     * @param <P2> the type of the second parameter
+     * @param <R>  the type of the value
+     * @return the new template
+     */
+    public static <P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(
+            Type<P1> p1, Function<? super R, ? extends P1> g1, Type<P2> p2, Function<? super R, ? extends P2> g2,
+            F2<? super P1, ? super P2, ? extends R> ctor
     ) {
+        Objects.requireNonNull(p1, "p1");
+        Objects.requireNonNull(g1, "g1");
+        Objects.requireNonNull(p2, "p2");
+        Objects.requireNonNull(g2, "g2");
+        Objects.requireNonNull(ctor, "ctor");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -160,15 +237,38 @@ public final class NetworkBufferTemplate {
 
             @Override
             public R read(NetworkBuffer buffer) {
-                return reader.apply(p1.read(buffer), p2.read(buffer));
+                return ctor.apply(p1.read(buffer), p2.read(buffer));
             }
         };
     }
 
-    public static <P1, P2, P3, R> Type<R> template(
-            Type<P1> p1, Function<R, P1> g1, Type<P2> p2, Function<R, P2> g2,
-            Type<P3> p3, Function<R, P3> g3, F3<P1, P2, P3, R> reader
+    /**
+     * Creates a template with three parameters
+     *
+     * @param p1   the first parameter {@link Type}
+     * @param g1   the first parameter getter
+     * @param p2   the second parameter {@link Type}
+     * @param g2   the second parameter getter
+     * @param p3   the third parameter {@link Type}
+     * @param g3   the third parameter getter
+     * @param ctor the constructor for {@link R}
+     * @param <P1> the type of the first parameter
+     * @param <P2> the type of the second parameter
+     * @param <P3> the type of the third parameter
+     * @param <R>  the type of the value
+     * @return the new template
+     */
+    public static <P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(
+            Type<P1> p1, Function<? super R, ? extends P1> g1, Type<P2> p2, Function<? super R, ? extends P2> g2,
+            Type<P3> p3, Function<? super R, ? extends P3> g3, F3<? super P1, ? super P2, ? super P3, ? extends R> ctor
     ) {
+        Objects.requireNonNull(p1, "p1");
+        Objects.requireNonNull(g1, "g1");
+        Objects.requireNonNull(p2, "p2");
+        Objects.requireNonNull(g2, "g2");
+        Objects.requireNonNull(p3, "p3");
+        Objects.requireNonNull(g3, "g3");
+        Objects.requireNonNull(ctor, "ctor");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -179,16 +279,44 @@ public final class NetworkBufferTemplate {
 
             @Override
             public R read(NetworkBuffer buffer) {
-                return reader.apply(p1.read(buffer), p2.read(buffer), p3.read(buffer));
+                return ctor.apply(p1.read(buffer), p2.read(buffer), p3.read(buffer));
             }
         };
     }
 
-    public static <P1, P2, P3, P4, R> Type<R> template(
-            Type<P1> p1, Function<R, P1> g1, Type<P2> p2, Function<R, P2> g2,
-            Type<P3> p3, Function<R, P3> g3, Type<P4> p4, Function<R, P4> g4,
-            F4<P1, P2, P3, P4, R> reader
+    /**
+     * Creates a template with four parameters
+     *
+     * @param p1   the first parameter {@link Type}
+     * @param g1   the first parameter getter
+     * @param p2   the second parameter {@link Type}
+     * @param g2   the second parameter getter
+     * @param p3   the third parameter {@link Type}
+     * @param g3   the third parameter getter
+     * @param p4   the fourth parameter {@link Type}
+     * @param g4   the fourth parameter getter
+     * @param ctor the constructor for {@link R}
+     * @param <P1> the type of the first parameter
+     * @param <P2> the type of the second parameter
+     * @param <P3> the type of the third parameter
+     * @param <P4> the type of the fourth parameter
+     * @param <R>  the type of the value
+     * @return the new template
+     */
+    public static <P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(
+            Type<P1> p1, Function<? super R, ? extends P1> g1, Type<P2> p2, Function<? super R, ? extends P2> g2,
+            Type<P3> p3, Function<? super R, ? extends P3> g3, Type<P4> p4, Function<? super R, ? extends P4> g4,
+            F4<? super P1, ? super P2, ? super P3, ? super P4, ? extends R> ctor
     ) {
+        Objects.requireNonNull(p1, "p1");
+        Objects.requireNonNull(g1, "g1");
+        Objects.requireNonNull(p2, "p2");
+        Objects.requireNonNull(g2, "g2");
+        Objects.requireNonNull(p3, "p3");
+        Objects.requireNonNull(g3, "g3");
+        Objects.requireNonNull(p4, "p4");
+        Objects.requireNonNull(g4, "g4");
+        Objects.requireNonNull(ctor, "ctor");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -200,7 +328,7 @@ public final class NetworkBufferTemplate {
 
             @Override
             public R read(NetworkBuffer buffer) {
-                return reader.apply(
+                return ctor.apply(
                         p1.read(buffer), p2.read(buffer),
                         p3.read(buffer), p4.read(buffer)
                 );
@@ -208,11 +336,44 @@ public final class NetworkBufferTemplate {
         };
     }
 
-    public static <P1, P2, P3, P4, P5, R> Type<R> template(
-            Type<P1> p1, Function<R, P1> g1, Type<P2> p2, Function<R, P2> g2,
-            Type<P3> p3, Function<R, P3> g3, Type<P4> p4, Function<R, P4> g4,
-            Type<P5> p5, Function<R, P5> g5, F5<P1, P2, P3, P4, P5, R> reader
+    /**
+     * Creates a template with five parameters
+     *
+     * @param p1   the first parameter {@link Type}
+     * @param g1   the first parameter getter
+     * @param p2   the second parameter {@link Type}
+     * @param g2   the second parameter getter
+     * @param p3   the third parameter {@link Type}
+     * @param g3   the third parameter getter
+     * @param p4   the fourth parameter {@link Type}
+     * @param g4   the fourth parameter getter
+     * @param p5   the fifth parameter {@link Type}
+     * @param g5   the fifth parameter getter
+     * @param ctor the constructor for {@link R}
+     * @param <P1> the type of the first parameter
+     * @param <P2> the type of the second parameter
+     * @param <P3> the type of the third parameter
+     * @param <P4> the type of the fourth parameter
+     * @param <P5> the type of the fifth parameter
+     * @param <R>  the type of the value
+     * @return the new template
+     */
+    public static <P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(
+            Type<P1> p1, Function<? super R, ? extends P1> g1, Type<P2> p2, Function<? super R, ? extends P2> g2,
+            Type<P3> p3, Function<? super R, ? extends P3> g3, Type<P4> p4, Function<? super R, ? extends P4> g4,
+            Type<P5> p5, Function<? super R, ? extends P5> g5, F5<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? extends R> ctor
     ) {
+        Objects.requireNonNull(p1, "p1");
+        Objects.requireNonNull(g1, "g1");
+        Objects.requireNonNull(p2, "p2");
+        Objects.requireNonNull(g2, "g2");
+        Objects.requireNonNull(p3, "p3");
+        Objects.requireNonNull(g3, "g3");
+        Objects.requireNonNull(p4, "p4");
+        Objects.requireNonNull(g4, "g4");
+        Objects.requireNonNull(p5, "p5");
+        Objects.requireNonNull(g5, "g5");
+        Objects.requireNonNull(ctor, "ctor");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -225,7 +386,7 @@ public final class NetworkBufferTemplate {
 
             @Override
             public R read(NetworkBuffer buffer) {
-                return reader.apply(
+                return ctor.apply(
                         p1.read(buffer), p2.read(buffer),
                         p3.read(buffer), p4.read(buffer),
                         p5.read(buffer)
@@ -234,12 +395,50 @@ public final class NetworkBufferTemplate {
         };
     }
 
-    public static <P1, P2, P3, P4, P5, P6, R> Type<R> template(
-            Type<P1> p1, Function<R, P1> g1, Type<P2> p2, Function<R, P2> g2,
-            Type<P3> p3, Function<R, P3> g3, Type<P4> p4, Function<R, P4> g4,
-            Type<P5> p5, Function<R, P5> g5, Type<P6> p6, Function<R, P6> g6,
-            F6<P1, P2, P3, P4, P5, P6, R> reader
+    /**
+     * Creates a template with six parameters
+     *
+     * @param p1   the first parameter {@link Type}
+     * @param g1   the first parameter getter
+     * @param p2   the second parameter {@link Type}
+     * @param g2   the second parameter getter
+     * @param p3   the third parameter {@link Type}
+     * @param g3   the third parameter getter
+     * @param p4   the fourth parameter {@link Type}
+     * @param g4   the fourth parameter getter
+     * @param p5   the fifth parameter {@link Type}
+     * @param g5   the fifth parameter getter
+     * @param p6   the sixth parameter {@link Type}
+     * @param g6   the sixth parameter getter
+     * @param ctor the constructor for {@link R}
+     * @param <P1> the type of the first parameter
+     * @param <P2> the type of the second parameter
+     * @param <P3> the type of the third parameter
+     * @param <P4> the type of the fourth parameter
+     * @param <P5> the type of the fifth parameter
+     * @param <P6> the type of the sixth parameter
+     * @param <R>  the type of the value
+     * @return the new template
+     */
+    public static <P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(
+            Type<P1> p1, Function<? super R, ? extends P1> g1, Type<P2> p2, Function<? super R, ? extends P2> g2,
+            Type<P3> p3, Function<? super R, ? extends P3> g3, Type<P4> p4, Function<? super R, ? extends P4> g4,
+            Type<P5> p5, Function<? super R, ? extends P5> g5, Type<P6> p6, Function<? super R, ? extends P6> g6,
+            F6<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? extends R> ctor
     ) {
+        Objects.requireNonNull(p1, "p1");
+        Objects.requireNonNull(g1, "g1");
+        Objects.requireNonNull(p2, "p2");
+        Objects.requireNonNull(g2, "g2");
+        Objects.requireNonNull(p3, "p3");
+        Objects.requireNonNull(g3, "g3");
+        Objects.requireNonNull(p4, "p4");
+        Objects.requireNonNull(g4, "g4");
+        Objects.requireNonNull(p5, "p5");
+        Objects.requireNonNull(g5, "g5");
+        Objects.requireNonNull(p6, "p6");
+        Objects.requireNonNull(g6, "g6");
+        Objects.requireNonNull(ctor, "ctor");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -253,7 +452,7 @@ public final class NetworkBufferTemplate {
 
             @Override
             public R read(NetworkBuffer buffer) {
-                return reader.apply(
+                return ctor.apply(
                         p1.read(buffer), p2.read(buffer),
                         p3.read(buffer), p4.read(buffer),
                         p5.read(buffer), p6.read(buffer)
@@ -262,12 +461,55 @@ public final class NetworkBufferTemplate {
         };
     }
 
-    public static <P1, P2, P3, P4, P5, P6, P7, R> Type<R> template(
-            Type<P1> p1, Function<R, P1> g1, Type<P2> p2, Function<R, P2> g2,
-            Type<P3> p3, Function<R, P3> g3, Type<P4> p4, Function<R, P4> g4,
-            Type<P5> p5, Function<R, P5> g5, Type<P6> p6, Function<R, P6> g6,
-            Type<P7> p7, Function<R, P7> g7, F7<P1, P2, P3, P4, P5, P6, P7, R> reader
+    /**
+     * Creates a template with seven parameters
+     *
+     * @param p1   the first parameter {@link Type}
+     * @param g1   the first parameter getter
+     * @param p2   the second parameter {@link Type}
+     * @param g2   the second parameter getter
+     * @param p3   the third parameter {@link Type}
+     * @param g3   the third parameter getter
+     * @param p4   the fourth parameter {@link Type}
+     * @param g4   the fourth parameter getter
+     * @param p5   the fifth parameter {@link Type}
+     * @param g5   the fifth parameter getter
+     * @param p6   the sixth parameter {@link Type}
+     * @param g6   the sixth parameter getter
+     * @param p7   the seventh parameter {@link Type}
+     * @param g7   the seventh parameter getter
+     * @param ctor the constructor for {@link R}
+     * @param <P1> the type of the first parameter
+     * @param <P2> the type of the second parameter
+     * @param <P3> the type of the third parameter
+     * @param <P4> the type of the fourth parameter
+     * @param <P5> the type of the fifth parameter
+     * @param <P6> the type of the sixth parameter
+     * @param <P7> the type of the seventh parameter
+     * @param <R>  the type of the value
+     * @return the new template
+     */
+    public static <P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(
+            Type<P1> p1, Function<? super R, ? extends P1> g1, Type<P2> p2, Function<? super R, ? extends P2> g2,
+            Type<P3> p3, Function<? super R, ? extends P3> g3, Type<P4> p4, Function<? super R, ? extends P4> g4,
+            Type<P5> p5, Function<? super R, ? extends P5> g5, Type<P6> p6, Function<? super R, ? extends P6> g6,
+            Type<P7> p7, Function<? super R, ? extends P7> g7, F7<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? extends R> ctor
     ) {
+        Objects.requireNonNull(p1, "p1");
+        Objects.requireNonNull(g1, "g1");
+        Objects.requireNonNull(p2, "p2");
+        Objects.requireNonNull(g2, "g2");
+        Objects.requireNonNull(p3, "p3");
+        Objects.requireNonNull(g3, "g3");
+        Objects.requireNonNull(p4, "p4");
+        Objects.requireNonNull(g4, "g4");
+        Objects.requireNonNull(p5, "p5");
+        Objects.requireNonNull(g5, "g5");
+        Objects.requireNonNull(p6, "p6");
+        Objects.requireNonNull(g6, "g6");
+        Objects.requireNonNull(p7, "p7");
+        Objects.requireNonNull(g7, "g7");
+        Objects.requireNonNull(ctor, "ctor");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -282,7 +524,7 @@ public final class NetworkBufferTemplate {
 
             @Override
             public R read(NetworkBuffer buffer) {
-                return reader.apply(
+                return ctor.apply(
                         p1.read(buffer), p2.read(buffer),
                         p3.read(buffer), p4.read(buffer),
                         p5.read(buffer), p6.read(buffer),
@@ -292,13 +534,61 @@ public final class NetworkBufferTemplate {
         };
     }
 
-    public static <P1, P2, P3, P4, P5, P6, P7, P8, R> Type<R> template(
-            Type<P1> p1, Function<R, P1> g1, Type<P2> p2, Function<R, P2> g2,
-            Type<P3> p3, Function<R, P3> g3, Type<P4> p4, Function<R, P4> g4,
-            Type<P5> p5, Function<R, P5> g5, Type<P6> p6, Function<R, P6> g6,
-            Type<P7> p7, Function<R, P7> g7, Type<P8> p8, Function<R, P8> g8,
-            F8<P1, P2, P3, P4, P5, P6, P7, P8, R> reader
+    /**
+     * Creates a template with eight parameters
+     *
+     * @param p1   the first parameter {@link Type}
+     * @param g1   the first parameter getter
+     * @param p2   the second parameter {@link Type}
+     * @param g2   the second parameter getter
+     * @param p3   the third parameter {@link Type}
+     * @param g3   the third parameter getter
+     * @param p4   the fourth parameter {@link Type}
+     * @param g4   the fourth parameter getter
+     * @param p5   the fifth parameter {@link Type}
+     * @param g5   the fifth parameter getter
+     * @param p6   the sixth parameter {@link Type}
+     * @param g6   the sixth parameter getter
+     * @param p7   the seventh parameter {@link Type}
+     * @param g7   the seventh parameter getter
+     * @param p8   the eighth parameter {@link Type}
+     * @param g8   the eighth parameter getter
+     * @param ctor the constructor for {@link R}
+     * @param <P1> the type of the first parameter
+     * @param <P2> the type of the second parameter
+     * @param <P3> the type of the third parameter
+     * @param <P4> the type of the fourth parameter
+     * @param <P5> the type of the fifth parameter
+     * @param <P6> the type of the sixth parameter
+     * @param <P7> the type of the seventh parameter
+     * @param <P8> the type of the eighth parameter
+     * @param <R>  the type of the value
+     * @return the new template
+     */
+    public static <P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(
+            Type<P1> p1, Function<? super R, ? extends P1> g1, Type<P2> p2, Function<? super R, ? extends P2> g2,
+            Type<P3> p3, Function<? super R, ? extends P3> g3, Type<P4> p4, Function<? super R, ? extends P4> g4,
+            Type<P5> p5, Function<? super R, ? extends P5> g5, Type<P6> p6, Function<? super R, ? extends P6> g6,
+            Type<P7> p7, Function<? super R, ? extends P7> g7, Type<P8> p8, Function<? super R, ? extends P8> g8,
+            F8<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? extends R> ctor
     ) {
+        Objects.requireNonNull(p1, "p1");
+        Objects.requireNonNull(g1, "g1");
+        Objects.requireNonNull(p2, "p2");
+        Objects.requireNonNull(g2, "g2");
+        Objects.requireNonNull(p3, "p3");
+        Objects.requireNonNull(g3, "g3");
+        Objects.requireNonNull(p4, "p4");
+        Objects.requireNonNull(g4, "g4");
+        Objects.requireNonNull(p5, "p5");
+        Objects.requireNonNull(g5, "g5");
+        Objects.requireNonNull(p6, "p6");
+        Objects.requireNonNull(g6, "g6");
+        Objects.requireNonNull(p7, "p7");
+        Objects.requireNonNull(g7, "g7");
+        Objects.requireNonNull(p8, "p8");
+        Objects.requireNonNull(g8, "g8");
+        Objects.requireNonNull(ctor, "ctor");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -314,7 +604,7 @@ public final class NetworkBufferTemplate {
 
             @Override
             public R read(NetworkBuffer buffer) {
-                return reader.apply(
+                return ctor.apply(
                         p1.read(buffer), p2.read(buffer),
                         p3.read(buffer), p4.read(buffer),
                         p5.read(buffer), p6.read(buffer),
@@ -324,13 +614,66 @@ public final class NetworkBufferTemplate {
         };
     }
 
-    public static <P1, P2, P3, P4, P5, P6, P7, P8, P9, R> Type<R> template(
-            Type<P1> p1, Function<R, P1> g1, Type<P2> p2, Function<R, P2> g2,
-            Type<P3> p3, Function<R, P3> g3, Type<P4> p4, Function<R, P4> g4,
-            Type<P5> p5, Function<R, P5> g5, Type<P6> p6, Function<R, P6> g6,
-            Type<P7> p7, Function<R, P7> g7, Type<P8> p8, Function<R, P8> g8,
-            Type<P9> p9, Function<R, P9> g9, F9<P1, P2, P3, P4, P5, P6, P7, P8, P9, R> reader
+    /**
+     * Creates a template with nine parameters
+     *
+     * @param p1   the first parameter {@link Type}
+     * @param g1   the first parameter getter
+     * @param p2   the second parameter {@link Type}
+     * @param g2   the second parameter getter
+     * @param p3   the third parameter {@link Type}
+     * @param g3   the third parameter getter
+     * @param p4   the fourth parameter {@link Type}
+     * @param g4   the fourth parameter getter
+     * @param p5   the fifth parameter {@link Type}
+     * @param g5   the fifth parameter getter
+     * @param p6   the sixth parameter {@link Type}
+     * @param g6   the sixth parameter getter
+     * @param p7   the seventh parameter {@link Type}
+     * @param g7   the seventh parameter getter
+     * @param p8   the eighth parameter {@link Type}
+     * @param g8   the eighth parameter getter
+     * @param p9   the ninth parameter {@link Type}
+     * @param g9   the ninth parameter getter
+     * @param ctor the constructor for {@link R}
+     * @param <P1> the type of the first parameter
+     * @param <P2> the type of the second parameter
+     * @param <P3> the type of the third parameter
+     * @param <P4> the type of the fourth parameter
+     * @param <P5> the type of the fifth parameter
+     * @param <P6> the type of the sixth parameter
+     * @param <P7> the type of the seventh parameter
+     * @param <P8> the type of the eighth parameter
+     * @param <P9> the type of the ninth parameter
+     * @param <R>  the type of the value
+     * @return the new template
+     */
+    public static <P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(
+            Type<P1> p1, Function<? super R, ? extends P1> g1, Type<P2> p2, Function<? super R, ? extends P2> g2,
+            Type<P3> p3, Function<? super R, ? extends P3> g3, Type<P4> p4, Function<? super R, ? extends P4> g4,
+            Type<P5> p5, Function<? super R, ? extends P5> g5, Type<P6> p6, Function<? super R, ? extends P6> g6,
+            Type<P7> p7, Function<? super R, ? extends P7> g7, Type<P8> p8, Function<? super R, ? extends P8> g8,
+            Type<P9> p9, Function<? super R, ? extends P9> g9, F9<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? extends R> ctor
     ) {
+        Objects.requireNonNull(p1, "p1");
+        Objects.requireNonNull(g1, "g1");
+        Objects.requireNonNull(p2, "p2");
+        Objects.requireNonNull(g2, "g2");
+        Objects.requireNonNull(p3, "p3");
+        Objects.requireNonNull(g3, "g3");
+        Objects.requireNonNull(p4, "p4");
+        Objects.requireNonNull(g4, "g4");
+        Objects.requireNonNull(p5, "p5");
+        Objects.requireNonNull(g5, "g5");
+        Objects.requireNonNull(p6, "p6");
+        Objects.requireNonNull(g6, "g6");
+        Objects.requireNonNull(p7, "p7");
+        Objects.requireNonNull(g7, "g7");
+        Objects.requireNonNull(p8, "p8");
+        Objects.requireNonNull(g8, "g8");
+        Objects.requireNonNull(p9, "p9");
+        Objects.requireNonNull(g9, "g9");
+        Objects.requireNonNull(ctor, "ctor");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -347,7 +690,7 @@ public final class NetworkBufferTemplate {
 
             @Override
             public R read(NetworkBuffer buffer) {
-                return reader.apply(
+                return ctor.apply(
                         p1.read(buffer), p2.read(buffer),
                         p3.read(buffer), p4.read(buffer),
                         p5.read(buffer), p6.read(buffer),
@@ -358,14 +701,72 @@ public final class NetworkBufferTemplate {
         };
     }
 
-    public static <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R> Type<R> template(
-            Type<P1> p1, Function<R, P1> g1, Type<P2> p2, Function<R, P2> g2,
-            Type<P3> p3, Function<R, P3> g3, Type<P4> p4, Function<R, P4> g4,
-            Type<P5> p5, Function<R, P5> g5, Type<P6> p6, Function<R, P6> g6,
-            Type<P7> p7, Function<R, P7> g7, Type<P8> p8, Function<R, P8> g8,
-            Type<P9> p9, Function<R, P9> g9, Type<P10> p10, Function<R, P10> g10,
-            F10<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R> reader
+    /**
+     * Creates a template with ten parameters
+     *
+     * @param p1    the first parameter {@link Type}
+     * @param g1    the first parameter getter
+     * @param p2    the second parameter {@link Type}
+     * @param g2    the second parameter getter
+     * @param p3    the third parameter {@link Type}
+     * @param g3    the third parameter getter
+     * @param p4    the fourth parameter {@link Type}
+     * @param g4    the fourth parameter getter
+     * @param p5    the fifth parameter {@link Type}
+     * @param g5    the fifth parameter getter
+     * @param p6    the sixth parameter {@link Type}
+     * @param g6    the sixth parameter getter
+     * @param p7    the seventh parameter {@link Type}
+     * @param g7    the seventh parameter getter
+     * @param p8    the eighth parameter {@link Type}
+     * @param g8    the eighth parameter getter
+     * @param p9    the ninth parameter {@link Type}
+     * @param g9    the ninth parameter getter
+     * @param p10   the tenth parameter {@link Type}
+     * @param g10   the tenth parameter getter
+     * @param ctor  the constructor for {@link R}
+     * @param <P1>  the type of the first parameter
+     * @param <P2>  the type of the second parameter
+     * @param <P3>  the type of the third parameter
+     * @param <P4>  the type of the fourth parameter
+     * @param <P5>  the type of the fifth parameter
+     * @param <P6>  the type of the sixth parameter
+     * @param <P7>  the type of the seventh parameter
+     * @param <P8>  the type of the eighth parameter
+     * @param <P9>  the type of the ninth parameter
+     * @param <P10> the type of the tenth parameter
+     * @param <R>   the type of the value
+     * @return the new template
+     */
+    public static <P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(
+            Type<P1> p1, Function<? super R, ? extends P1> g1, Type<P2> p2, Function<? super R, ? extends P2> g2,
+            Type<P3> p3, Function<? super R, ? extends P3> g3, Type<P4> p4, Function<? super R, ? extends P4> g4,
+            Type<P5> p5, Function<? super R, ? extends P5> g5, Type<P6> p6, Function<? super R, ? extends P6> g6,
+            Type<P7> p7, Function<? super R, ? extends P7> g7, Type<P8> p8, Function<? super R, ? extends P8> g8,
+            Type<P9> p9, Function<? super R, ? extends P9> g9, Type<P10> p10, Function<? super R, ? extends P10> g10,
+            F10<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? extends R> ctor
     ) {
+        Objects.requireNonNull(p1, "p1");
+        Objects.requireNonNull(g1, "g1");
+        Objects.requireNonNull(p2, "p2");
+        Objects.requireNonNull(g2, "g2");
+        Objects.requireNonNull(p3, "p3");
+        Objects.requireNonNull(g3, "g3");
+        Objects.requireNonNull(p4, "p4");
+        Objects.requireNonNull(g4, "g4");
+        Objects.requireNonNull(p5, "p5");
+        Objects.requireNonNull(g5, "g5");
+        Objects.requireNonNull(p6, "p6");
+        Objects.requireNonNull(g6, "g6");
+        Objects.requireNonNull(p7, "p7");
+        Objects.requireNonNull(g7, "g7");
+        Objects.requireNonNull(p8, "p8");
+        Objects.requireNonNull(g8, "g8");
+        Objects.requireNonNull(p9, "p9");
+        Objects.requireNonNull(g9, "g9");
+        Objects.requireNonNull(p10, "p10");
+        Objects.requireNonNull(g10, "g10");
+        Objects.requireNonNull(ctor, "ctor");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -383,7 +784,7 @@ public final class NetworkBufferTemplate {
 
             @Override
             public R read(NetworkBuffer buffer) {
-                return reader.apply(
+                return ctor.apply(
                         p1.read(buffer), p2.read(buffer),
                         p3.read(buffer), p4.read(buffer),
                         p5.read(buffer), p6.read(buffer),
@@ -394,14 +795,77 @@ public final class NetworkBufferTemplate {
         };
     }
 
-    public static <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, R> Type<R> template(
-            Type<P1> p1, Function<R, P1> g1, Type<P2> p2, Function<R, P2> g2,
-            Type<P3> p3, Function<R, P3> g3, Type<P4> p4, Function<R, P4> g4,
-            Type<P5> p5, Function<R, P5> g5, Type<P6> p6, Function<R, P6> g6,
-            Type<P7> p7, Function<R, P7> g7, Type<P8> p8, Function<R, P8> g8,
-            Type<P9> p9, Function<R, P9> g9, Type<P10> p10, Function<R, P10> g10,
-            Type<P11> p11, Function<R, P11> g11, F11<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, R> reader
+    /**
+     * Creates a template with eleven parameters
+     *
+     * @param p1    the first parameter {@link Type}
+     * @param g1    the first parameter getter
+     * @param p2    the second parameter {@link Type}
+     * @param g2    the second parameter getter
+     * @param p3    the third parameter {@link Type}
+     * @param g3    the third parameter getter
+     * @param p4    the fourth parameter {@link Type}
+     * @param g4    the fourth parameter getter
+     * @param p5    the fifth parameter {@link Type}
+     * @param g5    the fifth parameter getter
+     * @param p6    the sixth parameter {@link Type}
+     * @param g6    the sixth parameter getter
+     * @param p7    the seventh parameter {@link Type}
+     * @param g7    the seventh parameter getter
+     * @param p8    the eighth parameter {@link Type}
+     * @param g8    the eighth parameter getter
+     * @param p9    the ninth parameter {@link Type}
+     * @param g9    the ninth parameter getter
+     * @param p10   the tenth parameter {@link Type}
+     * @param g10   the tenth parameter getter
+     * @param p11   the eleventh parameter {@link Type}
+     * @param g11   the eleventh parameter getter
+     * @param ctor  the constructor for {@link R}
+     * @param <P1>  the type of the first parameter
+     * @param <P2>  the type of the second parameter
+     * @param <P3>  the type of the third parameter
+     * @param <P4>  the type of the fourth parameter
+     * @param <P5>  the type of the fifth parameter
+     * @param <P6>  the type of the sixth parameter
+     * @param <P7>  the type of the seventh parameter
+     * @param <P8>  the type of the eighth parameter
+     * @param <P9>  the type of the ninth parameter
+     * @param <P10> the type of the tenth parameter
+     * @param <P11> the type of the eleventh parameter
+     * @param <R>   the type of the value
+     * @return the new template
+     */
+    public static <P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(
+            Type<P1> p1, Function<? super R, ? extends P1> g1, Type<P2> p2, Function<? super R, ? extends P2> g2,
+            Type<P3> p3, Function<? super R, ? extends P3> g3, Type<P4> p4, Function<? super R, ? extends P4> g4,
+            Type<P5> p5, Function<? super R, ? extends P5> g5, Type<P6> p6, Function<? super R, ? extends P6> g6,
+            Type<P7> p7, Function<? super R, ? extends P7> g7, Type<P8> p8, Function<? super R, ? extends P8> g8,
+            Type<P9> p9, Function<? super R, ? extends P9> g9, Type<P10> p10, Function<? super R, ? extends P10> g10,
+            Type<P11> p11, Function<? super R, ? extends P11> g11, F11<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? super P11, ? extends R> ctor
     ) {
+        Objects.requireNonNull(p1, "p1");
+        Objects.requireNonNull(g1, "g1");
+        Objects.requireNonNull(p2, "p2");
+        Objects.requireNonNull(g2, "g2");
+        Objects.requireNonNull(p3, "p3");
+        Objects.requireNonNull(g3, "g3");
+        Objects.requireNonNull(p4, "p4");
+        Objects.requireNonNull(g4, "g4");
+        Objects.requireNonNull(p5, "p5");
+        Objects.requireNonNull(g5, "g5");
+        Objects.requireNonNull(p6, "p6");
+        Objects.requireNonNull(g6, "g6");
+        Objects.requireNonNull(p7, "p7");
+        Objects.requireNonNull(g7, "g7");
+        Objects.requireNonNull(p8, "p8");
+        Objects.requireNonNull(g8, "g8");
+        Objects.requireNonNull(p9, "p9");
+        Objects.requireNonNull(g9, "g9");
+        Objects.requireNonNull(p10, "p10");
+        Objects.requireNonNull(g10, "g10");
+        Objects.requireNonNull(p11, "p11");
+        Objects.requireNonNull(g11, "g11");
+        Objects.requireNonNull(ctor, "ctor");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -420,7 +884,7 @@ public final class NetworkBufferTemplate {
 
             @Override
             public R read(NetworkBuffer buffer) {
-                return reader.apply(
+                return ctor.apply(
                         p1.read(buffer), p2.read(buffer),
                         p3.read(buffer), p4.read(buffer),
                         p5.read(buffer), p6.read(buffer),
@@ -432,14 +896,82 @@ public final class NetworkBufferTemplate {
         };
     }
 
-    public static <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R> Type<R> template(
-            Type<P1> p1, Function<R, P1> g1, Type<P2> p2, Function<R, P2> g2,
-            Type<P3> p3, Function<R, P3> g3, Type<P4> p4, Function<R, P4> g4,
-            Type<P5> p5, Function<R, P5> g5, Type<P6> p6, Function<R, P6> g6,
-            Type<P7> p7, Function<R, P7> g7, Type<P8> p8, Function<R, P8> g8,
-            Type<P9> p9, Function<R, P9> g9, Type<P10> p10, Function<R, P10> g10,
-            Type<P11> p11, Function<R, P11> g11, Type<P12> p12, Function<R, P12> g12, F12<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R> reader
+    /**
+     * Creates a template with twelve parameters
+     *
+     * @param p1    the first parameter {@link Type}
+     * @param g1    the first parameter getter
+     * @param p2    the second parameter {@link Type}
+     * @param g2    the second parameter getter
+     * @param p3    the third parameter {@link Type}
+     * @param g3    the third parameter getter
+     * @param p4    the fourth parameter {@link Type}
+     * @param g4    the fourth parameter getter
+     * @param p5    the fifth parameter {@link Type}
+     * @param g5    the fifth parameter getter
+     * @param p6    the sixth parameter {@link Type}
+     * @param g6    the sixth parameter getter
+     * @param p7    the seventh parameter {@link Type}
+     * @param g7    the seventh parameter getter
+     * @param p8    the eighth parameter {@link Type}
+     * @param g8    the eighth parameter getter
+     * @param p9    the ninth parameter {@link Type}
+     * @param g9    the ninth parameter getter
+     * @param p10   the tenth parameter {@link Type}
+     * @param g10   the tenth parameter getter
+     * @param p11   the eleventh parameter {@link Type}
+     * @param g11   the eleventh parameter getter
+     * @param p12   the twelfth parameter {@link Type}
+     * @param g12   the twelfth parameter getter
+     * @param ctor  the constructor for {@link R}
+     * @param <P1>  the type of the first parameter
+     * @param <P2>  the type of the second parameter
+     * @param <P3>  the type of the third parameter
+     * @param <P4>  the type of the fourth parameter
+     * @param <P5>  the type of the fifth parameter
+     * @param <P6>  the type of the sixth parameter
+     * @param <P7>  the type of the seventh parameter
+     * @param <P8>  the type of the eighth parameter
+     * @param <P9>  the type of the ninth parameter
+     * @param <P10> the type of the tenth parameter
+     * @param <P11> the type of the eleventh parameter
+     * @param <P12> the type of the twelfth parameter
+     * @param <R>   the type of the value
+     * @return the new template
+     */
+    public static <P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(
+            Type<P1> p1, Function<? super R, ? extends P1> g1, Type<P2> p2, Function<? super R, ? extends P2> g2,
+            Type<P3> p3, Function<? super R, ? extends P3> g3, Type<P4> p4, Function<? super R, ? extends P4> g4,
+            Type<P5> p5, Function<? super R, ? extends P5> g5, Type<P6> p6, Function<? super R, ? extends P6> g6,
+            Type<P7> p7, Function<? super R, ? extends P7> g7, Type<P8> p8, Function<? super R, ? extends P8> g8,
+            Type<P9> p9, Function<? super R, ? extends P9> g9, Type<P10> p10, Function<? super R, ? extends P10> g10,
+            Type<P11> p11, Function<? super R, ? extends P11> g11, Type<P12> p12, Function<? super R, ? extends P12> g12, F12<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? super P11, ? super P12, ? extends R> ctor
     ) {
+        Objects.requireNonNull(p1, "p1");
+        Objects.requireNonNull(g1, "g1");
+        Objects.requireNonNull(p2, "p2");
+        Objects.requireNonNull(g2, "g2");
+        Objects.requireNonNull(p3, "p3");
+        Objects.requireNonNull(g3, "g3");
+        Objects.requireNonNull(p4, "p4");
+        Objects.requireNonNull(g4, "g4");
+        Objects.requireNonNull(p5, "p5");
+        Objects.requireNonNull(g5, "g5");
+        Objects.requireNonNull(p6, "p6");
+        Objects.requireNonNull(g6, "g6");
+        Objects.requireNonNull(p7, "p7");
+        Objects.requireNonNull(g7, "g7");
+        Objects.requireNonNull(p8, "p8");
+        Objects.requireNonNull(g8, "g8");
+        Objects.requireNonNull(p9, "p9");
+        Objects.requireNonNull(g9, "g9");
+        Objects.requireNonNull(p10, "p10");
+        Objects.requireNonNull(g10, "g10");
+        Objects.requireNonNull(p11, "p11");
+        Objects.requireNonNull(g11, "g11");
+        Objects.requireNonNull(p12, "p12");
+        Objects.requireNonNull(g12, "g12");
+        Objects.requireNonNull(ctor, "ctor");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -459,7 +991,7 @@ public final class NetworkBufferTemplate {
 
             @Override
             public R read(NetworkBuffer buffer) {
-                return reader.apply(
+                return ctor.apply(
                         p1.read(buffer), p2.read(buffer),
                         p3.read(buffer), p4.read(buffer),
                         p5.read(buffer), p6.read(buffer),
@@ -471,16 +1003,89 @@ public final class NetworkBufferTemplate {
         };
     }
 
-    public static <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, R> Type<R> template(
-            Type<P1> p1, Function<R, P1> g1, Type<P2> p2, Function<R, P2> g2,
-            Type<P3> p3, Function<R, P3> g3, Type<P4> p4, Function<R, P4> g4,
-            Type<P5> p5, Function<R, P5> g5, Type<P6> p6, Function<R, P6> g6,
-            Type<P7> p7, Function<R, P7> g7, Type<P8> p8, Function<R, P8> g8,
-            Type<P9> p9, Function<R, P9> g9, Type<P10> p10, Function<R, P10> g10,
-            Type<P11> p11, Function<R, P11> g11, Type<P12> p12, Function<R, P12> g12,
-            Type<P13> p13, Function<R, P13> g13,
-            F13<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, R> reader
+    /**
+     * Creates a template with thirteen parameters
+     *
+     * @param p1    the first parameter {@link Type}
+     * @param g1    the first parameter getter
+     * @param p2    the second parameter {@link Type}
+     * @param g2    the second parameter getter
+     * @param p3    the third parameter {@link Type}
+     * @param g3    the third parameter getter
+     * @param p4    the fourth parameter {@link Type}
+     * @param g4    the fourth parameter getter
+     * @param p5    the fifth parameter {@link Type}
+     * @param g5    the fifth parameter getter
+     * @param p6    the sixth parameter {@link Type}
+     * @param g6    the sixth parameter getter
+     * @param p7    the seventh parameter {@link Type}
+     * @param g7    the seventh parameter getter
+     * @param p8    the eighth parameter {@link Type}
+     * @param g8    the eighth parameter getter
+     * @param p9    the ninth parameter {@link Type}
+     * @param g9    the ninth parameter getter
+     * @param p10   the tenth parameter {@link Type}
+     * @param g10   the tenth parameter getter
+     * @param p11   the eleventh parameter {@link Type}
+     * @param g11   the eleventh parameter getter
+     * @param p12   the twelfth parameter {@link Type}
+     * @param g12   the twelfth parameter getter
+     * @param p13   the thirteenth parameter {@link Type}
+     * @param g13   the thirteenth parameter getter
+     * @param ctor  the constructor for {@link R}
+     * @param <P1>  the type of the first parameter
+     * @param <P2>  the type of the second parameter
+     * @param <P3>  the type of the third parameter
+     * @param <P4>  the type of the fourth parameter
+     * @param <P5>  the type of the fifth parameter
+     * @param <P6>  the type of the sixth parameter
+     * @param <P7>  the type of the seventh parameter
+     * @param <P8>  the type of the eighth parameter
+     * @param <P9>  the type of the ninth parameter
+     * @param <P10> the type of the tenth parameter
+     * @param <P11> the type of the eleventh parameter
+     * @param <P12> the type of the twelfth parameter
+     * @param <P13> the type of the thirteenth parameter
+     * @param <R>   the type of the value
+     * @return the new template
+     */
+    public static <P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(
+            Type<P1> p1, Function<? super R, ? extends P1> g1, Type<P2> p2, Function<? super R, ? extends P2> g2,
+            Type<P3> p3, Function<? super R, ? extends P3> g3, Type<P4> p4, Function<? super R, ? extends P4> g4,
+            Type<P5> p5, Function<? super R, ? extends P5> g5, Type<P6> p6, Function<? super R, ? extends P6> g6,
+            Type<P7> p7, Function<? super R, ? extends P7> g7, Type<P8> p8, Function<? super R, ? extends P8> g8,
+            Type<P9> p9, Function<? super R, ? extends P9> g9, Type<P10> p10, Function<? super R, ? extends P10> g10,
+            Type<P11> p11, Function<? super R, ? extends P11> g11, Type<P12> p12, Function<? super R, ? extends P12> g12,
+            Type<P13> p13, Function<? super R, ? extends P13> g13,
+            F13<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? super P11, ? super P12, ? super P13, ? extends R> ctor
     ) {
+        Objects.requireNonNull(p1, "p1");
+        Objects.requireNonNull(g1, "g1");
+        Objects.requireNonNull(p2, "p2");
+        Objects.requireNonNull(g2, "g2");
+        Objects.requireNonNull(p3, "p3");
+        Objects.requireNonNull(g3, "g3");
+        Objects.requireNonNull(p4, "p4");
+        Objects.requireNonNull(g4, "g4");
+        Objects.requireNonNull(p5, "p5");
+        Objects.requireNonNull(g5, "g5");
+        Objects.requireNonNull(p6, "p6");
+        Objects.requireNonNull(g6, "g6");
+        Objects.requireNonNull(p7, "p7");
+        Objects.requireNonNull(g7, "g7");
+        Objects.requireNonNull(p8, "p8");
+        Objects.requireNonNull(g8, "g8");
+        Objects.requireNonNull(p9, "p9");
+        Objects.requireNonNull(g9, "g9");
+        Objects.requireNonNull(p10, "p10");
+        Objects.requireNonNull(g10, "g10");
+        Objects.requireNonNull(p11, "p11");
+        Objects.requireNonNull(g11, "g11");
+        Objects.requireNonNull(p12, "p12");
+        Objects.requireNonNull(g12, "g12");
+        Objects.requireNonNull(p13, "p13");
+        Objects.requireNonNull(g13, "g13");
+        Objects.requireNonNull(ctor, "ctor");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -501,7 +1106,7 @@ public final class NetworkBufferTemplate {
 
             @Override
             public R read(NetworkBuffer buffer) {
-                return reader.apply(
+                return ctor.apply(
                         p1.read(buffer), p2.read(buffer),
                         p3.read(buffer), p4.read(buffer),
                         p5.read(buffer), p6.read(buffer),
@@ -514,16 +1119,94 @@ public final class NetworkBufferTemplate {
         };
     }
 
-    public static <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, R> Type<R> template(
-            Type<P1> p1, Function<R, P1> g1, Type<P2> p2, Function<R, P2> g2,
-            Type<P3> p3, Function<R, P3> g3, Type<P4> p4, Function<R, P4> g4,
-            Type<P5> p5, Function<R, P5> g5, Type<P6> p6, Function<R, P6> g6,
-            Type<P7> p7, Function<R, P7> g7, Type<P8> p8, Function<R, P8> g8,
-            Type<P9> p9, Function<R, P9> g9, Type<P10> p10, Function<R, P10> g10,
-            Type<P11> p11, Function<R, P11> g11, Type<P12> p12, Function<R, P12> g12,
-            Type<P13> p13, Function<R, P13> g13, Type<P14> p14, Function<R, P14> g14,
-            F14<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, R> reader
+    /**
+     * Creates a template with fourteen parameters
+     *
+     * @param p1    the first parameter {@link Type}
+     * @param g1    the first parameter getter
+     * @param p2    the second parameter {@link Type}
+     * @param g2    the second parameter getter
+     * @param p3    the third parameter {@link Type}
+     * @param g3    the third parameter getter
+     * @param p4    the fourth parameter {@link Type}
+     * @param g4    the fourth parameter getter
+     * @param p5    the fifth parameter {@link Type}
+     * @param g5    the fifth parameter getter
+     * @param p6    the sixth parameter {@link Type}
+     * @param g6    the sixth parameter getter
+     * @param p7    the seventh parameter {@link Type}
+     * @param g7    the seventh parameter getter
+     * @param p8    the eighth parameter {@link Type}
+     * @param g8    the eighth parameter getter
+     * @param p9    the ninth parameter {@link Type}
+     * @param g9    the ninth parameter getter
+     * @param p10   the tenth parameter {@link Type}
+     * @param g10   the tenth parameter getter
+     * @param p11   the eleventh parameter {@link Type}
+     * @param g11   the eleventh parameter getter
+     * @param p12   the twelfth parameter {@link Type}
+     * @param g12   the twelfth parameter getter
+     * @param p13   the thirteenth parameter {@link Type}
+     * @param g13   the thirteenth parameter getter
+     * @param p14   the fourteenth parameter {@link Type}
+     * @param g14   the fourteenth parameter getter
+     * @param ctor  the constructor for {@link R}
+     * @param <P1>  the type of the first parameter
+     * @param <P2>  the type of the second parameter
+     * @param <P3>  the type of the third parameter
+     * @param <P4>  the type of the fourth parameter
+     * @param <P5>  the type of the fifth parameter
+     * @param <P6>  the type of the sixth parameter
+     * @param <P7>  the type of the seventh parameter
+     * @param <P8>  the type of the eighth parameter
+     * @param <P9>  the type of the ninth parameter
+     * @param <P10> the type of the tenth parameter
+     * @param <P11> the type of the eleventh parameter
+     * @param <P12> the type of the twelfth parameter
+     * @param <P13> the type of the thirteenth parameter
+     * @param <P14> the type of the fourteenth parameter
+     * @param <R>   the type of the value
+     * @return the new template
+     */
+    public static <P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(
+            Type<P1> p1, Function<? super R, ? extends P1> g1, Type<P2> p2, Function<? super R, ? extends P2> g2,
+            Type<P3> p3, Function<? super R, ? extends P3> g3, Type<P4> p4, Function<? super R, ? extends P4> g4,
+            Type<P5> p5, Function<? super R, ? extends P5> g5, Type<P6> p6, Function<? super R, ? extends P6> g6,
+            Type<P7> p7, Function<? super R, ? extends P7> g7, Type<P8> p8, Function<? super R, ? extends P8> g8,
+            Type<P9> p9, Function<? super R, ? extends P9> g9, Type<P10> p10, Function<? super R, ? extends P10> g10,
+            Type<P11> p11, Function<? super R, ? extends P11> g11, Type<P12> p12, Function<? super R, ? extends P12> g12,
+            Type<P13> p13, Function<? super R, ? extends P13> g13, Type<P14> p14, Function<? super R, ? extends P14> g14,
+            F14<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? super P11, ? super P12, ? super P13, ? super P14, ? extends R> ctor
     ) {
+        Objects.requireNonNull(p1, "p1");
+        Objects.requireNonNull(g1, "g1");
+        Objects.requireNonNull(p2, "p2");
+        Objects.requireNonNull(g2, "g2");
+        Objects.requireNonNull(p3, "p3");
+        Objects.requireNonNull(g3, "g3");
+        Objects.requireNonNull(p4, "p4");
+        Objects.requireNonNull(g4, "g4");
+        Objects.requireNonNull(p5, "p5");
+        Objects.requireNonNull(g5, "g5");
+        Objects.requireNonNull(p6, "p6");
+        Objects.requireNonNull(g6, "g6");
+        Objects.requireNonNull(p7, "p7");
+        Objects.requireNonNull(g7, "g7");
+        Objects.requireNonNull(p8, "p8");
+        Objects.requireNonNull(g8, "g8");
+        Objects.requireNonNull(p9, "p9");
+        Objects.requireNonNull(g9, "g9");
+        Objects.requireNonNull(p10, "p10");
+        Objects.requireNonNull(g10, "g10");
+        Objects.requireNonNull(p11, "p11");
+        Objects.requireNonNull(g11, "g11");
+        Objects.requireNonNull(p12, "p12");
+        Objects.requireNonNull(g12, "g12");
+        Objects.requireNonNull(p13, "p13");
+        Objects.requireNonNull(g13, "g13");
+        Objects.requireNonNull(p14, "p14");
+        Objects.requireNonNull(g14, "g14");
+        Objects.requireNonNull(ctor, "ctor");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -545,7 +1228,7 @@ public final class NetworkBufferTemplate {
 
             @Override
             public R read(NetworkBuffer buffer) {
-                return reader.apply(
+                return ctor.apply(
                         p1.read(buffer), p2.read(buffer),
                         p3.read(buffer), p4.read(buffer),
                         p5.read(buffer), p6.read(buffer),
@@ -558,17 +1241,100 @@ public final class NetworkBufferTemplate {
         };
     }
 
-    public static <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, R> Type<R> template(
-            Type<P1> p1, Function<R, P1> g1, Type<P2> p2, Function<R, P2> g2,
-            Type<P3> p3, Function<R, P3> g3, Type<P4> p4, Function<R, P4> g4,
-            Type<P5> p5, Function<R, P5> g5, Type<P6> p6, Function<R, P6> g6,
-            Type<P7> p7, Function<R, P7> g7, Type<P8> p8, Function<R, P8> g8,
-            Type<P9> p9, Function<R, P9> g9, Type<P10> p10, Function<R, P10> g10,
-            Type<P11> p11, Function<R, P11> g11, Type<P12> p12, Function<R, P12> g12,
-            Type<P13> p13, Function<R, P13> g13, Type<P14> p14, Function<R, P14> g14,
-            Type<P15> p15, Function<R, P15> g15,
-            F15<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, R> reader
+    /**
+     * Creates a template with fifteen parameters
+     *
+     * @param p1    the first parameter {@link Type}
+     * @param g1    the first parameter getter
+     * @param p2    the second parameter {@link Type}
+     * @param g2    the second parameter getter
+     * @param p3    the third parameter {@link Type}
+     * @param g3    the third parameter getter
+     * @param p4    the fourth parameter {@link Type}
+     * @param g4    the fourth parameter getter
+     * @param p5    the fifth parameter {@link Type}
+     * @param g5    the fifth parameter getter
+     * @param p6    the sixth parameter {@link Type}
+     * @param g6    the sixth parameter getter
+     * @param p7    the seventh parameter {@link Type}
+     * @param g7    the seventh parameter getter
+     * @param p8    the eighth parameter {@link Type}
+     * @param g8    the eighth parameter getter
+     * @param p9    the ninth parameter {@link Type}
+     * @param g9    the ninth parameter getter
+     * @param p10   the tenth parameter {@link Type}
+     * @param g10   the tenth parameter getter
+     * @param p11   the eleventh parameter {@link Type}
+     * @param g11   the eleventh parameter getter
+     * @param p12   the twelfth parameter {@link Type}
+     * @param g12   the twelfth parameter getter
+     * @param p13   the thirteenth parameter {@link Type}
+     * @param g13   the thirteenth parameter getter
+     * @param p14   the fourteenth parameter {@link Type}
+     * @param g14   the fourteenth parameter getter
+     * @param p15   the fifteenth parameter {@link Type}
+     * @param g15   the fifteenth parameter getter
+     * @param ctor  the constructor for {@link R}
+     * @param <P1>  the type of the first parameter
+     * @param <P2>  the type of the second parameter
+     * @param <P3>  the type of the third parameter
+     * @param <P4>  the type of the fourth parameter
+     * @param <P5>  the type of the fifth parameter
+     * @param <P6>  the type of the sixth parameter
+     * @param <P7>  the type of the seventh parameter
+     * @param <P8>  the type of the eighth parameter
+     * @param <P9>  the type of the ninth parameter
+     * @param <P10> the type of the tenth parameter
+     * @param <P11> the type of the eleventh parameter
+     * @param <P12> the type of the twelfth parameter
+     * @param <P13> the type of the thirteenth parameter
+     * @param <P14> the type of the fourteenth parameter
+     * @param <P15> the type of the fifteenth parameter
+     * @param <R>   the type of the value
+     * @return the new template
+     */
+    public static <P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(
+            Type<P1> p1, Function<? super R, ? extends P1> g1, Type<P2> p2, Function<? super R, ? extends P2> g2,
+            Type<P3> p3, Function<? super R, ? extends P3> g3, Type<P4> p4, Function<? super R, ? extends P4> g4,
+            Type<P5> p5, Function<? super R, ? extends P5> g5, Type<P6> p6, Function<? super R, ? extends P6> g6,
+            Type<P7> p7, Function<? super R, ? extends P7> g7, Type<P8> p8, Function<? super R, ? extends P8> g8,
+            Type<P9> p9, Function<? super R, ? extends P9> g9, Type<P10> p10, Function<? super R, ? extends P10> g10,
+            Type<P11> p11, Function<? super R, ? extends P11> g11, Type<P12> p12, Function<? super R, ? extends P12> g12,
+            Type<P13> p13, Function<? super R, ? extends P13> g13, Type<P14> p14, Function<? super R, ? extends P14> g14,
+            Type<P15> p15, Function<? super R, ? extends P15> g15,
+            F15<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? super P11, ? super P12, ? super P13, ? super P14, ? super P15, ? extends R> ctor
     ) {
+        Objects.requireNonNull(p1, "p1");
+        Objects.requireNonNull(g1, "g1");
+        Objects.requireNonNull(p2, "p2");
+        Objects.requireNonNull(g2, "g2");
+        Objects.requireNonNull(p3, "p3");
+        Objects.requireNonNull(g3, "g3");
+        Objects.requireNonNull(p4, "p4");
+        Objects.requireNonNull(g4, "g4");
+        Objects.requireNonNull(p5, "p5");
+        Objects.requireNonNull(g5, "g5");
+        Objects.requireNonNull(p6, "p6");
+        Objects.requireNonNull(g6, "g6");
+        Objects.requireNonNull(p7, "p7");
+        Objects.requireNonNull(g7, "g7");
+        Objects.requireNonNull(p8, "p8");
+        Objects.requireNonNull(g8, "g8");
+        Objects.requireNonNull(p9, "p9");
+        Objects.requireNonNull(g9, "g9");
+        Objects.requireNonNull(p10, "p10");
+        Objects.requireNonNull(g10, "g10");
+        Objects.requireNonNull(p11, "p11");
+        Objects.requireNonNull(g11, "g11");
+        Objects.requireNonNull(p12, "p12");
+        Objects.requireNonNull(g12, "g12");
+        Objects.requireNonNull(p13, "p13");
+        Objects.requireNonNull(g13, "g13");
+        Objects.requireNonNull(p14, "p14");
+        Objects.requireNonNull(g14, "g14");
+        Objects.requireNonNull(p15, "p15");
+        Objects.requireNonNull(g15, "g15");
+        Objects.requireNonNull(ctor, "ctor");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -591,7 +1357,7 @@ public final class NetworkBufferTemplate {
 
             @Override
             public R read(NetworkBuffer buffer) {
-                return reader.apply(
+                return ctor.apply(
                         p1.read(buffer), p2.read(buffer),
                         p3.read(buffer), p4.read(buffer),
                         p5.read(buffer), p6.read(buffer),
@@ -605,17 +1371,105 @@ public final class NetworkBufferTemplate {
         };
     }
 
-    public static <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, R> Type<R> template(
-            Type<P1> p1, Function<R, P1> g1, Type<P2> p2, Function<R, P2> g2,
-            Type<P3> p3, Function<R, P3> g3, Type<P4> p4, Function<R, P4> g4,
-            Type<P5> p5, Function<R, P5> g5, Type<P6> p6, Function<R, P6> g6,
-            Type<P7> p7, Function<R, P7> g7, Type<P8> p8, Function<R, P8> g8,
-            Type<P9> p9, Function<R, P9> g9, Type<P10> p10, Function<R, P10> g10,
-            Type<P11> p11, Function<R, P11> g11, Type<P12> p12, Function<R, P12> g12,
-            Type<P13> p13, Function<R, P13> g13, Type<P14> p14, Function<R, P14> g14,
-            Type<P15> p15, Function<R, P15> g15, Type<P16> p16, Function<R, P16> g16,
-            F16<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, R> reader
+    /**
+     * Creates a template with sixteen parameters
+     *
+     * @param p1    the first parameter {@link Type}
+     * @param g1    the first parameter getter
+     * @param p2    the second parameter {@link Type}
+     * @param g2    the second parameter getter
+     * @param p3    the third parameter {@link Type}
+     * @param g3    the third parameter getter
+     * @param p4    the fourth parameter {@link Type}
+     * @param g4    the fourth parameter getter
+     * @param p5    the fifth parameter {@link Type}
+     * @param g5    the fifth parameter getter
+     * @param p6    the sixth parameter {@link Type}
+     * @param g6    the sixth parameter getter
+     * @param p7    the seventh parameter {@link Type}
+     * @param g7    the seventh parameter getter
+     * @param p8    the eighth parameter {@link Type}
+     * @param g8    the eighth parameter getter
+     * @param p9    the ninth parameter {@link Type}
+     * @param g9    the ninth parameter getter
+     * @param p10   the tenth parameter {@link Type}
+     * @param g10   the tenth parameter getter
+     * @param p11   the eleventh parameter {@link Type}
+     * @param g11   the eleventh parameter getter
+     * @param p12   the twelfth parameter {@link Type}
+     * @param g12   the twelfth parameter getter
+     * @param p13   the thirteenth parameter {@link Type}
+     * @param g13   the thirteenth parameter getter
+     * @param p14   the fourteenth parameter {@link Type}
+     * @param g14   the fourteenth parameter getter
+     * @param p15   the fifteenth parameter {@link Type}
+     * @param g15   the fifteenth parameter getter
+     * @param p16   the sixteenth parameter {@link Type}
+     * @param g16   the sixteenth parameter getter
+     * @param ctor  the constructor for {@link R}
+     * @param <P1>  the type of the first parameter
+     * @param <P2>  the type of the second parameter
+     * @param <P3>  the type of the third parameter
+     * @param <P4>  the type of the fourth parameter
+     * @param <P5>  the type of the fifth parameter
+     * @param <P6>  the type of the sixth parameter
+     * @param <P7>  the type of the seventh parameter
+     * @param <P8>  the type of the eighth parameter
+     * @param <P9>  the type of the ninth parameter
+     * @param <P10> the type of the tenth parameter
+     * @param <P11> the type of the eleventh parameter
+     * @param <P12> the type of the twelfth parameter
+     * @param <P13> the type of the thirteenth parameter
+     * @param <P14> the type of the fourteenth parameter
+     * @param <P15> the type of the fifteenth parameter
+     * @param <P16> the type of the sixteenth parameter
+     * @param <R>   the type of the value
+     * @return the new template
+     */
+    public static <P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(
+            Type<P1> p1, Function<? super R, ? extends P1> g1, Type<P2> p2, Function<? super R, ? extends P2> g2,
+            Type<P3> p3, Function<? super R, ? extends P3> g3, Type<P4> p4, Function<? super R, ? extends P4> g4,
+            Type<P5> p5, Function<? super R, ? extends P5> g5, Type<P6> p6, Function<? super R, ? extends P6> g6,
+            Type<P7> p7, Function<? super R, ? extends P7> g7, Type<P8> p8, Function<? super R, ? extends P8> g8,
+            Type<P9> p9, Function<? super R, ? extends P9> g9, Type<P10> p10, Function<? super R, ? extends P10> g10,
+            Type<P11> p11, Function<? super R, ? extends P11> g11, Type<P12> p12, Function<? super R, ? extends P12> g12,
+            Type<P13> p13, Function<? super R, ? extends P13> g13, Type<P14> p14, Function<? super R, ? extends P14> g14,
+            Type<P15> p15, Function<? super R, ? extends P15> g15, Type<P16> p16, Function<? super R, ? extends P16> g16,
+            F16<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? super P11, ? super P12, ? super P13, ? super P14, ? super P15, ? super P16, ? extends R> ctor
     ) {
+        Objects.requireNonNull(p1, "p1");
+        Objects.requireNonNull(g1, "g1");
+        Objects.requireNonNull(p2, "p2");
+        Objects.requireNonNull(g2, "g2");
+        Objects.requireNonNull(p3, "p3");
+        Objects.requireNonNull(g3, "g3");
+        Objects.requireNonNull(p4, "p4");
+        Objects.requireNonNull(g4, "g4");
+        Objects.requireNonNull(p5, "p5");
+        Objects.requireNonNull(g5, "g5");
+        Objects.requireNonNull(p6, "p6");
+        Objects.requireNonNull(g6, "g6");
+        Objects.requireNonNull(p7, "p7");
+        Objects.requireNonNull(g7, "g7");
+        Objects.requireNonNull(p8, "p8");
+        Objects.requireNonNull(g8, "g8");
+        Objects.requireNonNull(p9, "p9");
+        Objects.requireNonNull(g9, "g9");
+        Objects.requireNonNull(p10, "p10");
+        Objects.requireNonNull(g10, "g10");
+        Objects.requireNonNull(p11, "p11");
+        Objects.requireNonNull(g11, "g11");
+        Objects.requireNonNull(p12, "p12");
+        Objects.requireNonNull(g12, "g12");
+        Objects.requireNonNull(p13, "p13");
+        Objects.requireNonNull(g13, "g13");
+        Objects.requireNonNull(p14, "p14");
+        Objects.requireNonNull(g14, "g14");
+        Objects.requireNonNull(p15, "p15");
+        Objects.requireNonNull(g15, "g15");
+        Objects.requireNonNull(p16, "p16");
+        Objects.requireNonNull(g16, "g16");
+        Objects.requireNonNull(ctor, "ctor");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -639,7 +1493,7 @@ public final class NetworkBufferTemplate {
 
             @Override
             public R read(NetworkBuffer buffer) {
-                return reader.apply(
+                return ctor.apply(
                         p1.read(buffer), p2.read(buffer),
                         p3.read(buffer), p4.read(buffer),
                         p5.read(buffer), p6.read(buffer),
@@ -653,18 +1507,111 @@ public final class NetworkBufferTemplate {
         };
     }
 
-    public static <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, R> Type<R> template(
-            Type<P1> p1, Function<R, P1> g1, Type<P2> p2, Function<R, P2> g2,
-            Type<P3> p3, Function<R, P3> g3, Type<P4> p4, Function<R, P4> g4,
-            Type<P5> p5, Function<R, P5> g5, Type<P6> p6, Function<R, P6> g6,
-            Type<P7> p7, Function<R, P7> g7, Type<P8> p8, Function<R, P8> g8,
-            Type<P9> p9, Function<R, P9> g9, Type<P10> p10, Function<R, P10> g10,
-            Type<P11> p11, Function<R, P11> g11, Type<P12> p12, Function<R, P12> g12,
-            Type<P13> p13, Function<R, P13> g13, Type<P14> p14, Function<R, P14> g14,
-            Type<P15> p15, Function<R, P15> g15, Type<P16> p16, Function<R, P16> g16,
-            Type<P17> p17, Function<R, P17> g17,
-            F17<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, R> reader
+    /**
+     * Creates a template with seventeen parameters
+     *
+     * @param p1    the first parameter {@link Type}
+     * @param g1    the first parameter getter
+     * @param p2    the second parameter {@link Type}
+     * @param g2    the second parameter getter
+     * @param p3    the third parameter {@link Type}
+     * @param g3    the third parameter getter
+     * @param p4    the fourth parameter {@link Type}
+     * @param g4    the fourth parameter getter
+     * @param p5    the fifth parameter {@link Type}
+     * @param g5    the fifth parameter getter
+     * @param p6    the sixth parameter {@link Type}
+     * @param g6    the sixth parameter getter
+     * @param p7    the seventh parameter {@link Type}
+     * @param g7    the seventh parameter getter
+     * @param p8    the eighth parameter {@link Type}
+     * @param g8    the eighth parameter getter
+     * @param p9    the ninth parameter {@link Type}
+     * @param g9    the ninth parameter getter
+     * @param p10   the tenth parameter {@link Type}
+     * @param g10   the tenth parameter getter
+     * @param p11   the eleventh parameter {@link Type}
+     * @param g11   the eleventh parameter getter
+     * @param p12   the twelfth parameter {@link Type}
+     * @param g12   the twelfth parameter getter
+     * @param p13   the thirteenth parameter {@link Type}
+     * @param g13   the thirteenth parameter getter
+     * @param p14   the fourteenth parameter {@link Type}
+     * @param g14   the fourteenth parameter getter
+     * @param p15   the fifteenth parameter {@link Type}
+     * @param g15   the fifteenth parameter getter
+     * @param p16   the sixteenth parameter {@link Type}
+     * @param g16   the sixteenth parameter getter
+     * @param p17   the seventeenth parameter {@link Type}
+     * @param g17   the seventeenth parameter getter
+     * @param ctor  the constructor for {@link R}
+     * @param <P1>  the type of the first parameter
+     * @param <P2>  the type of the second parameter
+     * @param <P3>  the type of the third parameter
+     * @param <P4>  the type of the fourth parameter
+     * @param <P5>  the type of the fifth parameter
+     * @param <P6>  the type of the sixth parameter
+     * @param <P7>  the type of the seventh parameter
+     * @param <P8>  the type of the eighth parameter
+     * @param <P9>  the type of the ninth parameter
+     * @param <P10> the type of the tenth parameter
+     * @param <P11> the type of the eleventh parameter
+     * @param <P12> the type of the twelfth parameter
+     * @param <P13> the type of the thirteenth parameter
+     * @param <P14> the type of the fourteenth parameter
+     * @param <P15> the type of the fifteenth parameter
+     * @param <P16> the type of the sixteenth parameter
+     * @param <P17> the type of the seventeenth parameter
+     * @param <R>   the type of the value
+     * @return the new template
+     */
+    public static <P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(
+            Type<P1> p1, Function<? super R, ? extends P1> g1, Type<P2> p2, Function<? super R, ? extends P2> g2,
+            Type<P3> p3, Function<? super R, ? extends P3> g3, Type<P4> p4, Function<? super R, ? extends P4> g4,
+            Type<P5> p5, Function<? super R, ? extends P5> g5, Type<P6> p6, Function<? super R, ? extends P6> g6,
+            Type<P7> p7, Function<? super R, ? extends P7> g7, Type<P8> p8, Function<? super R, ? extends P8> g8,
+            Type<P9> p9, Function<? super R, ? extends P9> g9, Type<P10> p10, Function<? super R, ? extends P10> g10,
+            Type<P11> p11, Function<? super R, ? extends P11> g11, Type<P12> p12, Function<? super R, ? extends P12> g12,
+            Type<P13> p13, Function<? super R, ? extends P13> g13, Type<P14> p14, Function<? super R, ? extends P14> g14,
+            Type<P15> p15, Function<? super R, ? extends P15> g15, Type<P16> p16, Function<? super R, ? extends P16> g16,
+            Type<P17> p17, Function<? super R, ? extends P17> g17,
+            F17<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? super P11, ? super P12, ? super P13, ? super P14, ? super P15, ? super P16, ? super P17, ? extends R> ctor
     ) {
+        Objects.requireNonNull(p1, "p1");
+        Objects.requireNonNull(g1, "g1");
+        Objects.requireNonNull(p2, "p2");
+        Objects.requireNonNull(g2, "g2");
+        Objects.requireNonNull(p3, "p3");
+        Objects.requireNonNull(g3, "g3");
+        Objects.requireNonNull(p4, "p4");
+        Objects.requireNonNull(g4, "g4");
+        Objects.requireNonNull(p5, "p5");
+        Objects.requireNonNull(g5, "g5");
+        Objects.requireNonNull(p6, "p6");
+        Objects.requireNonNull(g6, "g6");
+        Objects.requireNonNull(p7, "p7");
+        Objects.requireNonNull(g7, "g7");
+        Objects.requireNonNull(p8, "p8");
+        Objects.requireNonNull(g8, "g8");
+        Objects.requireNonNull(p9, "p9");
+        Objects.requireNonNull(g9, "g9");
+        Objects.requireNonNull(p10, "p10");
+        Objects.requireNonNull(g10, "g10");
+        Objects.requireNonNull(p11, "p11");
+        Objects.requireNonNull(g11, "g11");
+        Objects.requireNonNull(p12, "p12");
+        Objects.requireNonNull(g12, "g12");
+        Objects.requireNonNull(p13, "p13");
+        Objects.requireNonNull(g13, "g13");
+        Objects.requireNonNull(p14, "p14");
+        Objects.requireNonNull(g14, "g14");
+        Objects.requireNonNull(p15, "p15");
+        Objects.requireNonNull(g15, "g15");
+        Objects.requireNonNull(p16, "p16");
+        Objects.requireNonNull(g16, "g16");
+        Objects.requireNonNull(p17, "p17");
+        Objects.requireNonNull(g17, "g17");
+        Objects.requireNonNull(ctor, "ctor");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -689,7 +1636,7 @@ public final class NetworkBufferTemplate {
 
             @Override
             public R read(NetworkBuffer buffer) {
-                return reader.apply(
+                return ctor.apply(
                         p1.read(buffer), p2.read(buffer),
                         p3.read(buffer), p4.read(buffer),
                         p5.read(buffer), p6.read(buffer),
@@ -704,18 +1651,116 @@ public final class NetworkBufferTemplate {
         };
     }
 
-    public static <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, R> Type<R> template(
-            Type<P1> p1, Function<R, P1> g1, Type<P2> p2, Function<R, P2> g2,
-            Type<P3> p3, Function<R, P3> g3, Type<P4> p4, Function<R, P4> g4,
-            Type<P5> p5, Function<R, P5> g5, Type<P6> p6, Function<R, P6> g6,
-            Type<P7> p7, Function<R, P7> g7, Type<P8> p8, Function<R, P8> g8,
-            Type<P9> p9, Function<R, P9> g9, Type<P10> p10, Function<R, P10> g10,
-            Type<P11> p11, Function<R, P11> g11, Type<P12> p12, Function<R, P12> g12,
-            Type<P13> p13, Function<R, P13> g13, Type<P14> p14, Function<R, P14> g14,
-            Type<P15> p15, Function<R, P15> g15, Type<P16> p16, Function<R, P16> g16,
-            Type<P17> p17, Function<R, P17> g17, Type<P18> p18, Function<R, P18> g18,
-            F18<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, R> reader
+    /**
+     * Creates a template with eighteen parameters
+     *
+     * @param p1    the first parameter {@link Type}
+     * @param g1    the first parameter getter
+     * @param p2    the second parameter {@link Type}
+     * @param g2    the second parameter getter
+     * @param p3    the third parameter {@link Type}
+     * @param g3    the third parameter getter
+     * @param p4    the fourth parameter {@link Type}
+     * @param g4    the fourth parameter getter
+     * @param p5    the fifth parameter {@link Type}
+     * @param g5    the fifth parameter getter
+     * @param p6    the sixth parameter {@link Type}
+     * @param g6    the sixth parameter getter
+     * @param p7    the seventh parameter {@link Type}
+     * @param g7    the seventh parameter getter
+     * @param p8    the eighth parameter {@link Type}
+     * @param g8    the eighth parameter getter
+     * @param p9    the ninth parameter {@link Type}
+     * @param g9    the ninth parameter getter
+     * @param p10   the tenth parameter {@link Type}
+     * @param g10   the tenth parameter getter
+     * @param p11   the eleventh parameter {@link Type}
+     * @param g11   the eleventh parameter getter
+     * @param p12   the twelfth parameter {@link Type}
+     * @param g12   the twelfth parameter getter
+     * @param p13   the thirteenth parameter {@link Type}
+     * @param g13   the thirteenth parameter getter
+     * @param p14   the fourteenth parameter {@link Type}
+     * @param g14   the fourteenth parameter getter
+     * @param p15   the fifteenth parameter {@link Type}
+     * @param g15   the fifteenth parameter getter
+     * @param p16   the sixteenth parameter {@link Type}
+     * @param g16   the sixteenth parameter getter
+     * @param p17   the seventeenth parameter {@link Type}
+     * @param g17   the seventeenth parameter getter
+     * @param p18   the eighteenth parameter {@link Type}
+     * @param g18   the eighteenth parameter getter
+     * @param ctor  the constructor for {@link R}
+     * @param <P1>  the type of the first parameter
+     * @param <P2>  the type of the second parameter
+     * @param <P3>  the type of the third parameter
+     * @param <P4>  the type of the fourth parameter
+     * @param <P5>  the type of the fifth parameter
+     * @param <P6>  the type of the sixth parameter
+     * @param <P7>  the type of the seventh parameter
+     * @param <P8>  the type of the eighth parameter
+     * @param <P9>  the type of the ninth parameter
+     * @param <P10> the type of the tenth parameter
+     * @param <P11> the type of the eleventh parameter
+     * @param <P12> the type of the twelfth parameter
+     * @param <P13> the type of the thirteenth parameter
+     * @param <P14> the type of the fourteenth parameter
+     * @param <P15> the type of the fifteenth parameter
+     * @param <P16> the type of the sixteenth parameter
+     * @param <P17> the type of the seventeenth parameter
+     * @param <P18> the type of the eighteenth parameter
+     * @param <R>   the type of the value
+     * @return the new template
+     */
+    public static <P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, P18 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(
+            Type<P1> p1, Function<? super R, ? extends P1> g1, Type<P2> p2, Function<? super R, ? extends P2> g2,
+            Type<P3> p3, Function<? super R, ? extends P3> g3, Type<P4> p4, Function<? super R, ? extends P4> g4,
+            Type<P5> p5, Function<? super R, ? extends P5> g5, Type<P6> p6, Function<? super R, ? extends P6> g6,
+            Type<P7> p7, Function<? super R, ? extends P7> g7, Type<P8> p8, Function<? super R, ? extends P8> g8,
+            Type<P9> p9, Function<? super R, ? extends P9> g9, Type<P10> p10, Function<? super R, ? extends P10> g10,
+            Type<P11> p11, Function<? super R, ? extends P11> g11, Type<P12> p12, Function<? super R, ? extends P12> g12,
+            Type<P13> p13, Function<? super R, ? extends P13> g13, Type<P14> p14, Function<? super R, ? extends P14> g14,
+            Type<P15> p15, Function<? super R, ? extends P15> g15, Type<P16> p16, Function<? super R, ? extends P16> g16,
+            Type<P17> p17, Function<? super R, ? extends P17> g17, Type<P18> p18, Function<? super R, ? extends P18> g18,
+            F18<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? super P11, ? super P12, ? super P13, ? super P14, ? super P15, ? super P16, ? super P17, ? super P18, ? extends R> ctor
     ) {
+        Objects.requireNonNull(p1, "p1");
+        Objects.requireNonNull(g1, "g1");
+        Objects.requireNonNull(p2, "p2");
+        Objects.requireNonNull(g2, "g2");
+        Objects.requireNonNull(p3, "p3");
+        Objects.requireNonNull(g3, "g3");
+        Objects.requireNonNull(p4, "p4");
+        Objects.requireNonNull(g4, "g4");
+        Objects.requireNonNull(p5, "p5");
+        Objects.requireNonNull(g5, "g5");
+        Objects.requireNonNull(p6, "p6");
+        Objects.requireNonNull(g6, "g6");
+        Objects.requireNonNull(p7, "p7");
+        Objects.requireNonNull(g7, "g7");
+        Objects.requireNonNull(p8, "p8");
+        Objects.requireNonNull(g8, "g8");
+        Objects.requireNonNull(p9, "p9");
+        Objects.requireNonNull(g9, "g9");
+        Objects.requireNonNull(p10, "p10");
+        Objects.requireNonNull(g10, "g10");
+        Objects.requireNonNull(p11, "p11");
+        Objects.requireNonNull(g11, "g11");
+        Objects.requireNonNull(p12, "p12");
+        Objects.requireNonNull(g12, "g12");
+        Objects.requireNonNull(p13, "p13");
+        Objects.requireNonNull(g13, "g13");
+        Objects.requireNonNull(p14, "p14");
+        Objects.requireNonNull(g14, "g14");
+        Objects.requireNonNull(p15, "p15");
+        Objects.requireNonNull(g15, "g15");
+        Objects.requireNonNull(p16, "p16");
+        Objects.requireNonNull(g16, "g16");
+        Objects.requireNonNull(p17, "p17");
+        Objects.requireNonNull(g17, "g17");
+        Objects.requireNonNull(p18, "p18");
+        Objects.requireNonNull(g18, "g18");
+        Objects.requireNonNull(ctor, "ctor");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -741,7 +1786,7 @@ public final class NetworkBufferTemplate {
 
             @Override
             public R read(NetworkBuffer buffer) {
-                return reader.apply(
+                return ctor.apply(
                         p1.read(buffer), p2.read(buffer),
                         p3.read(buffer), p4.read(buffer),
                         p5.read(buffer), p6.read(buffer),
@@ -756,18 +1801,120 @@ public final class NetworkBufferTemplate {
         };
     }
 
-    public static <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, R> Type<R> template(
-            Type<P1> p1, Function<R, P1> g1, Type<P2> p2, Function<R, P2> g2,
-            Type<P3> p3, Function<R, P3> g3, Type<P4> p4, Function<R, P4> g4,
-            Type<P5> p5, Function<R, P5> g5, Type<P6> p6, Function<R, P6> g6,
-            Type<P7> p7, Function<R, P7> g7, Type<P8> p8, Function<R, P8> g8,
-            Type<P9> p9, Function<R, P9> g9, Type<P10> p10, Function<R, P10> g10,
-            Type<P11> p11, Function<R, P11> g11, Type<P12> p12, Function<R, P12> g12,
-            Type<P13> p13, Function<R, P13> g13, Type<P14> p14, Function<R, P14> g14,
-            Type<P15> p15, Function<R, P15> g15, Type<P16> p16, Function<R, P16> g16,
-            Type<P17> p17, Function<R, P17> g17, Type<P18> p18, Function<R, P18> g18,
-            Type<P19> p19, Function<R, P19> g19, F19<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, R> reader
+    /**
+     * Creates a template with nineteen parameters
+     *
+     * @param p1    the first parameter {@link Type}
+     * @param g1    the first parameter getter
+     * @param p2    the second parameter {@link Type}
+     * @param g2    the second parameter getter
+     * @param p3    the third parameter {@link Type}
+     * @param g3    the third parameter getter
+     * @param p4    the fourth parameter {@link Type}
+     * @param g4    the fourth parameter getter
+     * @param p5    the fifth parameter {@link Type}
+     * @param g5    the fifth parameter getter
+     * @param p6    the sixth parameter {@link Type}
+     * @param g6    the sixth parameter getter
+     * @param p7    the seventh parameter {@link Type}
+     * @param g7    the seventh parameter getter
+     * @param p8    the eighth parameter {@link Type}
+     * @param g8    the eighth parameter getter
+     * @param p9    the ninth parameter {@link Type}
+     * @param g9    the ninth parameter getter
+     * @param p10   the tenth parameter {@link Type}
+     * @param g10   the tenth parameter getter
+     * @param p11   the eleventh parameter {@link Type}
+     * @param g11   the eleventh parameter getter
+     * @param p12   the twelfth parameter {@link Type}
+     * @param g12   the twelfth parameter getter
+     * @param p13   the thirteenth parameter {@link Type}
+     * @param g13   the thirteenth parameter getter
+     * @param p14   the fourteenth parameter {@link Type}
+     * @param g14   the fourteenth parameter getter
+     * @param p15   the fifteenth parameter {@link Type}
+     * @param g15   the fifteenth parameter getter
+     * @param p16   the sixteenth parameter {@link Type}
+     * @param g16   the sixteenth parameter getter
+     * @param p17   the seventeenth parameter {@link Type}
+     * @param g17   the seventeenth parameter getter
+     * @param p18   the eighteenth parameter {@link Type}
+     * @param g18   the eighteenth parameter getter
+     * @param p19   the nineteenth parameter {@link Type}
+     * @param g19   the nineteenth parameter getter
+     * @param ctor  the constructor for {@link R}
+     * @param <P1>  the type of the first parameter
+     * @param <P2>  the type of the second parameter
+     * @param <P3>  the type of the third parameter
+     * @param <P4>  the type of the fourth parameter
+     * @param <P5>  the type of the fifth parameter
+     * @param <P6>  the type of the sixth parameter
+     * @param <P7>  the type of the seventh parameter
+     * @param <P8>  the type of the eighth parameter
+     * @param <P9>  the type of the ninth parameter
+     * @param <P10> the type of the tenth parameter
+     * @param <P11> the type of the eleventh parameter
+     * @param <P12> the type of the twelfth parameter
+     * @param <P13> the type of the thirteenth parameter
+     * @param <P14> the type of the fourteenth parameter
+     * @param <P15> the type of the fifteenth parameter
+     * @param <P16> the type of the sixteenth parameter
+     * @param <P17> the type of the seventeenth parameter
+     * @param <P18> the type of the eighteenth parameter
+     * @param <R>   the type of the value
+     * @return the new template
+     */
+    public static <P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, P18 extends @UnknownNullability Object, P19 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(
+            Type<P1> p1, Function<? super R, ? extends P1> g1, Type<P2> p2, Function<? super R, ? extends P2> g2,
+            Type<P3> p3, Function<? super R, ? extends P3> g3, Type<P4> p4, Function<? super R, ? extends P4> g4,
+            Type<P5> p5, Function<? super R, ? extends P5> g5, Type<P6> p6, Function<? super R, ? extends P6> g6,
+            Type<P7> p7, Function<? super R, ? extends P7> g7, Type<P8> p8, Function<? super R, ? extends P8> g8,
+            Type<P9> p9, Function<? super R, ? extends P9> g9, Type<P10> p10, Function<? super R, ? extends P10> g10,
+            Type<P11> p11, Function<? super R, ? extends P11> g11, Type<P12> p12, Function<? super R, ? extends P12> g12,
+            Type<P13> p13, Function<? super R, ? extends P13> g13, Type<P14> p14, Function<? super R, ? extends P14> g14,
+            Type<P15> p15, Function<? super R, ? extends P15> g15, Type<P16> p16, Function<? super R, ? extends P16> g16,
+            Type<P17> p17, Function<? super R, ? extends P17> g17, Type<P18> p18, Function<? super R, ? extends P18> g18,
+            Type<P19> p19, Function<? super R, ? extends P19> g19, F19<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? super P11, ? super P12, ? super P13, ? super P14, ? super P15, ? super P16, ? super P17, ? super P18, ? super P19, ? extends R> ctor
     ) {
+        Objects.requireNonNull(p1, "p1");
+        Objects.requireNonNull(g1, "g1");
+        Objects.requireNonNull(p2, "p2");
+        Objects.requireNonNull(g2, "g2");
+        Objects.requireNonNull(p3, "p3");
+        Objects.requireNonNull(g3, "g3");
+        Objects.requireNonNull(p4, "p4");
+        Objects.requireNonNull(g4, "g4");
+        Objects.requireNonNull(p5, "p5");
+        Objects.requireNonNull(g5, "g5");
+        Objects.requireNonNull(p6, "p6");
+        Objects.requireNonNull(g6, "g6");
+        Objects.requireNonNull(p7, "p7");
+        Objects.requireNonNull(g7, "g7");
+        Objects.requireNonNull(p8, "p8");
+        Objects.requireNonNull(g8, "g8");
+        Objects.requireNonNull(p9, "p9");
+        Objects.requireNonNull(g9, "g9");
+        Objects.requireNonNull(p10, "p10");
+        Objects.requireNonNull(g10, "g10");
+        Objects.requireNonNull(p11, "p11");
+        Objects.requireNonNull(g11, "g11");
+        Objects.requireNonNull(p12, "p12");
+        Objects.requireNonNull(g12, "g12");
+        Objects.requireNonNull(p13, "p13");
+        Objects.requireNonNull(g13, "g13");
+        Objects.requireNonNull(p14, "p14");
+        Objects.requireNonNull(g14, "g14");
+        Objects.requireNonNull(p15, "p15");
+        Objects.requireNonNull(g15, "g15");
+        Objects.requireNonNull(p16, "p16");
+        Objects.requireNonNull(g16, "g16");
+        Objects.requireNonNull(p17, "p17");
+        Objects.requireNonNull(g17, "g17");
+        Objects.requireNonNull(p18, "p18");
+        Objects.requireNonNull(g18, "g18");
+        Objects.requireNonNull(p19, "p19");
+        Objects.requireNonNull(g19, "g19");
+        Objects.requireNonNull(ctor, "ctor");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -794,7 +1941,7 @@ public final class NetworkBufferTemplate {
 
             @Override
             public R read(NetworkBuffer buffer) {
-                return reader.apply(
+                return ctor.apply(
                         p1.read(buffer), p2.read(buffer),
                         p3.read(buffer), p4.read(buffer),
                         p5.read(buffer), p6.read(buffer),
@@ -810,19 +1957,128 @@ public final class NetworkBufferTemplate {
         };
     }
 
-    public static <P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, R> Type<R> template(
-            Type<P1> p1, Function<R, P1> g1, Type<P2> p2, Function<R, P2> g2,
-            Type<P3> p3, Function<R, P3> g3, Type<P4> p4, Function<R, P4> g4,
-            Type<P5> p5, Function<R, P5> g5, Type<P6> p6, Function<R, P6> g6,
-            Type<P7> p7, Function<R, P7> g7, Type<P8> p8, Function<R, P8> g8,
-            Type<P9> p9, Function<R, P9> g9, Type<P10> p10, Function<R, P10> g10,
-            Type<P11> p11, Function<R, P11> g11, Type<P12> p12, Function<R, P12> g12,
-            Type<P13> p13, Function<R, P13> g13, Type<P14> p14, Function<R, P14> g14,
-            Type<P15> p15, Function<R, P15> g15, Type<P16> p16, Function<R, P16> g16,
-            Type<P17> p17, Function<R, P17> g17, Type<P18> p18, Function<R, P18> g18,
-            Type<P19> p19, Function<R, P19> g19, Type<P20> p20, Function<R, P20> g20,
-            F20<P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, P16, P17, P18, P19, P20, R> reader
+    /**
+     * Creates a template with twenty parameters
+     *
+     * @param p1    the first parameter {@link Type}
+     * @param g1    the first parameter getter
+     * @param p2    the second parameter {@link Type}
+     * @param g2    the second parameter getter
+     * @param p3    the third parameter {@link Type}
+     * @param g3    the third parameter getter
+     * @param p4    the fourth parameter {@link Type}
+     * @param g4    the fourth parameter getter
+     * @param p5    the fifth parameter {@link Type}
+     * @param g5    the fifth parameter getter
+     * @param p6    the sixth parameter {@link Type}
+     * @param g6    the sixth parameter getter
+     * @param p7    the seventh parameter {@link Type}
+     * @param g7    the seventh parameter getter
+     * @param p8    the eighth parameter {@link Type}
+     * @param g8    the eighth parameter getter
+     * @param p9    the ninth parameter {@link Type}
+     * @param g9    the ninth parameter getter
+     * @param p10   the tenth parameter {@link Type}
+     * @param g10   the tenth parameter getter
+     * @param p11   the eleventh parameter {@link Type}
+     * @param g11   the eleventh parameter getter
+     * @param p12   the twelfth parameter {@link Type}
+     * @param g12   the twelfth parameter getter
+     * @param p13   the thirteenth parameter {@link Type}
+     * @param g13   the thirteenth parameter getter
+     * @param p14   the fourteenth parameter {@link Type}
+     * @param g14   the fourteenth parameter getter
+     * @param p15   the fifteenth parameter {@link Type}
+     * @param g15   the fifteenth parameter getter
+     * @param p16   the sixteenth parameter {@link Type}
+     * @param g16   the sixteenth parameter getter
+     * @param p17   the seventeenth parameter {@link Type}
+     * @param g17   the seventeenth parameter getter
+     * @param p18   the eighteenth parameter {@link Type}
+     * @param g18   the eighteenth parameter getter
+     * @param p19   the nineteenth parameter {@link Type}
+     * @param g19   the nineteenth parameter getter
+     * @param p20   the twentieth parameter {@link Type}
+     * @param g20   the twentieth parameter getter
+     * @param ctor  the constructor for {@link R}
+     * @param <P1>  the type of the first parameter
+     * @param <P2>  the type of the second parameter
+     * @param <P3>  the type of the third parameter
+     * @param <P4>  the type of the fourth parameter
+     * @param <P5>  the type of the fifth parameter
+     * @param <P6>  the type of the sixth parameter
+     * @param <P7>  the type of the seventh parameter
+     * @param <P8>  the type of the eighth parameter
+     * @param <P9>  the type of the ninth parameter
+     * @param <P10> the type of the tenth parameter
+     * @param <P11> the type of the eleventh parameter
+     * @param <P12> the type of the twelfth parameter
+     * @param <P13> the type of the thirteenth parameter
+     * @param <P14> the type of the fourteenth parameter
+     * @param <P15> the type of the fifteenth parameter
+     * @param <P16> the type of the sixteenth parameter
+     * @param <P17> the type of the seventeenth parameter
+     * @param <P18> the type of the eighteenth parameter
+     * @param <P19> the type of the nineteenth parameter
+     * @param <P20> the type of the twentieth parameter
+     * @param <R>   the type of the value
+     * @return the new template
+     */
+    public static <P1 extends @UnknownNullability Object, P2 extends @UnknownNullability Object, P3 extends @UnknownNullability Object, P4 extends @UnknownNullability Object, P5 extends @UnknownNullability Object, P6 extends @UnknownNullability Object, P7 extends @UnknownNullability Object, P8 extends @UnknownNullability Object, P9 extends @UnknownNullability Object, P10 extends @UnknownNullability Object, P11 extends @UnknownNullability Object, P12 extends @UnknownNullability Object, P13 extends @UnknownNullability Object, P14 extends @UnknownNullability Object, P15 extends @UnknownNullability Object, P16 extends @UnknownNullability Object, P17 extends @UnknownNullability Object, P18 extends @UnknownNullability Object, P19 extends @UnknownNullability Object, P20 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(
+            Type<P1> p1, Function<? super R, ? extends P1> g1, Type<P2> p2, Function<? super R, ? extends P2> g2,
+            Type<P3> p3, Function<? super R, ? extends P3> g3, Type<P4> p4, Function<? super R, ? extends P4> g4,
+            Type<P5> p5, Function<? super R, ? extends P5> g5, Type<P6> p6, Function<? super R, ? extends P6> g6,
+            Type<P7> p7, Function<? super R, ? extends P7> g7, Type<P8> p8, Function<? super R, ? extends P8> g8,
+            Type<P9> p9, Function<? super R, ? extends P9> g9, Type<P10> p10, Function<? super R, ? extends P10> g10,
+            Type<P11> p11, Function<? super R, ? extends P11> g11, Type<P12> p12, Function<? super R, ? extends P12> g12,
+            Type<P13> p13, Function<? super R, ? extends P13> g13, Type<P14> p14, Function<? super R, ? extends P14> g14,
+            Type<P15> p15, Function<? super R, ? extends P15> g15, Type<P16> p16, Function<? super R, ? extends P16> g16,
+            Type<P17> p17, Function<? super R, ? extends P17> g17, Type<P18> p18, Function<? super R, ? extends P18> g18,
+            Type<P19> p19, Function<? super R, ? extends P19> g19, Type<P20> p20, Function<? super R, ? extends P20> g20,
+            F20<? super P1, ? super P2, ? super P3, ? super P4, ? super P5, ? super P6, ? super P7, ? super P8, ? super P9, ? super P10, ? super P11, ? super P12, ? super P13, ? super P14, ? super P15, ? super P16, ? super P17, ? super P18, ? super P19, ? super P20, ? extends R> ctor
     ) {
+
+        Objects.requireNonNull(p1, "p1");
+        Objects.requireNonNull(g1, "g1");
+        Objects.requireNonNull(p2, "p2");
+        Objects.requireNonNull(g2, "g2");
+        Objects.requireNonNull(p3, "p3");
+        Objects.requireNonNull(g3, "g3");
+        Objects.requireNonNull(p4, "p4");
+        Objects.requireNonNull(g4, "g4");
+        Objects.requireNonNull(p5, "p5");
+        Objects.requireNonNull(g5, "g5");
+        Objects.requireNonNull(p6, "p6");
+        Objects.requireNonNull(g6, "g6");
+        Objects.requireNonNull(p7, "p7");
+        Objects.requireNonNull(g7, "g7");
+        Objects.requireNonNull(p8, "p8");
+        Objects.requireNonNull(g8, "g8");
+        Objects.requireNonNull(p9, "p9");
+        Objects.requireNonNull(g9, "g9");
+        Objects.requireNonNull(p10, "p10");
+        Objects.requireNonNull(g10, "g10");
+        Objects.requireNonNull(p11, "p11");
+        Objects.requireNonNull(g11, "g11");
+        Objects.requireNonNull(p12, "p12");
+        Objects.requireNonNull(g12, "g12");
+        Objects.requireNonNull(p13, "p13");
+        Objects.requireNonNull(g13, "g13");
+        Objects.requireNonNull(p14, "p14");
+        Objects.requireNonNull(g14, "g14");
+        Objects.requireNonNull(p15, "p15");
+        Objects.requireNonNull(g15, "g15");
+        Objects.requireNonNull(p16, "p16");
+        Objects.requireNonNull(g16, "g16");
+        Objects.requireNonNull(p17, "p17");
+        Objects.requireNonNull(g17, "g17");
+        Objects.requireNonNull(p18, "p18");
+        Objects.requireNonNull(g18, "g18");
+        Objects.requireNonNull(p19, "p19");
+        Objects.requireNonNull(g19, "g19");
+        Objects.requireNonNull(p20, "p20");
+        Objects.requireNonNull(g20, "g20");
+        Objects.requireNonNull(ctor, "ctor");
         return new NetworkBufferTypeImpl<>() {
             @Override
             public void write(NetworkBuffer buffer, R value) {
@@ -850,7 +2106,7 @@ public final class NetworkBufferTemplate {
 
             @Override
             public R read(NetworkBuffer buffer) {
-                return reader.apply(
+                return ctor.apply(
                         p1.read(buffer), p2.read(buffer),
                         p3.read(buffer), p4.read(buffer),
                         p5.read(buffer), p6.read(buffer),

--- a/src/main/java/net/minestom/server/network/packet/PacketParser.java
+++ b/src/main/java/net/minestom/server/network/packet/PacketParser.java
@@ -13,23 +13,23 @@ import net.minestom.server.network.packet.server.ServerPacket;
  */
 public sealed interface PacketParser<T> {
 
-    PacketRegistry<T> handshake();
+    PacketRegistry<? extends T> handshake();
 
-    PacketRegistry<T> status();
+    PacketRegistry<? extends T> status();
 
-    PacketRegistry<T> login();
+    PacketRegistry<? extends T> login();
 
-    PacketRegistry<T> configuration();
+    PacketRegistry<? extends T> configuration();
 
-    PacketRegistry<T> play();
+    PacketRegistry<? extends T> play();
 
     default T parse(ConnectionState connectionState,
                              int packetId, NetworkBuffer buffer) {
-        final PacketRegistry<T> registry = stateRegistry(connectionState);
+        final PacketRegistry<? extends T> registry = stateRegistry(connectionState);
         return registry.create(packetId, buffer);
     }
 
-    default PacketRegistry<T> stateRegistry(ConnectionState connectionState) {
+    default PacketRegistry<? extends T> stateRegistry(ConnectionState connectionState) {
         return switch (connectionState) {
             case HANDSHAKE -> handshake();
             case STATUS -> status();
@@ -40,11 +40,11 @@ public sealed interface PacketParser<T> {
     }
 
     record Client(
-            PacketRegistry<ClientPacket> handshake,
-            PacketRegistry<ClientPacket> status,
-            PacketRegistry<ClientPacket> login,
-            PacketRegistry<ClientPacket> configuration,
-            PacketRegistry<ClientPacket> play
+            PacketRegistry<ClientPacket.Handshake> handshake,
+            PacketRegistry<ClientPacket.Status> status,
+            PacketRegistry<ClientPacket.Login> login,
+            PacketRegistry<ClientPacket.Configuration> configuration,
+            PacketRegistry<ClientPacket.Play> play
     ) implements PacketParser<ClientPacket> {
         public Client() {
             this(
@@ -58,11 +58,11 @@ public sealed interface PacketParser<T> {
     }
 
     record Server(
-            PacketRegistry<ServerPacket> handshake,
-            PacketRegistry<ServerPacket> status,
-            PacketRegistry<ServerPacket> login,
-            PacketRegistry<ServerPacket> configuration,
-            PacketRegistry<ServerPacket> play
+            PacketRegistry<ServerPacket.Handshake> handshake,
+            PacketRegistry<ServerPacket.Status> status,
+            PacketRegistry<ServerPacket.Login> login,
+            PacketRegistry<ServerPacket.Configuration> configuration,
+            PacketRegistry<ServerPacket.Play> play
     ) implements PacketParser<ServerPacket> {
         public Server() {
             this(

--- a/src/main/java/net/minestom/server/network/packet/PacketReading.java
+++ b/src/main/java/net/minestom/server/network/packet/PacketReading.java
@@ -172,7 +172,7 @@ public final class PacketReading {
         final long readerEnd = readerStart + packetLength;
         final long writerEnd = buffer.writeIndex();
         buffer.writeIndex(readerEnd);
-        final PacketRegistry<T> registry = parser.stateRegistry(state);
+        final PacketRegistry<? extends T> registry = parser.stateRegistry(state);
         final T packet = readFramedPacket(buffer, registry, compressed);
         final ConnectionState nextState = stateUpdater.apply(packet, state);
         buffer.index(readerEnd, writerEnd);

--- a/src/main/java/net/minestom/server/network/packet/PacketRegistry.java
+++ b/src/main/java/net/minestom/server/network/packet/PacketRegistry.java
@@ -41,18 +41,18 @@ public interface PacketRegistry<T> {
     record PacketInfo<T>(Class<T> packetClass, int id, NetworkBuffer.Type<T> serializer) {
     }
 
-    abstract sealed class Client extends PacketRegistryTemplate<ClientPacket> {
-        @SafeVarargs Client(Entry<? extends ClientPacket>... suppliers) {
+    abstract sealed class Client<T extends ClientPacket> extends PacketRegistryTemplate<T> {
+        @SafeVarargs Client(Entry<? extends T>... suppliers) {
             super(suppliers);
         }
 
         @Override
-        public ConnectionSide side() {
+        public final ConnectionSide side() {
             return ConnectionSide.CLIENT;
         }
     }
 
-    final class ClientHandshake extends Client {
+    final class ClientHandshake extends Client<ClientPacket.Handshake> {
         public ClientHandshake() {
             super(
                     entry(ClientHandshakePacket.class, ClientHandshakePacket.SERIALIZER)
@@ -65,7 +65,7 @@ public interface PacketRegistry<T> {
         }
     }
 
-    final class ClientStatus extends Client {
+    final class ClientStatus extends Client<ClientPacket.Status> {
         public ClientStatus() {
             super(
                     entry(StatusRequestPacket.class, StatusRequestPacket.SERIALIZER),
@@ -79,7 +79,7 @@ public interface PacketRegistry<T> {
         }
     }
 
-    final class ClientLogin extends Client {
+    final class ClientLogin extends Client<ClientPacket.Login> {
         public ClientLogin() {
             super(
                     entry(ClientLoginStartPacket.class, ClientLoginStartPacket.SERIALIZER),
@@ -96,7 +96,7 @@ public interface PacketRegistry<T> {
         }
     }
 
-    final class ClientConfiguration extends Client {
+    final class ClientConfiguration extends Client<ClientPacket.Configuration> {
         public ClientConfiguration() {
             super(
                     entry(ClientSettingsPacket.class, ClientSettingsPacket.SERIALIZER),
@@ -118,7 +118,7 @@ public interface PacketRegistry<T> {
         }
     }
 
-    final class ClientPlay extends Client {
+    final class ClientPlay extends Client<ClientPacket.Play> {
         public ClientPlay() {
             super(
                     entry(ClientTeleportConfirmPacket.class, ClientTeleportConfirmPacket.SERIALIZER),
@@ -196,18 +196,18 @@ public interface PacketRegistry<T> {
         }
     }
 
-    abstract sealed class Server extends PacketRegistryTemplate<ServerPacket> {
-        @SafeVarargs Server(Entry<? extends ServerPacket>... suppliers) {
+    abstract sealed class Server<T extends ServerPacket> extends PacketRegistryTemplate<T> {
+        @SafeVarargs Server(Entry<? extends T>... suppliers) {
             super(suppliers);
         }
 
         @Override
-        public ConnectionSide side() {
+        public final ConnectionSide side() {
             return ConnectionSide.SERVER;
         }
     }
 
-    final class ServerHandshake extends Server {
+    final class ServerHandshake extends Server<ServerPacket.Handshake> {
         public ServerHandshake() {
             super(
                     // Empty
@@ -220,7 +220,7 @@ public interface PacketRegistry<T> {
         }
     }
 
-    final class ServerStatus extends Server {
+    final class ServerStatus extends Server<ServerPacket.Status> {
         public ServerStatus() {
             super(
                     entry(ResponsePacket.class, ResponsePacket.SERIALIZER),
@@ -234,7 +234,7 @@ public interface PacketRegistry<T> {
         }
     }
 
-    final class ServerLogin extends Server {
+    final class ServerLogin extends Server<ServerPacket.Login> {
         public ServerLogin() {
             super(
                     entry(LoginDisconnectPacket.class, LoginDisconnectPacket.SERIALIZER),
@@ -252,7 +252,7 @@ public interface PacketRegistry<T> {
         }
     }
 
-    final class ServerConfiguration extends Server {
+    final class ServerConfiguration extends Server<ServerPacket.Configuration> {
         public ServerConfiguration() {
             super(
                     entry(CookieRequestPacket.class, CookieRequestPacket.SERIALIZER),
@@ -284,7 +284,7 @@ public interface PacketRegistry<T> {
         }
     }
 
-    final class ServerPlay extends Server {
+    final class ServerPlay extends Server<ServerPacket.Play> {
         public ServerPlay() {
             super(
                     entry(BundlePacket.class, BundlePacket.SERIALIZER),

--- a/src/main/java/net/minestom/server/network/packet/PacketVanilla.java
+++ b/src/main/java/net/minestom/server/network/packet/PacketVanilla.java
@@ -21,8 +21,8 @@ import org.jetbrains.annotations.ApiStatus;
  */
 @ApiStatus.Internal
 public final class PacketVanilla {
-    public static final PacketParser<ClientPacket> CLIENT_PACKET_PARSER = new PacketParser.Client();
-    public static final PacketParser<ServerPacket> SERVER_PACKET_PARSER = new PacketParser.Server();
+    public static final PacketParser.Client CLIENT_PACKET_PARSER = new PacketParser.Client();
+    public static final PacketParser.Server SERVER_PACKET_PARSER = new PacketParser.Server();
 
     /**
      * Pool containing a buffer able to hold the largest packet.

--- a/src/main/java/net/minestom/server/network/packet/PacketWriting.java
+++ b/src/main/java/net/minestom/server/network/packet/PacketWriting.java
@@ -32,19 +32,20 @@ public final class PacketWriting {
     }
 
     public static <T> void writeFramedPacket(NetworkBuffer buffer,
-                                             PacketParser<T> parser,
+                                             PacketParser<? super T> parser,
                                              ConnectionState state,
                                              T packet,
                                              int compressionThreshold) throws IndexOutOfBoundsException {
-        final PacketRegistry<T> registry = parser.stateRegistry(state);
+        @SuppressWarnings("unchecked") // We assume ConnectionState and PacketRegistry are in sync
+        final PacketRegistry<? super T> registry = (PacketRegistry<? super T>) parser.stateRegistry(state);
         writeFramedPacket(buffer, registry, packet, compressionThreshold);
     }
 
     public static <T> void writeFramedPacket(NetworkBuffer buffer,
-                                             PacketRegistry<T> registry,
+                                             PacketRegistry<? super T> registry,
                                              T packet,
                                              int compressionThreshold) throws IndexOutOfBoundsException {
-        final PacketRegistry.PacketInfo<T> packetInfo = registry.packetInfo(packet);
+        final PacketRegistry.PacketInfo<? super T> packetInfo = registry.packetInfo(packet);
         writeFramedPacket(
                 buffer,
                 packetInfo, packet,
@@ -53,11 +54,11 @@ public final class PacketWriting {
     }
 
     public static <T> void writeFramedPacket(NetworkBuffer buffer,
-                                             PacketRegistry.PacketInfo<T> packetInfo,
+                                             PacketRegistry.PacketInfo<? super T> packetInfo,
                                              T packet,
                                              int compressionThreshold) throws IndexOutOfBoundsException {
         final int id = packetInfo.id();
-        final NetworkBuffer.Type<T> serializer = packetInfo.serializer();
+        final NetworkBuffer.Type<? super T> serializer = packetInfo.serializer();
         writeFramedPacket(
                 buffer, serializer,
                 id, packet,
@@ -66,7 +67,7 @@ public final class PacketWriting {
     }
 
     public static <T> void writeFramedPacket(NetworkBuffer buffer,
-                                             NetworkBuffer.Type<T> type,
+                                             NetworkBuffer.Type<? super T> type,
                                              int id, T packet,
                                              int compressionThreshold) throws IndexOutOfBoundsException {
         if (compressionThreshold <= 0) writeUncompressedFormat(buffer, type, id, packet);
@@ -74,7 +75,7 @@ public final class PacketWriting {
     }
 
     private static <T> void writeUncompressedFormat(NetworkBuffer buffer,
-                                                    NetworkBuffer.Type<T> type,
+                                                    NetworkBuffer.Type<? super T> type,
                                                     int id, T packet) throws IndexOutOfBoundsException {
         // Uncompressed format https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Protocol#Without_compression
         final long lengthIndex = buffer.advanceWrite(3);
@@ -85,7 +86,7 @@ public final class PacketWriting {
     }
 
     private static <T> void writeCompressedFormat(NetworkBuffer buffer,
-                                                  NetworkBuffer.Type<T> type,
+                                                  NetworkBuffer.Type<? super T> type,
                                                   int id, T packet,
                                                   int compressionThreshold) throws IndexOutOfBoundsException {
         // Compressed format https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Protocol#With_compression
@@ -141,22 +142,23 @@ public final class PacketWriting {
 
     public static <T> NetworkBuffer allocateTrimmedPacket(
             NetworkBuffer tmpBuffer,
-            PacketParser<T> parser,
+            PacketParser<? super T> parser,
             ConnectionState state,
             T packet,
             int compressionThreshold) {
-        final PacketRegistry<T> registry = parser.stateRegistry(state);
+        @SuppressWarnings("unchecked") // We assume ConnectionState and PacketRegistry are in sync
+        final PacketRegistry<? super T> registry = (PacketRegistry<? super T>) parser.stateRegistry(state);
         return allocateTrimmedPacket(tmpBuffer, registry, packet, compressionThreshold);
     }
 
     public static <T> NetworkBuffer allocateTrimmedPacket(
             NetworkBuffer tmpBuffer,
-            PacketRegistry<T> registry,
+            PacketRegistry<? super T> registry,
             T packet,
             int compressionThreshold) {
-        final PacketRegistry.PacketInfo<T> packetInfo = registry.packetInfo(packet);
+        final PacketRegistry.PacketInfo<? super T> packetInfo = registry.packetInfo(packet);
         final int id = packetInfo.id();
-        final NetworkBuffer.Type<T> serializer = packetInfo.serializer();
+        final NetworkBuffer.Type<? super T> serializer = packetInfo.serializer();
         try {
             writeFramedPacket(tmpBuffer, serializer, id, packet, compressionThreshold);
             return tmpBuffer.copy(0, tmpBuffer.writeIndex());

--- a/src/main/java/net/minestom/server/network/packet/client/ClientPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/ClientPacket.java
@@ -5,5 +5,19 @@ package net.minestom.server.network.packet.client;
  * <p>
  * Packets are value-based, and should therefore not be reliant on identity.
  */
-public interface ClientPacket {
+public sealed interface ClientPacket {
+    non-sealed interface Handshake extends ClientPacket {
+    }
+
+    non-sealed interface Status extends ClientPacket {
+    }
+
+    non-sealed interface Login extends ClientPacket {
+    }
+
+    non-sealed interface Configuration extends ClientPacket {
+    }
+
+    non-sealed interface Play extends ClientPacket {
+    }
 }

--- a/src/main/java/net/minestom/server/network/packet/client/common/ClientCookieResponsePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/common/ClientCookieResponsePacket.java
@@ -13,7 +13,7 @@ import static net.minestom.server.network.NetworkBuffer.STRING;
 public record ClientCookieResponsePacket(
         String key,
         byte @Nullable [] value
-) implements ClientPacket {
+) implements ClientPacket.Login, ClientPacket.Configuration, ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientCookieResponsePacket> SERIALIZER = NetworkBufferTemplate.template(
             STRING, ClientCookieResponsePacket::key,
             BYTE_ARRAY.optional(), ClientCookieResponsePacket::value,

--- a/src/main/java/net/minestom/server/network/packet/client/common/ClientCustomClickActionPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/common/ClientCustomClickActionPacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.client.ClientPacket;
 
-public record ClientCustomClickActionPacket(Key key, BinaryTag payload) implements ClientPacket {
+public record ClientCustomClickActionPacket(Key key, BinaryTag payload) implements ClientPacket.Configuration, ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientCustomClickActionPacket> SERIALIZER = NetworkBufferTemplate.template(
             NetworkBuffer.KEY, ClientCustomClickActionPacket::key,
             NetworkBuffer.NBT.lengthPrefixed(65536), ClientCustomClickActionPacket::payload,

--- a/src/main/java/net/minestom/server/network/packet/client/common/ClientKeepAlivePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/common/ClientKeepAlivePacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.LONG;
 
-public record ClientKeepAlivePacket(long id) implements ClientPacket {
+public record ClientKeepAlivePacket(long id) implements ClientPacket.Configuration, ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientKeepAlivePacket> SERIALIZER = NetworkBufferTemplate.template(
             LONG, ClientKeepAlivePacket::id, ClientKeepAlivePacket::new);
 }

--- a/src/main/java/net/minestom/server/network/packet/client/common/ClientPingRequestPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/common/ClientPingRequestPacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.LONG;
 
-public record ClientPingRequestPacket(long number) implements ClientPacket {
+public record ClientPingRequestPacket(long number) implements ClientPacket.Status, ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientPingRequestPacket> SERIALIZER = NetworkBufferTemplate.template(
             LONG, ClientPingRequestPacket::number, ClientPingRequestPacket::new);
 }

--- a/src/main/java/net/minestom/server/network/packet/client/common/ClientPluginMessagePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/common/ClientPluginMessagePacket.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 import static net.minestom.server.network.NetworkBuffer.RAW_BYTES;
 import static net.minestom.server.network.NetworkBuffer.STRING;
 
-public record ClientPluginMessagePacket(String channel, byte[] data) implements ClientPacket {
+public record ClientPluginMessagePacket(String channel, byte[] data) implements ClientPacket.Configuration, ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientPluginMessagePacket> SERIALIZER = NetworkBufferTemplate.template(
             STRING, ClientPluginMessagePacket::channel,
             RAW_BYTES, ClientPluginMessagePacket::data,

--- a/src/main/java/net/minestom/server/network/packet/client/common/ClientPongPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/common/ClientPongPacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.INT;
 
-public record ClientPongPacket(int id) implements ClientPacket {
+public record ClientPongPacket(int id) implements ClientPacket.Configuration, ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientPongPacket> SERIALIZER = NetworkBufferTemplate.template(
             INT, ClientPongPacket::id, ClientPongPacket::new);
 }

--- a/src/main/java/net/minestom/server/network/packet/client/common/ClientResourcePackStatusPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/common/ClientResourcePackStatusPacket.java
@@ -13,7 +13,7 @@ import static net.minestom.server.network.NetworkBuffer.VAR_INT;
 public record ClientResourcePackStatusPacket(
         UUID id,
         ResourcePackStatus status
-) implements ClientPacket {
+) implements ClientPacket.Configuration, ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientResourcePackStatusPacket> SERIALIZER = NetworkBufferTemplate.template(
             UUID, ClientResourcePackStatusPacket::id,
             VAR_INT.transform(ClientResourcePackStatusPacket::readStatus, ClientResourcePackStatusPacket::statusId), ClientResourcePackStatusPacket::status,

--- a/src/main/java/net/minestom/server/network/packet/client/common/ClientSettingsPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/common/ClientSettingsPacket.java
@@ -5,7 +5,7 @@ import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.client.ClientPacket;
 import net.minestom.server.network.player.ClientSettings;
 
-public record ClientSettingsPacket(ClientSettings settings) implements ClientPacket {
+public record ClientSettingsPacket(ClientSettings settings) implements ClientPacket.Configuration, ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientSettingsPacket> SERIALIZER = NetworkBufferTemplate.template(
             ClientSettings.NETWORK_TYPE, ClientSettingsPacket::settings,
             ClientSettingsPacket::new);

--- a/src/main/java/net/minestom/server/network/packet/client/configuration/ClientAcceptCodeOfConductPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/configuration/ClientAcceptCodeOfConductPacket.java
@@ -4,6 +4,6 @@ import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.client.ClientPacket;
 
-public record ClientAcceptCodeOfConductPacket() implements ClientPacket {
+public record ClientAcceptCodeOfConductPacket() implements ClientPacket.Configuration {
     public static final NetworkBuffer.Type<ClientAcceptCodeOfConductPacket> SERIALIZER = NetworkBufferTemplate.template(new ClientAcceptCodeOfConductPacket());
 }

--- a/src/main/java/net/minestom/server/network/packet/client/configuration/ClientFinishConfigurationPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/configuration/ClientFinishConfigurationPacket.java
@@ -4,6 +4,6 @@ import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.client.ClientPacket;
 
-public record ClientFinishConfigurationPacket() implements ClientPacket {
+public record ClientFinishConfigurationPacket() implements ClientPacket.Configuration {
     public static final NetworkBuffer.Type<ClientFinishConfigurationPacket> SERIALIZER = NetworkBufferTemplate.template(new ClientFinishConfigurationPacket());
 }

--- a/src/main/java/net/minestom/server/network/packet/client/configuration/ClientSelectKnownPacksPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/configuration/ClientSelectKnownPacksPacket.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public record ClientSelectKnownPacksPacket(
         List<SelectKnownPacksPacket.Entry> entries
-) implements ClientPacket {
+) implements ClientPacket.Configuration {
     private static final int MAX_ENTRIES = 64;
 
     public static final NetworkBuffer.Type<ClientSelectKnownPacksPacket> SERIALIZER = NetworkBufferTemplate.template(

--- a/src/main/java/net/minestom/server/network/packet/client/handshake/ClientHandshakePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/handshake/ClientHandshakePacket.java
@@ -9,7 +9,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 import static net.minestom.server.network.NetworkBuffer.*;
 
 public record ClientHandshakePacket(int protocolVersion, String serverAddress,
-                                    int serverPort, Intent intent) implements ClientPacket {
+                                    int serverPort, Intent intent) implements ClientPacket.Handshake {
 
     public ClientHandshakePacket {
         if (serverAddress.length() > maxHandshakeLength()) {

--- a/src/main/java/net/minestom/server/network/packet/client/login/ClientEncryptionResponsePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/login/ClientEncryptionResponsePacket.java
@@ -7,7 +7,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 import static net.minestom.server.network.NetworkBuffer.BYTE_ARRAY;
 
 public record ClientEncryptionResponsePacket(byte[] sharedSecret,
-                                             byte[] encryptedVerifyToken) implements ClientPacket {
+                                             byte[] encryptedVerifyToken) implements ClientPacket.Login {
     public static final NetworkBuffer.Type<ClientEncryptionResponsePacket> SERIALIZER = NetworkBufferTemplate.template(
             BYTE_ARRAY, ClientEncryptionResponsePacket::sharedSecret,
             BYTE_ARRAY, ClientEncryptionResponsePacket::encryptedVerifyToken,

--- a/src/main/java/net/minestom/server/network/packet/client/login/ClientLoginAcknowledgedPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/login/ClientLoginAcknowledgedPacket.java
@@ -4,6 +4,6 @@ import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.client.ClientPacket;
 
-public record ClientLoginAcknowledgedPacket() implements ClientPacket {
+public record ClientLoginAcknowledgedPacket() implements ClientPacket.Login {
     public static final NetworkBuffer.Type<ClientLoginAcknowledgedPacket> SERIALIZER = NetworkBufferTemplate.template(new ClientLoginAcknowledgedPacket());
 }

--- a/src/main/java/net/minestom/server/network/packet/client/login/ClientLoginPluginResponsePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/login/ClientLoginPluginResponsePacket.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.Nullable;
 import static net.minestom.server.network.NetworkBuffer.RAW_BYTES;
 import static net.minestom.server.network.NetworkBuffer.VAR_INT;
 
-public record ClientLoginPluginResponsePacket(int messageId, byte @Nullable [] data) implements ClientPacket {
+public record ClientLoginPluginResponsePacket(int messageId, byte @Nullable [] data) implements ClientPacket.Login {
     public static final NetworkBuffer.Type<ClientLoginPluginResponsePacket> SERIALIZER = NetworkBufferTemplate.template(
             VAR_INT, ClientLoginPluginResponsePacket::messageId,
             RAW_BYTES.optional(), ClientLoginPluginResponsePacket::data,

--- a/src/main/java/net/minestom/server/network/packet/client/login/ClientLoginStartPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/login/ClientLoginStartPacket.java
@@ -10,7 +10,7 @@ import static net.minestom.server.network.NetworkBuffer.STRING;
 import static net.minestom.server.network.NetworkBuffer.UUID;
 
 public record ClientLoginStartPacket(String username,
-                                     UUID profileId) implements ClientPacket {
+                                     UUID profileId) implements ClientPacket.Login {
     public static final NetworkBuffer.Type<ClientLoginStartPacket> SERIALIZER = NetworkBufferTemplate.template(
             STRING, ClientLoginStartPacket::username,
             UUID, ClientLoginStartPacket::profileId,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientAdvancementTabPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientAdvancementTabPacket.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.Nullable;
 import static net.minestom.server.network.NetworkBuffer.STRING;
 
 public record ClientAdvancementTabPacket(AdvancementAction action,
-                                         @Nullable String tabIdentifier) implements ClientPacket {
+                                         @Nullable String tabIdentifier) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientAdvancementTabPacket> SERIALIZER = new NetworkBuffer.Type<>() {
         @Override
         public void write(NetworkBuffer buffer, ClientAdvancementTabPacket value) {

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientAnimationPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientAnimationPacket.java
@@ -5,7 +5,7 @@ import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.client.ClientPacket;
 
-public record ClientAnimationPacket(PlayerHand hand) implements ClientPacket {
+public record ClientAnimationPacket(PlayerHand hand) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientAnimationPacket> SERIALIZER = NetworkBufferTemplate.template(
             NetworkBuffer.Enum(PlayerHand.class), ClientAnimationPacket::hand,
             ClientAnimationPacket::new);

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientChangeDifficultyPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientChangeDifficultyPacket.java
@@ -8,7 +8,7 @@ import net.minestom.server.world.Difficulty;
 import static net.minestom.server.network.NetworkBuffer.BOOLEAN;
 import static net.minestom.server.network.NetworkBuffer.Enum;
 
-public record ClientChangeDifficultyPacket(Difficulty difficulty, boolean locked) implements ClientPacket {
+public record ClientChangeDifficultyPacket(Difficulty difficulty, boolean locked) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientChangeDifficultyPacket> SERIALIZER = NetworkBufferTemplate.template(
             Enum(Difficulty.class), ClientChangeDifficultyPacket::difficulty,
             BOOLEAN, ClientChangeDifficultyPacket::locked,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientChangeGameModePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientChangeGameModePacket.java
@@ -5,7 +5,7 @@ import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.client.ClientPacket;
 
-public record ClientChangeGameModePacket(GameMode gameMode) implements ClientPacket {
+public record ClientChangeGameModePacket(GameMode gameMode) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientChangeGameModePacket> SERIALIZER = NetworkBufferTemplate.template(
             GameMode.NETWORK_TYPE, ClientChangeGameModePacket::gameMode,
             ClientChangeGameModePacket::new);

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientChatAckPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientChatAckPacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.VAR_INT;
 
-public record ClientChatAckPacket(int offset) implements ClientPacket {
+public record ClientChatAckPacket(int offset) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientChatAckPacket> SERIALIZER = NetworkBufferTemplate.template(
             VAR_INT, ClientChatAckPacket::offset,
             ClientChatAckPacket::new);

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientChatMessagePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientChatMessagePacket.java
@@ -11,7 +11,7 @@ import static net.minestom.server.network.NetworkBuffer.*;
 
 public record ClientChatMessagePacket(String message, long timestamp,
                                       long salt, byte @Nullable [] signature,
-                                      int ackOffset, BitSet ackList, byte checksum) implements ClientPacket {
+                                      int ackOffset, BitSet ackList, byte checksum) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientChatMessagePacket> SERIALIZER = NetworkBufferTemplate.template(
             STRING, ClientChatMessagePacket::message,
             LONG, ClientChatMessagePacket::timestamp,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientChatSessionUpdatePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientChatSessionUpdatePacket.java
@@ -5,7 +5,7 @@ import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.client.ClientPacket;
 
-public record ClientChatSessionUpdatePacket(ChatSession chatSession) implements ClientPacket {
+public record ClientChatSessionUpdatePacket(ChatSession chatSession) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientChatSessionUpdatePacket> SERIALIZER = NetworkBufferTemplate.template(
             ChatSession.SERIALIZER, ClientChatSessionUpdatePacket::chatSession,
             ClientChatSessionUpdatePacket::new

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientChunkBatchReceivedPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientChunkBatchReceivedPacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.FLOAT;
 
-public record ClientChunkBatchReceivedPacket(float targetChunksPerTick) implements ClientPacket {
+public record ClientChunkBatchReceivedPacket(float targetChunksPerTick) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientChunkBatchReceivedPacket> SERIALIZER = NetworkBufferTemplate.template(
             FLOAT, ClientChunkBatchReceivedPacket::targetChunksPerTick,
             ClientChunkBatchReceivedPacket::new);

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientClickWindowButtonPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientClickWindowButtonPacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.VAR_INT;
 
-public record ClientClickWindowButtonPacket(int windowId, int buttonId) implements ClientPacket {
+public record ClientClickWindowButtonPacket(int windowId, int buttonId) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientClickWindowButtonPacket> SERIALIZER = NetworkBufferTemplate.template(
             VAR_INT, ClientClickWindowButtonPacket::windowId,
             VAR_INT, ClientClickWindowButtonPacket::buttonId,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientClickWindowPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientClickWindowPacket.java
@@ -12,7 +12,7 @@ import static net.minestom.server.network.NetworkBuffer.*;
 public record ClientClickWindowPacket(int windowId, int stateId,
                                       short slot, byte button, ClickType clickType,
                                       Map<Short, ItemStack.Hash> changedSlots,
-                                      ItemStack.Hash clickedItem) implements ClientPacket {
+                                      ItemStack.Hash clickedItem) implements ClientPacket.Play {
     public static final int MAX_CHANGED_SLOTS = 128;
 
     public static final NetworkBuffer.Type<ClientClickWindowPacket> SERIALIZER = NetworkBufferTemplate.template(

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientCloseWindowPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientCloseWindowPacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.VAR_INT;
 
-public record ClientCloseWindowPacket(int windowId) implements ClientPacket {
+public record ClientCloseWindowPacket(int windowId) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientCloseWindowPacket> SERIALIZER = NetworkBufferTemplate.template(
             VAR_INT, ClientCloseWindowPacket::windowId,
             ClientCloseWindowPacket::new);

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientCommandChatPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientCommandChatPacket.java
@@ -7,7 +7,7 @@ import net.minestom.server.utils.validate.Check;
 
 import static net.minestom.server.network.NetworkBuffer.STRING;
 
-public record ClientCommandChatPacket(String message) implements ClientPacket {
+public record ClientCommandChatPacket(String message) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientCommandChatPacket> SERIALIZER = NetworkBufferTemplate.template(
             STRING, ClientCommandChatPacket::message,
             ClientCommandChatPacket::new);

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientConfigurationAckPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientConfigurationAckPacket.java
@@ -4,6 +4,6 @@ import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.client.ClientPacket;
 
-public record ClientConfigurationAckPacket() implements ClientPacket {
+public record ClientConfigurationAckPacket() implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientConfigurationAckPacket> SERIALIZER = NetworkBufferTemplate.template(new ClientConfigurationAckPacket());
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientCreativeInventoryActionPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientCreativeInventoryActionPacket.java
@@ -7,7 +7,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.SHORT;
 
-public record ClientCreativeInventoryActionPacket(short slot, ItemStack item) implements ClientPacket {
+public record ClientCreativeInventoryActionPacket(short slot, ItemStack item) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientCreativeInventoryActionPacket> SERIALIZER = NetworkBufferTemplate.template(
             SHORT, ClientCreativeInventoryActionPacket::slot,
             ItemStack.UNTRUSTED_NETWORK_TYPE, ClientCreativeInventoryActionPacket::item,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientDebugSubscriptionRequestPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientDebugSubscriptionRequestPacket.java
@@ -9,7 +9,7 @@ import java.util.Set;
 
 public record ClientDebugSubscriptionRequestPacket(
         Set<DebugSubscription<?>> subscriptions
-) implements ClientPacket {
+) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientDebugSubscriptionRequestPacket> SERIALIZER = NetworkBufferTemplate.template(
             DebugSubscription.NETWORK_TYPE.set(DebugSubscription.values().size()), ClientDebugSubscriptionRequestPacket::subscriptions,
             ClientDebugSubscriptionRequestPacket::new);

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientEditBookPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientEditBookPacket.java
@@ -11,7 +11,7 @@ import static net.minestom.server.network.NetworkBuffer.STRING;
 import static net.minestom.server.network.NetworkBuffer.VAR_INT;
 
 public record ClientEditBookPacket(int slot, List<String> pages,
-                                   @Nullable String title) implements ClientPacket {
+                                   @Nullable String title) implements ClientPacket.Play {
     public static final int MAX_PAGES = 100;
     public static final int MAX_TITLE_LENGTH = 32;
     public static final int MAX_PAGE_LENGTH = 1024;

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientEntityActionPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientEntityActionPacket.java
@@ -8,7 +8,7 @@ import static net.minestom.server.network.NetworkBuffer.Enum;
 import static net.minestom.server.network.NetworkBuffer.VAR_INT;
 
 public record ClientEntityActionPacket(int playerId, Action action,
-                                       int horseJumpBoost) implements ClientPacket {
+                                       int horseJumpBoost) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientEntityActionPacket> SERIALIZER = NetworkBufferTemplate.template(
             VAR_INT, ClientEntityActionPacket::playerId,
             Enum(Action.class), ClientEntityActionPacket::action,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientGenerateStructurePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientGenerateStructurePacket.java
@@ -8,7 +8,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 import static net.minestom.server.network.NetworkBuffer.*;
 
 public record ClientGenerateStructurePacket(Point blockPosition,
-                                            int level, boolean keepJigsaws) implements ClientPacket {
+                                            int level, boolean keepJigsaws) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientGenerateStructurePacket> SERIALIZER = NetworkBufferTemplate.template(
             BLOCK_POSITION, ClientGenerateStructurePacket::blockPosition,
             VAR_INT, ClientGenerateStructurePacket::level,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientHeldItemChangePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientHeldItemChangePacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.SHORT;
 
-public record ClientHeldItemChangePacket(short slot) implements ClientPacket {
+public record ClientHeldItemChangePacket(short slot) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientHeldItemChangePacket> SERIALIZER = NetworkBufferTemplate.template(
             SHORT, ClientHeldItemChangePacket::slot,
             ClientHeldItemChangePacket::new);

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientInputPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientInputPacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.BYTE;
 
-public record ClientInputPacket(byte flags) implements ClientPacket {
+public record ClientInputPacket(byte flags) implements ClientPacket.Play {
     private static final byte FLAG_FORWARD = 1;
     private static final byte FLAG_BACKWARD = 1 << 1;
     private static final byte FLAG_LEFT = 1 << 2;

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientInteractEntityPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientInteractEntityPacket.java
@@ -7,7 +7,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.*;
 
-public record ClientInteractEntityPacket(int targetId, Type type, boolean sneaking) implements ClientPacket {
+public record ClientInteractEntityPacket(int targetId, Type type, boolean sneaking) implements ClientPacket.Play {
 
     public static final NetworkBuffer.Type<ClientInteractEntityPacket> SERIALIZER = new NetworkBuffer.Type<>() {
         @Override

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientLockDifficultyPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientLockDifficultyPacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.BOOLEAN;
 
-public record ClientLockDifficultyPacket(boolean locked) implements ClientPacket {
+public record ClientLockDifficultyPacket(boolean locked) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientLockDifficultyPacket> SERIALIZER = NetworkBufferTemplate.template(
             BOOLEAN, ClientLockDifficultyPacket::locked,
             ClientLockDifficultyPacket::new);

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientNameItemPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientNameItemPacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.STRING;
 
-public record ClientNameItemPacket(String itemName) implements ClientPacket {
+public record ClientNameItemPacket(String itemName) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientNameItemPacket> SERIALIZER = NetworkBufferTemplate.template(
             STRING, ClientNameItemPacket::itemName,
             ClientNameItemPacket::new);

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPickItemFromBlockPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPickItemFromBlockPacket.java
@@ -8,7 +8,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 import static net.minestom.server.network.NetworkBuffer.BLOCK_POSITION;
 import static net.minestom.server.network.NetworkBuffer.BOOLEAN;
 
-public record ClientPickItemFromBlockPacket(Point pos, boolean includeData) implements ClientPacket {
+public record ClientPickItemFromBlockPacket(Point pos, boolean includeData) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientPickItemFromBlockPacket> SERIALIZER = NetworkBufferTemplate.template(
             BLOCK_POSITION, ClientPickItemFromBlockPacket::pos,
             BOOLEAN, ClientPickItemFromBlockPacket::includeData,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPickItemFromEntityPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPickItemFromEntityPacket.java
@@ -5,7 +5,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.*;
 
-public record ClientPickItemFromEntityPacket(int entityId, boolean includeData) implements ClientPacket {
+public record ClientPickItemFromEntityPacket(int entityId, boolean includeData) implements ClientPacket.Play {
     public static final Type<ClientPickItemFromEntityPacket> SERIALIZER = NetworkBufferTemplate.template(
             VAR_INT, ClientPickItemFromEntityPacket::entityId,
             BOOLEAN, ClientPickItemFromEntityPacket::includeData,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPlaceRecipePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPlaceRecipePacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.*;
 
-public record ClientPlaceRecipePacket(byte windowId, int recipeDisplayId, boolean makeAll) implements ClientPacket {
+public record ClientPlaceRecipePacket(byte windowId, int recipeDisplayId, boolean makeAll) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientPlaceRecipePacket> SERIALIZER = NetworkBufferTemplate.template(
             BYTE, ClientPlaceRecipePacket::windowId,
             VAR_INT, ClientPlaceRecipePacket::recipeDisplayId,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerAbilitiesPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerAbilitiesPacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.BYTE;
 
-public record ClientPlayerAbilitiesPacket(byte flags) implements ClientPacket {
+public record ClientPlayerAbilitiesPacket(byte flags) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientPlayerAbilitiesPacket> SERIALIZER = NetworkBufferTemplate.template(
             BYTE, ClientPlayerAbilitiesPacket::flags,
             ClientPlayerAbilitiesPacket::new);

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerActionPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerActionPacket.java
@@ -11,7 +11,7 @@ import static net.minestom.server.network.NetworkBuffer.*;
 public record ClientPlayerActionPacket(
         Status status, Point blockPosition,
         BlockFace blockFace, int sequence
-) implements ClientPacket {
+) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientPlayerActionPacket> SERIALIZER = NetworkBufferTemplate.template(
             NetworkBuffer.Enum(Status.class), ClientPlayerActionPacket::status,
             BLOCK_POSITION, ClientPlayerActionPacket::blockPosition,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerBlockPlacementPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerBlockPlacementPacket.java
@@ -12,7 +12,7 @@ import static net.minestom.server.network.NetworkBuffer.*;
 public record ClientPlayerBlockPlacementPacket(
         PlayerHand hand, Point blockPosition, BlockFace blockFace,
         float cursorPositionX, float cursorPositionY, float cursorPositionZ,
-        boolean insideBlock, boolean hitWorldBorder, int sequence) implements ClientPacket {
+        boolean insideBlock, boolean hitWorldBorder, int sequence) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientPlayerBlockPlacementPacket> SERIALIZER = NetworkBufferTemplate.template(
             Enum(PlayerHand.class), ClientPlayerBlockPlacementPacket::hand,
             BLOCK_POSITION, ClientPlayerBlockPlacementPacket::blockPosition,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerLoadedPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerLoadedPacket.java
@@ -4,7 +4,7 @@ import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.client.ClientPacket;
 
-public record ClientPlayerLoadedPacket() implements ClientPacket {
+public record ClientPlayerLoadedPacket() implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientPlayerLoadedPacket> SERIALIZER = NetworkBufferTemplate
             .template(new ClientPlayerLoadedPacket());
 }

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerPositionAndRotationPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerPositionAndRotationPacket.java
@@ -10,7 +10,7 @@ import static net.minestom.server.network.NetworkBuffer.POS;
 import static net.minestom.server.network.packet.client.play.ClientPlayerPositionPacket.FLAG_HORIZONTAL_COLLISION;
 import static net.minestom.server.network.packet.client.play.ClientPlayerPositionPacket.FLAG_ON_GROUND;
 
-public record ClientPlayerPositionAndRotationPacket(Pos position, byte flags) implements ClientPacket {
+public record ClientPlayerPositionAndRotationPacket(Pos position, byte flags) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientPlayerPositionAndRotationPacket> SERIALIZER = NetworkBufferTemplate.template(
             POS, ClientPlayerPositionAndRotationPacket::position,
             BYTE, ClientPlayerPositionAndRotationPacket::flags,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerPositionPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerPositionPacket.java
@@ -8,7 +8,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 import static net.minestom.server.network.NetworkBuffer.BYTE;
 import static net.minestom.server.network.NetworkBuffer.VECTOR3D;
 
-public record ClientPlayerPositionPacket(Point position, byte flags) implements ClientPacket {
+public record ClientPlayerPositionPacket(Point position, byte flags) implements ClientPacket.Play {
     public static final int FLAG_ON_GROUND = 1;
     public static final int FLAG_HORIZONTAL_COLLISION = 1 << 1;
 

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerPositionStatusPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerPositionStatusPacket.java
@@ -8,7 +8,7 @@ import static net.minestom.server.network.NetworkBuffer.BYTE;
 import static net.minestom.server.network.packet.client.play.ClientPlayerPositionPacket.FLAG_HORIZONTAL_COLLISION;
 import static net.minestom.server.network.packet.client.play.ClientPlayerPositionPacket.FLAG_ON_GROUND;
 
-public record ClientPlayerPositionStatusPacket(byte flags) implements ClientPacket {
+public record ClientPlayerPositionStatusPacket(byte flags) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientPlayerPositionStatusPacket> SERIALIZER = NetworkBufferTemplate.template(
             BYTE, ClientPlayerPositionStatusPacket::flags,
             ClientPlayerPositionStatusPacket::new);

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerRotationPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientPlayerRotationPacket.java
@@ -9,7 +9,7 @@ import static net.minestom.server.network.NetworkBuffer.FLOAT;
 import static net.minestom.server.network.packet.client.play.ClientPlayerPositionPacket.FLAG_HORIZONTAL_COLLISION;
 import static net.minestom.server.network.packet.client.play.ClientPlayerPositionPacket.FLAG_ON_GROUND;
 
-public record ClientPlayerRotationPacket(float yaw, float pitch, byte flags) implements ClientPacket {
+public record ClientPlayerRotationPacket(float yaw, float pitch, byte flags) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientPlayerRotationPacket> SERIALIZER = NetworkBufferTemplate.template(
             FLOAT, ClientPlayerRotationPacket::yaw,
             FLOAT, ClientPlayerRotationPacket::pitch,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientQueryBlockNbtPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientQueryBlockNbtPacket.java
@@ -8,7 +8,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 import static net.minestom.server.network.NetworkBuffer.BLOCK_POSITION;
 import static net.minestom.server.network.NetworkBuffer.VAR_INT;
 
-public record ClientQueryBlockNbtPacket(int transactionId, Point blockPosition) implements ClientPacket {
+public record ClientQueryBlockNbtPacket(int transactionId, Point blockPosition) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientQueryBlockNbtPacket> SERIALIZER = NetworkBufferTemplate.template(
             VAR_INT, ClientQueryBlockNbtPacket::transactionId,
             BLOCK_POSITION, ClientQueryBlockNbtPacket::blockPosition,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientQueryEntityNbtPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientQueryEntityNbtPacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.VAR_INT;
 
-public record ClientQueryEntityNbtPacket(int transactionId, int entityId) implements ClientPacket {
+public record ClientQueryEntityNbtPacket(int transactionId, int entityId) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientQueryEntityNbtPacket> SERIALIZER = NetworkBufferTemplate.template(
             VAR_INT, ClientQueryEntityNbtPacket::transactionId,
             VAR_INT, ClientQueryEntityNbtPacket::entityId,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientRecipeBookSeenRecipePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientRecipeBookSeenRecipePacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.VAR_INT;
 
-public record ClientRecipeBookSeenRecipePacket(int index) implements ClientPacket {
+public record ClientRecipeBookSeenRecipePacket(int index) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientRecipeBookSeenRecipePacket> SERIALIZER = NetworkBufferTemplate.template(
             VAR_INT, ClientRecipeBookSeenRecipePacket::index,
             ClientRecipeBookSeenRecipePacket::new);

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientSelectBundleItemPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientSelectBundleItemPacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.VAR_INT;
 
-public record ClientSelectBundleItemPacket(int slot, int selectedIndex) implements ClientPacket {
+public record ClientSelectBundleItemPacket(int slot, int selectedIndex) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientSelectBundleItemPacket> SERIALIZER = NetworkBufferTemplate.template(
             VAR_INT, ClientSelectBundleItemPacket::slot,
             VAR_INT, ClientSelectBundleItemPacket::selectedIndex,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientSelectTradePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientSelectTradePacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.VAR_INT;
 
-public record ClientSelectTradePacket(int selectedSlot) implements ClientPacket {
+public record ClientSelectTradePacket(int selectedSlot) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientSelectTradePacket> SERIALIZER = NetworkBufferTemplate.template(
             VAR_INT, ClientSelectTradePacket::selectedSlot,
             ClientSelectTradePacket::new);

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientSetBeaconEffectPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientSetBeaconEffectPacket.java
@@ -7,7 +7,7 @@ import net.minestom.server.potion.PotionType;
 import org.jetbrains.annotations.Nullable;
 
 public record ClientSetBeaconEffectPacket(@Nullable PotionType primaryEffect,
-                                          @Nullable PotionType secondaryEffect) implements ClientPacket {
+                                          @Nullable PotionType secondaryEffect) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientSetBeaconEffectPacket> SERIALIZER = NetworkBufferTemplate.template(
             PotionType.NETWORK_TYPE.optional(), ClientSetBeaconEffectPacket::primaryEffect,
             PotionType.NETWORK_TYPE.optional(), ClientSetBeaconEffectPacket::secondaryEffect,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientSetRecipeBookStatePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientSetRecipeBookStatePacket.java
@@ -7,7 +7,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 import static net.minestom.server.network.NetworkBuffer.BOOLEAN;
 
 public record ClientSetRecipeBookStatePacket(BookType bookType,
-                                             boolean bookOpen, boolean filterActive) implements ClientPacket {
+                                             boolean bookOpen, boolean filterActive) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientSetRecipeBookStatePacket> SERIALIZER = NetworkBufferTemplate.template(
             NetworkBuffer.Enum(BookType.class), ClientSetRecipeBookStatePacket::bookType,
             BOOLEAN, ClientSetRecipeBookStatePacket::bookOpen,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientSetTestBlockPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientSetTestBlockPacket.java
@@ -9,7 +9,7 @@ public record ClientSetTestBlockPacket(
         Point blockPosition,
         TestBlockMode mode,
         String message
-) implements ClientPacket {
+) implements ClientPacket.Play {
 
     public static final NetworkBuffer.Type<ClientSetTestBlockPacket> SERIALIZER = NetworkBufferTemplate.template(
             NetworkBuffer.BLOCK_POSITION, ClientSetTestBlockPacket::blockPosition,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientSignedCommandChatPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientSignedCommandChatPacket.java
@@ -12,7 +12,7 @@ import static net.minestom.server.network.NetworkBuffer.*;
 public record ClientSignedCommandChatPacket(String message, long timestamp,
                                             long salt, ArgumentSignatures signatures,
                                             LastSeenMessages.Update lastSeenMessages,
-                                            byte checksum) implements ClientPacket {
+                                            byte checksum) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientSignedCommandChatPacket> SERIALIZER = NetworkBufferTemplate.template(
             STRING, ClientSignedCommandChatPacket::message,
             LONG, ClientSignedCommandChatPacket::timestamp,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientSpectatePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientSpectatePacket.java
@@ -11,7 +11,7 @@ import java.util.UUID;
  * Contrary to its name, it is actually used to teleport the player to the entity they are switching to,
  * rather than spectating them.
  */
-public record ClientSpectatePacket(UUID target) implements ClientPacket {
+public record ClientSpectatePacket(UUID target) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientSpectatePacket> SERIALIZER = NetworkBufferTemplate.template(
             NetworkBuffer.UUID, ClientSpectatePacket::target,
             ClientSpectatePacket::new);

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientStatusPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientStatusPacket.java
@@ -4,7 +4,7 @@ import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.client.ClientPacket;
 
-public record ClientStatusPacket(Action action) implements ClientPacket {
+public record ClientStatusPacket(Action action) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientStatusPacket> SERIALIZER = NetworkBufferTemplate.template(
             NetworkBuffer.Enum(Action.class), ClientStatusPacket::action,
             ClientStatusPacket::new);

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientSteerBoatPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientSteerBoatPacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.BOOLEAN;
 
-public record ClientSteerBoatPacket(boolean leftPaddleTurning, boolean rightPaddleTurning) implements ClientPacket {
+public record ClientSteerBoatPacket(boolean leftPaddleTurning, boolean rightPaddleTurning) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientSteerBoatPacket> SERIALIZER = NetworkBufferTemplate.template(
             BOOLEAN, ClientSteerBoatPacket::leftPaddleTurning,
             BOOLEAN, ClientSteerBoatPacket::rightPaddleTurning,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientTabCompletePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientTabCompletePacket.java
@@ -7,7 +7,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 import static net.minestom.server.network.NetworkBuffer.STRING;
 import static net.minestom.server.network.NetworkBuffer.VAR_INT;
 
-public record ClientTabCompletePacket(int transactionId, String text) implements ClientPacket {
+public record ClientTabCompletePacket(int transactionId, String text) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientTabCompletePacket> SERIALIZER = NetworkBufferTemplate.template(
             VAR_INT, ClientTabCompletePacket::transactionId,
             STRING, ClientTabCompletePacket::text,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientTeleportConfirmPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientTeleportConfirmPacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.VAR_INT;
 
-public record ClientTeleportConfirmPacket(int teleportId) implements ClientPacket {
+public record ClientTeleportConfirmPacket(int teleportId) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientTeleportConfirmPacket> SERIALIZER = NetworkBufferTemplate.template(
             VAR_INT, ClientTeleportConfirmPacket::teleportId,
             ClientTeleportConfirmPacket::new);

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientTestInstanceBlockActionPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientTestInstanceBlockActionPacket.java
@@ -11,7 +11,7 @@ public record ClientTestInstanceBlockActionPacket(
         Point blockPosition,
         Action action,
         Data data
-) implements ClientPacket {
+) implements ClientPacket.Play {
 
     public static final NetworkBuffer.Type<ClientTestInstanceBlockActionPacket> SERIALIZER = NetworkBufferTemplate.template(
             NetworkBuffer.BLOCK_POSITION, ClientTestInstanceBlockActionPacket::blockPosition,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientTickEndPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientTickEndPacket.java
@@ -4,7 +4,7 @@ import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.client.ClientPacket;
 
-public record ClientTickEndPacket() implements ClientPacket {
+public record ClientTickEndPacket() implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientTickEndPacket> SERIALIZER =
             NetworkBufferTemplate.template(new ClientTickEndPacket());
 

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientUpdateCommandBlockMinecartPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientUpdateCommandBlockMinecartPacket.java
@@ -7,7 +7,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 import static net.minestom.server.network.NetworkBuffer.*;
 
 public record ClientUpdateCommandBlockMinecartPacket(int entityId, String command,
-                                                     boolean trackOutput) implements ClientPacket {
+                                                     boolean trackOutput) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientUpdateCommandBlockMinecartPacket> SERIALIZER = NetworkBufferTemplate.template(
             VAR_INT, ClientUpdateCommandBlockMinecartPacket::entityId,
             STRING, ClientUpdateCommandBlockMinecartPacket::command,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientUpdateCommandBlockPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientUpdateCommandBlockPacket.java
@@ -8,7 +8,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 import static net.minestom.server.network.NetworkBuffer.*;
 
 public record ClientUpdateCommandBlockPacket(Point blockPosition, String command,
-                                             Mode mode, byte flags) implements ClientPacket {
+                                             Mode mode, byte flags) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientUpdateCommandBlockPacket> SERIALIZER = NetworkBufferTemplate.template(
             BLOCK_POSITION, ClientUpdateCommandBlockPacket::blockPosition,
             STRING, ClientUpdateCommandBlockPacket::command,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientUpdateJigsawBlockPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientUpdateJigsawBlockPacket.java
@@ -18,7 +18,7 @@ public record ClientUpdateJigsawBlockPacket(
         String jointType,
         int selectionPriority,
         int placementPriority
-) implements ClientPacket {
+) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientUpdateJigsawBlockPacket> SERIALIZER = NetworkBufferTemplate.template(
             BLOCK_POSITION, ClientUpdateJigsawBlockPacket::location,
             STRING, ClientUpdateJigsawBlockPacket::name,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientUpdateSignPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientUpdateSignPacket.java
@@ -12,7 +12,7 @@ public record ClientUpdateSignPacket(
         Point blockPosition,
         boolean isFrontText,
         List<String> lines
-) implements ClientPacket {
+) implements ClientPacket.Play {
     public ClientUpdateSignPacket {
         lines = List.copyOf(lines);
         if (lines.size() != 4) {

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientUpdateStructureBlockPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientUpdateStructureBlockPacket.java
@@ -15,7 +15,7 @@ public record ClientUpdateStructureBlockPacket(
         Mirror mirror, Rotation rotation,
         String metadata, float integrity,
         long seed, byte flags
-) implements ClientPacket {
+) implements ClientPacket.Play {
 
     public static final NetworkBuffer.Type<ClientUpdateStructureBlockPacket> SERIALIZER = NetworkBufferTemplate.template(
             BLOCK_POSITION, ClientUpdateStructureBlockPacket::location,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientUseItemPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientUseItemPacket.java
@@ -8,7 +8,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 import static net.minestom.server.network.NetworkBuffer.*;
 
 public record ClientUseItemPacket(PlayerHand hand, int sequence, float yaw,
-                                  float pitch) implements ClientPacket {
+                                  float pitch) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientUseItemPacket> SERIALIZER = NetworkBufferTemplate.template(
             Enum(PlayerHand.class), ClientUseItemPacket::hand,
             VAR_INT, ClientUseItemPacket::sequence,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientVehicleMovePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientVehicleMovePacket.java
@@ -8,7 +8,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 import static net.minestom.server.network.NetworkBuffer.BOOLEAN;
 import static net.minestom.server.network.NetworkBuffer.POS;
 
-public record ClientVehicleMovePacket(Pos position, boolean onGround) implements ClientPacket {
+public record ClientVehicleMovePacket(Pos position, boolean onGround) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientVehicleMovePacket> SERIALIZER = NetworkBufferTemplate.template(
             POS, ClientVehicleMovePacket::position,
             BOOLEAN, ClientVehicleMovePacket::onGround,

--- a/src/main/java/net/minestom/server/network/packet/client/play/ClientWindowSlotStatePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/play/ClientWindowSlotStatePacket.java
@@ -8,7 +8,7 @@ import static net.minestom.server.network.NetworkBuffer.BOOLEAN;
 import static net.minestom.server.network.NetworkBuffer.VAR_INT;
 
 // This is the packet sent when you toggle a slot in a crafter UI
-public record ClientWindowSlotStatePacket(int slot, int windowId, boolean newState) implements ClientPacket {
+public record ClientWindowSlotStatePacket(int slot, int windowId, boolean newState) implements ClientPacket.Play {
     public static final NetworkBuffer.Type<ClientWindowSlotStatePacket> SERIALIZER = NetworkBufferTemplate.template(
             VAR_INT, ClientWindowSlotStatePacket::slot,
             VAR_INT, ClientWindowSlotStatePacket::windowId,

--- a/src/main/java/net/minestom/server/network/packet/client/status/LegacyServerListPingPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/status/LegacyServerListPingPacket.java
@@ -6,7 +6,7 @@ import net.minestom.server.network.packet.client.ClientPacket;
 
 import static net.minestom.server.network.NetworkBuffer.BYTE;
 
-public record LegacyServerListPingPacket(byte payload) implements ClientPacket {
+public record LegacyServerListPingPacket(byte payload) implements ClientPacket.Status {
     public static final NetworkBuffer.Type<LegacyServerListPingPacket> SERIALIZER = NetworkBufferTemplate.template(
             BYTE, LegacyServerListPingPacket::payload,
             LegacyServerListPingPacket::new);

--- a/src/main/java/net/minestom/server/network/packet/client/status/StatusRequestPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/status/StatusRequestPacket.java
@@ -4,6 +4,6 @@ import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.client.ClientPacket;
 
-public record StatusRequestPacket() implements ClientPacket {
+public record StatusRequestPacket() implements ClientPacket.Status {
     public static final NetworkBuffer.Type<StatusRequestPacket> SERIALIZER = NetworkBufferTemplate.template(new StatusRequestPacket());
 }

--- a/src/main/java/net/minestom/server/network/packet/server/ServerPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/ServerPacket.java
@@ -8,15 +8,19 @@ import net.minestom.server.network.player.PlayerConnection;
  * <p>
  * Packets are value-based, and should therefore not be reliant on identity.
  */
-public sealed interface ServerPacket extends SendablePacket permits ServerPacket.Configuration, ServerPacket.Login, ServerPacket.Play, ServerPacket.Status {
+public sealed interface ServerPacket extends SendablePacket {
 
-    non-sealed interface Configuration extends ServerPacket {
+    // By default, this isn't used
+    non-sealed interface Handshake extends ServerPacket {
     }
 
     non-sealed interface Status extends ServerPacket {
     }
 
     non-sealed interface Login extends ServerPacket {
+    }
+
+    non-sealed interface Configuration extends ServerPacket {
     }
 
     non-sealed interface Play extends ServerPacket {

--- a/src/main/java/net/minestom/server/network/packet/server/play/BossBarPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/BossBarPacket.java
@@ -36,7 +36,7 @@ public record BossBarPacket(UUID uuid,
     };
 
     @Override
-    public Collection<Component> components() {
+    public Collection<? extends Component> components() {
         return this.action instanceof ComponentHolder<?> holder
                 ? holder.components()
                 : List.of();

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityTeleportPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityTeleportPacket.java
@@ -31,7 +31,7 @@ public record EntityTeleportPacket(
             // Order is x,y,z for position, then x,y,z for delta move, then yaw and pitch
             Point absPosition = buffer.read(VECTOR3D);
             Point deltaMovement = buffer.read(VECTOR3D);
-            return new EntityTeleportPacket(entityId, new Pos(absPosition, buffer.read(FLOAT), buffer.read(FLOAT)),
+            return new EntityTeleportPacket(entityId, absPosition.asPos().withView(buffer.read(FLOAT), buffer.read(FLOAT)),
                             deltaMovement, buffer.read(INT), buffer.read(BOOLEAN));
         }
     };

--- a/src/main/java/net/minestom/server/network/packet/server/play/TeamsPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/TeamsPacket.java
@@ -40,7 +40,7 @@ public record TeamsPacket(String teamName, Action action) implements ServerPacke
     };
 
     @Override
-    public Collection<Component> components() {
+    public Collection<? extends Component> components() {
         return this.action instanceof ComponentHolder<?> holder ? holder.components() : List.of();
     }
 

--- a/src/main/java/net/minestom/server/network/socket/Server.java
+++ b/src/main/java/net/minestom/server/network/socket/Server.java
@@ -22,14 +22,14 @@ import java.util.concurrent.atomic.AtomicReference;
 public final class Server {
     private volatile boolean stop;
 
-    private final PacketParser<ClientPacket> packetParser;
+    private final PacketParser.Client packetParser;
 
     private ServerSocketChannel serverSocket;
     private SocketAddress socketAddress;
     private String address;
     private int port;
 
-    public Server(PacketParser<ClientPacket> packetParser) {
+    public Server(PacketParser.Client packetParser) {
         this.packetParser = packetParser;
     }
 
@@ -171,7 +171,7 @@ public final class Server {
     }
 
     @ApiStatus.Internal
-    public PacketParser<ClientPacket> packetParser() {
+    public PacketParser.Client packetParser() {
         return packetParser;
     }
 

--- a/src/main/java/net/minestom/server/registry/RegistryData.java
+++ b/src/main/java/net/minestom/server/registry/RegistryData.java
@@ -16,6 +16,7 @@ import net.minestom.server.component.DataComponent;
 import net.minestom.server.component.DataComponentMap;
 import net.minestom.server.component.DataComponents;
 import net.minestom.server.entity.EntityType;
+import net.minestom.server.entity.attribute.Attribute;
 import net.minestom.server.entity.EquipmentSlot;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockEntityType;
@@ -562,6 +563,7 @@ public final class RegistryData {
         private final int clientTrackingRange;
         private final boolean fireImmune;
         private final Map<String, List<Double>> entityOffsets;
+        private final Map<Attribute, Double> defaultAttributes;
         private final BoundingBox boundingBox;
 
         public EntityEntry(String namespace, Properties main) {
@@ -592,6 +594,24 @@ public final class RegistryData {
                 }
             }
             this.entityOffsets = Map.copyOf(entityOffsets);
+
+            Properties defaultAttributesSection = main.section("defaultAttributes");
+
+            if (defaultAttributesSection == null) {
+                this.defaultAttributes = Map.of();
+            } else {
+                Map<Attribute, Double> attributes = new HashMap<>();
+
+                for (var entry : defaultAttributesSection) {
+                    Attribute attribute = Attribute.fromKey(entry.getKey());
+                    Check.notNull(attribute, "Failed to find attribute {0}", entry.getKey());
+                    Object value = entry.getValue();
+                    Check.stateCondition(!(value instanceof Number), "Attribute value {0} is not a number", value);
+                    attributes.put(attribute, ((Number) value).doubleValue());
+                }
+
+                this.defaultAttributes = Map.copyOf(attributes);
+            }
         }
 
         public Key key() {
@@ -658,6 +678,10 @@ public final class RegistryData {
 
         public BoundingBox boundingBox() {
             return boundingBox;
+        }
+
+        public Map<Attribute, Double> defaultAttributes() {
+            return defaultAttributes;
         }
     }
 

--- a/src/main/java/net/minestom/server/scoreboard/BelowNameTag.java
+++ b/src/main/java/net/minestom/server/scoreboard/BelowNameTag.java
@@ -74,7 +74,7 @@ public class BelowNameTag implements Scoreboard {
     }
 
     @Override
-    public Set<Player> getViewers() {
+    public Set<? extends Player> getViewers() {
         return unmodifiableViewers;
     }
 }

--- a/src/main/java/net/minestom/server/scoreboard/Scoreboard.java
+++ b/src/main/java/net/minestom/server/scoreboard/Scoreboard.java
@@ -76,7 +76,7 @@ public interface Scoreboard extends Viewable, PacketGroupingAudience {
     String getObjectiveName();
 
     @Override
-    default Collection<Player> getPlayers() {
+    default Collection<? extends Player> getPlayers() {
         return this.getViewers();
     }
 }

--- a/src/main/java/net/minestom/server/scoreboard/Sidebar.java
+++ b/src/main/java/net/minestom/server/scoreboard/Sidebar.java
@@ -256,7 +256,7 @@ public class Sidebar implements Scoreboard {
     }
 
     @Override
-    public Set<Player> getViewers() {
+    public Set<? extends Player> getViewers() {
         return Collections.unmodifiableSet(viewers);
     }
 

--- a/src/main/java/net/minestom/server/scoreboard/TabList.java
+++ b/src/main/java/net/minestom/server/scoreboard/TabList.java
@@ -68,7 +68,7 @@ public class TabList implements Scoreboard {
     }
 
     @Override
-    public Set<Player> getViewers() {
+    public Set<? extends Player> getViewers() {
         return unmodifiableViewers;
     }
 

--- a/src/main/java/net/minestom/server/scoreboard/Team.java
+++ b/src/main/java/net/minestom/server/scoreboard/Team.java
@@ -465,7 +465,7 @@ public class Team implements PacketGroupingAudience {
     }
 
     @Override
-    public Collection<Player> getPlayers() {
+    public Collection<? extends Player> getPlayers() {
         if (!this.isPlayerMembersUpToDate) {
             this.playerMembers.clear();
 

--- a/src/main/java/net/minestom/server/utils/PacketSendingUtils.java
+++ b/src/main/java/net/minestom/server/utils/PacketSendingUtils.java
@@ -63,8 +63,8 @@ public final class PacketSendingUtils {
      * @param packet    the packet to send to the players
      * @param predicate predicate to ignore specific players
      */
-    public static void sendGroupedPacket(Collection<Player> players, ServerPacket packet,
-                                         Predicate<Player> predicate) {
+    public static <T extends Player> void sendGroupedPacket(Collection<T> players, ServerPacket packet,
+                                         Predicate<? super T> predicate) {
         final SendablePacket sendablePacket = groupedPacket(packet);
         players.forEach(player -> {
             if (predicate.test(player)) player.sendPacket(sendablePacket);
@@ -77,7 +77,7 @@ public final class PacketSendingUtils {
      *
      * @see #sendGroupedPacket(Collection, ServerPacket, Predicate)
      */
-    public static void sendGroupedPacket(Collection<Player> players, ServerPacket packet) {
+    public static void sendGroupedPacket(Collection<? extends Player> players, ServerPacket packet) {
         final SendablePacket sendablePacket = groupedPacket(packet);
         players.forEach(player -> player.sendPacket(sendablePacket));
     }

--- a/src/main/java/net/minestom/server/utils/chunk/ChunkCache.java
+++ b/src/main/java/net/minestom/server/utils/chunk/ChunkCache.java
@@ -5,23 +5,24 @@ import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
 
 @ApiStatus.Internal
 public final class ChunkCache implements Block.Getter {
     private final Instance instance;
-    private Chunk chunk;
+    private @Nullable Chunk chunk;
 
-    private final Block defaultBlock;
+    private final @Nullable Block defaultBlock;
 
-    public ChunkCache(Instance instance, Chunk chunk,
-                      Block defaultBlock) {
+    public ChunkCache(Instance instance, @Nullable Chunk chunk,
+                      @Nullable Block defaultBlock) {
         this.instance = instance;
         this.chunk = chunk;
         this.defaultBlock = defaultBlock;
     }
 
-    public ChunkCache(Instance instance, Chunk chunk) {
+    public ChunkCache(Instance instance, @Nullable Chunk chunk) {
         this(instance, chunk, Block.AIR);
     }
 
@@ -35,8 +36,11 @@ public final class ChunkCache implements Block.Getter {
             this.chunk = chunk = this.instance.getChunk(chunkX, chunkZ);
         }
         if (chunk != null) {
-            synchronized (chunk) {
+            chunk.lockReadLock();
+            try {
                 return chunk.getBlock(x, y, z, condition);
+            } finally {
+                chunk.unlockReadLock();
             }
         } else return defaultBlock;
     }

--- a/src/test/java/net/minestom/server/command/ArgumentTypeTest.java
+++ b/src/test/java/net/minestom/server/command/ArgumentTypeTest.java
@@ -23,7 +23,6 @@ import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
 import net.minestom.server.item.component.CustomData;
 import net.minestom.server.particle.Particle;
-import net.minestom.server.tag.Tag;
 import net.minestom.server.utils.Range;
 import net.minestom.server.utils.location.RelativeVec;
 import net.minestom.server.utils.time.TimeUnit;
@@ -164,11 +163,12 @@ public class ArgumentTypeTest {
     public void testArgumentItemStack() {
         var arg = ArgumentType.ItemStack("item_stack");
         assertArg(arg, ItemStack.AIR, "air");
-        assertArg(arg, ItemStack.of(Material.GLASS_PANE).withTag(Tag.String("tag"), "value"), "glass_pane{tag:value}");
+        assertInvalidArg(arg, "glass_pane{tag:value}");
+        assertArg(arg, ItemStack.of(Material.COOKED_BEEF).without(DataComponents.CONSUMABLE), "cooked_beef[!consumable]");
         assertArg(arg, ItemStack.of(Material.GLASS_PANE).with(DataComponents.REPAIR_COST, 5), "glass_pane[repair_cost=5]");
-        assertArg(arg, ItemStack.of(Material.GLASS_PANE).with(DataComponents.REPAIR_COST, 5).withTag(Tag.String("tag"), "value"), "glass_pane[repair_cost=5]{tag:value}");
-        assertArg(arg, ItemStack.of(Material.GLASS_PANE).with(DataComponents.REPAIR_COST, 5).with(DataComponents.CUSTOM_DATA, new CustomData(CompoundBinaryTag.builder().putInt("hi", 232).build())).withTag(Tag.String("tag"), "value"),
-                "glass_pane[repair_cost=5,minecraft:custom_data={hi:232}]{tag:value}");
+        assertInvalidArg(arg, "glass_pane[repair_cost=5]{tag:value}");
+        assertArg(arg, ItemStack.of(Material.GLASS_PANE).with(DataComponents.REPAIR_COST, 5).with(DataComponents.CUSTOM_DATA, new CustomData(CompoundBinaryTag.builder().putInt("hi", 232).build())),
+                "glass_pane[repair_cost=5,minecraft:custom_data={hi:232}]");
     }
 
     @Test

--- a/src/test/java/net/minestom/server/coordinate/BlockVecTest.java
+++ b/src/test/java/net/minestom/server/coordinate/BlockVecTest.java
@@ -1,0 +1,401 @@
+package net.minestom.server.coordinate;
+
+import net.minestom.server.instance.block.BlockFace;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BlockVecTest {
+
+    @Test
+    public void testConstructors() {
+        // Test primary constructor
+        BlockVec vec1 = new BlockVec(5, 10, 15);
+        assertEquals(5, vec1.blockX());
+        assertEquals(10, vec1.blockY());
+        assertEquals(15, vec1.blockZ());
+
+        // Test double constructor (floors values)
+        BlockVec vec2 = new BlockVec(5.7, 10.3, 15.9);
+        assertEquals(5, vec2.blockX());
+        assertEquals(10, vec2.blockY());
+        assertEquals(15, vec2.blockZ());
+
+        // Test negative double values
+        BlockVec vec3 = new BlockVec(-5.7, -10.3, -15.9);
+        assertEquals(-6, vec3.blockX());
+        assertEquals(-11, vec3.blockY());
+        assertEquals(-16, vec3.blockZ());
+
+        // Test single value constructor (int)
+        BlockVec vec4 = new BlockVec(7);
+        assertEquals(7, vec4.blockX());
+        assertEquals(7, vec4.blockY());
+        assertEquals(7, vec4.blockZ());
+
+        // Test single value constructor (double)
+        BlockVec vec5 = new BlockVec(7.5);
+        assertEquals(7, vec5.blockX());
+        assertEquals(7, vec5.blockY());
+        assertEquals(7, vec5.blockZ());
+
+        // Test double value constructor (int)
+        BlockVec vec6 = new BlockVec(6, 7);
+        assertEquals(6, vec6.blockX());
+        assertEquals(0, vec6.blockY());
+        assertEquals(7, vec6.blockZ());
+    }
+
+    @Test
+    public void testConstants() {
+        assertEquals(0, BlockVec.ZERO.blockX());
+        assertEquals(0, BlockVec.ZERO.blockY());
+        assertEquals(0, BlockVec.ZERO.blockZ());
+
+        assertEquals(1, BlockVec.ONE.blockX());
+        assertEquals(1, BlockVec.ONE.blockY());
+        assertEquals(1, BlockVec.ONE.blockZ());
+
+        assertEquals(Point.SECTION_SIZE, BlockVec.SECTION.blockX());
+        assertEquals(Point.SECTION_SIZE, BlockVec.SECTION.blockY());
+        assertEquals(Point.SECTION_SIZE, BlockVec.SECTION.blockZ());
+    }
+
+    @Test
+    public void testWithBlock() {
+        BlockVec base = new BlockVec(10, 20, 30);
+
+        // Test withBlockX
+        BlockVec modified = base.withBlockX(15);
+        assertEquals(15, modified.blockX());
+        assertEquals(20, modified.blockY());
+        assertEquals(30, modified.blockZ());
+
+        // Test withBlockX with operator
+        modified = base.withBlockX(x -> x * 2);
+        assertEquals(20, modified.blockX());
+        assertEquals(20, modified.blockY());
+        assertEquals(30, modified.blockZ());
+
+        // Test withBlockY
+        modified = base.withBlockY(25);
+        assertEquals(10, modified.blockX());
+        assertEquals(25, modified.blockY());
+        assertEquals(30, modified.blockZ());
+
+        // Test withBlockY with operator
+        modified = base.withBlockY(y -> y + 5);
+        assertEquals(10, modified.blockX());
+        assertEquals(25, modified.blockY());
+        assertEquals(30, modified.blockZ());
+
+        // Test withBlockZ
+        modified = base.withBlockZ(35);
+        assertEquals(10, modified.blockX());
+        assertEquals(20, modified.blockY());
+        assertEquals(35, modified.blockZ());
+
+        // Test withBlockZ with operator
+        modified = base.withBlockZ(z -> z - 10);
+        assertEquals(10, modified.blockX());
+        assertEquals(20, modified.blockY());
+        assertEquals(20, modified.blockZ());
+    }
+
+    @Test
+    public void testIntegerArithmetic() {
+        BlockVec v1 = new BlockVec(10, 20, 30);
+        BlockVec v2 = new BlockVec(5, 8, 12);
+
+        // Test add with integers
+        BlockVec result = v1.add(5, 10, 15);
+        assertEquals(15, result.blockX());
+        assertEquals(30, result.blockY());
+        assertEquals(45, result.blockZ());
+
+        // Test add with BlockVec
+        result = v1.add(v2);
+        assertEquals(15, result.blockX());
+        assertEquals(28, result.blockY());
+        assertEquals(42, result.blockZ());
+
+        // Test add with single value
+        result = v1.add(3);
+        assertEquals(13, result.blockX());
+        assertEquals(23, result.blockY());
+        assertEquals(33, result.blockZ());
+
+        // Test sub with integers
+        result = v1.sub(5, 10, 15);
+        assertEquals(5, result.blockX());
+        assertEquals(10, result.blockY());
+        assertEquals(15, result.blockZ());
+
+        // Test sub with BlockVec
+        result = v1.sub(v2);
+        assertEquals(5, result.blockX());
+        assertEquals(12, result.blockY());
+        assertEquals(18, result.blockZ());
+
+        // Test sub with single value
+        result = v1.sub(3);
+        assertEquals(7, result.blockX());
+        assertEquals(17, result.blockY());
+        assertEquals(27, result.blockZ());
+    }
+
+    @Test
+    public void testMultiplicationDivision() {
+        BlockVec base = new BlockVec(10, 20, 30);
+
+        // Test mul with integers
+        BlockVec result = base.mul(2, 3, 4);
+        assertEquals(20, result.blockX());
+        assertEquals(60, result.blockY());
+        assertEquals(120, result.blockZ());
+
+        // Test mul with BlockVec
+        BlockVec v2 = new BlockVec(2, 3, 4);
+        result = base.mul(v2);
+        assertEquals(20, result.blockX());
+        assertEquals(60, result.blockY());
+        assertEquals(120, result.blockZ());
+
+        // Test mul with single value
+        result = base.mul(2);
+        assertEquals(20, result.blockX());
+        assertEquals(40, result.blockY());
+        assertEquals(60, result.blockZ());
+
+        // Test div with integers
+        result = base.div(2, 4, 5);
+        assertEquals(5, result.blockX());
+        assertEquals(5, result.blockY());
+        assertEquals(6, result.blockZ());
+
+        // Test div with BlockVec
+        result = base.div(new BlockVec(2, 4, 5));
+        assertEquals(5, result.blockX());
+        assertEquals(5, result.blockY());
+        assertEquals(6, result.blockZ());
+
+        // Test div with single value
+        result = base.div(2);
+        assertEquals(5, result.blockX());
+        assertEquals(10, result.blockY());
+        assertEquals(15, result.blockZ());
+    }
+
+    @Test
+    public void testMinMax() {
+        BlockVec v1 = new BlockVec(10, 20, 30);
+        BlockVec v2 = new BlockVec(15, 5, 25);
+
+        // Test min with BlockVec
+        BlockVec result = v1.min(v2);
+        assertEquals(10, result.blockX());
+        assertEquals(5, result.blockY());
+        assertEquals(25, result.blockZ());
+
+        // Test min with coordinates
+        result = v1.min(15, 5, 25);
+        assertEquals(10, result.blockX());
+        assertEquals(5, result.blockY());
+        assertEquals(25, result.blockZ());
+
+        // Test min with single value
+        result = v1.min(15);
+        assertEquals(10, result.blockX());
+        assertEquals(15, result.blockY());
+        assertEquals(15, result.blockZ());
+
+        // Test max with BlockVec
+        result = v1.max(v2);
+        assertEquals(15, result.blockX());
+        assertEquals(20, result.blockY());
+        assertEquals(30, result.blockZ());
+
+        // Test max with coordinates
+        result = v1.max(15, 5, 25);
+        assertEquals(15, result.blockX());
+        assertEquals(20, result.blockY());
+        assertEquals(30, result.blockZ());
+
+        // Test max with single value
+        result = v1.max(15);
+        assertEquals(15, result.blockX());
+        assertEquals(20, result.blockY());
+        assertEquals(30, result.blockZ());
+    }
+
+    @Test
+    public void testNegAbs() {
+        BlockVec positive = new BlockVec(10, 20, 30);
+        BlockVec negative = new BlockVec(-10, -20, -30);
+        BlockVec mixed = new BlockVec(-10, 20, -30);
+
+        // Test neg
+        BlockVec result = positive.neg();
+        assertEquals(-10, result.blockX());
+        assertEquals(-20, result.blockY());
+        assertEquals(-30, result.blockZ());
+
+        result = negative.neg();
+        assertEquals(10, result.blockX());
+        assertEquals(20, result.blockY());
+        assertEquals(30, result.blockZ());
+
+        // Test abs
+        result = negative.abs();
+        assertEquals(10, result.blockX());
+        assertEquals(20, result.blockY());
+        assertEquals(30, result.blockZ());
+
+        result = mixed.abs();
+        assertEquals(10, result.blockX());
+        assertEquals(20, result.blockY());
+        assertEquals(30, result.blockZ());
+    }
+
+    @Test
+    public void testCross() {
+        BlockVec v1 = new BlockVec(1, 0, 0);
+        BlockVec v2 = new BlockVec(0, 1, 0);
+
+        // Cross product of unit vectors
+        BlockVec result = v1.cross(v2);
+        assertEquals(0, result.blockX());
+        assertEquals(0, result.blockY());
+        assertEquals(1, result.blockZ());
+
+        // Reverse order
+        result = v2.cross(v1);
+        assertEquals(0, result.blockX());
+        assertEquals(0, result.blockY());
+        assertEquals(-1, result.blockZ());
+
+        // More complex case
+        BlockVec v3 = new BlockVec(2, 3, 4);
+        BlockVec v4 = new BlockVec(5, 6, 7);
+        result = v3.cross(v4);
+        assertEquals(-3, result.blockX());
+        assertEquals(6, result.blockY());
+        assertEquals(-3, result.blockZ());
+    }
+
+    @Test
+    public void testSamePoint() {
+        BlockVec v1 = new BlockVec(10, 20, 30);
+        BlockVec v2 = new BlockVec(10, 20, 30);
+        BlockVec v3 = new BlockVec(10, 20, 31);
+
+        // Test with BlockVec
+        assertTrue(v1.samePoint(v2));
+        assertFalse(v1.samePoint(v3));
+
+        // Test with coordinates
+        assertTrue(v1.samePoint(10, 20, 30));
+        assertFalse(v1.samePoint(10, 20, 31));
+        assertFalse(v1.samePoint(11, 20, 30));
+        assertFalse(v1.samePoint(10, 21, 30));
+    }
+
+    @Test
+    public void testRelative() {
+        BlockVec base = new BlockVec(10, 20, 30);
+
+        assertEquals(new BlockVec(10, 21, 30), base.relative(BlockFace.TOP));
+        assertEquals(new BlockVec(10, 19, 30), base.relative(BlockFace.BOTTOM));
+        assertEquals(new BlockVec(11, 20, 30), base.relative(BlockFace.EAST));
+        assertEquals(new BlockVec(9, 20, 30), base.relative(BlockFace.WEST));
+        assertEquals(new BlockVec(10, 20, 31), base.relative(BlockFace.SOUTH));
+        assertEquals(new BlockVec(10, 20, 29), base.relative(BlockFace.NORTH));
+    }
+
+    @Test
+    public void testApply() {
+        BlockVec base = new BlockVec(10, 20, 30);
+
+        // Test operator that doubles all values
+        BlockVec result = base.apply((x, y, z) -> new BlockVec(x * 2, y * 2, z * 2));
+        assertEquals(20, result.blockX());
+        assertEquals(40, result.blockY());
+        assertEquals(60, result.blockZ());
+
+        // Test operator that creates constant
+        result = base.apply((_, _, _) -> BlockVec.ZERO);
+        assertEquals(BlockVec.ZERO, result);
+    }
+
+    @Test
+    public void testAsBlockVec() {
+        Point vec = new BlockVec(5, 10, 15);
+        assertSame(vec, vec.asBlockVec());
+    }
+
+    @Test
+    public void testDoubleOperations() {
+        BlockVec base = new BlockVec(10, 20, 30);
+
+        // Test that double operations return Vec
+        Vec result = base.add(1.5, 2.5, 3.5);
+        assertInstanceOf(Vec.class, result);
+        assertEquals(11.5, result.x(), 0.001);
+        assertEquals(22.5, result.y(), 0.001);
+        assertEquals(33.5, result.z(), 0.001);
+
+        // Test withX returns Vec
+        result = base.withX(15.5);
+        assertInstanceOf(Vec.class, result);
+        assertEquals(15.5, result.x(), 0.001);
+
+        // Test normalize returns Vec
+        result = base.normalize();
+        assertInstanceOf(Vec.class, result);
+    }
+
+    @Test
+    public void testRandomBlockVectors() {
+        Random random = new Random(12345L);
+
+        for (int i = 0; i < 100; i++) {
+            int x = random.nextInt(2000) - 1000;
+            int y = random.nextInt(2000) - 1000;
+            int z = random.nextInt(2000) - 1000;
+
+            BlockVec vec = new BlockVec(x, y, z);
+            assertEquals(x, vec.blockX());
+            assertEquals(y, vec.blockY());
+            assertEquals(z, vec.blockZ());
+
+            // Test that operations preserve immutability
+            BlockVec original = vec;
+            BlockVec modified = vec.add(1, 2, 3);
+            assertNotEquals(original, modified);
+            assertEquals(x, original.blockX());
+            assertEquals(x + 1, modified.blockX());
+        }
+    }
+
+    @Test
+    public void testCoordinateConversions() {
+        BlockVec vec = new BlockVec(32, 64, 96);
+
+        // Test x/y/z methods return double values
+        assertEquals(32.0, vec.x());
+        assertEquals(64.0, vec.y());
+        assertEquals(96.0, vec.z());
+
+        // Test section coordinates
+        assertEquals(2, vec.sectionX());
+        assertEquals(4, vec.sectionY());
+        assertEquals(6, vec.sectionZ());
+
+        // Test chunk coordinates
+        assertEquals(2, vec.chunkX());
+        assertEquals(6, vec.chunkZ());
+    }
+}
+

--- a/src/test/java/net/minestom/server/coordinate/PosTest.java
+++ b/src/test/java/net/minestom/server/coordinate/PosTest.java
@@ -1,0 +1,474 @@
+package net.minestom.server.coordinate;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static net.minestom.server.coordinate.Point.EPSILON;
+import static net.minestom.server.coordinate.Pos.VIEW_EPSILON;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PosTest {
+
+    @Test
+    public void testConstructors() {
+        // Test full constructor
+        Pos pos1 = new Pos(1.5, 2.5, 3.5, 45f, 30f);
+        assertEquals(1.5, pos1.x());
+        assertEquals(2.5, pos1.y());
+        assertEquals(3.5, pos1.z());
+        assertEquals(45f, pos1.yaw());
+        assertEquals(30f, pos1.pitch());
+
+        // Test coordinate-only constructor
+        Pos pos2 = new Pos(1.5, 2.5, 3.5);
+        assertEquals(1.5, pos2.x());
+        assertEquals(2.5, pos2.y());
+        assertEquals(3.5, pos2.z());
+        assertEquals(0f, pos2.yaw());
+        assertEquals(0f, pos2.pitch());
+    }
+
+    @Test
+    public void testYawPitchNormalization() {
+        // Test yaw wrapping
+        Pos pos1 = new Pos(0, 0, 0, 200f, 0f);
+        assertEquals(-160f, pos1.yaw(), EPSILON);
+
+        Pos pos2 = new Pos(0, 0, 0, -200f, 0f);
+        assertEquals(160f, pos2.yaw(), EPSILON);
+
+        Pos pos3 = new Pos(0, 0, 0, 720f, 0f);
+        assertEquals(0f, pos3.yaw(), EPSILON);
+
+        // Test pitch clamping
+        Pos pos4 = new Pos(0, 0, 0, 0f, 100f);
+        assertEquals(90f, pos4.pitch());
+
+        Pos pos5 = new Pos(0, 0, 0, 0f, -100f);
+        assertEquals(-90f, pos5.pitch());
+    }
+
+    @Test
+    public void testFixYaw() {
+        assertEquals(0f, Pos.fixYaw(0f), VIEW_EPSILON);
+        assertEquals(90f, Pos.fixYaw(90f), VIEW_EPSILON);
+        assertEquals(-90f, Pos.fixYaw(-90f), VIEW_EPSILON);
+        assertEquals(180f, Pos.fixYaw(180f), VIEW_EPSILON);
+        assertEquals(180f, Pos.fixYaw(-180f), VIEW_EPSILON);
+
+        // Test wrapping
+        assertEquals(-160f, Pos.fixYaw(200f), VIEW_EPSILON);
+        assertEquals(160f, Pos.fixYaw(-200f), VIEW_EPSILON);
+        assertEquals(0f, Pos.fixYaw(360f), VIEW_EPSILON);
+        assertEquals(0f, Pos.fixYaw(720f), VIEW_EPSILON);
+        assertEquals(85f, Pos.fixYaw(-1355f), VIEW_EPSILON);
+        assertEquals(-135f, Pos.fixYaw(225f), VIEW_EPSILON);
+    }
+
+    @Test
+    public void testFixPitch() {
+        assertEquals(0f, Pos.fixPitch(0f));
+        assertEquals(45f, Pos.fixPitch(45f));
+        assertEquals(-45f, Pos.fixPitch(-45f));
+
+        // Test clamping
+        assertEquals(90f, Pos.fixPitch(90f));
+        assertEquals(-90f, Pos.fixPitch(-90f));
+        assertEquals(90f, Pos.fixPitch(100f));
+        assertEquals(-90f, Pos.fixPitch(-100f));
+        assertEquals(90f, Pos.fixPitch(225f));
+        assertEquals(-90f, Pos.fixPitch(-135f));
+    }
+
+    @Test
+    public void testWithCoord() {
+        Pos base = new Pos(10, 20, 30, 45f, 30f);
+
+        // Test with coordinates
+        Pos modified = base.withCoord(15, 25, 35);
+        assertEquals(15, modified.x());
+        assertEquals(25, modified.y());
+        assertEquals(35, modified.z());
+        assertEquals(45f, modified.yaw());
+        assertEquals(30f, modified.pitch());
+
+        // Test with Point
+        Vec point = new Vec(5, 10, 15);
+        modified = base.withCoord(point);
+        assertEquals(5, modified.x());
+        assertEquals(10, modified.y());
+        assertEquals(15, modified.z());
+        assertEquals(45f, modified.yaw());
+        assertEquals(30f, modified.pitch());
+    }
+
+    @Test
+    public void testWithView() {
+        Pos base = new Pos(10, 20, 30, 45f, 30f);
+
+        // Test with yaw/pitch
+        Pos modified = base.withView(90f, -45f);
+        assertEquals(10, modified.x());
+        assertEquals(20, modified.y());
+        assertEquals(30, modified.z());
+        assertEquals(90f, modified.yaw());
+        assertEquals(-45f, modified.pitch());
+
+        // Test with Pos
+        Pos other = new Pos(0, 0, 0, 120f, -60f);
+        modified = base.withView(other);
+        assertEquals(10, modified.x());
+        assertEquals(20, modified.y());
+        assertEquals(30, modified.z());
+        assertEquals(120f, modified.yaw());
+        assertEquals(-60f, modified.pitch());
+    }
+
+    @Test
+    public void testWithDirection() {
+        Pos base = new Pos(0, 0, 0);
+
+        // Look straight ahead (z positive)
+        Pos pos = base.withDirection(new Vec(0, 0, 10));
+        assertEquals(0f, pos.yaw(), 0.001f);
+        assertEquals(0f, pos.pitch(), 0.001f);
+
+        // Look to the right (x positive)
+        pos = base.withDirection(new Vec(10, 0, 0));
+        assertEquals(-90f, pos.yaw(), 0.001f);
+        assertEquals(0f, pos.pitch(), 0.001f);
+
+        // Look straight up
+        pos = base.withDirection(new Vec(0, 10, 0));
+        assertEquals(-90f, pos.pitch(), 0.001f);
+
+        // Look straight down
+        pos = base.withDirection(new Vec(0, -10, 0));
+        assertEquals(90f, pos.pitch(), 0.001f);
+
+        // Look at itself (edge case - x=0, z=0)
+        pos = base.withDirection(Vec.ZERO);
+        // Should default to looking down
+        assertEquals(90f, pos.pitch(), 0.001f);
+    }
+
+    @Test
+    public void testWithYaw() {
+        Pos base = new Pos(10, 20, 30, 45f, 30f);
+
+        // Test with value
+        Pos modified = base.withYaw(90f);
+        assertEquals(10, modified.x());
+        assertEquals(20, modified.y());
+        assertEquals(30, modified.z());
+        assertEquals(90f, modified.yaw());
+        assertEquals(30f, modified.pitch());
+
+        // Test with operator
+        modified = base.withYaw(yaw -> yaw + 45f);
+        assertEquals(90f, modified.yaw());
+        assertEquals(30f, modified.pitch());
+    }
+
+    @Test
+    public void testWithPitch() {
+        Pos base = new Pos(10, 20, 30, 45f, 30f);
+
+        // Test with value
+        Pos modified = base.withPitch(-45f);
+        assertEquals(10, modified.x());
+        assertEquals(20, modified.y());
+        assertEquals(30, modified.z());
+        assertEquals(45f, modified.yaw());
+        assertEquals(-45f, modified.pitch());
+
+        // Test with operator
+        modified = base.withPitch(pitch -> pitch + 15f);
+        assertEquals(45f, modified.yaw());
+        assertEquals(45f, modified.pitch());
+    }
+
+    @Test
+    public void testSameView() {
+        Pos pos1 = new Pos(0, 0, 0, 45f, 30f);
+        Pos pos2 = new Pos(10, 20, 30, 45f, 30f);
+        Pos pos3 = new Pos(0, 0, 0, 46f, 30f);
+
+        // Test with Pos
+        assertTrue(pos1.sameView(pos2));
+        assertFalse(pos1.sameView(pos3));
+
+        // Test with values
+        assertTrue(pos1.sameView(45f, 30f));
+        assertFalse(pos1.sameView(46f, 30f));
+        assertFalse(pos1.sameView(45f, 31f));
+    }
+
+    @Test
+    public void testSimilarView() {
+        Pos pos1 = new Pos(0, 0, 0, 45f, 30f);
+        Pos pos2 = new Pos(0, 0, 0, 45.0001f, 30.0001f);
+        Pos pos3 = new Pos(0, 0, 0, 46f, 31f);
+
+        // Test with default epsilon
+        assertTrue(pos1.similarView(pos2));
+        assertFalse(pos1.similarView(pos3));
+
+        // Test with custom epsilon
+        assertTrue(pos1.similarView(pos3, 2f));
+        assertFalse(pos1.similarView(pos3, 0.5f));
+
+        // Test with yaw/pitch values
+        assertTrue(pos1.similarView(45.0001f, 30.0001f));
+        assertTrue(pos1.similarView(45.0001f, 30.0001f, VIEW_EPSILON));
+        assertFalse(pos1.similarView(46f, 31f, 0.5f));
+    }
+
+    @Test
+    public void testDirection() {
+        // Facing south (default)
+        Pos pos1 = new Pos(0, 0, 0, 0f, 0f);
+        Vec dir1 = pos1.direction();
+        assertEquals(0, dir1.x(), 0.0001);
+        assertEquals(0, dir1.y(), 0.0001);
+        assertEquals(1, dir1.z(), 0.0001);
+
+        // Facing east
+        Pos pos2 = new Pos(0, 0, 0, -90f, 0f);
+        Vec dir2 = pos2.direction();
+        assertEquals(1, dir2.x(), 0.0001);
+        assertEquals(0, dir2.y(), 0.0001);
+        assertEquals(0, dir2.z(), 0.0001);
+
+        // Facing down
+        Pos pos3 = new Pos(0, 0, 0, 0f, 90f);
+        Vec dir3 = pos3.direction();
+        assertEquals(0, dir3.x(), 0.0001);
+        assertEquals(-1, dir3.y(), 0.0001);
+        assertEquals(0, dir3.z(), 0.0001);
+
+        // Direction should be unit vector
+        assertTrue(dir1.isNormalized());
+        assertTrue(dir2.isNormalized());
+        assertTrue(dir3.isNormalized());
+    }
+
+    @Test
+    public void testLerpView() {
+        Pos start = new Pos(0, 0, 0, 0f, 0f);
+        Pos end = new Pos(0, 0, 0, 90f, 45f);
+
+        // Halfway
+        Pos mid = start.lerpView(end, 0.5f);
+        assertEquals(0, mid.x());
+        assertEquals(0, mid.y());
+        assertEquals(0, mid.z());
+        assertEquals(45f, mid.yaw(), VIEW_EPSILON);
+        assertEquals(22.5f, mid.pitch(), VIEW_EPSILON);
+
+        // At start
+        Pos atStart = start.lerpView(end, 0);
+        assertEquals(0f, atStart.yaw());
+        assertEquals(0f, atStart.pitch());
+
+        // At end
+        Pos atEnd = start.lerpView(end, 1);
+        assertEquals(90f, atEnd.yaw());
+        assertEquals(45f, atEnd.pitch());
+    }
+
+    @Test
+    public void testNegView() {
+        Pos pos = new Pos(10, 20, 30, 45f, 30f);
+        Pos negated = pos.negView();
+
+        assertEquals(10, negated.x());
+        assertEquals(20, negated.y());
+        assertEquals(30, negated.z());
+        assertEquals(-45f, negated.yaw());
+        assertEquals(-30f, negated.pitch());
+    }
+
+    @Test
+    public void testAbsView() {
+        Pos pos = new Pos(10, 20, 30, -45f, -30f);
+        Pos absolute = pos.absView();
+
+        assertEquals(10, absolute.x());
+        assertEquals(20, absolute.y());
+        assertEquals(30, absolute.z());
+        assertEquals(45f, absolute.yaw());
+        assertEquals(30f, absolute.pitch());
+    }
+
+    @Test
+    public void testApply() {
+        Pos pos = new Pos(10, 20, 30, 45f, 30f);
+
+        // Test operator
+        Pos result = pos.apply((x, y, z, yaw, pitch) ->
+            new Pos(x * 2, y * 2, z * 2, yaw + 45f, pitch + 15f));
+
+        assertEquals(20, result.x());
+        assertEquals(40, result.y());
+        assertEquals(60, result.z());
+        assertEquals(90f, result.yaw());
+        assertEquals(45f, result.pitch());
+    }
+
+    @Test
+    public void testAsPos() {
+        Point pos = new Pos(1, 2, 3, 45f, 30f);
+        assertSame(pos, pos.asPos());
+    }
+
+    @Test
+    public void testArithmeticPreservesView() {
+        Pos base = new Pos(10, 20, 30, 45f, 30f);
+
+        // Test add
+        Pos added = base.add(5, 10, 15);
+        assertEquals(15, added.x());
+        assertEquals(30, added.y());
+        assertEquals(45, added.z());
+        assertEquals(45f, added.yaw());
+        assertEquals(30f, added.pitch());
+
+        // Test sub
+        Pos subtracted = base.sub(5, 10, 15);
+        assertEquals(5, subtracted.x());
+        assertEquals(10, subtracted.y());
+        assertEquals(15, subtracted.z());
+        assertEquals(45f, subtracted.yaw());
+        assertEquals(30f, subtracted.pitch());
+
+        // Test mul
+        Pos multiplied = base.mul(2);
+        assertEquals(20, multiplied.x());
+        assertEquals(40, multiplied.y());
+        assertEquals(60, multiplied.z());
+        assertEquals(45f, multiplied.yaw());
+        assertEquals(30f, multiplied.pitch());
+
+        // Test div
+        Pos divided = base.div(2);
+        assertEquals(5, divided.x());
+        assertEquals(10, divided.y());
+        assertEquals(15, divided.z());
+        assertEquals(45f, divided.yaw());
+        assertEquals(30f, divided.pitch());
+    }
+
+    @Test
+    public void testTransformationsPreserveView() {
+        Pos base = new Pos(10, 20, 30, 45f, 30f);
+
+        // Test neg
+        Pos negated = base.neg();
+        assertEquals(-10, negated.x());
+        assertEquals(-20, negated.y());
+        assertEquals(-30, negated.z());
+        assertEquals(45f, negated.yaw());
+        assertEquals(30f, negated.pitch());
+
+        // Test abs
+        Pos absolute = negated.abs();
+        assertEquals(10, absolute.x());
+        assertEquals(20, absolute.y());
+        assertEquals(30, absolute.z());
+        assertEquals(45f, absolute.yaw());
+        assertEquals(30f, absolute.pitch());
+
+        // Test normalize
+        Pos normalized = base.normalize();
+        assertTrue(normalized.isNormalized());
+        assertEquals(45f, normalized.yaw());
+        assertEquals(30f, normalized.pitch());
+
+        // Test cross
+        Pos other = new Pos(1, 0, 0);
+        Pos crossed = base.cross(other);
+        assertEquals(45f, crossed.yaw());
+        assertEquals(30f, crossed.pitch());
+
+        // Test lerp
+        Pos end = new Pos(20, 40, 60);
+        Pos lerped = base.lerp(end, 0.5);
+        assertEquals(45f, lerped.yaw());
+        assertEquals(30f, lerped.pitch());
+    }
+
+    @Test
+    public void testRandomPositions() {
+        Random random = new Random(98765L);
+
+        for (int i = 0; i < 100; i++) {
+            double x = random.nextDouble() * 200 - 100;
+            double y = random.nextDouble() * 200 - 100;
+            double z = random.nextDouble() * 200 - 100;
+            float yaw = random.nextFloat() * 720 - 360;
+            float pitch = random.nextFloat() * 200 - 100;
+
+            Pos pos = new Pos(x, y, z, yaw, pitch);
+            assertEquals(x, pos.x(), 0.0001);
+            assertEquals(y, pos.y(), 0.0001);
+            assertEquals(z, pos.z(), 0.0001);
+
+            // Verify yaw is normalized
+            assertTrue(pos.yaw() >= -180f && pos.yaw() <= 180f);
+            // Verify pitch is clamped
+            assertTrue(pos.pitch() >= -90f && pos.pitch() <= 90f);
+
+            // Test immutability
+            Pos original = pos;
+            Pos modified = pos.withCoord(0, 0, 0);
+            assertEquals(x, original.x(), 0.0001);
+            assertEquals(0, modified.x(), 0.0001);
+        }
+    }
+
+    @Test
+    public void testMinMaxPreserveView() {
+        Pos pos1 = new Pos(10, 20, 30, 45f, 30f);
+        Pos pos2 = new Pos(15, 5, 25);
+
+        // Test min
+        Pos min = pos1.min(pos2);
+        assertEquals(10, min.x());
+        assertEquals(5, min.y());
+        assertEquals(25, min.z());
+        assertEquals(45f, min.yaw());
+        assertEquals(30f, min.pitch());
+
+        // Test max
+        Pos max = pos1.max(pos2);
+        assertEquals(15, max.x());
+        assertEquals(20, max.y());
+        assertEquals(30, max.z());
+        assertEquals(45f, max.yaw());
+        assertEquals(30f, max.pitch());
+    }
+
+    @Test
+    public void testViewEdgeCases() {
+        // Test exact boundaries
+        Pos pos1 = new Pos(0, 0, 0, 180f, 90f);
+        assertEquals(180f, pos1.yaw());
+        assertEquals(90f, pos1.pitch());
+
+        Pos pos2 = new Pos(0, 0, 0, -180f, -90f);
+        assertEquals(180f, pos2.yaw());
+        assertEquals(-90f, pos2.pitch());
+
+        // Test just outside boundaries
+        Pos pos3 = new Pos(0, 0, 0, 180.1f, 90.1f);
+        assertTrue(pos3.yaw() >= -180f && pos3.yaw() <= 180f);
+        assertEquals(90f, pos3.pitch());
+
+        Pos pos4 = new Pos(0, 0, 0, -180.1f, -90.1f);
+        assertTrue(pos4.yaw() >= -180f && pos4.yaw() <= 180f);
+        assertEquals(-90f, pos4.pitch());
+    }
+}
+

--- a/src/test/java/net/minestom/server/coordinate/VecTest.java
+++ b/src/test/java/net/minestom/server/coordinate/VecTest.java
@@ -1,0 +1,445 @@
+package net.minestom.server.coordinate;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static net.minestom.server.coordinate.Point.EPSILON;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VecTest {
+
+    @Test
+    public void testConstructors() {
+        // Test 3-param constructor
+        Vec vec1 = new Vec(1.5, 2.5, 3.5);
+        assertEquals(1.5, vec1.x());
+        assertEquals(2.5, vec1.y());
+        assertEquals(3.5, vec1.z());
+
+        // Test 2-param constructor (x, z) - y defaults to 0
+        Vec vec2 = new Vec(1.5, 3.5);
+        assertEquals(1.5, vec2.x());
+        assertEquals(0.0, vec2.y());
+        assertEquals(3.5, vec2.z());
+
+        // Test single value constructor
+        Vec vec3 = new Vec(5.5);
+        assertEquals(5.5, vec3.x());
+        assertEquals(5.5, vec3.y());
+        assertEquals(5.5, vec3.z());
+    }
+
+    @Test
+    public void testConstants() {
+        assertEquals(0, Vec.ZERO.x());
+        assertEquals(0, Vec.ZERO.y());
+        assertEquals(0, Vec.ZERO.z());
+
+        assertEquals(1, Vec.ONE.x());
+        assertEquals(1, Vec.ONE.y());
+        assertEquals(1, Vec.ONE.z());
+
+        assertEquals(Point.SECTION_SIZE, Vec.SECTION.x());
+        assertEquals(Point.SECTION_SIZE, Vec.SECTION.y());
+        assertEquals(Point.SECTION_SIZE, Vec.SECTION.z());
+    }
+
+    @Test
+    public void testRotateAroundX() {
+        Vec vec = new Vec(0, 1, 0);
+
+        // Rotate 90 degrees (pi/2 radians)
+        Vec rotated = vec.rotateAroundX(Math.PI / 2);
+        assertEquals(0, rotated.x(), EPSILON);
+        assertEquals(0, rotated.y(), EPSILON);
+        assertEquals(1, rotated.z(), EPSILON);
+
+        // Rotate 180 degrees
+        rotated = vec.rotateAroundX(Math.PI);
+        assertEquals(0, rotated.x(), EPSILON);
+        assertEquals(-1, rotated.y(), EPSILON);
+        assertEquals(0, rotated.z(), EPSILON);
+
+        // Rotate 360 degrees (should return to original)
+        rotated = vec.rotateAroundX(2 * Math.PI);
+        assertEquals(0, rotated.x(), EPSILON);
+        assertEquals(1, rotated.y(), EPSILON);
+        assertEquals(0, rotated.z(), EPSILON);
+    }
+
+    @Test
+    public void testRotateAroundY() {
+        Vec vec = new Vec(1, 0, 0);
+
+        // Rotate 90 degrees
+        Vec rotated = vec.rotateAroundY(Math.PI / 2);
+        assertEquals(0, rotated.x(), EPSILON);
+        assertEquals(0, rotated.y(), EPSILON);
+        assertEquals(-1, rotated.z(), EPSILON);
+
+        // Rotate 180 degrees
+        rotated = vec.rotateAroundY(Math.PI);
+        assertEquals(-1, rotated.x(), EPSILON);
+        assertEquals(0, rotated.y(), EPSILON);
+        assertEquals(0, rotated.z(), EPSILON);
+
+        // Rotate 360 degrees
+        rotated = vec.rotateAroundY(2 * Math.PI);
+        assertEquals(1, rotated.x(), EPSILON);
+        assertEquals(0, rotated.y(), EPSILON);
+        assertEquals(0, rotated.z(), EPSILON);
+    }
+
+    @Test
+    public void testRotateAroundZ() {
+        Vec vec = new Vec(1, 0, 0);
+
+        // Rotate 90 degrees
+        Vec rotated = vec.rotateAroundZ(Math.PI / 2);
+        assertEquals(0, rotated.x(), EPSILON);
+        assertEquals(1, rotated.y(), EPSILON);
+        assertEquals(0, rotated.z(), EPSILON);
+
+        // Rotate 180 degrees
+        rotated = vec.rotateAroundZ(Math.PI);
+        assertEquals(-1, rotated.x(), EPSILON);
+        assertEquals(0, rotated.y(), EPSILON);
+        assertEquals(0, rotated.z(), EPSILON);
+
+        // Rotate 360 degrees
+        rotated = vec.rotateAroundZ(2 * Math.PI);
+        assertEquals(1, rotated.x(), EPSILON);
+        assertEquals(0, rotated.y(), EPSILON);
+        assertEquals(0, rotated.z(), EPSILON);
+    }
+
+    @Test
+    public void testRotate() {
+        Vec vec = new Vec(1, 0, 0);
+
+        // Rotate around all axes
+        Vec rotated = vec.rotate(Math.PI / 2, Math.PI / 2, Math.PI / 2);
+        assertNotNull(rotated);
+
+        // Verify it's a combination of individual rotations
+        Vec expected = vec.rotateAroundX(Math.PI / 2)
+                .rotateAroundY(Math.PI / 2)
+                .rotateAroundZ(Math.PI / 2);
+        assertEquals(expected.x(), rotated.x(), EPSILON);
+        assertEquals(expected.y(), rotated.y(), EPSILON);
+        assertEquals(expected.z(), rotated.z(), EPSILON);
+    }
+
+    @Test
+    public void testRotateFromView() {
+        Vec vec = new Vec(1, 0, 0);
+
+        // Test rotation with yaw and pitch
+        Vec rotated = vec.rotateFromView(0f, 0f);
+        assertNotNull(rotated);
+
+        // Test with 90 degree yaw
+        rotated = vec.rotateFromView(90f, 0f);
+        assertNotNull(rotated);
+
+        // Test with pitch
+        rotated = vec.rotateFromView(0f, 45f);
+        assertNotNull(rotated);
+
+        // Test with both
+        rotated = vec.rotateFromView(45f, 30f);
+        assertNotNull(rotated);
+    }
+
+    @Test
+    public void testRotateFromViewWithPos() {
+        Vec vec = new Vec(1, 0, 0);
+        Pos pos = new Pos(0, 0, 0, 45f, 30f);
+
+        Vec rotated = vec.rotateFromView(pos);
+        Vec expected = vec.rotateFromView(45f, 30f);
+
+        assertEquals(expected.x(), rotated.x(), EPSILON);
+        assertEquals(expected.y(), rotated.y(), EPSILON);
+        assertEquals(expected.z(), rotated.z(), EPSILON);
+    }
+
+    @Test
+    public void testRotateAroundAxis() {
+        Vec vec = new Vec(1, 0, 0);
+        Vec axis = new Vec(0, 1, 0); // Y-axis
+
+        // Rotate 90 degrees around Y-axis
+        Vec rotated = vec.rotateAroundAxis(axis, Math.PI / 2);
+        assertEquals(0, rotated.x(), EPSILON);
+        assertEquals(0, rotated.y(), EPSILON);
+        assertEquals(-1, rotated.z(), EPSILON);
+
+        // Test with non-unit axis (should normalize automatically)
+        Vec nonUnitAxis = new Vec(0, 2, 0);
+        rotated = vec.rotateAroundAxis(nonUnitAxis, Math.PI / 2);
+        assertEquals(0, rotated.x(), EPSILON);
+        assertEquals(0, rotated.y(), EPSILON);
+        assertEquals(-1, rotated.z(), EPSILON);
+    }
+
+    @Test
+    public void testRotateAroundNonUnitAxis() {
+        Vec vec = new Vec(1, 0, 0);
+        Vec axis = new Vec(0, 1, 0);
+
+        Vec rotated = vec.rotateAroundNonUnitAxis(axis, Math.PI / 2);
+        assertEquals(0, rotated.x(), EPSILON);
+        assertEquals(0, rotated.y(), EPSILON);
+        assertEquals(-1, rotated.z(), EPSILON);
+
+        // Test with scaled axis - result should be scaled
+        Vec scaledAxis = new Vec(0, 2, 0);
+        Vec scaledRotated = vec.rotateAroundNonUnitAxis(scaledAxis, Math.PI / 2);
+        // Length should be different from normalized version
+        assertNotEquals(rotated.length(), scaledRotated.length(), EPSILON);
+    }
+
+    @Test
+    public void testNormalize() {
+        Vec vec = new Vec(3, 4, 0);
+        Vec normalized = vec.normalize();
+
+        // Length should be 1
+        assertEquals(1.0, normalized.length(), EPSILON);
+
+        // Direction should be preserved
+        assertEquals(0.6, normalized.x(), EPSILON);
+        assertEquals(0.8, normalized.y(), EPSILON);
+        assertEquals(0, normalized.z(), EPSILON);
+
+        // Already normalized vector
+        Vec unit = new Vec(1, 0, 0);
+        Vec normalizedUnit = unit.normalize();
+        assertEquals(1.0, normalizedUnit.length(), EPSILON);
+    }
+
+    @Test
+    public void testIsNormalized() {
+        Vec unit = new Vec(1, 0, 0);
+        assertTrue(unit.isNormalized());
+
+        Vec normalized = new Vec(3, 4, 0).normalize();
+        assertTrue(normalized.isNormalized());
+
+        Vec notNormalized = new Vec(2, 0, 0);
+        assertFalse(notNormalized.isNormalized());
+
+        Vec zero = Vec.ZERO;
+        assertFalse(zero.isNormalized());
+    }
+
+    @Test
+    public void testLength() {
+        Vec vec = new Vec(3, 4, 0);
+        assertEquals(5.0, vec.length(), EPSILON);
+
+        Vec vec2 = new Vec(1, 1, 1);
+        assertEquals(Math.sqrt(3), vec2.length(), EPSILON);
+
+        assertEquals(0, Vec.ZERO.length(), EPSILON);
+    }
+
+    @Test
+    public void testLengthSquared() {
+        Vec vec = new Vec(3, 4, 0);
+        assertEquals(25.0, vec.lengthSquared(), EPSILON);
+
+        Vec vec2 = new Vec(1, 1, 1);
+        assertEquals(3.0, vec2.lengthSquared(), EPSILON);
+
+        assertEquals(0, Vec.ZERO.lengthSquared(), EPSILON);
+    }
+
+    @Test
+    public void testDot() {
+        Vec v1 = new Vec(1, 2, 3);
+        Vec v2 = new Vec(4, 5, 6);
+
+        // 1*4 + 2*5 + 3*6 = 4 + 10 + 18 = 32
+        assertEquals(32.0, v1.dot(v2), EPSILON);
+
+        // Perpendicular vectors
+        Vec v3 = new Vec(1, 0, 0);
+        Vec v4 = new Vec(0, 1, 0);
+        assertEquals(0.0, v3.dot(v4), EPSILON);
+
+        // Parallel vectors
+        Vec v5 = new Vec(2, 0, 0);
+        assertEquals(2.0, v3.dot(v5), EPSILON);
+    }
+
+    @Test
+    public void testAngle() {
+        Vec v1 = new Vec(1, 0, 0);
+        Vec v2 = new Vec(0, 1, 0);
+
+        // 90 degrees = pi/2 radians
+        assertEquals(Math.PI / 2, v1.angle(v2), EPSILON);
+
+        // 180 degrees
+        Vec v3 = new Vec(-1, 0, 0);
+        assertEquals(Math.PI, v1.angle(v3), EPSILON);
+
+        // 0 degrees (same direction)
+        Vec v4 = new Vec(2, 0, 0);
+        assertEquals(0, v1.angle(v4), EPSILON);
+    }
+
+    @Test
+    public void testCross() {
+        Vec v1 = new Vec(1, 0, 0);
+        Vec v2 = new Vec(0, 1, 0);
+
+        Vec cross = v1.cross(v2);
+        assertEquals(0, cross.x(), EPSILON);
+        assertEquals(0, cross.y(), EPSILON);
+        assertEquals(1, cross.z(), EPSILON);
+
+        // Reverse order should negate
+        Vec crossReverse = v2.cross(v1);
+        assertEquals(0, crossReverse.x(), EPSILON);
+        assertEquals(0, crossReverse.y(), EPSILON);
+        assertEquals(-1, crossReverse.z(), EPSILON);
+
+        // More complex
+        Vec v3 = new Vec(2, 3, 4);
+        Vec v4 = new Vec(5, 6, 7);
+        Vec result = v3.cross(v4);
+        assertEquals(-3, result.x(), EPSILON);
+        assertEquals(6, result.y(), EPSILON);
+        assertEquals(-3, result.z(), EPSILON);
+    }
+
+    @Test
+    public void testLerp() {
+        Vec start = new Vec(0, 0, 0);
+        Vec end = new Vec(10, 10, 10);
+
+        // Halfway
+        Vec mid = start.lerp(end, 0.5);
+        assertEquals(5, mid.x(), EPSILON);
+        assertEquals(5, mid.y(), EPSILON);
+        assertEquals(5, mid.z(), EPSILON);
+
+        // Start
+        Vec atStart = start.lerp(end, 0);
+        assertEquals(0, atStart.x(), EPSILON);
+        assertEquals(0, atStart.y(), EPSILON);
+        assertEquals(0, atStart.z(), EPSILON);
+
+        // End
+        Vec atEnd = start.lerp(end, 1);
+        assertEquals(10, atEnd.x(), EPSILON);
+        assertEquals(10, atEnd.y(), EPSILON);
+        assertEquals(10, atEnd.z(), EPSILON);
+    }
+
+    @Test
+    public void testApply() {
+        Vec vec = new Vec(1, 2, 3);
+
+        // Test operator
+        Vec result = vec.apply((x, y, z) -> new Vec(x * 2, y * 2, z * 2));
+        assertEquals(2, result.x(), EPSILON);
+        assertEquals(4, result.y(), EPSILON);
+        assertEquals(6, result.z(), EPSILON);
+
+        // Test with predefined operators
+        Vec epsilon = new Vec(0.0000001, 0.0000001, 0.0000001);
+        Vec epsilonResult = epsilon.apply(Vec.Operator.EPSILON);
+        assertEquals(0, epsilonResult.x(), EPSILON);
+        assertEquals(0, epsilonResult.y(), EPSILON);
+        assertEquals(0, epsilonResult.z(), EPSILON);
+
+        // Test FLOOR
+        Vec decimal = new Vec(1.7, 2.3, 3.9);
+        Vec floored = decimal.apply(Vec.Operator.FLOOR);
+        assertEquals(1, floored.x(), EPSILON);
+        assertEquals(2, floored.y(), EPSILON);
+        assertEquals(3, floored.z(), EPSILON);
+
+        // Test CEIL
+        Vec ceiled = decimal.apply(Vec.Operator.CEIL);
+        assertEquals(2, ceiled.x(), EPSILON);
+        assertEquals(3, ceiled.y(), EPSILON);
+        assertEquals(4, ceiled.z(), EPSILON);
+
+        // Test SIGNUM
+        Vec signed = new Vec(-5, 0, 5);
+        Vec signum = signed.apply(Vec.Operator.SIGNUM);
+        assertEquals(-1, signum.x(), EPSILON);
+        assertEquals(0, signum.y(), EPSILON);
+        assertEquals(1, signum.z(), EPSILON);
+    }
+
+    @Test
+    public void testAsVec() {
+        Point vec = new Vec(1, 2, 3);
+        assertSame(vec, vec.asVec());
+    }
+
+    @Test
+    public void testDistance() {
+        Vec v1 = new Vec(0, 0, 0);
+        Vec v2 = new Vec(3, 4, 0);
+
+        assertEquals(5.0, v1.distance(v2), EPSILON);
+        assertEquals(5.0, v2.distance(v1), EPSILON);
+
+        // Distance to self
+        assertEquals(0, v1.distance(v1), EPSILON);
+    }
+
+    @Test
+    public void testDistanceSquared() {
+        Vec v1 = new Vec(0, 0, 0);
+        Vec v2 = new Vec(3, 4, 0);
+
+        assertEquals(25.0, v1.distanceSquared(v2), EPSILON);
+        assertEquals(25.0, v2.distanceSquared(v1), EPSILON);
+    }
+
+    @Test
+    public void testIsZero() {
+        assertTrue(Vec.ZERO.isZero());
+        assertFalse(Vec.ONE.isZero());
+        assertFalse(new Vec(EPSILON, 0, 0).isZero());
+        assertFalse(new Vec(0, EPSILON, 0).isZero());
+        assertFalse(new Vec(0, 0, EPSILON).isZero());
+    }
+
+    @Test
+    public void testRandomVectors() {
+        Random random = new Random(54321L);
+
+        for (int i = 0; i < 100; i++) {
+            double x = random.nextDouble() * 200 - 100;
+            double y = random.nextDouble() * 200 - 100;
+            double z = random.nextDouble() * 200 - 100;
+
+            Vec vec = new Vec(x, y, z);
+            assertEquals(x, vec.x(), EPSILON);
+            assertEquals(y, vec.y(), EPSILON);
+            assertEquals(z, vec.z(), EPSILON);
+
+            // Test immutability
+            Vec original = vec;
+            Vec modified = vec.add(1, 2, 3);
+            assertEquals(x, original.x(), EPSILON);
+            assertEquals(x + 1, modified.x(), EPSILON);
+
+            // Test length consistency
+            double length = vec.length();
+            double lengthFromSquared = Math.sqrt(vec.lengthSquared());
+            assertEquals(length, lengthFromSquared, EPSILON);
+        }
+    }
+}
+

--- a/src/test/java/net/minestom/server/entity/EntityAttributeTest.java
+++ b/src/test/java/net/minestom/server/entity/EntityAttributeTest.java
@@ -3,6 +3,7 @@ package net.minestom.server.entity;
 import net.minestom.server.component.DataComponents;
 import net.kyori.adventure.key.Key;
 import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.EntityType;
 import net.minestom.server.entity.attribute.Attribute;
 import net.minestom.server.entity.attribute.AttributeModifier;
 import net.minestom.server.entity.attribute.AttributeOperation;
@@ -14,6 +15,9 @@ import net.minestom.testing.EnvTest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnvTest
 public class EntityAttributeTest {
@@ -26,11 +30,10 @@ public class EntityAttributeTest {
         LivingEntity entity = new LivingEntity(EntityTypes.CHICKEN);
         entity.setInstance(instance).join();
 
-        double baseHealth = 20;
         double addition = 10;
 
-        double baseAmount = entity.getAttribute(Attribute.MAX_HEALTH).getValue();
-        assertEquals(0, Double.compare(baseAmount, baseHealth)); // Avoid floating-point rounding issues
+        double baseHealth = entity.getAttribute(Attribute.MAX_HEALTH).getValue();
+        assertEquals(0, Double.compare(baseHealth, entity.getAttributeValue(Attribute.MAX_HEALTH))); // Avoid floating-point rounding issues
 
         ItemStack itemStack = ItemStack.builder(Material.DIAMOND).set(DataComponents.ATTRIBUTE_MODIFIERS,
                 new AttributeList(new AttributeList.Modifier(Attribute.MAX_HEALTH,
@@ -50,11 +53,10 @@ public class EntityAttributeTest {
         var connection = env.createConnection();
         var player = connection.connect(instance, new Pos(0, 42, 1));
 
-        double baseHealth = 20;
         double addition = 10;
 
-        double baseAmount = player.getAttribute(Attribute.MAX_HEALTH).getValue();
-        assertEquals(0, Double.compare(baseAmount, baseHealth)); // Avoid floating-point rounding issues
+        double baseHealth = player.getAttribute(Attribute.MAX_HEALTH).getValue();
+        assertEquals(0, Double.compare(baseHealth, player.getAttributeValue(Attribute.MAX_HEALTH))); // Avoid floating-point rounding issues
 
         ItemStack itemStack = ItemStack.builder(Material.DIAMOND).set(DataComponents.ATTRIBUTE_MODIFIERS,
                 new AttributeList(new AttributeList.Modifier(Attribute.MAX_HEALTH,
@@ -88,5 +90,46 @@ public class EntityAttributeTest {
 
         player.setItemInMainHand(itemStack);
         assertEquals(0, Double.compare(player.getAttribute(Attribute.MAX_HEALTH).getValue(), baseHealth + addition));
+    }
+
+    @Test
+    public void testEntityDefaultAttributes(Env ignored) {
+        var ironGolem = new EntityCreature(EntityType.IRON_GOLEM);
+        var zombie = new EntityCreature(EntityType.ZOMBIE);
+
+        var golemHealth = ironGolem.getAttribute(Attribute.MAX_HEALTH);
+        assertNotNull(golemHealth);
+        assertEquals(100.0, golemHealth.getBaseValue(), 0.001);
+        assertEquals(golemHealth.getBaseValue(), ironGolem.getAttributeValue(Attribute.MAX_HEALTH), 0.001);
+
+        var zombieHealth = zombie.getAttribute(Attribute.MAX_HEALTH);
+        assertNotNull(zombieHealth);
+        assertEquals(20.0, zombieHealth.getBaseValue(), 0.001);
+        assertEquals(zombieHealth.getBaseValue(), zombie.getAttributeValue(Attribute.MAX_HEALTH), 0.001);
+    }
+
+    @Test
+    public void testEntitySpawnsWithCorrectHealth(Env ignored) {
+        var ironGolem = new EntityCreature(EntityType.IRON_GOLEM);
+        assertEquals(100.0f, ironGolem.getHealth(), 0.001f);
+    }
+
+    @Test
+    public void testDefaultAttributesFromRegistry() {
+        var golemDefaults = EntityType.IRON_GOLEM.defaultAttributes();
+        assertEquals(100.0, golemDefaults.getOrDefault(Attribute.MAX_HEALTH, Double.NaN), 0.001);
+        assertEquals(0.25, golemDefaults.getOrDefault(Attribute.MOVEMENT_SPEED, Double.NaN), 0.001);
+
+        var zombieDefaults = EntityType.ZOMBIE.defaultAttributes();
+        assertEquals(3.0, zombieDefaults.getOrDefault(Attribute.ATTACK_DAMAGE, Double.NaN), 0.001);
+        assertEquals(20.0, zombieDefaults.getOrDefault(Attribute.MAX_HEALTH, Double.NaN), 0.001);
+
+        assertTrue(EntityType.AREA_EFFECT_CLOUD.defaultAttributes().isEmpty());
+    }
+
+    @Test
+    public void testDefaultAttributesAreImmutable() {
+        var defaults = EntityType.IRON_GOLEM.defaultAttributes();
+        assertThrows(UnsupportedOperationException.class, () -> defaults.put(Attribute.MAX_HEALTH, 1.0));
     }
 }

--- a/src/test/java/net/minestom/server/entity/EntityViewDirectionIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/EntityViewDirectionIntegrationTest.java
@@ -163,7 +163,7 @@ public class EntityViewDirectionIntegrationTest {
 
         e2.teleport(new Pos(0, 30, -2)).join();
         e1.lookAt(e2);
-        assertEquals(-180f, e1.getPosition().yaw(), EPSILON);
+        assertEquals(180f, e1.getPosition().yaw(), EPSILON);
         assertEquals(79.78f, e1.getPosition().pitch(), EPSILON);
     }
 }

--- a/src/test/java/net/minestom/server/instance/GeneratorIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/GeneratorIntegrationTest.java
@@ -127,7 +127,7 @@ public class GeneratorIntegrationTest {
         var instance = env.createEmptyInstance();
         DynamicChunk chunk = (DynamicChunk) instance.loadChunk(0, 0).join();
         Generator generator = unit -> {
-            chunk.assertLock();
+            chunk.assertWriteLock();
             unit.modifier().fill(Block.GRASS_BLOCK);
         };
         instance.generateChunk(0, 0, generator).join();

--- a/src/test/java/net/minestom/server/instance/anvil/AnvilLoaderIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/anvil/AnvilLoaderIntegrationTest.java
@@ -107,7 +107,8 @@ public class AnvilLoaderIntegrationTest {
         Instance instance = env.createFlatInstance(chunkLoader);
 
         Consumer<Chunk> checkChunk = chunk -> {
-            synchronized (chunk) {
+            chunk.lockReadLock();
+            try {
                 assertEquals(-4, chunk.getMinSection());
                 assertEquals(20, chunk.getMaxSection());
 
@@ -119,6 +120,8 @@ public class AnvilLoaderIntegrationTest {
                         }
                     }
                 }
+            } finally {
+                chunk.unlockReadLock();
             }
         };
 

--- a/src/test/java/net/minestom/server/instance/block/handler/BlockHandlerIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/block/handler/BlockHandlerIntegrationTest.java
@@ -81,7 +81,7 @@ class BlockHandlerIntegrationTest {
         };
 
         instance.setBlock(blockPosition, Block.STONE.withHandler(handler));
-        var player = env.createPlayer(instance, blockPosition.asPosition());
+        var player = env.createPlayer(instance, blockPosition.asPos());
         player.addPacketToQueue(new ClientPlayerBlockPlacementPacket(PlayerHand.MAIN, blockPosition, BlockFace.TOP, 0, 0, 0, false, false, 1));
         player.interpretPacketQueue(); // Use packets
 


### PR DESCRIPTION
## Proposed changes

This PR aims to be more in-line with what the vanilla client expects:
- Resolves #3118 (allows for component removal via `[!consumable]` for example
- Removes the ability to apply custom nbt at the end of the item e.g. `cooked_beef[!consumable]{hi:1b}` as that errors clientside before you run the command. You can still achieve the same result through the `custom_data` component.
- Doesn't successfully parse if there are two of the same component e.g. `slime_block[consumable={consume_seconds:10000},!consumable]` as that errors clientside before you run the command.

Also made an invalid material being provided simply fail parsing instead of destroying the command.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)