### PR TITLE
feat: Add ChunkData.Section

### DIFF
--- a/src/main/java/net/minestom/server/instance/DynamicChunk.java
+++ b/src/main/java/net/minestom/server/instance/DynamicChunk.java
@@ -12,7 +12,6 @@ import net.minestom.server.instance.block.BlockHandler;
 import net.minestom.server.instance.heightmap.Heightmap;
 import net.minestom.server.instance.heightmap.MotionBlockingHeightmap;
 import net.minestom.server.instance.heightmap.WorldSurfaceHeightmap;
-import net.minestom.server.instance.palette.Palette;
 import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.packet.server.CachedPacket;
 import net.minestom.server.network.packet.server.SendablePacket;
@@ -29,7 +28,6 @@ import net.minestom.server.utils.ArrayUtils;
 import net.minestom.server.utils.validate.Check;
 import net.minestom.server.world.DimensionType;
 import net.minestom.server.world.biome.Biome;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +35,6 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 
 import static net.minestom.server.coordinate.CoordConversion.globalToSectionRelative;
-import static net.minestom.server.network.NetworkBuffer.SHORT;
 
 /**
  * Represents a {@link Chunk} which store each individual block in memory.
@@ -269,14 +266,10 @@ public class DynamicChunk extends Chunk {
 
         lockReadLock();
         try {
-            NetworkBuffer.Type<Palette> biomeSerializer = Palette.biomeSerializer(MinecraftServer.getBiomeRegistry().size());
+            NetworkBuffer.Type<ChunkData.Section> sectionSerializer = ChunkData.Section.networkType(MinecraftServer.getBiomeRegistry().size());
             final byte[] data = NetworkBuffer.makeArray(networkBuffer -> {
                 for (Section section : sections) {
-                    final int fillCount = section.blockPalette().count();
-                    networkBuffer.write(SHORT, (short) fillCount);
-                    networkBuffer.write(SHORT, (short) (fillCount > 0 ? 1 : 0)); //TODO(26.1) proper fluid count
-                    networkBuffer.write(Palette.BLOCK_SERIALIZER, section.blockPalette());
-                    networkBuffer.write(biomeSerializer, section.biomePalette());
+                    networkBuffer.write(sectionSerializer, ChunkData.Section.from(section));
                 }
             });
 

--- a/src/main/java/net/minestom/server/instance/DynamicChunk.java
+++ b/src/main/java/net/minestom/server/instance/DynamicChunk.java
@@ -269,7 +269,9 @@ public class DynamicChunk extends Chunk {
             NetworkBuffer.Type<ChunkData.Section> sectionSerializer = ChunkData.Section.networkType(MinecraftServer.getBiomeRegistry().size());
             final byte[] data = NetworkBuffer.makeArray(networkBuffer -> {
                 for (Section section : sections) {
-                    networkBuffer.write(sectionSerializer, new ChunkData.Section((short) section.blockPalette().count(), (short) 0, section.blockPalette(), section.biomePalette()));
+                    final short blockCount = (short) section.blockPalette().count();
+                    final short liquidCount = (short) (blockCount > 0 ? 1 : 0); //TODO(26.1) proper fluid count
+                    networkBuffer.write(sectionSerializer, new ChunkData.Section(blockCount, liquidCount, section.blockPalette(), section.biomePalette()));
                 }
             });
 

--- a/src/main/java/net/minestom/server/instance/DynamicChunk.java
+++ b/src/main/java/net/minestom/server/instance/DynamicChunk.java
@@ -269,7 +269,7 @@ public class DynamicChunk extends Chunk {
             NetworkBuffer.Type<ChunkData.Section> sectionSerializer = ChunkData.Section.networkType(MinecraftServer.getBiomeRegistry().size());
             final byte[] data = NetworkBuffer.makeArray(networkBuffer -> {
                 for (Section section : sections) {
-                    networkBuffer.write(sectionSerializer, ChunkData.Section.from(section));
+                    networkBuffer.write(sectionSerializer, new ChunkData.Section((short) section.blockPalette().count(), (short) 0, section.blockPalette(), section.biomePalette()));
                 }
             });
 

--- a/src/main/java/net/minestom/server/network/packet/server/play/data/ChunkData.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/data/ChunkData.java
@@ -78,14 +78,15 @@ public record ChunkData(Map<Heightmap.Type, long[]> heightmaps, byte[] data,
         return blockEntities;
     }
 
-    public record Section(short blockCount, Palette blockStates, Palette biomes) {
+    public record Section(short blockCount, short liquidCount, Palette blockStates, Palette biomes) {
         public static Section from(net.minestom.server.instance.Section section) {
-            return new Section((short) section.blockPalette().count(), section.blockPalette(), section.biomePalette());
+            return new Section((short) section.blockPalette().count(), (short) (section.blockPalette().count() > 0 ? 1 : 0), section.blockPalette(), section.biomePalette());
         }
 
         public static NetworkBuffer.Type<Section> networkType(int biomeCount) {
             return NetworkBufferTemplate.template(
                     SHORT, Section::blockCount,
+                    SHORT, Section::liquidCount,
                     Palette.BLOCK_SERIALIZER, Section::blockStates,
                     Palette.biomeSerializer(biomeCount), Section::biomes,
                     Section::new

--- a/src/main/java/net/minestom/server/network/packet/server/play/data/ChunkData.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/data/ChunkData.java
@@ -79,22 +79,6 @@ public record ChunkData(Map<Heightmap.Type, long[]> heightmaps, byte[] data,
     }
 
     public record Section(short blockCount, short liquidCount, Palette blockStates, Palette biomes) {
-        private static final int[] LIQUID_STATE_IDS = Block.values().stream()
-                .filter(b -> b.registry().isLiquid())
-                .mapToInt(Block::stateId)
-                .toArray();
-
-
-        public static Section from(net.minestom.server.instance.Section section) {
-            final Palette blocks = section.blockPalette();
-            final short blockCount = (short) blocks.count();
-
-            int liquid = 0;
-            for (int stateId : LIQUID_STATE_IDS) liquid += blocks.count(stateId);
-
-            return new Section(blockCount, (short) liquid, blocks, section.biomePalette());
-        }
-
         public static NetworkBuffer.Type<Section> networkType(int biomeCount) {
             return NetworkBufferTemplate.template(
                     SHORT, Section::blockCount,

--- a/src/main/java/net/minestom/server/network/packet/server/play/data/ChunkData.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/data/ChunkData.java
@@ -6,7 +6,9 @@ import net.minestom.server.coordinate.Point;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockEntityType;
 import net.minestom.server.instance.heightmap.Heightmap;
+import net.minestom.server.instance.palette.Palette;
 import net.minestom.server.network.NetworkBuffer;
+import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.utils.block.BlockUtils;
 
 import java.util.HashMap;
@@ -74,5 +76,20 @@ public record ChunkData(Map<Heightmap.Type, long[]> heightmaps, byte[] data,
             blockEntities.put(index, block.withNbt(nbt));
         }
         return blockEntities;
+    }
+
+    public record Section(short blockCount, Palette blockStates, Palette biomes) {
+        public static Section from(net.minestom.server.instance.Section section) {
+            return new Section((short) section.blockPalette().count(), section.blockPalette(), section.biomePalette());
+        }
+
+        public static NetworkBuffer.Type<Section> networkType(int biomeCount) {
+            return NetworkBufferTemplate.template(
+                    SHORT, Section::blockCount,
+                    Palette.BLOCK_SERIALIZER, Section::blockStates,
+                    Palette.biomeSerializer(biomeCount), Section::biomes,
+                    Section::new
+            );
+        }
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/data/ChunkData.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/data/ChunkData.java
@@ -79,8 +79,20 @@ public record ChunkData(Map<Heightmap.Type, long[]> heightmaps, byte[] data,
     }
 
     public record Section(short blockCount, short liquidCount, Palette blockStates, Palette biomes) {
+        private static final int[] LIQUID_STATE_IDS = Block.values().stream()
+                .filter(b -> b.registry().isLiquid())
+                .mapToInt(Block::stateId)
+                .toArray();
+
+
         public static Section from(net.minestom.server.instance.Section section) {
-            return new Section((short) section.blockPalette().count(), (short) (section.blockPalette().count() > 0 ? 1 : 0), section.blockPalette(), section.biomePalette());
+            final Palette blocks = section.blockPalette();
+            final short blockCount = (short) blocks.count();
+
+            int liquid = 0;
+            for (int stateId : LIQUID_STATE_IDS) liquid += blocks.count(stateId);
+
+            return new Section(blockCount, (short) liquid, blocks, section.biomePalette());
         }
 
         public static NetworkBuffer.Type<Section> networkType(int biomeCount) {

--- a/src/test/java/net/minestom/server/instance/anvil/AnvilLoaderIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/anvil/AnvilLoaderIntegrationTest.java
@@ -10,8 +10,8 @@ import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.Section;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockHandler;
-import net.minestom.server.instance.palette.Palette;
 import net.minestom.server.network.NetworkBuffer;
+import net.minestom.server.network.packet.server.play.data.ChunkData;
 import net.minestom.server.registry.RegistryKey;
 import net.minestom.server.world.biome.Biome;
 import net.minestom.testing.Env;
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import static net.minestom.server.network.NetworkBuffer.SHORT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -207,18 +206,10 @@ public class AnvilLoaderIntegrationTest {
             Section originalSection = originalChunk.getSection(section);
             Section reloadedSection = reloadedChunk.getSection(section);
 
-            NetworkBuffer.Type<Palette> biomeSerializer = Palette.biomeSerializer(MinecraftServer.getBiomeRegistry().size());
+            NetworkBuffer.Type<ChunkData.Section> sectionSerializer = ChunkData.Section.networkType(MinecraftServer.getBiomeRegistry().size());
             // easiest equality check to write is a memory compare on written output
-            var original = NetworkBuffer.makeArray(buffer -> {
-                buffer.write(SHORT, (short) originalSection.blockPalette().count());
-                buffer.write(Palette.BLOCK_SERIALIZER, originalSection.blockPalette());
-                buffer.write(biomeSerializer, originalSection.biomePalette());
-            });
-            var reloaded = NetworkBuffer.makeArray(buffer -> {
-                buffer.write(SHORT, (short) reloadedSection.blockPalette().count());
-                buffer.write(Palette.BLOCK_SERIALIZER, reloadedSection.blockPalette());
-                buffer.write(biomeSerializer, reloadedSection.biomePalette());
-            });
+            var original = NetworkBuffer.makeArray(buffer -> buffer.write(sectionSerializer, ChunkData.Section.from(originalSection)));
+            var reloaded = NetworkBuffer.makeArray(buffer -> buffer.write(sectionSerializer, ChunkData.Section.from(reloadedSection)));
             Assertions.assertArrayEquals(original, reloaded);
         }
     }

--- a/src/test/java/net/minestom/server/instance/anvil/AnvilLoaderIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/anvil/AnvilLoaderIntegrationTest.java
@@ -208,8 +208,10 @@ public class AnvilLoaderIntegrationTest {
 
             NetworkBuffer.Type<ChunkData.Section> sectionSerializer = ChunkData.Section.networkType(MinecraftServer.getBiomeRegistry().size());
             // easiest equality check to write is a memory compare on written output
-            var original = NetworkBuffer.makeArray(buffer -> buffer.write(sectionSerializer, ChunkData.Section.from(originalSection)));
-            var reloaded = NetworkBuffer.makeArray(buffer -> buffer.write(sectionSerializer, ChunkData.Section.from(reloadedSection)));
+            var original = NetworkBuffer.makeArray(buffer ->
+                    buffer.write(sectionSerializer, new ChunkData.Section((short) originalSection.blockPalette().count(), (short) 0, originalSection.blockPalette(), originalSection.biomePalette())));
+            var reloaded = NetworkBuffer.makeArray(buffer ->
+                    buffer.write(sectionSerializer, new ChunkData.Section((short) reloadedSection.blockPalette().count(), (short) 0, reloadedSection.blockPalette(), reloadedSection.biomePalette())));
             Assertions.assertArrayEquals(original, reloaded);
         }
     }


### PR DESCRIPTION
Avoid duplication for the ChunkData data array serialization.

Not sure I am a fan of this solution, might be better to directly replace the `ChunkData` byte array, or perhaps that `ChunkSectionData` is unnecessary and the serializer should just be defined elsewhere (`Palette`? `ChunkData`?). But the fact that it lacks light information make me think it shouldn't be in `Section` (or at least perhaps with a different name)