### PR TITLE
fix: Stateless ClientHandshakePacket

### DIFF
--- a/src/main/java/net/minestom/server/listener/preplay/HandshakeListener.java
+++ b/src/main/java/net/minestom/server/listener/preplay/HandshakeListener.java
@@ -41,8 +41,17 @@ public final class HandshakeListener {
      */
     private static final Component TRANSFERS_DISABLED_TEXT = Component.translatable("multiplayer.disconnect.transfers_disabled");
 
+    private static int maxHandshakeLength() {
+        // BungeeGuard limits handshake length to 2500 characters, while vanilla limits it to 255
+        return MinecraftServer.process().auth() instanceof Auth.Bungee bungee ? (bungee.guard() ? 2500 : Short.MAX_VALUE) : 255;
+    }
+
     public static void listener(ClientHandshakePacket packet, PlayerConnection connection) {
         String address = packet.serverAddress();
+        if (address.length() > maxHandshakeLength()) {
+            throw new IllegalArgumentException("Server address too long: " + address.length());
+        }
+
         switch (packet.intent()) {
             case TRANSFER:
                 connection.markTransferred(true);
@@ -145,5 +154,4 @@ public final class HandshakeListener {
         LOGGER.warn("{} tried to log in without valid BungeeGuard forwarding information.", connection.getIdentifier());
         connection.kick(INVALID_BUNGEE_FORWARDING);
     }
-
 }

--- a/src/main/java/net/minestom/server/network/packet/client/handshake/ClientHandshakePacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/handshake/ClientHandshakePacket.java
@@ -1,7 +1,5 @@
 package net.minestom.server.network.packet.client.handshake;
 
-import net.minestom.server.Auth;
-import net.minestom.server.MinecraftServer;
 import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.client.ClientPacket;
@@ -10,24 +8,12 @@ import static net.minestom.server.network.NetworkBuffer.*;
 
 public record ClientHandshakePacket(int protocolVersion, String serverAddress,
                                     int serverPort, Intent intent) implements ClientPacket {
-
-    public ClientHandshakePacket {
-        if (serverAddress.length() > maxHandshakeLength()) {
-            throw new IllegalArgumentException("Server address too long: " + serverAddress.length());
-        }
-    }
-
     public static final NetworkBuffer.Type<ClientHandshakePacket> SERIALIZER = NetworkBufferTemplate.template(
             VAR_INT, ClientHandshakePacket::protocolVersion,
             STRING, ClientHandshakePacket::serverAddress,
             UNSIGNED_SHORT, ClientHandshakePacket::serverPort,
             VAR_INT.transform(Intent::fromId, Intent::id), ClientHandshakePacket::intent,
             ClientHandshakePacket::new);
-
-    private static int maxHandshakeLength() {
-        // BungeeGuard limits handshake length to 2500 characters, while vanilla limits it to 255
-        return MinecraftServer.process().auth() instanceof Auth.Bungee bungee ? (bungee.guard() ? 2500 : Short.MAX_VALUE) : 255;
-    }
 
     public enum Intent {
         STATUS,


### PR DESCRIPTION
Avoid `ServerProcess` dependency