### PR TITLE
Add data component reset

### DIFF
--- a/src/main/java/net/minestom/server/component/DataComponentMap.java
+++ b/src/main/java/net/minestom/server/component/DataComponentMap.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 
@@ -145,12 +144,6 @@ public sealed interface DataComponentMap extends DataComponent.Holder permits Da
 
     default DataComponentMap set(DataComponent<Unit> component) {
         return set(component, Unit.INSTANCE);
-    }
-
-    default DataComponentMap with(Consumer<PatchBuilder> consumer) {
-        final PatchBuilder builder = toPatchBuilder();
-        consumer.accept(builder);
-        return builder.build();
     }
 
     /**

--- a/src/main/java/net/minestom/server/component/DataComponentMap.java
+++ b/src/main/java/net/minestom/server/component/DataComponentMap.java
@@ -88,7 +88,7 @@ public sealed interface DataComponentMap extends DataComponent.Holder permits Da
             }
         }
 
-        return diff.isEmpty() ? EMPTY : new DataComponentMapImpl(diff);
+        return DataComponentMapImpl.fromMap(diff);
     }
 
     static DataComponentMap applyPatch(DataComponentMap prototype, DataComponentMap patch) {
@@ -104,7 +104,7 @@ public sealed interface DataComponentMap extends DataComponent.Holder permits Da
                 result.put(entry.getIntKey(), entry.getValue());
             }
         }
-        return result.isEmpty() ? EMPTY : new DataComponentMapImpl(result);
+        return DataComponentMapImpl.fromMap(result);
     }
 
     boolean isEmpty();
@@ -154,6 +154,15 @@ public sealed interface DataComponentMap extends DataComponent.Holder permits Da
      */
     DataComponentMap remove(DataComponent<?> component);
 
+    /**
+     * Removes the explicit override for a component from this patch.
+     *
+     * <p>This operation is only meaningful for component patches. When the patch is applied to a prototype,
+     * the component will resolve to the prototype value.</p>
+     *
+     * @param component the component whose override should be reset
+     * @return a new patch without an override for the component, or this patch if none was present
+     */
     DataComponentMap reset(DataComponent<?> component);
 
     Collection<DataComponent.Value> entrySet();
@@ -183,6 +192,12 @@ public sealed interface DataComponentMap extends DataComponent.Holder permits Da
 
         PatchBuilder remove(DataComponent<?> component);
 
+        /**
+         * Removes the explicit override for a component from this patch builder.
+         *
+         * @param component the component whose override should be reset
+         * @return this builder
+         */
         PatchBuilder reset(DataComponent<?> component);
 
         DataComponentMap build();

--- a/src/main/java/net/minestom/server/component/DataComponentMap.java
+++ b/src/main/java/net/minestom/server/component/DataComponentMap.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 
@@ -88,7 +89,23 @@ public sealed interface DataComponentMap extends DataComponent.Holder permits Da
             }
         }
 
-        return new DataComponentMapImpl(diff);
+        return diff.isEmpty() ? EMPTY : new DataComponentMapImpl(diff);
+    }
+
+    static DataComponentMap applyPatch(DataComponentMap prototype, DataComponentMap patch) {
+        final DataComponentMapImpl patchImpl = (DataComponentMapImpl) patch;
+        if (patchImpl.components().isEmpty()) return prototype;
+
+        final DataComponentMapImpl protoImpl = (DataComponentMapImpl) prototype;
+        final Int2ObjectArrayMap<@Nullable Object> result = new Int2ObjectArrayMap<>(protoImpl.components());
+        for (var entry : patchImpl.components().int2ObjectEntrySet()) {
+            if (entry.getValue() == null) {
+                result.remove(entry.getIntKey());
+            } else {
+                result.put(entry.getIntKey(), entry.getValue());
+            }
+        }
+        return result.isEmpty() ? EMPTY : new DataComponentMapImpl(result);
     }
 
     boolean isEmpty();
@@ -130,6 +147,12 @@ public sealed interface DataComponentMap extends DataComponent.Holder permits Da
         return set(component, Unit.INSTANCE);
     }
 
+    default DataComponentMap with(Consumer<PatchBuilder> consumer) {
+        final PatchBuilder builder = toPatchBuilder();
+        consumer.accept(builder);
+        return builder.build();
+    }
+
     /**
      * Removes the component from the map (or patch).
      *
@@ -137,6 +160,8 @@ public sealed interface DataComponentMap extends DataComponent.Holder permits Da
      * @return A new map with the component removed
      */
     DataComponentMap remove(DataComponent<?> component);
