### PR TITLE
Add RegistriesPacket

### DIFF
--- a/src/main/java/net/minestom/server/network/ConnectionManager.java
+++ b/src/main/java/net/minestom/server/network/ConnectionManager.java
@@ -13,7 +13,6 @@ import net.minestom.server.listener.preplay.LoginListener;
 import net.minestom.server.network.packet.server.CachedPacket;
 import net.minestom.server.network.packet.server.common.KeepAlivePacket;
 import net.minestom.server.network.packet.server.common.PluginMessagePacket;
-import net.minestom.server.network.packet.server.common.TagsPacket;
 import net.minestom.server.network.packet.server.configuration.FinishConfigurationPacket;
 import net.minestom.server.network.packet.server.configuration.ResetChatPacket;
 import net.minestom.server.network.packet.server.configuration.SelectKnownPacksPacket;
@@ -48,7 +47,7 @@ public final class ConnectionManager {
     private static final Component TIMEOUT_TEXT = Component.text("Timeout", NamedTextColor.RED);
     private static final Component SHUTDOWN_TEXT = Component.text("Server shutting down");
 
-    private final CachedPacket cachedTagsPacket = new CachedPacket(this::createTagsPacket);
+    private final CachedPacket cachedTagsPacket = new CachedPacket(() -> Registries.tagsPacket(MinecraftServer.process()));
 
     // All players once their Player object has been instantiated.
     private final Map<PlayerConnection, Player> connectionPlayerMap = new ConcurrentHashMap<>();
@@ -262,28 +261,7 @@ public final class ConnectionManager {
             boolean excludeVanilla = knownPacks.contains(SelectKnownPacksPacket.MINECRAFT_CORE);
 
             Registries registries = MinecraftServer.process();
-            player.sendPacket(registries.chatType().registryDataPacket(registries, excludeVanilla));
-            player.sendPacket(registries.biome().registryDataPacket(registries, excludeVanilla));
-            player.sendPacket(registries.dialog().registryDataPacket(registries, excludeVanilla));
-            player.sendPacket(registries.damageType().registryDataPacket(registries, excludeVanilla));
-            player.sendPacket(registries.trimMaterial().registryDataPacket(registries, excludeVanilla));
-            player.sendPacket(registries.trimPattern().registryDataPacket(registries, excludeVanilla));
-            player.sendPacket(registries.bannerPattern().registryDataPacket(registries, excludeVanilla));
-            player.sendPacket(registries.enchantment().registryDataPacket(registries, excludeVanilla));
-            player.sendPacket(registries.paintingVariant().registryDataPacket(registries, excludeVanilla));
-            player.sendPacket(registries.jukeboxSong().registryDataPacket(registries, excludeVanilla));
-            player.sendPacket(registries.instrument().registryDataPacket(registries, excludeVanilla));
-            player.sendPacket(registries.wolfVariant().registryDataPacket(registries, excludeVanilla));
-            player.sendPacket(registries.wolfSoundVariant().registryDataPacket(registries, excludeVanilla));
-            player.sendPacket(registries.catVariant().registryDataPacket(registries, excludeVanilla));
-            player.sendPacket(registries.chickenVariant().registryDataPacket(registries, excludeVanilla));
-            player.sendPacket(registries.cowVariant().registryDataPacket(registries, excludeVanilla));
-            player.sendPacket(registries.frogVariant().registryDataPacket(registries, excludeVanilla));
-            player.sendPacket(registries.pigVariant().registryDataPacket(registries, excludeVanilla));
-            player.sendPacket(registries.zombieNautilusVariant().registryDataPacket(registries, excludeVanilla));
-            player.sendPacket(registries.timeline().registryDataPacket(registries, excludeVanilla));
-            player.sendPacket(registries.dimensionType().registryDataPacket(registries, excludeVanilla));
-            // MUST BE IN SYNC WITH #createTagsPacket
+            player.sendPackets(Registries.registryDataPackets(registries, excludeVanilla));
             // TODO: TEST_ENVIRONMENT, TEST_INSTANCE
 
             sendRegistryTags(player);
@@ -396,43 +374,4 @@ public final class ConnectionManager {
         }
     }
 
-    private TagsPacket createTagsPacket() {
-        final List<TagsPacket.Registry> entries = new ArrayList<>();
-
-        // The following are the registries which contain tags used by the vanilla client.
-        // We don't care about registries unused by the client.
-        final Registries registries = MinecraftServer.process();
-
-        // static registries (with tags)
-        entries.add(registries.blocks().tagRegistry());
-        entries.add(registries.entityType().tagRegistry());
-        entries.add(registries.fluid().tagRegistry());
-        entries.add(registries.gameEvent().tagRegistry());
-        entries.add(registries.material().tagRegistry());
-        // dynamic registries
-        entries.add(registries.chatType().tagRegistry());
-        entries.add(registries.biome().tagRegistry());
-        entries.add(registries.dialog().tagRegistry());
-        entries.add(registries.damageType().tagRegistry());
-        entries.add(registries.trimMaterial().tagRegistry());
-        entries.add(registries.trimPattern().tagRegistry());
-        entries.add(registries.bannerPattern().tagRegistry());
-        entries.add(registries.enchantment().tagRegistry());
-        entries.add(registries.paintingVariant().tagRegistry());
-        entries.add(registries.jukeboxSong().tagRegistry());
-        entries.add(registries.instrument().tagRegistry());
-        entries.add(registries.wolfVariant().tagRegistry());
-        entries.add(registries.wolfSoundVariant().tagRegistry());
-        entries.add(registries.catVariant().tagRegistry());
-        entries.add(registries.chickenVariant().tagRegistry());
-        entries.add(registries.cowVariant().tagRegistry());
-        entries.add(registries.frogVariant().tagRegistry());
-        entries.add(registries.pigVariant().tagRegistry());
-        entries.add(registries.zombieNautilusVariant().tagRegistry());
-        entries.add(registries.timeline().tagRegistry());
-        entries.add(registries.dimensionType().tagRegistry());
-        // MUST BE IN SYNC WITH #doConfiguration
-
-        return new TagsPacket(entries);
-    }
 }

