### PR TITLE
feat: Scratch demo server

### DIFF
--- a/demo/src/main/java/net/minestom/demo/Scratch.java
+++ b/demo/src/main/java/net/minestom/demo/Scratch.java
@@ -1,5 +1,6 @@
 package net.minestom.demo;
 
+import net.minestom.server.coordinate.ChunkRange;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.GameMode;
 import net.minestom.server.entity.RelativeFlags;
@@ -142,14 +143,13 @@ public final class Scratch {
         }
     }
 
-    private static void sendConfigurationStart(Connection connection) throws IOException {
+    private static void sendConfigurationStart(Connection connection) {
         connection.send(PluginMessagePacket.brandPacket("Minestom Scratch"));
         connection.send(new UpdateEnabledFeaturesPacket(List.of("minecraft:vanilla")));
         connection.send(new SelectKnownPacksPacket(List.of(SelectKnownPacksPacket.MINECRAFT_CORE)));
     }
 
-    private static void sendConfigurationData(Connection connection, Registries registries, boolean excludeVanilla)
-            throws IOException {
+    private static void sendConfigurationData(Connection connection, Registries registries, boolean excludeVanilla) {
         for (SendablePacket packet : Registries.registryDataPackets(registries, excludeVanilla)) {
             connection.send(packet);
         }
@@ -158,7 +158,7 @@ public final class Scratch {
         connection.send(new FinishConfigurationPacket());
     }
 
-    private static void sendJoinGame(Connection connection, Registries registries, FlatWorld flatWorld) throws IOException {
+    private static void sendJoinGame(Connection connection, Registries registries, FlatWorld flatWorld) {
         int dimensionTypeId = registries.dimensionType().getId(DimensionType.OVERWORLD);
         var spawn = new Vec(8.5, GROUND_Y + 2, 8.5);
 
@@ -181,11 +181,7 @@ public final class Scratch {
         connection.send(new ChangeGameStatePacket(ChangeGameStatePacket.Reason.LEVEL_CHUNKS_LOAD_START, 0));
         connection.send(new UpdateViewPositionPacket(0, 0));
         connection.send(new ChunkBatchStartPacket());
-        for (int chunkX = -VIEW_DISTANCE; chunkX <= VIEW_DISTANCE; chunkX++) {
-            for (int chunkZ = -VIEW_DISTANCE; chunkZ <= VIEW_DISTANCE; chunkZ++) {
-                connection.send(flatWorld.chunk(chunkX, chunkZ));
-            }
-        }
+        ChunkRange.chunksInRange(0, 0, VIEW_DISTANCE, (chunkX, chunkZ) -> connection.send(flatWorld.chunk(chunkX, chunkZ)));
         connection.send(new ChunkBatchFinishedPacket((VIEW_DISTANCE * 2 + 1) * (VIEW_DISTANCE * 2 + 1)));
     }
 
@@ -201,14 +197,21 @@ public final class Scratch {
             this.readBuffer = NetworkBuffer.resizableBuffer(4096, registries);
         }
 
-        private void send(SendablePacket packet) throws IOException {
+        private void send(SendablePacket packet) {
             ConnectionState previousState = serverState;
             ServerPacket serverPacket = SendablePacket.extractServerPacket(previousState, packet);
             if (serverPacket == null) throw new IllegalArgumentException("Unsupported packet: " + packet);
             serverState = PacketVanilla.nextServerState(serverPacket, serverState);
             NetworkBuffer buffer = NetworkBuffer.resizableBuffer(1024, registries);
             PacketWriting.writeFramedPacket(buffer, previousState, serverPacket, 0);
-            while (!buffer.writeChannel(channel)) Thread.onSpinWait();
+            while (true) {
+                try {
+                    if (buffer.writeChannel(channel)) break;
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+                Thread.onSpinWait();
+            }
         }
     }
 

--- a/demo/src/main/java/net/minestom/demo/Scratch.java
+++ b/demo/src/main/java/net/minestom/demo/Scratch.java
@@ -1,0 +1,272 @@
+package net.minestom.demo;
+
+import net.minestom.server.coordinate.Vec;
+import net.minestom.server.entity.GameMode;
+import net.minestom.server.entity.RelativeFlags;
+import net.minestom.server.instance.Section;
+import net.minestom.server.instance.block.Block;
+import net.minestom.server.instance.generator.Generator;
+import net.minestom.server.instance.generator.GeneratorImpl;
+import net.minestom.server.instance.heightmap.Heightmap;
+import net.minestom.server.network.ConnectionState;
+import net.minestom.server.network.NetworkBuffer;
+import net.minestom.server.network.packet.PacketReading;
+import net.minestom.server.network.packet.PacketVanilla;
+import net.minestom.server.network.packet.PacketWriting;
+import net.minestom.server.network.packet.client.ClientPacket;
+import net.minestom.server.network.packet.client.common.ClientPingRequestPacket;
+import net.minestom.server.network.packet.client.configuration.ClientFinishConfigurationPacket;
+import net.minestom.server.network.packet.client.configuration.ClientSelectKnownPacksPacket;
+import net.minestom.server.network.packet.client.handshake.ClientHandshakePacket;
+import net.minestom.server.network.packet.client.login.ClientLoginAcknowledgedPacket;
+import net.minestom.server.network.packet.client.login.ClientLoginStartPacket;
+import net.minestom.server.network.packet.client.status.StatusRequestPacket;
+import net.minestom.server.network.packet.server.SendablePacket;
+import net.minestom.server.network.packet.server.ServerPacket;
+import net.minestom.server.network.packet.server.common.PingResponsePacket;
+import net.minestom.server.network.packet.server.common.PluginMessagePacket;
+import net.minestom.server.network.packet.server.configuration.FinishConfigurationPacket;
+import net.minestom.server.network.packet.server.configuration.SelectKnownPacksPacket;
+import net.minestom.server.network.packet.server.configuration.UpdateEnabledFeaturesPacket;
+import net.minestom.server.network.packet.server.login.LoginSuccessPacket;
+import net.minestom.server.network.packet.server.play.*;
+import net.minestom.server.network.packet.server.play.data.ChunkData;
+import net.minestom.server.network.packet.server.play.data.LightData;
+import net.minestom.server.network.packet.server.play.data.WorldPos;
+import net.minestom.server.network.packet.server.status.ResponsePacket;
+import net.minestom.server.network.player.GameProfile;
+import net.minestom.server.registry.Registries;
+import net.minestom.server.utils.MathUtils;
+import net.minestom.server.world.Difficulty;
+import net.minestom.server.world.DimensionType;
+import net.minestom.server.world.biome.Biome;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.util.*;
+
+import static net.minestom.server.MinecraftServer.PROTOCOL_VERSION;
+
+/**
+ * A deliberately small Minecraft server built directly on Minestom's packet/data API.
+ * <p>
+ * This does not start Minestom's socket server, player system, instances, entities, or tick loop.
+ * Everything below is plain sockets plus virtual threads, backed by a tiny Registries implementation for packet codecs.
+ */
+public final class Scratch {
+    private static final SocketAddress ADDRESS = new InetSocketAddress("0.0.0.0", 25565);
+    private static final int VIEW_DISTANCE = 3;
+    private static final String WORLD = "minecraft:overworld";
+    private static final int ENTITY_ID = 1;
+    private static final int SEA_LEVEL = 63;
+    private static final int MIN_Y = DimensionType.VANILLA_MIN_Y;
+    private static final int HEIGHT = DimensionType.VANILLA_MAX_Y - DimensionType.VANILLA_MIN_Y + 1;
+    private static final int SECTION_COUNT = HEIGHT / 16;
+    private static final int GROUND_Y = 0;
+    private static final String STATUS_JSON = """
+            {
+              "version": {"name": "Minestom Scratch", "protocol": %d},
+              "players": {"max": 1, "online": 0},
+              "description": {"text": "Minestom packet API scratch server"},
+              "enforcesSecureChat": false
+            }
+            """.formatted(PROTOCOL_VERSION);
+
+    static void main() throws IOException {
+        var registries = Registries.vanilla();
+        var flatWorld = FlatWorld.create(registries);
+
+        try (ServerSocketChannel server = ServerSocketChannel.open()) {
+            server.bind(ADDRESS);
+            System.out.println("Scratch server listening on " + ADDRESS);
+
+            while (true) {
+                SocketChannel channel = server.accept();
+                channel.configureBlocking(true);
+                Thread.ofVirtual().name("scratch-client-", 0).start(() -> serve(channel, registries, flatWorld));
+            }
+        }
+    }
+
+    private static void serve(SocketChannel channel, Registries registries, FlatWorld flatWorld) {
+        try (channel) {
+            var connection = new Connection(channel, registries);
+            ConnectionState clientState = ConnectionState.HANDSHAKE;
+            while (channel.isOpen()) {
+                connection.readBuffer.readChannel(channel);
+                switch (PacketReading.readPackets(
+                        connection.readBuffer,
+                        PacketVanilla.CLIENT_PACKET_PARSER,
+                        clientState,
+                        PacketVanilla::nextClientState,
+                        false
+                )) {
+                    case PacketReading.Result.Success<ClientPacket> success -> {
+                        for (var parsed : success.packets()) {
+                            clientState = parsed.nextState();
+                            if (parsed.packet() instanceof ClientHandshakePacket) {
+                                connection.serverState = clientState;
+                            }
+                            switch (parsed.packet()) {
+                                case StatusRequestPacket ignored -> connection.send(new ResponsePacket(STATUS_JSON));
+                                case ClientPingRequestPacket ping ->
+                                        connection.send(new PingResponsePacket(ping.number()));
+                                case ClientLoginStartPacket login -> connection.send(new LoginSuccessPacket(
+                                        new GameProfile(login.profileId(), login.username())));
+                                case ClientLoginAcknowledgedPacket _ -> sendConfigurationStart(connection);
+                                case ClientSelectKnownPacksPacket knownPacks ->
+                                        sendConfigurationData(connection, registries,
+                                                knownPacks.entries().contains(SelectKnownPacksPacket.MINECRAFT_CORE));
+                                case ClientFinishConfigurationPacket _ ->
+                                        sendJoinGame(connection, registries, flatWorld);
+                                default -> {
+                                }
+                            }
+                        }
+                        connection.readBuffer.compact();
+                    }
+                    case PacketReading.Result.Empty<ClientPacket> _ -> {
+                    }
+                    case PacketReading.Result.Failure<ClientPacket> failure ->
+                            connection.readBuffer.resize(failure.requiredCapacity());
+                }
+            }
+        } catch (EOFException _) {
+            // Normal client disconnect.
+        } catch (Throwable throwable) {
+            throwable.printStackTrace();
+        }
+    }
+
+    private static void sendConfigurationStart(Connection connection) throws IOException {
+        connection.send(PluginMessagePacket.brandPacket("Minestom Scratch"));
+        connection.send(new UpdateEnabledFeaturesPacket(List.of("minecraft:vanilla")));
+        connection.send(new SelectKnownPacksPacket(List.of(SelectKnownPacksPacket.MINECRAFT_CORE)));
+    }
+
+    private static void sendConfigurationData(Connection connection, Registries registries, boolean excludeVanilla)
+            throws IOException {
+        for (SendablePacket packet : Registries.registryDataPackets(registries, excludeVanilla)) {
+            connection.send(packet);
+        }
+
+        connection.send(Registries.tagsPacket(registries));
+        connection.send(new FinishConfigurationPacket());
+    }
+
+    private static void sendJoinGame(Connection connection, Registries registries, FlatWorld flatWorld) throws IOException {
+        int dimensionTypeId = registries.dimensionType().getId(DimensionType.OVERWORLD);
+        var spawn = new Vec(8.5, GROUND_Y + 2, 8.5);
+
+        connection.send(new JoinGamePacket(
+                ENTITY_ID, false, List.of(WORLD), 1,
+                VIEW_DISTANCE, VIEW_DISTANCE, false, true, false,
+                dimensionTypeId, WORLD, 0L, GameMode.CREATIVE, null,
+                false, true, null, 0, SEA_LEVEL, false
+        ));
+        connection.send(new ServerDifficultyPacket(Difficulty.PEACEFUL, true));
+        connection.send(new SpawnPositionPacket(new WorldPos(WORLD, spawn), 0f, 0f));
+        connection.send(new PlayerAbilitiesPacket(
+                (byte) (PlayerAbilitiesPacket.FLAG_INVULNERABLE
+                        | PlayerAbilitiesPacket.FLAG_ALLOW_FLYING
+                        | PlayerAbilitiesPacket.FLAG_INSTANT_BREAK),
+                0.05f, 0.1f
+        ));
+        connection.send(new UpdateViewDistancePacket(VIEW_DISTANCE));
+        connection.send(new PlayerPositionAndLookPacket(1, spawn, Vec.ZERO, 0f, 0f, RelativeFlags.NONE));
+        connection.send(new ChangeGameStatePacket(ChangeGameStatePacket.Reason.LEVEL_CHUNKS_LOAD_START, 0));
+        connection.send(new UpdateViewPositionPacket(0, 0));
+        connection.send(new ChunkBatchStartPacket());
+        for (int chunkX = -VIEW_DISTANCE; chunkX <= VIEW_DISTANCE; chunkX++) {
+            for (int chunkZ = -VIEW_DISTANCE; chunkZ <= VIEW_DISTANCE; chunkZ++) {
+                connection.send(flatWorld.chunk(chunkX, chunkZ));
+            }
+        }
+        connection.send(new ChunkBatchFinishedPacket((VIEW_DISTANCE * 2 + 1) * (VIEW_DISTANCE * 2 + 1)));
+    }
+
+    private static final class Connection {
+        private final SocketChannel channel;
+        private final Registries registries;
+        private final NetworkBuffer readBuffer;
+        private ConnectionState serverState = ConnectionState.STATUS;
+
+        private Connection(SocketChannel channel, Registries registries) {
+            this.channel = channel;
+            this.registries = registries;
+            this.readBuffer = NetworkBuffer.resizableBuffer(4096, registries);
+        }
+
+        private void send(SendablePacket packet) throws IOException {
+            ConnectionState previousState = serverState;
+            ServerPacket serverPacket = SendablePacket.extractServerPacket(previousState, packet);
+            if (serverPacket == null) throw new IllegalArgumentException("Unsupported packet: " + packet);
+            serverState = PacketVanilla.nextServerState(serverPacket, serverState);
+            NetworkBuffer buffer = NetworkBuffer.resizableBuffer(1024, registries);
+            PacketWriting.writeFramedPacket(buffer, previousState, serverPacket, 0);
+            while (!buffer.writeChannel(channel)) Thread.onSpinWait();
+        }
+    }
+
+    private record FlatWorld(byte[] chunkData, Map<Heightmap.Type, long[]> heightmaps, LightData lightData) {
+        private static final Generator GENERATOR = unit -> {
+            unit.modifier().fillBiome(Biome.PLAINS);
+            unit.modifier().fillHeight(MIN_Y, GROUND_Y, Block.DIRT);
+            unit.modifier().fillHeight(MIN_Y, MIN_Y + 1, Block.BEDROCK);
+            unit.modifier().fillHeight(GROUND_Y, GROUND_Y + 1, Block.GRASS_BLOCK);
+        };
+
+        private static FlatWorld create(Registries registries) {
+            GeneratorImpl.GenSection[] genSections = new GeneratorImpl.GenSection[SECTION_COUNT];
+            for (int i = 0; i < SECTION_COUNT; i++) {
+                Section section = new Section();
+                genSections[i] = new GeneratorImpl.GenSection(section.blockPalette(), section.biomePalette());
+            }
+            GENERATOR.generate(GeneratorImpl.chunk(registries.biome(), genSections, 0, MIN_Y / 16, 0));
+
+            final NetworkBuffer.Type<ChunkData.Section> serializer = ChunkData.Section.networkType(registries.biome().size());
+            byte[] data = NetworkBuffer.makeArray(buffer -> {
+                for (GeneratorImpl.GenSection section : genSections) {
+                    final int blockCount = section.blocks().count();
+                    buffer.write(serializer, new ChunkData.Section(
+                            (short) blockCount,
+                            (short) (blockCount > 0 ? 1 : 0),  // fluid count (26.1)
+                            section.blocks(), section.biomes()
+                    ));
+                }
+            }, registries);
+
+            return new FlatWorld(data, createHeightmaps(), fullBrightLight());
+        }
+
+        private ChunkDataPacket chunk(int chunkX, int chunkZ) {
+            return new ChunkDataPacket(chunkX, chunkZ,
+                    new ChunkData(heightmaps, chunkData, Map.of()),
+                    lightData
+            );
+        }
+
+        private static Map<Heightmap.Type, long[]> createHeightmaps() {
+            short[] heights = new short[16 * 16];
+            Arrays.fill(heights, (short) (GROUND_Y - (MIN_Y - 1)));
+            long[] packed = Heightmap.encode(heights, MathUtils.bitsToRepresent(HEIGHT));
+            return Map.of(
+                    Heightmap.Type.MOTION_BLOCKING, packed,
+                    Heightmap.Type.WORLD_SURFACE, packed
+            );
+        }
+
+        private static LightData fullBrightLight() {
+            BitSet mask = new BitSet();
+            mask.set(1, SECTION_COUNT + 1);
+            byte[] full = new byte[2048];
+            Arrays.fill(full, (byte) 0xFF);
+            return new LightData(mask, new BitSet(), new BitSet(), mask,
+                    Collections.nCopies(SECTION_COUNT, full), List.of());
+        }
+    }
+}

--- a/demo/src/main/java/net/minestom/demo/Scratch.java
+++ b/demo/src/main/java/net/minestom/demo/Scratch.java
@@ -44,6 +44,7 @@ import net.minestom.server.world.biome.Biome;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.channels.ServerSocketChannel;
@@ -119,9 +120,7 @@ public final class Scratch {
                                 case ClientLoginStartPacket login -> connection.send(new LoginSuccessPacket(
                                         new GameProfile(login.profileId(), login.username())));
                                 case ClientLoginAcknowledgedPacket _ -> sendConfigurationStart(connection);
-                                case ClientSelectKnownPacksPacket knownPacks ->
-                                        sendConfigurationData(connection, registries,
-                                                knownPacks.entries().contains(SelectKnownPacksPacket.MINECRAFT_CORE));
+                                case ClientSelectKnownPacksPacket _ -> sendConfigurationData(connection, registries);
                                 case ClientFinishConfigurationPacket _ ->
                                         sendJoinGame(connection, registries, flatWorld);
                                 default -> {
@@ -149,8 +148,8 @@ public final class Scratch {
         connection.send(new SelectKnownPacksPacket(List.of(SelectKnownPacksPacket.MINECRAFT_CORE)));
     }
 
-    private static void sendConfigurationData(Connection connection, Registries registries, boolean excludeVanilla) {
-        for (SendablePacket packet : Registries.registryDataPackets(registries, excludeVanilla)) {
+    private static void sendConfigurationData(Connection connection, Registries registries) {
+        for (SendablePacket packet : Registries.registryDataPackets(registries, false)) {
             connection.send(packet);
         }
 
@@ -182,7 +181,7 @@ public final class Scratch {
         connection.send(new UpdateViewPositionPacket(0, 0));
         connection.send(new ChunkBatchStartPacket());
         ChunkRange.chunksInRange(0, 0, VIEW_DISTANCE, (chunkX, chunkZ) -> connection.send(flatWorld.chunk(chunkX, chunkZ)));
-        connection.send(new ChunkBatchFinishedPacket((VIEW_DISTANCE * 2 + 1) * (VIEW_DISTANCE * 2 + 1)));
+        connection.send(new ChunkBatchFinishedPacket(ChunkRange.chunksCount(VIEW_DISTANCE)));
     }
 
     private static final class Connection {
@@ -204,13 +203,10 @@ public final class Scratch {
             serverState = PacketVanilla.nextServerState(serverPacket, serverState);
             NetworkBuffer buffer = NetworkBuffer.resizableBuffer(1024, registries);
             PacketWriting.writeFramedPacket(buffer, previousState, serverPacket, 0);
-            while (true) {
-                try {
-                    if (buffer.writeChannel(channel)) break;
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-                Thread.onSpinWait();
+            try {
+                while (!buffer.writeChannel(channel)) Thread.onSpinWait();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
             }
         }
     }

--- a/src/main/java/net/minestom/server/instance/heightmap/Heightmap.java
+++ b/src/main/java/net/minestom/server/instance/heightmap/Heightmap.java
@@ -150,7 +150,7 @@ public abstract class Heightmap {
      *                     container.
      * @return array of encoded heights.
      */
-    static long[] encode(short[] heights, int bitsPerEntry) {
+    public static long[] encode(short[] heights, int bitsPerEntry) {
         final int entriesPerLong = 64 / bitsPerEntry;
         // ceil(HeightsCount / entriesPerLong)
         final int len = (heights.length + entriesPerLong - 1) / entriesPerLong;


### PR DESCRIPTION
Barebone pingable + joinable server using raw Minestom packet/registry API.

The goal is not to showcase features (or add scratch specific code to the framework), but to have a simple, easy to maintain template ensuring that scratch servers work.