+
+    DataComponentMap reset(DataComponent<?> component);
 
     Collection<DataComponent.Value> entrySet();
 
@@ -164,6 +189,8 @@ public sealed interface DataComponentMap extends DataComponent.Holder permits Da
         }
 
         PatchBuilder remove(DataComponent<?> component);
+
+        PatchBuilder reset(DataComponent<?> component);
 
         DataComponentMap build();
     }

--- a/src/main/java/net/minestom/server/component/DataComponentMap.java
+++ b/src/main/java/net/minestom/server/component/DataComponentMap.java
@@ -66,6 +66,15 @@ public sealed interface DataComponentMap extends DataComponent.Holder permits Da
         return new DataComponentMapImpl.CodecImpl(idToType, nameToType, true);
     }
 
+    /**
+     * Minimizes a component patch relative to a prototype without changing its resolved result.
+     * Overrides matching the prototype and removals of components absent from the prototype are omitted; components
+     * not mentioned by the patch remain inherited from the prototype.
+     *
+     * @param prototype the component defaults to compare against
+     * @param patch the component overrides to minimize
+     * @return the minimal equivalent patch, or {@link #EMPTY} when no explicit overrides are needed
+     */
     static DataComponentMap diff(DataComponentMap prototype, DataComponentMap patch) {
         final DataComponentMapImpl patchImpl = (DataComponentMapImpl) patch;
         if (patchImpl.components().isEmpty()) return EMPTY;
@@ -91,6 +100,15 @@ public sealed interface DataComponentMap extends DataComponent.Holder permits Da
         return DataComponentMapImpl.fromMap(diff);
     }
 
+    /**
+     * Resolves a component patch against a prototype into an absolute component map.
+     * Components set by the patch replace prototype values, components removed by the patch are omitted, and
+     * components not mentioned by the patch retain their prototype values.
+     *
+     * @param prototype the component defaults to resolve against
+     * @param patch the component overrides to apply
+     * @return the resolved component map, or {@code prototype} when the patch is empty
+     */
     static DataComponentMap applyPatch(DataComponentMap prototype, DataComponentMap patch) {
         final DataComponentMapImpl patchImpl = (DataComponentMapImpl) patch;
         if (patchImpl.components().isEmpty()) return prototype;

--- a/src/main/java/net/minestom/server/component/DataComponentMapImpl.java
+++ b/src/main/java/net/minestom/server/component/DataComponentMapImpl.java
@@ -28,6 +28,10 @@ import java.util.function.IntFunction;
 record DataComponentMapImpl(Int2ObjectMap<@Nullable Object> components) implements DataComponentMap {
     private static final char REMOVAL_PREFIX = '!';
 
+    static DataComponentMap fromMap(Int2ObjectMap<@Nullable Object> components) {
+        return components.isEmpty() ? DataComponentMap.EMPTY : new DataComponentMapImpl(components);
+    }
+
     @Override
     public boolean isEmpty() {
         return components.isEmpty();
@@ -82,7 +86,7 @@ record DataComponentMapImpl(Int2ObjectMap<@Nullable Object> components) implemen
         if (!components.containsKey(component.id())) return this;
         Int2ObjectMap<@Nullable Object> newComponents = new Int2ObjectArrayMap<>(components);
         newComponents.remove(component.id());
-        return newComponents.isEmpty() ? DataComponentMap.EMPTY : new DataComponentMapImpl(newComponents);
+        return fromMap(newComponents);
     }
 
     @Override
@@ -125,7 +129,7 @@ record DataComponentMapImpl(Int2ObjectMap<@Nullable Object> components) implemen
 
         @Override
         public DataComponentMap build() {
-            return components.isEmpty() ? DataComponentMap.EMPTY : new DataComponentMapImpl(new Int2ObjectArrayMap<>(components));
+            return fromMap(new Int2ObjectArrayMap<>(components));
         }
     }
 
@@ -162,7 +166,7 @@ record DataComponentMapImpl(Int2ObjectMap<@Nullable Object> components) implemen
 
         @Override
         public DataComponentMap build() {
-            return components.isEmpty() ? DataComponentMap.EMPTY : new DataComponentMapImpl(new Int2ObjectArrayMap<>(components));
+            return fromMap(new Int2ObjectArrayMap<>(components));
         }
     }
 
