### PR TITLE
fix: Trident/Spear ItemAnimation

### DIFF
--- a/src/main/java/net/minestom/server/item/ItemAnimation.java
+++ b/src/main/java/net/minestom/server/item/ItemAnimation.java
@@ -9,13 +9,13 @@ public enum ItemAnimation {
     DRINK,
     BLOCK,
     BOW,
-    SPEAR,
+    TRIDENT,
     CROSSBOW,
     SPYGLASS,
     TOOT_HORN,
     BRUSH,
     BUNDLE,
-    TRIDENT;
+    SPEAR;
 
     public static final NetworkBuffer.Type<ItemAnimation> NETWORK_TYPE = NetworkBuffer.Enum(ItemAnimation.class);
     public static final Codec<ItemAnimation> CODEC = Codec.Enum(ItemAnimation.class);

--- a/src/main/java/net/minestom/server/item/ItemAnimation.java
+++ b/src/main/java/net/minestom/server/item/ItemAnimation.java
@@ -14,7 +14,8 @@ public enum ItemAnimation {
     SPYGLASS,
     TOOT_HORN,
     BRUSH,
-    BUNDLE;
+    BUNDLE,
+    TRIDENT;
 
     public static final NetworkBuffer.Type<ItemAnimation> NETWORK_TYPE = NetworkBuffer.Enum(ItemAnimation.class);
     public static final Codec<ItemAnimation> CODEC = Codec.Enum(ItemAnimation.class);

--- a/src/main/java/net/minestom/server/listener/UseItemListener.java
+++ b/src/main/java/net/minestom/server/listener/UseItemListener.java
@@ -46,7 +46,7 @@ public class UseItemListener {
             useAnimation = ItemAnimation.BLOCK;
         } else if (material == Material.TRIDENT) {
             useItemTime = 72000;
-            useAnimation = ItemAnimation.SPEAR;
+            useAnimation = ItemAnimation.TRIDENT;
         } else if (material == Material.SPYGLASS) {
             useItemTime = 1200;
             useAnimation = ItemAnimation.SPYGLASS;

--- a/src/main/java/net/minestom/server/listener/UseItemListener.java
+++ b/src/main/java/net/minestom/server/listener/UseItemListener.java
@@ -63,6 +63,9 @@ public class UseItemListener {
         } else if (consumable != null) {
             useItemTime = consumable.consumeTicks();
             useAnimation = consumable.animation();
+        } else if (itemStack.has(DataComponents.KINETIC_WEAPON)) {
+            useItemTime = 72000;
+            useAnimation = ItemAnimation.SPEAR;
         }
 
         boolean usingMainHand = player.getItemUseHand() == PlayerHand.MAIN && hand == PlayerHand.OFF;


### PR DESCRIPTION
## Proposed changes

Adds the TRIDENT enum value for the `consumable` data component, added in 1.21.11
see https://minecraft.wiki/w/Data_component_format#consumable

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Should the spear be added to UseItemListener? Seems to be the only one not in it, but it has a different useItemTime for each material