### PR TITLE
Add missing adventure modules to demo server

### DIFF
--- a/demo/src/main/java/module-info.java
+++ b/demo/src/main/java/module-info.java
@@ -4,4 +4,6 @@ module net.minestom.demo {
     requires net.kyori.adventure;
     requires net.kyori.adventure.nbt;
     requires net.kyori.adventure.key;
+    requires net.kyori.examination.string;
+    requires net.kyori.option;
 }


### PR DESCRIPTION
Fix error
```
Exception in thread "main" java.lang.NoClassDefFoundError: net/kyori/examination/string/StringExaminer
    at net.kyori.adventure@4.25.0/net.kyori.adventure.internal.Internals.toString(Internals.java:47)
    at net.kyori.adventure@4.25.0/net.kyori.adventure.text.TextComponentImpl.toString(TextComponentImpl.java:128)
    at java.base/java.lang.String.valueOf(String.java:4530)
    at it.unimi.dsi.fastutil@8.5.18/it.unimi.dsi.fastutil.ints.AbstractInt2ObjectMap.toString(AbstractInt2ObjectMap.java:402)
```