@@ -273,7 +277,7 @@ record DataComponentMapImpl(Int2ObjectMap<@Nullable Object> components) implemen
                 }
             }
 
-            return new Result.Ok<>(patch.isEmpty() ? EMPTY : new DataComponentMapImpl(patch));
+            return new Result.Ok<>(fromMap(patch));
         }
 
         @Override

--- a/src/main/java/net/minestom/server/component/DataComponentMapImpl.java
+++ b/src/main/java/net/minestom/server/component/DataComponentMapImpl.java
@@ -78,6 +78,14 @@ record DataComponentMapImpl(Int2ObjectMap<@Nullable Object> components) implemen
     }
 
     @Override
+    public DataComponentMap reset(DataComponent<?> component) {
+        if (!components.containsKey(component.id())) return this;
+        Int2ObjectMap<@Nullable Object> newComponents = new Int2ObjectArrayMap<>(components);
+        newComponents.remove(component.id());
+        return newComponents.isEmpty() ? DataComponentMap.EMPTY : new DataComponentMapImpl(newComponents);
+    }
+
+    @Override
     public Collection<DataComponent.Value> entrySet() {
         if (components.isEmpty()) return List.of();
         final List<DataComponent.Value> entries = new ArrayList<>(components.size());
@@ -117,7 +125,7 @@ record DataComponentMapImpl(Int2ObjectMap<@Nullable Object> components) implemen
 
         @Override
         public DataComponentMap build() {
-            return new DataComponentMapImpl(new Int2ObjectArrayMap<>(components));
+            return components.isEmpty() ? DataComponentMap.EMPTY : new DataComponentMapImpl(new Int2ObjectArrayMap<>(components));
         }
     }
 
@@ -147,8 +155,14 @@ record DataComponentMapImpl(Int2ObjectMap<@Nullable Object> components) implemen
         }
 
         @Override
+        public PatchBuilder reset(DataComponent<?> component) {
+            components.remove(component.id());
+            return this;
+        }
+
+        @Override
         public DataComponentMap build() {
-            return new DataComponentMapImpl(new Int2ObjectArrayMap<>(components));
+            return components.isEmpty() ? DataComponentMap.EMPTY : new DataComponentMapImpl(new Int2ObjectArrayMap<>(components));
         }
     }
 
@@ -259,7 +273,7 @@ record DataComponentMapImpl(Int2ObjectMap<@Nullable Object> components) implemen
                 }
             }
 
-            return new Result.Ok<>(new DataComponentMapImpl(patch));
+            return new Result.Ok<>(patch.isEmpty() ? EMPTY : new DataComponentMapImpl(patch));
         }
 
         @Override

--- a/src/main/java/net/minestom/server/item/ItemStack.java
+++ b/src/main/java/net/minestom/server/item/ItemStack.java
@@ -146,9 +146,6 @@ public sealed interface ItemStack extends TagReadable, DataComponent.Holder, Hov
     @Contract(value = "_, -> new", pure = true)
     ItemStack with(Consumer<Builder> consumer);
 
-    @Contract(value = "_ -> new", pure = true)
-    ItemStack withComponents(Consumer<DataComponentMap.PatchBuilder> consumer);
-
     /**
      * Returns a new ItemStack with the given Material set.
      *

--- a/src/main/java/net/minestom/server/item/ItemStack.java
+++ b/src/main/java/net/minestom/server/item/ItemStack.java
@@ -140,6 +140,11 @@ public sealed interface ItemStack extends TagReadable, DataComponent.Holder, Hov
     @Contract(pure = true)
     DataComponentMap componentPatch();
 
+    /**
+     * Returns the resolved component map, including material defaults and explicit overrides.
+     *
+     * @return the complete resolved component map
+     */
     @Contract(pure = true)
     DataComponentMap components();
 
@@ -216,7 +221,7 @@ public sealed interface ItemStack extends TagReadable, DataComponent.Holder, Hov
      * Returns a new ItemStack with the given component reset to the material default.
      *
      * @param component The component to reset
-     * @return A new ItemStack without an explicit patch for the given component
+     * @return A new ItemStack without an explicit override for the given component
      */
     @Contract(value = "_, -> new", pure = true)
     ItemStack reset(DataComponent<?> component);

--- a/src/main/java/net/minestom/server/item/ItemStack.java
+++ b/src/main/java/net/minestom/server/item/ItemStack.java
@@ -140,8 +140,14 @@ public sealed interface ItemStack extends TagReadable, DataComponent.Holder, Hov
     @Contract(pure = true)
     DataComponentMap componentPatch();
 
