### PR TITLE
fix: Make DisplayContext reflect vanilla

### DIFF
--- a/src/main/java/net/minestom/server/entity/metadata/display/ItemDisplayMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/display/ItemDisplayMeta.java
@@ -28,14 +28,15 @@ public class ItemDisplayMeta extends AbstractDisplayMeta {
 
     public enum DisplayContext {
         NONE,
-        THIRDPERSON_LEFT_HAND,
-        THIRDPERSON_RIGHT_HAND,
-        FIRSTPERSON_LEFT_HAND,
-        FIRSTPERSON_RIGHT_HAND,
+        THIRDPERSON_LEFTHAND,
+        THIRDPERSON_RIGHTHAND,
+        FIRSTPERSON_LEFTHAND,
+        FIRSTPERSON_RIGHTHAND,
         HEAD,
         GUI,
         GROUND,
-        FIXED;
+        FIXED,
+        ON_SHELF;
 
         private final static DisplayContext[] VALUES = values();
 


### PR DESCRIPTION
## Proposed changes

While parsing item display entities I've encountered that the DisplayContext enum doesn't match the vanilla one. 
There was already an attempt to solve this with 3b12cb7, but these changes also weren't correct.
With Minecraft 1.21.9 shelves were introduced, and these are also not available in the enum.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...