--- a/src/main/java/net/minestom/server/registry/Registries.java
+++ b/src/main/java/net/minestom/server/registry/Registries.java
@@ -20,10 +20,14 @@ import net.minestom.server.item.armor.TrimPattern;
 import net.minestom.server.item.enchant.*;
 import net.minestom.server.item.instrument.Instrument;
 import net.minestom.server.message.ChatType;
+import net.minestom.server.network.packet.server.SendablePacket;
+import net.minestom.server.network.packet.server.common.TagsPacket;
 import net.minestom.server.potion.PotionEffect;
 import net.minestom.server.world.DimensionType;
 import net.minestom.server.world.biome.Biome;
 import net.minestom.server.world.timeline.Timeline;
+
+import java.util.List;
 
 /**
  * <p>Provides access to all the dynamic registries. {@link net.minestom.server.ServerProcess} is the most relevant
@@ -34,6 +38,14 @@ import net.minestom.server.world.timeline.Timeline;
 public interface Registries {
     static Registries vanilla() {
         return new VanillaRegistries();
+    }
+
+    static List<SendablePacket> registryDataPackets(Registries registries, boolean excludeVanilla) {
+        return RegistriesImpl.registryDataPackets(registries, excludeVanilla);
+    }
+
+    static TagsPacket tagsPacket(Registries registries) {
+        return RegistriesImpl.tagsPacket(registries);
     }
 
     // Static registries

--- a/src/main/java/net/minestom/server/registry/RegistriesImpl.java
+++ b/src/main/java/net/minestom/server/registry/RegistriesImpl.java
@@ -1,0 +1,67 @@
+package net.minestom.server.registry;
+
+import net.minestom.server.network.packet.server.SendablePacket;
+import net.minestom.server.network.packet.server.common.TagsPacket;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class RegistriesImpl {
+    private RegistriesImpl() {
+    }
+
+    static List<SendablePacket> registryDataPackets(Registries registries, boolean excludeVanilla) {
+        final List<SendablePacket> packets = new ArrayList<>();
+        for (DynamicRegistry<?> registry : configurationRegistries(registries)) {
+            packets.add(registry.registryDataPacket(registries, excludeVanilla));
+        }
+        return packets;
+    }
+
+    static TagsPacket tagsPacket(Registries registries) {
+        final List<TagsPacket.Registry> entries = new ArrayList<>();
+        for (Registry<?> registry : tagRegistries(registries)) {
+            entries.add(registry.tagRegistry());
+        }
+        return new TagsPacket(entries);
+    }
+
+    private static List<DynamicRegistry<?>> configurationRegistries(Registries registries) {
+        return List.of(
+                registries.chatType(),
+                registries.biome(),
+                registries.dialog(),
+                registries.damageType(),
+                registries.trimMaterial(),
+                registries.trimPattern(),
+                registries.bannerPattern(),
+                registries.enchantment(),
+                registries.paintingVariant(),
+                registries.jukeboxSong(),
+                registries.instrument(),
+                registries.wolfVariant(),
+                registries.wolfSoundVariant(),
+                registries.catVariant(),
+                registries.chickenVariant(),
+                registries.cowVariant(),
+                registries.frogVariant(),
+                registries.pigVariant(),
+                registries.zombieNautilusVariant(),
+                registries.timeline(),
+                registries.dimensionType()
+        );
+    }
+
+    private static List<Registry<?>> tagRegistries(Registries registries) {
+        // These are the registries which contain tags used by the vanilla client.
+        // Registries unused by the client do not need to be included.
+        final List<Registry<?>> entries = new ArrayList<>();
+        entries.add(registries.blocks());
+        entries.add(registries.entityType());
+        entries.add(registries.fluid());
+        entries.add(registries.gameEvent());
+        entries.add(registries.material());
+        entries.addAll(configurationRegistries(registries));
+        return entries;
+    }
+}


### PR DESCRIPTION
Remove ugly lists from `ConnectionManager` ensuring more potential code reuse and better responsibility separation.

Thought about having those in `Registries` directly, no strong opinion either way.