+    @Contract(pure = true)
+    DataComponentMap components();
+
     @Contract(value = "_, -> new", pure = true)
     ItemStack with(Consumer<Builder> consumer);
+
+    @Contract(value = "_ -> new", pure = true)
+    ItemStack withComponents(Consumer<DataComponentMap.PatchBuilder> consumer);
 
     /**
      * Returns a new ItemStack with the given Material set.
@@ -208,6 +214,15 @@ public sealed interface ItemStack extends TagReadable, DataComponent.Holder, Hov
      */
     @Contract(value = "_, -> new", pure = true)
     ItemStack without(DataComponent<?> component);
+
+    /**
+     * Returns a new ItemStack with the given component reset to the material default.
+     *
+     * @param component The component to reset
+     * @return A new ItemStack without an explicit patch for the given component
+     */
+    @Contract(value = "_, -> new", pure = true)
+    ItemStack reset(DataComponent<?> component);
 
     @Contract(value = "_, -> new", pure = true)
     default ItemStack withCustomName(Component customName) {

--- a/src/main/java/net/minestom/server/item/ItemStackHashImpl.java
+++ b/src/main/java/net/minestom/server/item/ItemStackHashImpl.java
@@ -15,6 +15,7 @@ final class ItemStackHashImpl {
 
     public static ItemStack.Hash of(Transcoder<Integer> hashCoder, ItemStack itemStack) {
         if (itemStack.isAir()) return ItemStack.Hash.AIR;
+
         final Map<DataComponent<?>, Integer> addedComponents = new HashMap<>();
         final Set<DataComponent<?>> removedComponents = new HashSet<>();
         for (var entry : itemStack.componentPatch().entrySet()) {

--- a/src/main/java/net/minestom/server/item/ItemStackHashImpl.java
+++ b/src/main/java/net/minestom/server/item/ItemStackHashImpl.java
@@ -10,12 +10,15 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-//TODO(1.21.5) hashes of components should be cached. Vanilla does it on a per player basis, could also do it globally perhaps.
 final class ItemStackHashImpl {
 
     public static ItemStack.Hash of(Transcoder<Integer> hashCoder, ItemStack itemStack) {
         if (itemStack.isAir()) return ItemStack.Hash.AIR;
+        if (itemStack instanceof ItemStackImpl impl) return impl.hash(hashCoder);
+        return compute(hashCoder, itemStack);
+    }
 
+    static ItemStack.Hash compute(Transcoder<Integer> hashCoder, ItemStack itemStack) {
         final Map<DataComponent<?>, Integer> addedComponents = new HashMap<>();
         final Set<DataComponent<?>> removedComponents = new HashSet<>();
         for (var entry : itemStack.componentPatch().entrySet()) {

--- a/src/main/java/net/minestom/server/item/ItemStackHashImpl.java
+++ b/src/main/java/net/minestom/server/item/ItemStackHashImpl.java
@@ -10,15 +10,11 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+//TODO(1.21.5) hashes of components should be cached. Vanilla does it on a per player basis, could also do it globally perhaps.
 final class ItemStackHashImpl {
 
     public static ItemStack.Hash of(Transcoder<Integer> hashCoder, ItemStack itemStack) {
         if (itemStack.isAir()) return ItemStack.Hash.AIR;
-        if (itemStack instanceof ItemStackImpl impl) return impl.hash(hashCoder);
-        return compute(hashCoder, itemStack);
-    }
-
-    static ItemStack.Hash compute(Transcoder<Integer> hashCoder, ItemStack itemStack) {
         final Map<DataComponent<?>, Integer> addedComponents = new HashMap<>();
         final Set<DataComponent<?>> removedComponents = new HashSet<>();
         for (var entry : itemStack.componentPatch().entrySet()) {

--- a/src/main/java/net/minestom/server/item/ItemStackImpl.java
+++ b/src/main/java/net/minestom/server/item/ItemStackImpl.java
@@ -125,13 +125,6 @@ final class ItemStackImpl implements ItemStack {
     }
 
     @Override
-    public ItemStack withComponents(Consumer<DataComponentMap.PatchBuilder> consumer) {
-        final DataComponentMap.PatchBuilder builder = components.toPatchBuilder();
-        consumer.accept(builder);
-        return create(material, amount, builder.build());
-    }
-
-    @Override
     public ItemStack withMaterial(Material material) {
         return create(material, Math.max(1, amount), components);
     }

--- a/src/main/java/net/minestom/server/item/ItemStackImpl.java
+++ b/src/main/java/net/minestom/server/item/ItemStackImpl.java
@@ -19,12 +19,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 
-final class ItemStackImpl implements ItemStack {
-    private final Material material;
-    private final int amount;
-    private final DataComponentMap components;
-    private @Nullable ItemStack.Hash cachedHash;
-    private int cachedHashCode;
+record ItemStackImpl(Material material, int amount, DataComponentMap componentPatch) implements ItemStack {
 
     static NetworkBuffer.Type<ItemStack> networkType(NetworkBuffer.Type<DataComponentMap> componentPatchType) {
         return new NetworkBuffer.Type<>() {
@@ -41,7 +36,7 @@ final class ItemStackImpl implements ItemStack {
 
                 buffer.write(NetworkBuffer.VAR_INT, value.amount());
                 buffer.write(NetworkBuffer.VAR_INT, value.material().id());
-                buffer.write(componentPatchType, ((ItemStackImpl) value).components);
+                buffer.write(componentPatchType, ((ItemStackImpl) value).componentPatch());
             }
 
             @Override
@@ -64,7 +59,7 @@ final class ItemStackImpl implements ItemStack {
         return create(material, amount, DataComponentMap.EMPTY);
     }
 
-    public ItemStackImpl(Material material, int amount, DataComponentMap components) {
+    public ItemStackImpl {
         Objects.requireNonNull(material, "Material cannot be null");
 
         // It is relevant to create the minimal diff of the prototype so that #isSimilar returns consistent
@@ -76,45 +71,27 @@ final class ItemStackImpl implements ItemStack {
         // max stack size of 64. If we did not do this, #isSimilar would return false for these two items because of
         // their different patches.
         // It is worth noting that the client would handle both cases perfectly fine.
-        if (components != DataComponentMap.EMPTY) {
-            components = DataComponentMap.diff(material.prototype(), components);
+        if (componentPatch != DataComponentMap.EMPTY) {
+            componentPatch = DataComponentMap.diff(material.prototype(), componentPatch);
         }
 
         // Having items with amount being 0 and material not being air kicks players
         if (amount == 0) material = Material.AIR;
-        this.material = material;
-        this.amount = amount;
-        this.components = components;
-    }
-
-    @Override
-    public Material material() {
-        return material;
-    }
-
-    @Override
-    public int amount() {
-        return amount;
-    }
-
-    @Override
-    public DataComponentMap componentPatch() {
-        return this.components;
     }
 
     @Override
     public DataComponentMap components() {
-        return DataComponentMap.applyPatch(material.prototype(), components);
+        return DataComponentMap.applyPatch(material.prototype(), componentPatch);
     }
 
     @Override
     public <T> @Nullable T get(DataComponent<T> component) {
-        return components.get(material.prototype(), component);
+        return componentPatch.get(material.prototype(), component);
     }
 
     @Override
     public boolean has(DataComponent<?> component) {
-        return components.has(material.prototype(), component);
+        return componentPatch.has(material.prototype(), component);
     }
 
     @Override
@@ -126,18 +103,18 @@ final class ItemStackImpl implements ItemStack {
 
     @Override
     public ItemStack withMaterial(Material material) {
-        return create(material, Math.max(1, amount), components);
+        return create(material, Math.max(1, amount), componentPatch);
     }
 
     @Override
     public ItemStack withAmount(int amount) {
         if (amount <= 0) return ItemStack.AIR;
-        return create(material, amount, components);
+        return create(material, amount, componentPatch);
     }
 
     @Override
     public <T> ItemStack with(DataComponent<T> component, T value) {
-        return create(material, amount, components.set(component, value));
+        return create(material, amount, componentPatch.set(component, value));
     }
 
     @Override
@@ -145,12 +122,14 @@ final class ItemStackImpl implements ItemStack {
         // We can be slightly smart here. If the component is not present, this will always be a noop.
         // No need to make a new patch with the removal only for it to be removed again when doing a diff.
         if (get(component) == null) return this;
-        return create(material, amount, components.remove(component));
+        return create(material, amount, componentPatch.remove(component));
     }
 
     @Override
     public ItemStack reset(DataComponent<?> component) {
-        return create(material, amount, components.reset(component));
+        final DataComponentMap newComponentPatch = componentPatch.reset(component);
+        if (newComponentPatch == componentPatch) return this;
+        return create(material, amount, newComponentPatch);
     }
 
     @Override
@@ -172,15 +151,7 @@ final class ItemStackImpl implements ItemStack {
 
     @Override
     public boolean isSimilar(ItemStack itemStack) {
-        return material == itemStack.material() && components.equals(((ItemStackImpl) itemStack).components);
-    }
-
-    ItemStack.Hash hash(Transcoder<Integer> hashCoder) {
-        ItemStack.Hash hash = cachedHash;
-        if (hash == null) {
-            cachedHash = hash = ItemStackHashImpl.compute(hashCoder, this);
-        }
-        return hash;
+        return material == itemStack.material() && componentPatch.equals(((ItemStackImpl) itemStack).componentPatch);
     }
 
     @Override
@@ -192,30 +163,7 @@ final class ItemStackImpl implements ItemStack {
     @Override
     @Contract(value = "-> new", pure = true)
     public ItemStack.Builder builder() {
-        return new Builder(material, amount, components.toPatchBuilder());
-    }
-
-    @Override
-    public boolean equals(Object object) {
-        if (this == object) return true;
-        if (!(object instanceof ItemStackImpl that)) return false;
-        return amount == that.amount && material == that.material && components.equals(that.components);
-    }
-
-    @Override
-    public int hashCode() {
-        int hashCode = cachedHashCode;
-        if (hashCode == 0) {
-            hashCode = Objects.hash(material, amount, components);
-            if (hashCode == 0) hashCode = 1;
-            cachedHashCode = hashCode;
-        }
-        return hashCode;
-    }
-
-    @Override
-    public String toString() {
-        return "ItemStackImpl[material=" + material + ", amount=" + amount + ", components=" + components + ']';
+        return new Builder(material, amount, componentPatch.toPatchBuilder());
     }
 
     static final class Builder implements ItemStack.Builder {

--- a/src/main/java/net/minestom/server/item/ItemStackImpl.java
+++ b/src/main/java/net/minestom/server/item/ItemStackImpl.java
@@ -19,7 +19,12 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 
-record ItemStackImpl(Material material, int amount, DataComponentMap components) implements ItemStack {
+final class ItemStackImpl implements ItemStack {
+    private final Material material;
+    private final int amount;
+    private final DataComponentMap components;
+    private @Nullable ItemStack.Hash cachedHash;
+    private int cachedHashCode;
 
     static NetworkBuffer.Type<ItemStack> networkType(NetworkBuffer.Type<DataComponentMap> componentPatchType) {
         return new NetworkBuffer.Type<>() {
@@ -36,7 +41,7 @@ record ItemStackImpl(Material material, int amount, DataComponentMap components)
 
                 buffer.write(NetworkBuffer.VAR_INT, value.amount());
                 buffer.write(NetworkBuffer.VAR_INT, value.material().id());
-                buffer.write(componentPatchType, ((ItemStackImpl) value).components());
+                buffer.write(componentPatchType, ((ItemStackImpl) value).components);
             }
 
             @Override
@@ -59,7 +64,7 @@ record ItemStackImpl(Material material, int amount, DataComponentMap components)
         return create(material, amount, DataComponentMap.EMPTY);
     }
 
-    public ItemStackImpl {
+    public ItemStackImpl(Material material, int amount, DataComponentMap components) {
         Objects.requireNonNull(material, "Material cannot be null");
 
         // It is relevant to create the minimal diff of the prototype so that #isSimilar returns consistent
@@ -77,11 +82,29 @@ record ItemStackImpl(Material material, int amount, DataComponentMap components)
 
         // Having items with amount being 0 and material not being air kicks players
         if (amount == 0) material = Material.AIR;
+        this.material = material;
+        this.amount = amount;
+        this.components = components;
+    }
+
+    @Override
+    public Material material() {
+        return material;
+    }
+
+    @Override
+    public int amount() {
+        return amount;
     }
 
     @Override
     public DataComponentMap componentPatch() {
         return this.components;
+    }
+
+    @Override
+    public DataComponentMap components() {
+        return DataComponentMap.applyPatch(material.prototype(), components);
     }
 
     @Override
@@ -99,6 +122,13 @@ record ItemStackImpl(Material material, int amount, DataComponentMap components)
         ItemStack.Builder builder = builder();
         consumer.accept(builder);
         return builder.build();
+    }
+
+    @Override
+    public ItemStack withComponents(Consumer<DataComponentMap.PatchBuilder> consumer) {
+        final DataComponentMap.PatchBuilder builder = components.toPatchBuilder();
+        consumer.accept(builder);
+        return create(material, amount, builder.build());
     }
 
     @Override
@@ -126,6 +156,11 @@ record ItemStackImpl(Material material, int amount, DataComponentMap components)
     }
 
     @Override
+    public ItemStack reset(DataComponent<?> component) {
+        return create(material, amount, components.reset(component));
+    }
+
+    @Override
     public ItemStack consume(int amount) {
         return withAmount(amount() - amount);
     }
@@ -147,6 +182,14 @@ record ItemStackImpl(Material material, int amount, DataComponentMap components)
         return material == itemStack.material() && components.equals(((ItemStackImpl) itemStack).components);
     }
 
+    ItemStack.Hash hash(Transcoder<Integer> hashCoder) {
+        ItemStack.Hash hash = cachedHash;
+        if (hash == null) {
+            cachedHash = hash = ItemStackHashImpl.compute(hashCoder, this);
+        }
+        return hash;
+    }
+
     @Override
     public CompoundBinaryTag toItemNBT(Registries registries) {
         final Transcoder<BinaryTag> coder = new RegistryTranscoder<>(Transcoder.NBT, registries);
@@ -157,6 +200,29 @@ record ItemStackImpl(Material material, int amount, DataComponentMap components)
     @Contract(value = "-> new", pure = true)
     public ItemStack.Builder builder() {
         return new Builder(material, amount, components.toPatchBuilder());
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (!(object instanceof ItemStackImpl that)) return false;
+        return amount == that.amount && material == that.material && components.equals(that.components);
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = cachedHashCode;
+        if (hashCode == 0) {
+            hashCode = Objects.hash(material, amount, components);
+            if (hashCode == 0) hashCode = 1;
+            cachedHashCode = hashCode;
+        }
+        return hashCode;
+    }
+
+    @Override
+    public String toString() {
+        return "ItemStackImpl[material=" + material + ", amount=" + amount + ", components=" + components + ']';
     }
 
     static final class Builder implements ItemStack.Builder {

--- a/src/test/java/net/minestom/server/component/DataComponentMapTest.java
+++ b/src/test/java/net/minestom/server/component/DataComponentMapTest.java
@@ -97,4 +97,41 @@ public class DataComponentMapTest {
         assertEquals(42, map1.get(DataComponents.REPAIR_COST));
         assertEquals(24, map2.get(DataComponents.REPAIR_COST));
     }
+
+    @Test
+    void testEmptyBuildsAreCanonical() {
+        assertSame(DataComponentMap.EMPTY, DataComponentMap.builder().build());
+        assertSame(DataComponentMap.EMPTY, DataComponentMap.patchBuilder().build());
+    }
+
+    @Test
+    void testReset() {
+        var map = DataComponentMap.patchBuilder()
+                .set(DataComponents.REPAIR_COST, 42)
+                .remove(DataComponents.CUSTOM_NAME)
+                .reset(DataComponents.REPAIR_COST)
+                .build();
+
+        assertNull(map.get(DataComponents.REPAIR_COST));
+        assertFalse(map.has(DataComponents.CUSTOM_NAME));
+        assertEquals(1, map.entrySet().size());
+    }
+
+    @Test
+    void testApplyPatch() {
+        var prototype = DataComponentMap.builder()
+                .set(DataComponents.REPAIR_COST, 42)
+                .set(DataComponents.CUSTOM_NAME, Component.text("Name"))
+                .build();
+        var patch = DataComponentMap.patchBuilder()
+                .set(DataComponents.REPAIR_COST, 24)
+                .remove(DataComponents.CUSTOM_NAME)
+                .set(DataComponents.ITEM_NAME, Component.text("Item"))
+                .build();
+        var resolved = DataComponentMap.applyPatch(prototype, patch);
+
+        assertEquals(24, resolved.get(DataComponents.REPAIR_COST));
+        assertNull(resolved.get(DataComponents.CUSTOM_NAME));
+        assertEquals(Component.text("Item"), resolved.get(DataComponents.ITEM_NAME));
+    }
 }

--- a/src/test/java/net/minestom/server/item/ItemStackTest.java
+++ b/src/test/java/net/minestom/server/item/ItemStackTest.java
@@ -5,7 +5,11 @@ import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnvTest
 public class ItemStackTest {

--- a/src/test/java/net/minestom/server/item/ItemStackTest.java
+++ b/src/test/java/net/minestom/server/item/ItemStackTest.java
@@ -1,6 +1,5 @@
 package net.minestom.server.item;
 
-import net.kyori.adventure.text.Component;
 import net.minestom.server.component.DataComponents;
 import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
@@ -12,18 +11,11 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ItemStackTest {
 
     @Test
-    void hashIsCached(Env env) {
-        ItemStack item = ItemStack.of(Material.DIAMOND_SWORD)
-                .with(DataComponents.CUSTOM_NAME, Component.text("Blade"));
-
-        assertSame(ItemStack.Hash.of(item), ItemStack.Hash.of(item));
-    }
-
-    @Test
     void resetRevertsToMaterialDefault(Env env) {
         ItemStack apple = ItemStack.of(Material.APPLE).without(DataComponents.FOOD);
 
         assertFalse(apple.has(DataComponents.FOOD));
+        assertSame(apple, apple.reset(DataComponents.REPAIR_COST));
         assertTrue(apple.reset(DataComponents.FOOD).has(DataComponents.FOOD));
     }
 

--- a/src/test/java/net/minestom/server/item/ItemStackTest.java
+++ b/src/test/java/net/minestom/server/item/ItemStackTest.java
@@ -20,17 +20,6 @@ public class ItemStackTest {
     }
 
     @Test
-    void withComponentsBatchesPatchChanges(Env env) {
-        ItemStack item = ItemStack.of(Material.STONE)
-                .withComponents(components -> components
-                        .set(DataComponents.REPAIR_COST, 42)
-                        .set(DataComponents.CUSTOM_NAME, Component.text("Name")));
-
-        assertEquals(42, item.get(DataComponents.REPAIR_COST));
-        assertEquals(Component.text("Name"), item.get(DataComponents.CUSTOM_NAME));
-    }
-
-    @Test
     void resetRevertsToMaterialDefault(Env env) {
         ItemStack apple = ItemStack.of(Material.APPLE).without(DataComponents.FOOD);
 

--- a/src/test/java/net/minestom/server/item/ItemStackTest.java
+++ b/src/test/java/net/minestom/server/item/ItemStackTest.java
@@ -1,0 +1,51 @@
+package net.minestom.server.item;
+
+import net.kyori.adventure.text.Component;
+import net.minestom.server.component.DataComponents;
+import net.minestom.testing.Env;
+import net.minestom.testing.EnvTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@EnvTest
+public class ItemStackTest {
+
+    @Test
+    void hashIsCached(Env env) {
+        ItemStack item = ItemStack.of(Material.DIAMOND_SWORD)
+                .with(DataComponents.CUSTOM_NAME, Component.text("Blade"));
+
+        assertSame(ItemStack.Hash.of(item), ItemStack.Hash.of(item));
+    }
+
+    @Test
+    void withComponentsBatchesPatchChanges(Env env) {
+        ItemStack item = ItemStack.of(Material.STONE)
+                .withComponents(components -> components
+                        .set(DataComponents.REPAIR_COST, 42)
+                        .set(DataComponents.CUSTOM_NAME, Component.text("Name")));
+
+        assertEquals(42, item.get(DataComponents.REPAIR_COST));
+        assertEquals(Component.text("Name"), item.get(DataComponents.CUSTOM_NAME));
+    }
+
+    @Test
+    void resetRevertsToMaterialDefault(Env env) {
+        ItemStack apple = ItemStack.of(Material.APPLE).without(DataComponents.FOOD);
+
+        assertFalse(apple.has(DataComponents.FOOD));
+        assertTrue(apple.reset(DataComponents.FOOD).has(DataComponents.FOOD));
+    }
+
+    @Test
+    void componentsReturnsResolvedView(Env env) {
+        ItemStack item = ItemStack.of(Material.APPLE)
+                .without(DataComponents.FOOD)
+                .with(DataComponents.REPAIR_COST, 5);
+
+        assertFalse(item.components().has(DataComponents.FOOD));
+        assertEquals(5, item.components().get(DataComponents.REPAIR_COST));
+        assertNull(item.componentPatch().get(DataComponents.FOOD));
+    }
+}


### PR DESCRIPTION
* Add `DataComponentMap#reset`
* Add `ItemStack#components` which return the material prototype patched with the custom components
* Intern DataComponentMap into EMPTY
* ~Cache `ItemStack` hash and hashCode, both with a benign data race to avoid read overhead. Which unfortunately required moving away from record.~

~Item comparison could perhaps first compare the hashCodes as a fast exit, unsure if worth the trouble.~