### PR TITLE
Collision speedup

### DIFF
--- a/jmh-benchmarks/src/jmh/java/net/minestom/server/collision/CollisionBenchmark.java
+++ b/jmh-benchmarks/src/jmh/java/net/minestom/server/collision/CollisionBenchmark.java
@@ -1,0 +1,219 @@
+package net.minestom.server.collision;
+
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.coordinate.CoordConversion;
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.coordinate.Vec;
+import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.EntityType;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.instance.block.Block;
+import org.jetbrains.annotations.Nullable;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+public class CollisionBenchmark {
+
+    @Benchmark
+    public void blockPhysics(BlockCollisionState state, Blackhole blackhole) {
+        blackhole.consume(state.run());
+    }
+
+    @Benchmark
+    public void entityCollision(EntityCollisionState state, Blackhole blackhole) {
+        blackhole.consume(state.run());
+    }
+
+    @State(Scope.Benchmark)
+    public static class BlockCollisionState {
+        @Param({
+                "empty_short",
+                "floor_gravity",
+                "wall_horizontal",
+                "corner_diagonal",
+                "ceiling_vertical",
+                "long_sweep",
+                "slab_subblock",
+                "fence_tall"
+        })
+        public String collisionCase;
+
+        private StaticBlockGetter getter;
+        private BoundingBox boundingBox;
+        private Pos position;
+        private Vec velocity;
+
+        @Setup
+        public void setup() {
+            getter = new StaticBlockGetter();
+            boundingBox = new BoundingBox(0.6, 1.8, 0.6);
+
+            switch (collisionCase) {
+                case "empty_short" -> {
+                    position = new Pos(0, 42, 0);
+                    velocity = new Vec(0.3, -0.08, 0.3);
+                }
+                case "floor_gravity" -> {
+                    fill(getter, -1, 40, -1, 1, 40, 1, Block.STONE);
+                    position = new Pos(0, 42, 0);
+                    velocity = new Vec(0, -4, 0);
+                }
+                case "wall_horizontal" -> {
+                    fill(getter, -1, 42, 1, 1, 44, 1, Block.STONE);
+                    position = new Pos(0, 42, 0);
+                    velocity = new Vec(0, 0, 2);
+                }
+                case "corner_diagonal" -> {
+                    fill(getter, 1, 42, 0, 1, 44, 1, Block.STONE);
+                    fill(getter, 0, 42, 1, 1, 44, 1, Block.STONE);
+                    position = new Pos(0, 42, 0);
+                    velocity = new Vec(2, 0, 2);
+                }
+                case "ceiling_vertical" -> {
+                    fill(getter, -1, 44, -1, 1, 44, 1, Block.STONE);
+                    position = new Pos(0, 42, 0);
+                    velocity = new Vec(0, 5, 0);
+                }
+                case "long_sweep" -> {
+                    fill(getter, 48, 42, -1, 48, 44, 1, Block.STONE);
+                    position = new Pos(0, 42, 0);
+                    velocity = new Vec(64, 0, 0);
+                }
+                case "slab_subblock" -> {
+                    fill(getter, -1, 41, -1, 1, 41, 1, Block.STONE_SLAB);
+                    position = new Pos(0, 42, 0);
+                    velocity = new Vec(0.4, -1.2, 0.4);
+                }
+                case "fence_tall" -> {
+                    getter.set(0, 41, 0, Block.OAK_FENCE);
+                    position = new Pos(0, 42, -0.7);
+                    velocity = new Vec(0, -0.4, 1.2);
+                }
+                default -> throw new IllegalArgumentException("Unknown collision case: " + collisionCase);
+            }
+        }
+
+        public PhysicsResult run() {
+            return CollisionUtils.handlePhysics(getter, boundingBox, position, velocity, false);
+        }
+    }
+
+    @State(Scope.Benchmark)
+    public static class EntityCollisionState {
+        @Param({
+                "single_hit",
+                "multi_hit",
+                "overlap",
+                "miss_many",
+                "filtered_many"
+        })
+        public String collisionCase;
+
+        private Instance instance;
+        private Entity movingEntity;
+        private Vec velocity;
+
+        @Setup
+        public void setup() {
+            MinecraftServer.init();
+            instance = MinecraftServer.getInstanceManager().createInstanceContainer();
+            for (int x = -2; x <= 2; x++) {
+                for (int z = -2; z <= 2; z++) {
+                    instance.loadChunk(x, z).join();
+                }
+            }
+
+            movingEntity = spawn(new Pos(0, 42, 0));
+
+            switch (collisionCase) {
+                case "single_hit" -> {
+                    spawn(new Pos(0, 42, 1));
+                    spawn(new Pos(0, 42, 3));
+                    velocity = new Vec(0, 0, 1);
+                }
+                case "multi_hit" -> {
+                    spawn(new Pos(0, 42, 1));
+                    spawn(new Pos(0, 42, 2));
+                    spawn(new Pos(0, 42, 3));
+                    velocity = new Vec(0, 0, 3);
+                }
+                case "overlap" -> {
+                    spawn(new Pos(0, 42, 0));
+                    velocity = new Vec(0, 0, 1);
+                }
+                case "miss_many" -> {
+                    for (int i = 0; i < 48; i++) {
+                        spawn(new Pos((i % 8) + 4, 42, ((double) i / 8) + 4));
+                    }
+                    velocity = new Vec(0, 0, 1);
+                }
+                case "filtered_many" -> {
+                    for (int i = 0; i < 48; i++) {
+                        spawn(new Pos(0, 42, i + 1));
+                    }
+                    velocity = new Vec(0, 0, 48);
+                }
+                default -> throw new IllegalArgumentException("Unknown collision case: " + collisionCase);
+            }
+        }
+
+        @TearDown
+        public void tearDown() {
+            MinecraftServer.stopCleanly();
+        }
+
+        public Collection<EntityCollisionResult> run() {
+            return switch (collisionCase) {
+                case "filtered_many" ->
+                        CollisionUtils.checkEntityCollisions(movingEntity, velocity, 1.51, _ -> false, null);
+                default ->
+                        CollisionUtils.checkEntityCollisions(movingEntity, velocity, 1.51, entity -> entity != movingEntity, null);
+            };
+        }
+
+        private Entity spawn(Pos position) {
+            Entity entity = new Entity(EntityType.ZOMBIE);
+            entity.setInstance(instance, position).join();
+            return entity;
+        }
+    }
+
+    private static void fill(StaticBlockGetter getter,
+                             int minX, int minY, int minZ,
+                             int maxX, int maxY, int maxZ,
+                             Block block) {
+        for (int x = minX; x <= maxX; x++) {
+            for (int y = minY; y <= maxY; y++) {
+                for (int z = minZ; z <= maxZ; z++) {
+                    getter.set(x, y, z, block);
+                }
+            }
+        }
+    }
+
+    private static final class StaticBlockGetter implements Block.Getter {
+        private final Long2ObjectOpenHashMap<Block> blocks = new Long2ObjectOpenHashMap<>();
+
+        private StaticBlockGetter() {
+            blocks.defaultReturnValue(Block.AIR);
+        }
+
+        private void set(int x, int y, int z, Block block) {
+            blocks.put(CoordConversion.hashBlockCoord(x, y, z), block);
+        }
+
+        @Override
+        public Block getBlock(int x, int y, int z, @Nullable Condition condition) {
+            return blocks.get(CoordConversion.hashBlockCoord(x, y, z));
+        }
+    }
+}

--- a/src/main/java/net/minestom/server/collision/BlockCollision.java
+++ b/src/main/java/net/minestom/server/collision/BlockCollision.java
@@ -7,8 +7,6 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.Player;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.utils.block.BlockIterator;
-import org.jetbrains.annotations.Nullable;
 
 final class BlockCollision {
     /**
@@ -20,19 +18,12 @@ final class BlockCollision {
     static PhysicsResult handlePhysics(BoundingBox boundingBox,
                                        Vec velocity, Pos entityPosition,
                                        Block.Getter getter,
-                                       @Nullable PhysicsResult lastPhysicsResult,
                                        boolean singleCollision) {
         if (velocity.isZero()) {
             // TODO should return a constant
             return new PhysicsResult(entityPosition, Vec.ZERO, false, false, false, false,
                     velocity, new Point[3], new Shape[3], new Point[3], false, SweepResult.NO_COLLISION);
         }
-        // Fast-exit using cache
-        final PhysicsResult cachedResult = cachedPhysics(velocity, entityPosition, getter, lastPhysicsResult);
-        if (cachedResult != null) {
-            return cachedResult;
-        }
-        // Expensive AABB computation
         return stepPhysics(boundingBox, velocity, entityPosition, getter, singleCollision);
     }
 
@@ -56,34 +47,6 @@ final class BlockCollision {
         return null;
     }
 
-    private static PhysicsResult cachedPhysics(Vec velocity, Pos entityPosition,
-                                               Block.Getter getter, PhysicsResult lastPhysicsResult) {
-        if (lastPhysicsResult != null && lastPhysicsResult.collisionShapes()[1] instanceof ShapeImpl shape) {
-            var currentBlock = getter.getBlock(lastPhysicsResult.collisionShapePositions()[1], Block.Getter.Condition.TYPE);
-            var lastBlockBoxes = shape.boundingBoxes();
-            var currentBlockBoxes = ((ShapeImpl) currentBlock.registry().collisionShape()).boundingBoxes();
-
-            // Fast exit if entity hasn't moved
-            if (lastPhysicsResult.collisionY()
-                    && velocity.y() == lastPhysicsResult.originalDelta().y()
-                    // Check block below to fast exit gravity
-                    && currentBlockBoxes.equals(lastBlockBoxes)
-                    && velocity.x() == 0 && velocity.z() == 0
-                    && entityPosition.samePoint(lastPhysicsResult.newPosition())
-                    && !lastBlockBoxes.isEmpty()) {
-                if (lastPhysicsResult.cached()) {
-                    return lastPhysicsResult;
-                } else {
-                    return new PhysicsResult(lastPhysicsResult.newPosition(), lastPhysicsResult.newVelocity(),
-                            lastPhysicsResult.isOnGround(), lastPhysicsResult.collisionX(), lastPhysicsResult.collisionY(),
-                            lastPhysicsResult.collisionZ(), lastPhysicsResult.originalDelta(), lastPhysicsResult.collisionPoints(),
-                            lastPhysicsResult.collisionShapes(), lastPhysicsResult.collisionShapePositions(), lastPhysicsResult.hasCollision(), lastPhysicsResult.res(), true);
-                }
-            }
-        }
-        return null;
-    }
-
     private static PhysicsResult stepPhysics(BoundingBox boundingBox,
                                              Vec velocity, Pos entityPosition,
                                              Block.Getter getter, boolean singleCollision) {
@@ -98,9 +61,7 @@ final class BlockCollision {
 
         boolean hasCollided = false;
 
-        // Query faces to get the points needed for collision
-        final Vec[] allFaces = calculateFaces(velocity, boundingBox);
-        PhysicsResult result = computePhysics(boundingBox, velocity, entityPosition, getter, allFaces, finalResult);
+        PhysicsResult result = computePhysics(boundingBox, velocity, entityPosition, getter, finalResult);
         // Loop until no collisions are found.
         // When collisions are found, the collision axis is set to 0
         // Looping until there are no collisions will allow the entity to move in axis other than the collision axis after a collision.
@@ -139,7 +100,7 @@ final class BlockCollision {
             if (result.newVelocity().isZero()) break;
 
             finalResult.res = 1 - Vec.EPSILON;
-            result = computePhysics(boundingBox, result.newVelocity(), result.newPosition(), getter, allFaces, finalResult);
+            result = computePhysics(boundingBox, result.newVelocity(), result.newPosition(), getter, finalResult);
         }
 
         finalResult.res = result.res().res;
@@ -156,16 +117,8 @@ final class BlockCollision {
     private static PhysicsResult computePhysics(BoundingBox boundingBox,
                                                 Vec velocity, Pos entityPosition,
                                                 Block.Getter getter,
-                                                Vec[] allFaces,
                                                 SweepResult finalResult) {
-        // If the movement is small we don't need to run the expensive ray casting.
-        // Positions of move less than one can have hardcoded blocks to check for every direction
-        // Diagonals are a special case which will work with fast physics
-        if (velocity.length() <= 1 || isDiagonal(velocity)) {
-            fastPhysics(boundingBox, velocity, entityPosition, getter, allFaces, finalResult);
-        } else {
-            slowPhysics(boundingBox, velocity, entityPosition, getter, allFaces, finalResult);
-        }
+        sweepBlocks(boundingBox, velocity, entityPosition, getter, finalResult);
 
         final boolean collisionX = finalResult.normalX != 0;
         final boolean collisionY = finalResult.normalY != 0;
@@ -190,84 +143,39 @@ final class BlockCollision {
                 Vec.ZERO, null, null, null, false, finalResult);
     }
 
-    private static boolean isDiagonal(Vec velocity) {
-        return Math.abs(velocity.x()) == 1 && Math.abs(velocity.z()) == 1;
-    }
-
-    private static void slowPhysics(BoundingBox boundingBox,
+    private static void sweepBlocks(BoundingBox boundingBox,
                                     Vec velocity, Pos entityPosition,
                                     Block.Getter getter,
-                                    Vec[] allFaces,
                                     SweepResult finalResult) {
-        BlockIterator iterator = new BlockIterator();
-        // When large moves are done we need to ray-cast to find all blocks that could intersect with the movement
-        for (Vec point : allFaces) {
-            iterator.reset(point.add(entityPosition), velocity, 0, velocity.length(), false);
-            int timer = -1;
+        final double startX = entityPosition.x();
+        final double startY = entityPosition.y();
+        final double startZ = entityPosition.z();
+        final double endX = startX + velocity.x();
+        final double endY = startY + velocity.y();
+        final double endZ = startZ + velocity.z();
 
-            while (iterator.hasNext() && timer != 0) {
-                Point p = iterator.next();
+        final int minX = (int) Math.floor(Math.min(startX, endX) + boundingBox.minX());
+        final int minY = (int) Math.floor(Math.min(startY, endY) + boundingBox.minY());
+        final int minZ = (int) Math.floor(Math.min(startZ, endZ) + boundingBox.minZ());
+        final int maxX = (int) Math.floor(Math.max(startX, endX) + boundingBox.maxX());
+        final int maxY = (int) Math.floor(Math.max(startY, endY) + boundingBox.maxY());
+        final int maxZ = (int) Math.floor(Math.max(startZ, endZ) + boundingBox.maxZ());
 
-                // If we hit a block, there are at most 3 other blocks that could be closer
-                if (checkBoundingBox(p.blockX(), p.blockY(), p.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult))
-                    timer = 3;
+        final int stepX = velocity.x() < 0 ? -1 : 1;
+        final int stepY = velocity.y() < 0 ? -1 : 1;
+        final int stepZ = velocity.z() < 0 ? -1 : 1;
+        final int startBlockX = stepX > 0 ? minX : maxX;
+        final int endBlockX = stepX > 0 ? maxX : minX;
+        final int startBlockY = stepY > 0 ? minY : maxY;
+        final int endBlockY = stepY > 0 ? maxY : minY;
+        final int startBlockZ = stepZ > 0 ? minZ : maxZ;
+        final int endBlockZ = stepZ > 0 ? maxZ : minZ;
 
-                timer--;
-            }
-        }
-    }
-
-    private static void fastPhysics(BoundingBox boundingBox,
-                                    Vec velocity, Pos entityPosition,
-                                    Block.Getter getter,
-                                    Vec[] allFaces,
-                                    SweepResult finalResult) {
-        for (Vec point : allFaces) {
-            final Vec pointBefore = point.add(entityPosition);
-            final Vec pointAfter = point.add(entityPosition).add(velocity);
-            // Entity can pass through up to 4 blocks. Starting block, Two intermediate blocks, and a final block.
-            // This means we must check every combination of block movements when an entity moves over an axis.
-            // 000, 001, 010, 011, etc.
-            // There are 8 of these combinations
-            // Checks can be limited by checking if we moved across an axis line
-
-            boolean needsX = pointBefore.x() != pointAfter.x();
-            boolean needsY = pointBefore.y() != pointAfter.y();
-            boolean needsZ = pointBefore.z() != pointAfter.z();
-
-            checkBoundingBox(pointBefore.blockX(), pointBefore.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-
-            if (needsX && needsY && needsZ) {
-                checkBoundingBox(pointAfter.blockX(), pointAfter.blockY(), pointAfter.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-
-                checkBoundingBox(pointAfter.blockX(), pointAfter.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-                checkBoundingBox(pointAfter.blockX(), pointBefore.blockY(), pointAfter.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-                checkBoundingBox(pointBefore.blockX(), pointAfter.blockY(), pointAfter.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-
-                checkBoundingBox(pointAfter.blockX(), pointBefore.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-                checkBoundingBox(pointBefore.blockX(), pointAfter.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-                checkBoundingBox(pointBefore.blockX(), pointBefore.blockY(), pointAfter.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-            } else if (needsX && needsY) {
-                checkBoundingBox(pointAfter.blockX(), pointAfter.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-
-                checkBoundingBox(pointAfter.blockX(), pointBefore.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-                checkBoundingBox(pointBefore.blockX(), pointAfter.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-            } else if (needsX && needsZ) {
-                checkBoundingBox(pointAfter.blockX(), pointBefore.blockY(), pointAfter.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-
-                checkBoundingBox(pointAfter.blockX(), pointBefore.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-                checkBoundingBox(pointBefore.blockX(), pointBefore.blockY(), pointAfter.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-            } else if (needsY && needsZ) {
-                checkBoundingBox(pointBefore.blockX(), pointAfter.blockY(), pointAfter.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-
-                checkBoundingBox(pointBefore.blockX(), pointAfter.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-                checkBoundingBox(pointBefore.blockX(), pointBefore.blockY(), pointAfter.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-            } else if (needsX) {
-                checkBoundingBox(pointAfter.blockX(), pointBefore.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-            } else if (needsY) {
-                checkBoundingBox(pointBefore.blockX(), pointAfter.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-            } else if (needsZ) {
-                checkBoundingBox(pointBefore.blockX(), pointBefore.blockY(), pointAfter.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
+        for (int x = startBlockX; x != endBlockX + stepX; x += stepX) {
+            for (int y = startBlockY; y != endBlockY + stepY; y += stepY) {
+                for (int z = startBlockZ; z != endBlockZ + stepZ; z += stepZ) {
+                    checkBoundingBox(x, y, z, velocity, entityPosition, boundingBox, getter, finalResult);
+                }
             }
         }
     }
@@ -365,110 +273,4 @@ final class BlockCollision {
         return m * (blockPos - pos + (m > 0 ? 1 : 0)) + entityY;
     }
 
-    private static Vec[] calculateFaces(Vec queryVec, BoundingBox boundingBox) {
-        final int queryX = (int) Math.signum(queryVec.x());
-        final int queryY = (int) Math.signum(queryVec.y());
-        final int queryZ = (int) Math.signum(queryVec.z());
-
-        final int ceilWidth = (int) Math.ceil(boundingBox.width());
-        final int ceilHeight = (int) Math.ceil(boundingBox.height());
-        final int ceilDepth = (int) Math.ceil(boundingBox.depth());
-        Vec[] facePoints;
-        // Compute array length
-        {
-            final int ceilX = ceilWidth + 1;
-            final int ceilY = ceilHeight + 1;
-            final int ceilZ = ceilDepth + 1;
-            int pointCount = 0;
-            if (queryX != 0) pointCount += ceilY * ceilZ;
-            if (queryY != 0) pointCount += ceilX * ceilZ;
-            if (queryZ != 0) pointCount += ceilX * ceilY;
-            // Three edge reduction
-            if (queryX != 0 && queryY != 0 && queryZ != 0) {
-                pointCount -= ceilX + ceilY + ceilZ;
-                // inclusion exclusion principle
-                pointCount++;
-            } else if (queryX != 0 && queryY != 0) { // Two edge reduction
-                pointCount -= ceilZ;
-            } else if (queryY != 0 && queryZ != 0) { // Two edge reduction
-                pointCount -= ceilX;
-            } else if (queryX != 0 && queryZ != 0) { // Two edge reduction
-                pointCount -= ceilY;
-            }
-            facePoints = new Vec[pointCount];
-        }
-        int insertIndex = 0;
-        // X -> Y x Z
-        if (queryX != 0) {
-            int startIOffset = 0, endIOffset = 0, startJOffset = 0, endJOffset = 0;
-            // Y handles XY edge
-            if (queryY < 0) startJOffset = 1;
-            if (queryY > 0) endJOffset = 1;
-            // Z handles XZ edge
-            if (queryZ < 0) startIOffset = 1;
-            if (queryZ > 0) endIOffset = 1;
-
-            for (int i = startIOffset; i <= ceilDepth - endIOffset; ++i) {
-                for (int j = startJOffset; j <= ceilHeight - endJOffset; ++j) {
-                    double cellI = i;
-                    double cellJ = j;
-                    double cellK = queryX < 0 ? 0 : boundingBox.width();
-
-                    if (i >= boundingBox.depth()) cellI = boundingBox.depth();
-                    if (j >= boundingBox.height()) cellJ = boundingBox.height();
-
-                    cellI += boundingBox.minZ();
-                    cellJ += boundingBox.minY();
-                    cellK += boundingBox.minX();
-
-                    facePoints[insertIndex++] = new Vec(cellK, cellJ, cellI);
-                }
-            }
-        }
-        // Y -> X x Z
-        if (queryY != 0) {
-            int startJOffset = 0, endJOffset = 0;
-            // Z handles YZ edge
-            if (queryZ < 0) startJOffset = 1;
-            if (queryZ > 0) endJOffset = 1;
-
-            for (int i = startJOffset; i <= ceilDepth - endJOffset; ++i) {
-                for (int j = 0; j <= ceilWidth; ++j) {
-                    double cellI = i;
-                    double cellJ = j;
-                    double cellK = queryY < 0 ? 0 : boundingBox.height();
-
-                    if (i >= boundingBox.depth()) cellI = boundingBox.depth();
-                    if (j >= boundingBox.width()) cellJ = boundingBox.width();
-
-                    cellI += boundingBox.minZ();
-                    cellJ += boundingBox.minX();
-                    cellK += boundingBox.minY();
-
-                    facePoints[insertIndex++] = new Vec(cellJ, cellK, cellI);
-                }
-            }
-        }
-        // Z -> X x Y
-        if (queryZ != 0) {
-            for (int i = 0; i <= ceilHeight; ++i) {
-                for (int j = 0; j <= ceilWidth; ++j) {
-                    double cellI = i;
-                    double cellJ = j;
-                    double cellK = queryZ < 0 ? 0 : boundingBox.depth();
-
-                    if (i >= boundingBox.height()) cellI = boundingBox.height();
-                    if (j >= boundingBox.width()) cellJ = boundingBox.width();
-
-                    cellI += boundingBox.minY();
-                    cellJ += boundingBox.minX();
-                    cellK += boundingBox.minZ();
-
-                    facePoints[insertIndex++] = new Vec(cellJ, cellI, cellK);
-                }
-            }
-        }
-
-        return facePoints;
-    }
 }

--- a/src/main/java/net/minestom/server/collision/BlockCollision.java
+++ b/src/main/java/net/minestom/server/collision/BlockCollision.java
@@ -51,97 +51,63 @@ final class BlockCollision {
     private static PhysicsResult stepPhysics(BoundingBox boundingBox,
                                              Vec velocity, Pos entityPosition,
                                              Block.Getter getter, boolean singleCollision) {
-        // Allocate once and update values
-        SweepResult finalResult = new SweepResult(1 - Vec.EPSILON, 0, 0, 0, null, 0, 0, 0, 0, 0, 0);
+        final SweepResult finalResult = new SweepResult(1 - Vec.EPSILON, 0, 0, 0, null, 0, 0, 0, 0, 0, 0);
+        final Point[] collidedPoints = new Point[3];
+        final Shape[] collisionShapes = new Shape[3];
+        final Point[] collisionShapePositions = new Point[3];
 
-        boolean foundCollisionX = false, foundCollisionY = false, foundCollisionZ = false;
+        Pos position = entityPosition;
+        Vec remaining = velocity;
+        // Each sweep advances along `remaining` until the first hit, zeroes
+        // the collided axis, then repeats so the entity slides on the others.
+        while (true) {
+            sweepBlocks(boundingBox, remaining, position, getter, finalResult);
+            double dx = finalResult.res * remaining.x();
+            double dy = finalResult.res * remaining.y();
+            double dz = finalResult.res * remaining.z();
+            if (Math.abs(dx) < Vec.EPSILON) dx = 0;
+            if (Math.abs(dy) < Vec.EPSILON) dy = 0;
+            if (Math.abs(dz) < Vec.EPSILON) dz = 0;
+            position = position.add(dx, dy, dz);
 
-        Point[] collidedPoints = new Point[3];
-        Shape[] collisionShapes = new Shape[3];
-        Point[] collisionShapePositions = new Point[3];
+            // The slab method records the entry face as a single non-zero normal.
+            final int axis;
+            if (finalResult.normalX != 0) axis = 0;
+            else if (finalResult.normalY != 0) axis = 1;
+            else if (finalResult.normalZ != 0) axis = 2;
+            else break; // no collision this pass
 
-        boolean hasCollided = false;
+            collisionShapes[axis] = finalResult.collidedShape;
+            collisionShapePositions[axis] = new Vec(finalResult.collidedShapeX, finalResult.collidedShapeY, finalResult.collidedShapeZ);
+            collidedPoints[axis] = new Vec(finalResult.collidedPositionX, finalResult.collidedPositionY, finalResult.collidedPositionZ);
 
-        PhysicsResult result = computePhysics(boundingBox, velocity, entityPosition, getter, finalResult);
-        // Loop until no collisions are found.
-        // When collisions are found, the collision axis is set to 0
-        // Looping until there are no collisions will allow the entity to move in axis other than the collision axis after a collision.
-        while (result.collisionX() || result.collisionY() || result.collisionZ()) {
-            // Reset final result
+            if (singleCollision || (collisionShapes[0] != null && collisionShapes[1] != null && collisionShapes[2] != null))
+                break;
+
+            remaining = new Vec(
+                    axis == 0 ? 0 : remaining.x() - dx,
+                    axis == 1 ? 0 : remaining.y() - dy,
+                    axis == 2 ? 0 : remaining.z() - dz);
+            if (remaining.isZero()) break;
+
             finalResult.normalX = 0;
             finalResult.normalY = 0;
             finalResult.normalZ = 0;
-
-            if (result.collisionX()) {
-                foundCollisionX = true;
-                collisionShapes[0] = finalResult.collidedShape;
-                collisionShapePositions[0] = new Vec(finalResult.collidedShapeX, finalResult.collidedShapeY, finalResult.collidedShapeZ);
-                collidedPoints[0] = new Vec(finalResult.collidedPositionX, finalResult.collidedPositionY, finalResult.collidedPositionZ);
-                hasCollided = true;
-                if (singleCollision) break;
-            } else if (result.collisionZ()) {
-                foundCollisionZ = true;
-                collisionShapes[2] = finalResult.collidedShape;
-                collisionShapePositions[2] = new Vec(finalResult.collidedShapeX, finalResult.collidedShapeY, finalResult.collidedShapeZ);
-                collidedPoints[2] = new Vec(finalResult.collidedPositionX, finalResult.collidedPositionY, finalResult.collidedPositionZ);
-                hasCollided = true;
-                if (singleCollision) break;
-            } else if (result.collisionY()) {
-                foundCollisionY = true;
-                collisionShapes[1] = finalResult.collidedShape;
-                collisionShapePositions[1] = new Vec(finalResult.collidedShapeX, finalResult.collidedShapeY, finalResult.collidedShapeZ);
-                collidedPoints[1] = new Vec(finalResult.collidedPositionX, finalResult.collidedPositionY, finalResult.collidedPositionZ);
-                hasCollided = true;
-                if (singleCollision) break;
-            }
-
-            // If all axis have had collisions, break
-            if (foundCollisionX && foundCollisionY && foundCollisionZ) break;
-            // If the entity isn't moving, break
-            if (result.newVelocity().isZero()) break;
-
             finalResult.res = 1 - Vec.EPSILON;
-            result = computePhysics(boundingBox, result.newVelocity(), result.newPosition(), getter, finalResult);
         }
 
-        finalResult.res = result.res().res;
-
-        final double newDeltaX = foundCollisionX ? 0 : velocity.x();
-        final double newDeltaY = foundCollisionY ? 0 : velocity.y();
-        final double newDeltaZ = foundCollisionZ ? 0 : velocity.z();
-
-        return new PhysicsResult(result.newPosition(), new Vec(newDeltaX, newDeltaY, newDeltaZ),
-                newDeltaY == 0 && velocity.y() < 0,
-                foundCollisionX, foundCollisionY, foundCollisionZ, velocity, collidedPoints, collisionShapes, collisionShapePositions, hasCollided, finalResult);
-    }
-
-    private static PhysicsResult computePhysics(BoundingBox boundingBox,
-                                                Vec velocity, Pos entityPosition,
-                                                Block.Getter getter,
-                                                SweepResult finalResult) {
-        sweepBlocks(boundingBox, velocity, entityPosition, getter, finalResult);
-
-        final boolean collisionX = finalResult.normalX != 0;
-        final boolean collisionY = finalResult.normalY != 0;
-        final boolean collisionZ = finalResult.normalZ != 0;
-
-        double deltaX = finalResult.res * velocity.x();
-        double deltaY = finalResult.res * velocity.y();
-        double deltaZ = finalResult.res * velocity.z();
-
-        if (Math.abs(deltaX) < Vec.EPSILON) deltaX = 0;
-        if (Math.abs(deltaY) < Vec.EPSILON) deltaY = 0;
-        if (Math.abs(deltaZ) < Vec.EPSILON) deltaZ = 0;
-
-        final Pos finalPos = entityPosition.add(deltaX, deltaY, deltaZ);
-
-        final double remainingX = collisionX ? 0 : velocity.x() - deltaX;
-        final double remainingY = collisionY ? 0 : velocity.y() - deltaY;
-        final double remainingZ = collisionZ ? 0 : velocity.z() - deltaZ;
-
-        return new PhysicsResult(finalPos, new Vec(remainingX, remainingY, remainingZ),
-                collisionY, collisionX, collisionY, collisionZ,
-                Vec.ZERO, null, null, null, false, finalResult);
+        final boolean foundX = collisionShapes[0] != null;
+        final boolean foundY = collisionShapes[1] != null;
+        final boolean foundZ = collisionShapes[2] != null;
+        final Vec newDelta = new Vec(
+                foundX ? 0 : velocity.x(),
+                foundY ? 0 : velocity.y(),
+                foundZ ? 0 : velocity.z());
+        return new PhysicsResult(position, newDelta,
+                foundY && velocity.y() < 0,
+                foundX, foundY, foundZ,
+                velocity, collidedPoints, collisionShapes, collisionShapePositions,
+                foundX || foundY || foundZ, finalResult);
     }
 
     private static void sweepBlocks(BoundingBox boundingBox,
@@ -155,6 +121,7 @@ final class BlockCollision {
         final double endY = startY + velocity.y();
         final double endZ = startZ + velocity.z();
 
+        // Block-aligned bounds of the swept AABB.
         final int minX = (int) Math.floor(Math.min(startX, endX) + boundingBox.minX());
         final int minY = (int) Math.floor(Math.min(startY, endY) + boundingBox.minY());
         final int minZ = (int) Math.floor(Math.min(startZ, endZ) + boundingBox.minZ());
@@ -162,19 +129,18 @@ final class BlockCollision {
         final int maxY = (int) Math.floor(Math.max(startY, endY) + boundingBox.maxY());
         final int maxZ = (int) Math.floor(Math.max(startZ, endZ) + boundingBox.maxZ());
 
+        // Walk from near to far along velocity so finalResult.res tightens early
+        // (later iterations reject more candidates via `percentage <= res`).
         final int stepX = velocity.x() < 0 ? -1 : 1;
         final int stepY = velocity.y() < 0 ? -1 : 1;
         final int stepZ = velocity.z() < 0 ? -1 : 1;
-        final int startBlockX = stepX > 0 ? minX : maxX;
-        final int endBlockX = stepX > 0 ? maxX : minX;
-        final int startBlockY = stepY > 0 ? minY : maxY;
-        final int endBlockY = stepY > 0 ? maxY : minY;
-        final int startBlockZ = stepZ > 0 ? minZ : maxZ;
-        final int endBlockZ = stepZ > 0 ? maxZ : minZ;
+        final int firstX = stepX > 0 ? minX : maxX, lastX = stepX > 0 ? maxX : minX;
+        final int firstY = stepY > 0 ? minY : maxY, lastY = stepY > 0 ? maxY : minY;
+        final int firstZ = stepZ > 0 ? minZ : maxZ, lastZ = stepZ > 0 ? maxZ : minZ;
 
-        for (int x = startBlockX; x != endBlockX + stepX; x += stepX) {
-            for (int y = startBlockY; y != endBlockY + stepY; y += stepY) {
-                for (int z = startBlockZ; z != endBlockZ + stepZ; z += stepZ) {
+        for (int x = firstX; x != lastX + stepX; x += stepX) {
+            for (int y = firstY; y != lastY + stepY; y += stepY) {
+                for (int z = firstZ; z != lastZ + stepZ; z += stepZ) {
                     checkBoundingBox(x, y, z, velocity, entityPosition, boundingBox, getter, finalResult);
                 }
             }
@@ -182,58 +148,44 @@ final class BlockCollision {
     }
 
     /**
-     * Check if a moving entity will collide with a block. Updates finalResult
-     *
-     * @param blockX         block x position
-     * @param blockY         block y position
-     * @param blockZ         block z position
-     * @param entityVelocity entity movement vector
-     * @param entityPosition entity position
-     * @param boundingBox    entity bounding box
-     * @param getter         block getter
-     * @param finalResult    place to store final result of collision
-     * @return true if entity finds collision, other false
+     * Check if a moving entity will collide with a block. Updates finalResult.
+     * Handles the "tall block below" case (fences/walls) when the current shape
+     * is short enough that an entity could be touching the block below.
      */
     static boolean checkBoundingBox(int blockX, int blockY, int blockZ,
                                     Vec entityVelocity, Pos entityPosition, BoundingBox boundingBox,
                                     Block.Getter getter, SweepResult finalResult) {
-        // Don't step if chunk isn't loaded yet
         final Block currentBlock = getter.getBlock(blockX, blockY, blockZ, Block.Getter.Condition.TYPE);
         final Shape currentShape = currentBlock.registry().collisionShape();
-
         final boolean currentCollidable = !currentShape.relativeEnd().isZero();
         final boolean currentShort = currentShape.relativeEnd().y() < 0.5;
 
-        // only consider the block below if our current shape is sufficiently short
         if (currentShort && shouldCheckLower(entityVelocity, entityPosition, blockX, blockY, blockZ)) {
-            // we need to check below for a tall block (fence, wall, ...)
-            final Vec belowPos = new Vec(blockX, blockY - 1, blockZ);
-            final Block belowBlock = getter.getBlock(belowPos, Block.Getter.Condition.TYPE);
-            final Shape belowShape = belowBlock.registry().collisionShape();
-
-            final Vec currentPos = new Vec(blockX, blockY, blockZ);
-            // don't fall out of if statement, we could end up redundantly grabbing a block, and we only need to
-            // collision check against the current shape since the below shape isn't tall
+            // Below block could be a tall shape (fence, wall) extending into this cell.
+            final Shape belowShape = getter.getBlock(blockX, blockY - 1, blockZ, Block.Getter.Condition.TYPE)
+                    .registry().collisionShape();
+            // Always test both shapes here so we never miss the tall one even if the short one hits.
             if (belowShape.relativeEnd().y() > 1) {
-                // we should always check both shapes, so no short-circuit here, to handle properties where the bounding box
-                // hits the current solid but misses the tall solid
-                return belowShape.intersectBoxSwept(entityPosition, entityVelocity, belowPos, boundingBox, finalResult) |
-                        (currentCollidable && currentShape.intersectBoxSwept(entityPosition, entityVelocity, currentPos, boundingBox, finalResult));
-            } else {
-                return currentCollidable && currentShape.intersectBoxSwept(entityPosition, entityVelocity, currentPos, boundingBox, finalResult);
+                final boolean belowHit = belowShape.intersectBoxSwept(entityPosition, entityVelocity,
+                        blockX, blockY - 1, blockZ, boundingBox, finalResult);
+                final boolean currentHit = currentCollidable && currentShape.intersectBoxSwept(entityPosition, entityVelocity,
+                        blockX, blockY, blockZ, boundingBox, finalResult);
+                return belowHit | currentHit;
             }
+            return currentCollidable && currentShape.intersectBoxSwept(entityPosition, entityVelocity,
+                    blockX, blockY, blockZ, boundingBox, finalResult);
         }
 
         if (currentCollidable && currentShape.intersectBoxSwept(entityPosition, entityVelocity,
-                new Vec(blockX, blockY, blockZ), boundingBox, finalResult)) {
-            // if the current collision is sufficiently short, we might need to collide against the block below too
+                blockX, blockY, blockZ, boundingBox, finalResult)) {
+            // If the current collision is sufficiently short, we might also need to collide against the block below.
             if (currentShort) {
-                final Vec belowPos = new Vec(blockX, blockY - 1, blockZ);
-                final Block belowBlock = getter.getBlock(belowPos, Block.Getter.Condition.TYPE);
-                final Shape belowShape = belowBlock.registry().collisionShape();
-                // only do sweep if the below block is big enough to possibly hit
-                if (belowShape.relativeEnd().y() > 1)
-                    belowShape.intersectBoxSwept(entityPosition, entityVelocity, belowPos, boundingBox, finalResult);
+                final Shape belowShape = getter.getBlock(blockX, blockY - 1, blockZ, Block.Getter.Condition.TYPE)
+                        .registry().collisionShape();
+                if (belowShape.relativeEnd().y() > 1) {
+                    belowShape.intersectBoxSwept(entityPosition, entityVelocity,
+                            blockX, blockY - 1, blockZ, boundingBox, finalResult);
+                }
             }
             return true;
         }
@@ -253,8 +205,7 @@ final class BlockCollision {
         // default to true: if no x velocity, only consider YZ line, and vice-versa
         final boolean underYX = xVelocity != 0 && computeHeight(yVelocity, xVelocity, entityPosition.y(), entityPosition.x(), blockX) >= blockY;
         final boolean underYZ = zVelocity != 0 && computeHeight(yVelocity, zVelocity, entityPosition.y(), entityPosition.z(), blockZ) >= blockY;
-        // true if the block is at or below the same height as a line drawn from the entity's position to its final
-        // destination
+        // true if the block is at or below the same height as a line drawn from the entity's position to its final destination
         return underYX && underYZ;
     }
 

--- a/src/main/java/net/minestom/server/collision/BlockCollision.java
+++ b/src/main/java/net/minestom/server/collision/BlockCollision.java
@@ -7,6 +7,7 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.Player;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
+import org.jetbrains.annotations.Nullable;
 
 final class BlockCollision {
     /**
@@ -27,7 +28,7 @@ final class BlockCollision {
         return stepPhysics(boundingBox, velocity, entityPosition, getter, singleCollision);
     }
 
-    static Entity canPlaceBlockAt(Instance instance, Point blockPos, Block b) {
+    static @Nullable Entity canPlaceBlockAt(Instance instance, Point blockPos, Block b) {
         for (Entity entity : instance.getNearbyEntities(blockPos, 3)) {
             if (!entity.preventBlockPlacement())
                 continue;

--- a/src/main/java/net/minestom/server/collision/BoundingBox.java
+++ b/src/main/java/net/minestom/server/collision/BoundingBox.java
@@ -42,18 +42,7 @@ public record BoundingBox(Vec relativeStart, Vec relativeEnd) implements Shape {
 
     @Override
     public boolean intersectBoxSwept(Point rayStart, Point rayDirection, Point shapePos, BoundingBox moving, SweepResult finalResult) {
-        if (RayUtils.BoundingBoxIntersectionCheck(moving, rayStart, rayDirection, this, shapePos, finalResult)) {
-            finalResult.collidedPositionX = rayStart.x() + rayDirection.x() * finalResult.res;
-            finalResult.collidedPositionY = rayStart.y() + rayDirection.y() * finalResult.res;
-            finalResult.collidedPositionZ = rayStart.z() + rayDirection.z() * finalResult.res;
-            finalResult.collidedShapeX = shapePos.x();
-            finalResult.collidedShapeY = shapePos.y();
-            finalResult.collidedShapeZ = shapePos.z();
-            finalResult.collidedShape = this;
-            return true;
-        }
-
-        return false;
+        return RayUtils.BoundingBoxIntersectionCheck(this, moving, rayStart, rayDirection, this, shapePos, finalResult);
     }
 
     public boolean boundingBoxRayIntersectionCheck(Vec start, Vec direction, Pos position) {

--- a/src/main/java/net/minestom/server/collision/BoundingBox.java
+++ b/src/main/java/net/minestom/server/collision/BoundingBox.java
@@ -42,7 +42,16 @@ public record BoundingBox(Vec relativeStart, Vec relativeEnd) implements Shape {
 
     @Override
     public boolean intersectBoxSwept(Point rayStart, Point rayDirection, Point shapePos, BoundingBox moving, SweepResult finalResult) {
-        return RayUtils.BoundingBoxIntersectionCheck(this, moving, rayStart, rayDirection, this, shapePos, finalResult);
+        return RayUtils.BoundingBoxIntersectionCheck(this, moving, rayStart, rayDirection, this,
+                shapePos.x(), shapePos.y(), shapePos.z(), finalResult);
+    }
+
+    @Override
+    public boolean intersectBoxSwept(Point rayStart, Point rayDirection,
+                                     double shapeX, double shapeY, double shapeZ,
+                                     BoundingBox moving, SweepResult finalResult) {
+        return RayUtils.BoundingBoxIntersectionCheck(this, moving, rayStart, rayDirection, this,
+                shapeX, shapeY, shapeZ, finalResult);
     }
 
     public boolean boundingBoxRayIntersectionCheck(Vec start, Vec direction, Pos position) {

--- a/src/main/java/net/minestom/server/collision/CollisionUtils.java
+++ b/src/main/java/net/minestom/server/collision/CollisionUtils.java
@@ -20,28 +20,6 @@ import java.util.function.Function;
 public final class CollisionUtils {
 
     /**
-     * Moves an entity with physics applied (ie checking against blocks)
-     * <p>
-     * Works by getting all the full blocks that an entity could interact with.
-     * All bounding boxes inside the full blocks are checked for collisions with the entity.
-     *
-     * @param entity            the entity to move
-     * @param entityVelocity    the velocity of the entity
-     * @param lastPhysicsResult the last physics result, can be null
-     * @param singleCollision   if the entity should only collide with one block
-     * @return the result of physics simulation
-     */
-    public static PhysicsResult handlePhysics(Entity entity, Vec entityVelocity,
-                                              @Nullable PhysicsResult lastPhysicsResult, boolean singleCollision) {
-        final Instance instance = entity.getInstance();
-        assert instance != null;
-        return handlePhysics(instance, entity.getChunk(),
-                entity.getBoundingBox(),
-                entity.getPosition(), entityVelocity,
-                lastPhysicsResult, singleCollision);
-    }
-
-    /**
      * Checks for entity collisions
      *
      * @param velocity     the velocity of the entity
@@ -69,27 +47,6 @@ public final class CollisionUtils {
     }
 
     /**
-     * Moves an entity with physics applied (ie checking against blocks)
-     * <p>
-     * Works by getting all the full blocks that an entity could interact with.
-     * All bounding boxes inside the full blocks are checked for collisions with the entity.
-     *
-     * @param entity            the entity to move
-     * @param entityVelocity    the velocity of the entity
-     * @param lastPhysicsResult the last physics result, can be null
-     * @return the result of physics simulation
-     */
-    public static PhysicsResult handlePhysics(Entity entity, Vec entityVelocity,
-                                              @Nullable PhysicsResult lastPhysicsResult) {
-        final Instance instance = entity.getInstance();
-        assert instance != null;
-        return handlePhysics(instance, entity.getChunk(),
-                entity.getBoundingBox(),
-                entity.getPosition(), entityVelocity,
-                lastPhysicsResult, false);
-    }
-
-    /**
      * Moves bounding box with physics applied (ie checking against blocks)
      * <p>
      * Works by getting all the full blocks that a bounding box could interact with.
@@ -101,9 +58,9 @@ public final class CollisionUtils {
     public static PhysicsResult handlePhysics(Instance instance, @Nullable Chunk chunk,
                                               BoundingBox boundingBox,
                                               Pos position, Vec velocity,
-                                              @Nullable PhysicsResult lastPhysicsResult, boolean singleCollision) {
+                                              boolean singleCollision) {
         final Block.Getter getter = new ChunkCache(instance, chunk != null ? chunk : instance.getChunkAt(position), Block.STONE);
-        return handlePhysics(getter, boundingBox, position, velocity, lastPhysicsResult, singleCollision);
+        return handlePhysics(getter, boundingBox, position, velocity, singleCollision);
     }
 
     /**
@@ -119,10 +76,10 @@ public final class CollisionUtils {
     public static PhysicsResult handlePhysics(Block.Getter blockGetter,
                                               BoundingBox boundingBox,
                                               Pos position, Vec velocity,
-                                              @Nullable PhysicsResult lastPhysicsResult, boolean singleCollision) {
+                                              boolean singleCollision) {
         return BlockCollision.handlePhysics(boundingBox,
                 velocity, position,
-                blockGetter, lastPhysicsResult, singleCollision);
+                blockGetter, singleCollision);
     }
 
     /**
@@ -142,13 +99,18 @@ public final class CollisionUtils {
                                                      Shape shape, Point shapePos) {
         final PhysicsResult result = handlePhysics(instance, chunk,
                 BoundingBox.ZERO, start.asPos(), end.sub(start).asVec(),
-                null, false);
+                false);
 
         return shape.intersectBox(shapePos.sub(result.newPosition()).sub(Vec.EPSILON), BoundingBox.ZERO);
     }
 
     public static PhysicsResult handlePhysics(Entity entity, Vec entityVelocity) {
-        return handlePhysics(entity, entityVelocity, null);
+        final Instance instance = entity.getInstance();
+        assert instance != null;
+        return handlePhysics(instance, entity.getChunk(),
+                entity.getBoundingBox(),
+                entity.getPosition(), entityVelocity,
+                false);
     }
 
     public static Entity canPlaceBlockAt(Instance instance, Point blockPos, Block b) {

--- a/src/main/java/net/minestom/server/collision/EntityCollision.java
+++ b/src/main/java/net/minestom/server/collision/EntityCollision.java
@@ -16,27 +16,31 @@ final class EntityCollision {
 
         List<EntityCollisionResult> result = new ArrayList<>();
 
-        var maxDistance = Math.pow(boundingBox.height() * boundingBox.height() + boundingBox.depth() / 2 * boundingBox.depth() / 2 + boundingBox.width() / 2 * boundingBox.width() / 2, 1 / 3.0);
-        double projectileDistance = entityVelocity.length();
+        final double halfWidth = boundingBox.width() / 2;
+        final double halfDepth = boundingBox.depth() / 2;
+        final double maxDistance = Math.pow(boundingBox.height() * boundingBox.height() + halfDepth * halfDepth + halfWidth * halfWidth, 1 / 3.0);
+        final double projectileDistance = entityVelocity.length();
+        final var startPosition = point.asPos();
 
         for (Entity e : instance.getNearbyEntities(point, extendRadius + maxDistance + projectileDistance)) {
-            SweepResult sweepResult = new SweepResult(minimumRes, 0, 0, 0, null, 0, 0, 0, 0, 0, 0);
-
             if (!entityFilter.apply(e)) continue;
             if (!e.hasEntityCollision()) continue;
 
+            final BoundingBox targetBoundingBox = e.getBoundingBox();
+            final Point targetPosition = e.getPosition();
+
             // Overlapping with entity, math can't be done we return the entity
-            if (e.getBoundingBox().intersectBox(e.getPosition().sub(point), boundingBox)) {
-                var p = point.asPos();
-                result.add(new EntityCollisionResult(p, e, Vec.ZERO, 0));
+            if (targetBoundingBox.intersectBox(targetPosition.sub(point), boundingBox)) {
+                result.add(new EntityCollisionResult(startPosition, e, Vec.ZERO, 0));
                 continue;
             }
 
             // Check collisions with entity
-            boolean intersected = e.getBoundingBox().intersectBoxSwept(point, entityVelocity, e.getPosition(), boundingBox, sweepResult);
+            SweepResult sweepResult = new SweepResult(minimumRes, 0, 0, 0, null, 0, 0, 0, 0, 0, 0);
+            boolean intersected = targetBoundingBox.intersectBoxSwept(point, entityVelocity, targetPosition, boundingBox, sweepResult);
 
             if (intersected && sweepResult.res < 1) {
-                var p = point.asPos().add(entityVelocity.mul(sweepResult.res));
+                var p = startPosition.add(entityVelocity.mul(sweepResult.res));
                 Vec direction = new Vec(sweepResult.collidedPositionX, sweepResult.collidedPositionY, sweepResult.collidedPositionZ);
                 result.add(new EntityCollisionResult(p, e, direction, sweepResult.res));
             }

--- a/src/main/java/net/minestom/server/collision/EntityCollision.java
+++ b/src/main/java/net/minestom/server/collision/EntityCollision.java
@@ -37,7 +37,8 @@ final class EntityCollision {
 
             // Check collisions with entity
             SweepResult sweepResult = new SweepResult(minimumRes, 0, 0, 0, null, 0, 0, 0, 0, 0, 0);
-            boolean intersected = targetBoundingBox.intersectBoxSwept(point, entityVelocity, targetPosition, boundingBox, sweepResult);
+            boolean intersected = targetBoundingBox.intersectBoxSwept(point, entityVelocity,
+                    targetPosition.x(), targetPosition.y(), targetPosition.z(), boundingBox, sweepResult);
 
             if (intersected && sweepResult.res < 1) {
                 var p = startPosition.add(entityVelocity.mul(sweepResult.res));

--- a/src/main/java/net/minestom/server/collision/PhysicsResult.java
+++ b/src/main/java/net/minestom/server/collision/PhysicsResult.java
@@ -20,7 +20,6 @@ import org.jetbrains.annotations.UnknownNullability;
  * @param collisionShapePositions the positions of the shapes the entity collided with
  * @param hasCollision if the entity collided
  * @param res sweep result of the collision
- * @param cached if the result was due to quickly exiting
  */
 @ApiStatus.Experimental
 public record PhysicsResult(
@@ -35,10 +34,6 @@ public record PhysicsResult(
         @UnknownNullability Shape @UnknownNullability [] collisionShapes,
         @UnknownNullability Point @UnknownNullability [] collisionShapePositions,
         boolean hasCollision,
-        SweepResult res,
-        boolean cached
+        SweepResult res
 ) {
-    public PhysicsResult(Pos newPosition, Vec newVelocity, boolean isOnGround, boolean collisionX, boolean collisionY, boolean collisionZ, Vec originalDelta, Point[] collisionPoints, Shape[] collisionShapes, Point[] collisionShapePositions, boolean hasCollision, SweepResult res) {
-        this(newPosition, newVelocity, isOnGround, collisionX, collisionY, collisionZ, originalDelta, collisionPoints, collisionShapes, collisionShapePositions, hasCollision, res, false);
-    }
 }

--- a/src/main/java/net/minestom/server/collision/PhysicsUtils.java
+++ b/src/main/java/net/minestom/server/collision/PhysicsUtils.java
@@ -4,7 +4,6 @@ import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.WorldBorder;
 import net.minestom.server.instance.block.Block;
-import org.jetbrains.annotations.Nullable;
 
 public final class PhysicsUtils {
     /**
@@ -24,14 +23,13 @@ public final class PhysicsUtils {
      * @param entityHasPhysics whether the entity has physics
      * @param entityOnGround whether the entity is on the ground
      * @param entityFlying whether the entity is flying
-     * @param previousPhysicsResult the physics result from the previous simulation or null
      * @return a {@link PhysicsResult} containing the resulting physics state of this simulation
      */
     public static PhysicsResult simulateMovement(Pos entityPosition, Vec entityVelocityPerTick, BoundingBox entityBoundingBox,
                                                           WorldBorder worldBorder, Block.Getter blockGetter, Aerodynamics aerodynamics, boolean entityNoGravity,
-                                                          boolean entityHasPhysics, boolean entityOnGround, boolean entityFlying, @Nullable PhysicsResult previousPhysicsResult) {
+                                                          boolean entityHasPhysics, boolean entityOnGround, boolean entityFlying) {
         final PhysicsResult physicsResult = entityHasPhysics ?
-                CollisionUtils.handlePhysics(blockGetter, entityBoundingBox, entityPosition, entityVelocityPerTick, previousPhysicsResult, false) :
+                CollisionUtils.handlePhysics(blockGetter, entityBoundingBox, entityPosition, entityVelocityPerTick, false) :
                 CollisionUtils.blocklessCollision(entityPosition, entityVelocityPerTick);
 
         Pos newPosition = physicsResult.newPosition();
@@ -40,10 +38,8 @@ public final class PhysicsUtils {
         Pos positionWithinBorder = CollisionUtils.applyWorldBorder(worldBorder, entityPosition, newPosition);
         newVelocity = updateVelocity(positionWithinBorder, newVelocity, blockGetter, aerodynamics, !positionWithinBorder.samePoint(entityPosition), entityFlying, entityOnGround, entityNoGravity);
 
-        final boolean stillCached = physicsResult.cached() && newVelocity.samePoint(physicsResult.newVelocity()) && positionWithinBorder.samePoint(physicsResult.newPosition());
-
         return new PhysicsResult(positionWithinBorder, newVelocity, physicsResult.isOnGround(), physicsResult.collisionX(), physicsResult.collisionY(), physicsResult.collisionZ(),
-                physicsResult.originalDelta(), physicsResult.collisionPoints(), physicsResult.collisionShapes(), physicsResult.collisionShapePositions(), physicsResult.hasCollision(), physicsResult.res(), stillCached);
+                physicsResult.originalDelta(), physicsResult.collisionPoints(), physicsResult.collisionShapes(), physicsResult.collisionShapePositions(), physicsResult.hasCollision(), physicsResult.res());
     }
 
     /**

--- a/src/main/java/net/minestom/server/collision/RayUtils.java
+++ b/src/main/java/net/minestom/server/collision/RayUtils.java
@@ -5,175 +5,119 @@ import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
 
 final class RayUtils {
+
     /**
-     * Check if a bounding box intersects a ray
+     * Swept AABB-vs-AABB intersection via the slab method.
+     * <p>
+     * The moving box is treated as a point by expanding the static box by the
+     * moving box's half-extents (Minkowski sum) and intersecting the ray with
+     * the expanded box. If a hit is found that improves on the current
+     * {@code finalResult.res}, the result is updated with the new percentage,
+     * the axis-aligned entry-face normal, the world-space hit position and
+     * a reference to the colliding shape.
      *
-     * @param rayStart         Ray start position
-     * @param rayDirection     Ray to check
-     * @param collidableStatic Bounding box
-     * @param finalResult
-     * @return true if an intersection between the ray and the bounding box was found
+     * @param shape the shape that owns {@code collidableStatic} (recorded on hit)
+     * @return true iff {@code finalResult} was updated
      */
-    public static boolean BoundingBoxIntersectionCheck(BoundingBox moving, Point rayStart, Point rayDirection, BoundingBox collidableStatic, Point staticCollidableOffset, SweepResult finalResult) {
-        Point bbCentre = new Vec(moving.minX() + moving.width() / 2, moving.minY() + moving.height() / 2, moving.minZ() + moving.depth() / 2);
-        Point rayCentre = rayStart.add(bbCentre);
+    public static boolean BoundingBoxIntersectionCheck(Shape shape,
+                                                       BoundingBox moving, Point rayStart, Point rayDirection,
+                                                       BoundingBox collidableStatic, Point staticOffset,
+                                                       SweepResult finalResult) {
+        // Moving box origin (in its own frame) and half-extents
+        final double mMinX = moving.minX(), mMinY = moving.minY(), mMinZ = moving.minZ();
+        final double mw2 = (moving.maxX() - mMinX) * 0.5;
+        final double mh2 = (moving.maxY() - mMinY) * 0.5;
+        final double md2 = (moving.maxZ() - mMinZ) * 0.5;
 
-        // Translate bounding box
-        Vec bbOffMin = new Vec(collidableStatic.minX() - rayCentre.x() + staticCollidableOffset.x() - moving.width() / 2, collidableStatic.minY() - rayCentre.y() + staticCollidableOffset.y() - moving.height() / 2, collidableStatic.minZ() - rayCentre.z() + staticCollidableOffset.z() - moving.depth() / 2);
-        Vec bbOffMax = new Vec(collidableStatic.maxX() - rayCentre.x() + staticCollidableOffset.x() + moving.width() / 2, collidableStatic.maxY() - rayCentre.y() + staticCollidableOffset.y() + moving.height() / 2, collidableStatic.maxZ() - rayCentre.z() + staticCollidableOffset.z() + moving.depth() / 2);
+        // Expanded static box bounds (Minkowski sum) in world space
+        final double sx = staticOffset.x(), sy = staticOffset.y(), sz = staticOffset.z();
+        final double minX = sx + collidableStatic.minX() - mw2;
+        final double maxX = sx + collidableStatic.maxX() + mw2;
+        final double minY = sy + collidableStatic.minY() - mh2;
+        final double maxY = sy + collidableStatic.maxY() + mh2;
+        final double minZ = sz + collidableStatic.minZ() - md2;
+        final double maxZ = sz + collidableStatic.maxZ() + md2;
 
-        // This check is done in 2d. it can be visualised as a rectangle (the face we are checking), and a point.
-        // If the point is within the rectangle, we know the vector intersects the face.
+        // Ray origin = moving box centre in world space
+        final double rsx = rayStart.x(), rsy = rayStart.y(), rsz = rayStart.z();
+        final double rx = rsx + mMinX + mw2;
+        final double ry = rsy + mMinY + mh2;
+        final double rz = rsz + mMinZ + md2;
 
-        double signumRayX = Math.signum(rayDirection.x());
-        double signumRayY = Math.signum(rayDirection.y());
-        double signumRayZ = Math.signum(rayDirection.z());
+        final double dx = rayDirection.x();
+        final double dy = rayDirection.y();
+        final double dz = rayDirection.z();
 
-        boolean isHit = false;
-        double percentage = Double.MAX_VALUE;
-        int collisionFace = -1;
-
-        // Intersect X
-        // Left side of bounding box
-        if (rayDirection.x() > 0) {
-            double xFac = epsilon(bbOffMin.x() / rayDirection.x());
-            if (xFac < percentage) {
-                double yix = rayDirection.y() * xFac + rayCentre.y();
-                double zix = rayDirection.z() * xFac + rayCentre.z();
-
-                // Check if ray passes through y/z plane
-                if (((yix - rayCentre.y()) * signumRayY) >= 0
-                        && ((zix - rayCentre.z()) * signumRayZ) >= 0
-                        && yix >= collidableStatic.minY() + staticCollidableOffset.y() - moving.height() / 2
-                        && yix <= collidableStatic.maxY() + staticCollidableOffset.y() + moving.height() / 2
-                        && zix >= collidableStatic.minZ() + staticCollidableOffset.z() - moving.depth() / 2
-                        && zix <= collidableStatic.maxZ() + staticCollidableOffset.z() + moving.depth() / 2) {
-                    isHit = true;
-                    percentage = xFac;
-                    collisionFace = 0;
-                }
-            }
+        // Per-axis slab intervals.
+        // For zero-velocity axes, the ray is parallel to the slab so an
+        // overlap requires the origin to lie within the slab.
+        final double tMinX, tMaxX;
+        if (dx == 0) {
+            if (rx < minX || rx > maxX) return false;
+            tMinX = Double.NEGATIVE_INFINITY;
+            tMaxX = Double.POSITIVE_INFINITY;
+        } else {
+            double t1 = (minX - rx) / dx;
+            double t2 = (maxX - rx) / dx;
+            // Snap near-zero values: forgives the "just past the face" case
+            // that legacy behavior accepted via the same epsilon clamp.
+            if (Math.abs(t1) < Vec.EPSILON) t1 = 0;
+            if (Math.abs(t2) < Vec.EPSILON) t2 = 0;
+            if (t1 > t2) { tMinX = t2; tMaxX = t1; } else { tMinX = t1; tMaxX = t2; }
         }
-        // Right side of bounding box
-        if (rayDirection.x() < 0) {
-            double xFac = epsilon(bbOffMax.x() / rayDirection.x());
-            if (xFac < percentage) {
-                double yix = rayDirection.y() * xFac + rayCentre.y();
-                double zix = rayDirection.z() * xFac + rayCentre.z();
-
-                if (((yix - rayCentre.y()) * signumRayY) >= 0
-                        && ((zix - rayCentre.z()) * signumRayZ) >= 0
-                        && yix >= collidableStatic.minY() + staticCollidableOffset.y() - moving.height() / 2
-                        && yix <= collidableStatic.maxY() + staticCollidableOffset.y() + moving.height() / 2
-                        && zix >= collidableStatic.minZ() + staticCollidableOffset.z() - moving.depth() / 2
-                        && zix <= collidableStatic.maxZ() + staticCollidableOffset.z() + moving.depth() / 2) {
-                    isHit = true;
-                    percentage = xFac;
-                    collisionFace = 0;
-                }
-            }
+        final double tMinY, tMaxY;
+        if (dy == 0) {
+            if (ry < minY || ry > maxY) return false;
+            tMinY = Double.NEGATIVE_INFINITY;
+            tMaxY = Double.POSITIVE_INFINITY;
+        } else {
+            double t1 = (minY - ry) / dy;
+            double t2 = (maxY - ry) / dy;
+            if (Math.abs(t1) < Vec.EPSILON) t1 = 0;
+            if (Math.abs(t2) < Vec.EPSILON) t2 = 0;
+            if (t1 > t2) { tMinY = t2; tMaxY = t1; } else { tMinY = t1; tMaxY = t2; }
         }
-
-        // Intersect Z
-        if (rayDirection.z() > 0) {
-            double zFac = epsilon(bbOffMin.z() / rayDirection.z());
-            if (zFac < percentage) {
-                double xiz = rayDirection.x() * zFac + rayCentre.x();
-                double yiz = rayDirection.y() * zFac + rayCentre.y();
-
-                if (((yiz - rayCentre.y()) * signumRayY) >= 0
-                        && ((xiz - rayCentre.x()) * signumRayX) >= 0
-                        && xiz >= collidableStatic.minX() + staticCollidableOffset.x() - moving.width() / 2
-                        && xiz <= collidableStatic.maxX() + staticCollidableOffset.x() + moving.width() / 2
-                        && yiz >= collidableStatic.minY() + staticCollidableOffset.y() - moving.height() / 2
-                        && yiz <= collidableStatic.maxY() + staticCollidableOffset.y() + moving.height() / 2) {
-                    isHit = true;
-                    percentage = zFac;
-                    collisionFace = 1;
-                }
-            }
-        }
-        if (rayDirection.z() < 0) {
-            double zFac = epsilon(bbOffMax.z() / rayDirection.z());
-            if (zFac < percentage) {
-                double xiz = rayDirection.x() * zFac + rayCentre.x();
-                double yiz = rayDirection.y() * zFac + rayCentre.y();
-
-                if (((yiz - rayCentre.y()) * signumRayY) >= 0
-                        && ((xiz - rayCentre.x()) * signumRayX) >= 0
-                        && xiz >= collidableStatic.minX() + staticCollidableOffset.x() - moving.width() / 2
-                        && xiz <= collidableStatic.maxX() + staticCollidableOffset.x() + moving.width() / 2
-                        && yiz >= collidableStatic.minY() + staticCollidableOffset.y() - moving.height() / 2
-                        && yiz <= collidableStatic.maxY() + staticCollidableOffset.y() + moving.height() / 2) {
-                    isHit = true;
-                    percentage = zFac;
-                    collisionFace = 1;
-                }
-            }
+        final double tMinZ, tMaxZ;
+        if (dz == 0) {
+            if (rz < minZ || rz > maxZ) return false;
+            tMinZ = Double.NEGATIVE_INFINITY;
+            tMaxZ = Double.POSITIVE_INFINITY;
+        } else {
+            double t1 = (minZ - rz) / dz;
+            double t2 = (maxZ - rz) / dz;
+            if (Math.abs(t1) < Vec.EPSILON) t1 = 0;
+            if (Math.abs(t2) < Vec.EPSILON) t2 = 0;
+            if (t1 > t2) { tMinZ = t2; tMaxZ = t1; } else { tMinZ = t1; tMaxZ = t2; }
         }
 
-        // Intersect Y
-        if (rayDirection.y() > 0) {
-            double yFac = epsilon(bbOffMin.y() / rayDirection.y());
-            if (yFac < percentage) {
-                double xiy = rayDirection.x() * yFac + rayCentre.x();
-                double ziy = rayDirection.z() * yFac + rayCentre.z();
+        // Entry t and axis. Tie-break order X > Z > Y matches legacy face precedence.
+        double tNear = tMinX;
+        int face = 0;
+        if (tMinZ > tNear) { tNear = tMinZ; face = 1; }
+        if (tMinY > tNear) { tNear = tMinY; face = 2; }
+        final double tFar = Math.min(Math.min(tMaxX, tMaxY), tMaxZ);
+        // NaN-safe: any NaN makes both comparisons false, returning here.
+        if (!(tNear <= tFar)) return false;
 
-                if (((ziy - rayCentre.z()) * signumRayZ) >= 0
-                        && ((xiy - rayCentre.x()) * signumRayX) >= 0
-                        && xiy >= collidableStatic.minX() + staticCollidableOffset.x() - moving.width() / 2
-                        && xiy <= collidableStatic.maxX() + staticCollidableOffset.x() + moving.width() / 2
-                        && ziy >= collidableStatic.minZ() + staticCollidableOffset.z() - moving.depth() / 2
-                        && ziy <= collidableStatic.maxZ() + staticCollidableOffset.z() + moving.depth() / 2) {
-                    isHit = true;
-                    percentage = yFac;
-                    collisionFace = 2;
-                }
-            }
-        }
+        final double percentage = tNear * 0.99999;
+        if (!(percentage >= 0 && percentage <= finalResult.res)) return false;
 
-        if (rayDirection.y() < 0) {
-            double yFac = epsilon(bbOffMax.y() / rayDirection.y());
-            if (yFac < percentage) {
-                double xiy = rayDirection.x() * yFac + rayCentre.x();
-                double ziy = rayDirection.z() * yFac + rayCentre.z();
-
-                if (((ziy - rayCentre.z()) * signumRayZ) >= 0
-                        && ((xiy - rayCentre.x()) * signumRayX) >= 0
-                        && xiy >= collidableStatic.minX() + staticCollidableOffset.x() - moving.width() / 2
-                        && xiy <= collidableStatic.maxX() + staticCollidableOffset.x() + moving.width() / 2
-                        && ziy >= collidableStatic.minZ() + staticCollidableOffset.z() - moving.depth() / 2
-                        && ziy <= collidableStatic.maxZ() + staticCollidableOffset.z() + moving.depth() / 2) {
-                    isHit = true;
-                    percentage = yFac;
-                    collisionFace = 2;
-                }
-            }
-        }
-
-        percentage *= 0.99999;
-
-        if (isHit && percentage >= 0 && percentage <= finalResult.res) {
-            finalResult.res = percentage;
-            finalResult.normalX = 0;
-            finalResult.normalY = 0;
-            finalResult.normalZ = 0;
-
-            if (collisionFace == 0) finalResult.normalX = 1;
-            if (collisionFace == 1) finalResult.normalZ = 1;
-            if (collisionFace == 2) finalResult.normalY = 1;
-
-            return true;
-        }
-
-        return false;
-    }
-
-    private static double epsilon(double value) {
-        return Math.abs(value) < Vec.EPSILON ? 0 : value;
+        finalResult.res = percentage;
+        finalResult.normalX = (face == 0) ? 1 : 0;
+        finalResult.normalY = (face == 2) ? 1 : 0;
+        finalResult.normalZ = (face == 1) ? 1 : 0;
+        finalResult.collidedPositionX = rsx + dx * percentage;
+        finalResult.collidedPositionY = rsy + dy * percentage;
+        finalResult.collidedPositionZ = rsz + dz * percentage;
+        finalResult.collidedShapeX = sx;
+        finalResult.collidedShapeY = sy;
+        finalResult.collidedShapeZ = sz;
+        finalResult.collidedShape = shape;
+        return true;
     }
 
     public static boolean BoundingBoxRayIntersectionCheck(Vec start, Vec direction, BoundingBox boundingBox, Pos position) {
-        return BoundingBoxIntersectionCheck(BoundingBox.ZERO, start, direction, boundingBox, position, new SweepResult(Double.MAX_VALUE, 0, 0, 0, null, 0, 0, 0, 0, 0, 0));
+        return BoundingBoxIntersectionCheck(boundingBox, BoundingBox.ZERO, start, direction, boundingBox, position,
+                new SweepResult(Double.MAX_VALUE, 0, 0, 0, null, 0, 0, 0, 0, 0, 0));
     }
 }

--- a/src/main/java/net/minestom/server/collision/RayUtils.java
+++ b/src/main/java/net/minestom/server/collision/RayUtils.java
@@ -19,10 +19,11 @@ final class RayUtils {
      * @param shape the shape that owns {@code collidableStatic} (recorded on hit)
      * @return true iff {@code finalResult} was updated
      */
-    public static boolean BoundingBoxIntersectionCheck(Shape shape,
-                                                       BoundingBox moving, Point rayStart, Point rayDirection,
-                                                       BoundingBox collidableStatic, Point staticOffset,
-                                                       SweepResult finalResult) {
+    static boolean BoundingBoxIntersectionCheck(Shape shape,
+                                                BoundingBox moving, Point rayStart, Point rayDirection,
+                                                BoundingBox collidableStatic,
+                                                double sx, double sy, double sz,
+                                                SweepResult finalResult) {
         // Moving box origin (in its own frame) and half-extents
         final double mMinX = moving.minX(), mMinY = moving.minY(), mMinZ = moving.minZ();
         final double mw2 = (moving.maxX() - mMinX) * 0.5;
@@ -30,7 +31,6 @@ final class RayUtils {
         final double md2 = (moving.maxZ() - mMinZ) * 0.5;
 
         // Expanded static box bounds (Minkowski sum) in world space
-        final double sx = staticOffset.x(), sy = staticOffset.y(), sz = staticOffset.z();
         final double minX = sx + collidableStatic.minX() - mw2;
         final double maxX = sx + collidableStatic.maxX() + mw2;
         final double minY = sy + collidableStatic.minY() - mh2;
@@ -63,7 +63,13 @@ final class RayUtils {
             // that legacy behavior accepted via the same epsilon clamp.
             if (Math.abs(t1) < Vec.EPSILON) t1 = 0;
             if (Math.abs(t2) < Vec.EPSILON) t2 = 0;
-            if (t1 > t2) { tMinX = t2; tMaxX = t1; } else { tMinX = t1; tMaxX = t2; }
+            if (t1 > t2) {
+                tMinX = t2;
+                tMaxX = t1;
+            } else {
+                tMinX = t1;
+                tMaxX = t2;
+            }
         }
         final double tMinY, tMaxY;
         if (dy == 0) {
@@ -75,7 +81,13 @@ final class RayUtils {
             double t2 = (maxY - ry) / dy;
             if (Math.abs(t1) < Vec.EPSILON) t1 = 0;
             if (Math.abs(t2) < Vec.EPSILON) t2 = 0;
-            if (t1 > t2) { tMinY = t2; tMaxY = t1; } else { tMinY = t1; tMaxY = t2; }
+            if (t1 > t2) {
+                tMinY = t2;
+                tMaxY = t1;
+            } else {
+                tMinY = t1;
+                tMaxY = t2;
+            }
         }
         final double tMinZ, tMaxZ;
         if (dz == 0) {
@@ -87,14 +99,26 @@ final class RayUtils {
             double t2 = (maxZ - rz) / dz;
             if (Math.abs(t1) < Vec.EPSILON) t1 = 0;
             if (Math.abs(t2) < Vec.EPSILON) t2 = 0;
-            if (t1 > t2) { tMinZ = t2; tMaxZ = t1; } else { tMinZ = t1; tMaxZ = t2; }
+            if (t1 > t2) {
+                tMinZ = t2;
+                tMaxZ = t1;
+            } else {
+                tMinZ = t1;
+                tMaxZ = t2;
+            }
         }
 
         // Entry t and axis. Tie-break order X > Z > Y matches legacy face precedence.
         double tNear = tMinX;
         int face = 0;
-        if (tMinZ > tNear) { tNear = tMinZ; face = 1; }
-        if (tMinY > tNear) { tNear = tMinY; face = 2; }
+        if (tMinZ > tNear) {
+            tNear = tMinZ;
+            face = 1;
+        }
+        if (tMinY > tNear) {
+            tNear = tMinY;
+            face = 2;
+        }
         final double tFar = Math.min(Math.min(tMaxX, tMaxY), tMaxZ);
         // NaN-safe: any NaN makes both comparisons false, returning here.
         if (!(tNear <= tFar)) return false;
@@ -116,8 +140,9 @@ final class RayUtils {
         return true;
     }
 
-    public static boolean BoundingBoxRayIntersectionCheck(Vec start, Vec direction, BoundingBox boundingBox, Pos position) {
-        return BoundingBoxIntersectionCheck(boundingBox, BoundingBox.ZERO, start, direction, boundingBox, position,
+    static boolean BoundingBoxRayIntersectionCheck(Vec start, Vec direction, BoundingBox boundingBox, Pos position) {
+        return BoundingBoxIntersectionCheck(boundingBox, BoundingBox.ZERO, start, direction, boundingBox,
+                position.x(), position.y(), position.z(),
                 new SweepResult(Double.MAX_VALUE, 0, 0, 0, null, 0, 0, 0, 0, 0, 0));
     }
 }

--- a/src/main/java/net/minestom/server/collision/Shape.java
+++ b/src/main/java/net/minestom/server/collision/Shape.java
@@ -1,6 +1,7 @@
 package net.minestom.server.collision;
 
 import net.minestom.server.coordinate.Point;
+import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.instance.block.BlockFace;
 
@@ -36,6 +37,17 @@ public interface Shape {
      */
     boolean intersectBoxSwept(Point rayStart, Point rayDirection,
                               Point shapePos, BoundingBox moving, SweepResult finalResult);
+
+    /**
+     * Primitive-coordinate overload of {@link #intersectBoxSwept(Point, Point, Point, BoundingBox, SweepResult)}
+     * used on hot paths (block sweeps) to avoid allocating a {@link Vec} per call.
+     * The default implementation allocates and delegates; optimized shapes override it.
+     */
+    default boolean intersectBoxSwept(Point rayStart, Point rayDirection,
+                                      double shapeX, double shapeY, double shapeZ,
+                                      BoundingBox moving, SweepResult finalResult) {
+        return intersectBoxSwept(rayStart, rayDirection, new Vec(shapeX, shapeY, shapeZ), moving, finalResult);
+    }
 
 
     /**

--- a/src/main/java/net/minestom/server/collision/ShapeImpl.java
+++ b/src/main/java/net/minestom/server/collision/ShapeImpl.java
@@ -106,9 +106,18 @@ public record ShapeImpl(ShapeData shapeData, OcclusionData occlusionData) implem
     @Override
     public boolean intersectBoxSwept(Point rayStart, Point rayDirection,
                                      Point shapePos, BoundingBox moving, SweepResult finalResult) {
+        return intersectBoxSwept(rayStart, rayDirection,
+                shapePos.x(), shapePos.y(), shapePos.z(), moving, finalResult);
+    }
+
+    @Override
+    public boolean intersectBoxSwept(Point rayStart, Point rayDirection,
+                                     double shapeX, double shapeY, double shapeZ,
+                                     BoundingBox moving, SweepResult finalResult) {
         boolean hitBlock = false;
         for (BoundingBox blockSection : shapeData.boundingBoxes) {
-            if (RayUtils.BoundingBoxIntersectionCheck(this, moving, rayStart, rayDirection, blockSection, shapePos, finalResult)) {
+            if (RayUtils.BoundingBoxIntersectionCheck(this, moving, rayStart, rayDirection, blockSection,
+                    shapeX, shapeY, shapeZ, finalResult)) {
                 hitBlock = true;
             }
         }

--- a/src/main/java/net/minestom/server/collision/ShapeImpl.java
+++ b/src/main/java/net/minestom/server/collision/ShapeImpl.java
@@ -108,15 +108,7 @@ public record ShapeImpl(ShapeData shapeData, OcclusionData occlusionData) implem
                                      Point shapePos, BoundingBox moving, SweepResult finalResult) {
         boolean hitBlock = false;
         for (BoundingBox blockSection : shapeData.boundingBoxes) {
-            // Update final result if the temp result collision is sooner than the current final result
-            if (RayUtils.BoundingBoxIntersectionCheck(moving, rayStart, rayDirection, blockSection, shapePos, finalResult)) {
-                finalResult.collidedPositionX = rayStart.x() + rayDirection.x() * finalResult.res;
-                finalResult.collidedPositionY = rayStart.y() + rayDirection.y() * finalResult.res;
-                finalResult.collidedPositionZ = rayStart.z() + rayDirection.z() * finalResult.res;
-                finalResult.collidedShapeX = shapePos.x();
-                finalResult.collidedShapeY = shapePos.y();
-                finalResult.collidedShapeZ = shapePos.z();
-                finalResult.collidedShape = this;
+            if (RayUtils.BoundingBoxIntersectionCheck(this, moving, rayStart, rayDirection, blockSection, shapePos, finalResult)) {
                 hitBlock = true;
             }
         }

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -125,7 +125,6 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     protected boolean onGround;
 
     protected BoundingBox boundingBox;
-    private @Nullable PhysicsResult previousPhysicsResult = null;
 
     protected @Nullable Entity vehicle;
 
@@ -654,8 +653,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         boolean entityFlying = entityIsPlayer && ((Player) this).isFlying();
         final Block.Getter chunkCache = new ChunkCache(instance, currentChunk, Block.STONE);
         PhysicsResult physicsResult = PhysicsUtils.simulateMovement(position, velocity.div(ServerFlag.SERVER_TICKS_PER_SECOND), boundingBox,
-                instance.getWorldBorder(), chunkCache, aerodynamics, hasNoGravity(), hasPhysics, onGround, entityFlying, previousPhysicsResult);
-        this.previousPhysicsResult = physicsResult;
+                instance.getWorldBorder(), chunkCache, aerodynamics, hasNoGravity(), hasPhysics, onGround, entityFlying);
 
         Chunk finalChunk = ChunkUtils.retrieve(instance, currentChunk, physicsResult.newPosition());
         if (!ChunkUtils.isLoaded(finalChunk)) return;
@@ -872,7 +870,6 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         setPositionInternal(spawnPosition, spawnPosition.yaw());
         this.previousPosition = spawnPosition;
         this.lastSyncedPosition = spawnPosition;
-        this.previousPhysicsResult = null;
         this.instance = instance;
         return instance.loadOptionalChunk(spawnPosition).thenAccept(chunk -> {
             try {

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -1855,6 +1855,13 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     }
 
     @Override
+    public boolean intersectBoxSwept(Point rayStart, Point rayDirection,
+                                     double shapeX, double shapeY, double shapeZ,
+                                     BoundingBox moving, SweepResult finalResult) {
+        return boundingBox.intersectBoxSwept(rayStart, rayDirection, shapeX, shapeY, shapeZ, moving, finalResult);
+    }
+
+    @Override
     public Point relativeStart() {
         return boundingBox.relativeStart();
     }

--- a/src/main/java/net/minestom/server/entity/pathfinding/generators/NodeGenerator.java
+++ b/src/main/java/net/minestom/server/entity/pathfinding/generators/NodeGenerator.java
@@ -58,7 +58,7 @@ public interface NodeGenerator {
 
         if (getter.getBlock(end) != Block.AIR) return false;
         PhysicsResult res = CollisionUtils.handlePhysics(getter, boundingBox,
-                start.asPos(), diff.asVec(), null, false);
+                start.asPos(), diff.asVec(), false);
         return !res.collisionZ() && !res.collisionY() && !res.collisionX();
     }
 

--- a/src/main/java/net/minestom/server/entity/pathfinding/generators/PreciseGroundNodeGenerator.java
+++ b/src/main/java/net/minestom/server/entity/pathfinding/generators/PreciseGroundNodeGenerator.java
@@ -129,7 +129,7 @@ public class PreciseGroundNodeGenerator implements NodeGenerator {
         final double pointZ = (int) Math.floor(pointOrgZ) + 0.5;
         final PhysicsResult res = CollisionUtils.handlePhysics(getter, boundingBox,
                 new Pos(pointX, pointOrgY, pointZ), new Vec(0, -MAX_FALL_DISTANCE, 0),
-                null, true);
+                true);
         return OptionalDouble.of(res.newPosition().y());
     }
 
@@ -138,7 +138,7 @@ public class PreciseGroundNodeGenerator implements NodeGenerator {
         final Point end = endOrg.add(0, Vec.EPSILON, 0);
         final Point start = startOrg.add(0, Vec.EPSILON, 0);
         final Point diff = end.sub(start);
-        PhysicsResult res = CollisionUtils.handlePhysics(getter, boundingBox, start.asPos(), diff.asVec(), null, false);
+        PhysicsResult res = CollisionUtils.handlePhysics(getter, boundingBox, start.asPos(), diff.asVec(), false);
         return !res.collisionZ() && !res.collisionY() && !res.collisionX();
     }
 }

--- a/src/test/java/net/minestom/server/collision/EntityBlockPhysicsIntegrationTest.java
+++ b/src/test/java/net/minestom/server/collision/EntityBlockPhysicsIntegrationTest.java
@@ -963,7 +963,7 @@ public class EntityBlockPhysicsIntegrationTest {
     }
 
     @Test
-    public void entityPhysicsCheckNoMoveCache(Env env) {
+    public void entityPhysicsCheckNoMoveRepeat(Env env) {
         var instance = env.createFlatInstance();
         var entity = new Entity(EntityType.ZOMBIE);
 
@@ -972,7 +972,7 @@ public class EntityBlockPhysicsIntegrationTest {
 
         PhysicsResult res = CollisionUtils.handlePhysics(entity, Vec.ZERO);
         entity.teleport(res.newPosition());
-        res = CollisionUtils.handlePhysics(entity, Vec.ZERO, res);
+        res = CollisionUtils.handlePhysics(entity, Vec.ZERO);
         assertEqualsPoint(new Pos(5, 42, 5), res.newPosition());
     }
 
@@ -991,7 +991,7 @@ public class EntityBlockPhysicsIntegrationTest {
 
         PhysicsResult res = CollisionUtils.handlePhysics(entity, Vec.ZERO);
         entity.teleport(res.newPosition());
-        res = CollisionUtils.handlePhysics(entity, new Vec((distance - 1) * 16, 0, 0), res);
+        res = CollisionUtils.handlePhysics(entity, new Vec((distance - 1) * 16, 0, 0));
         assertEqualsPoint(new Pos(distance * 8 - 0.3, 42, 5), res.newPosition());
     }
 
@@ -1010,7 +1010,7 @@ public class EntityBlockPhysicsIntegrationTest {
 
         PhysicsResult res = CollisionUtils.handlePhysics(entity, new Vec((distance - 1) * 16, 0, 0));
         entity.teleport(res.newPosition());
-        res = CollisionUtils.handlePhysics(entity, Vec.ZERO, res);
+        res = CollisionUtils.handlePhysics(entity, Vec.ZERO);
         assertEqualsPoint(new Pos(distance * 8 - 0.3, 42, 5), res.newPosition());
     }
 
@@ -1027,13 +1027,13 @@ public class EntityBlockPhysicsIntegrationTest {
 
         PhysicsResult res = CollisionUtils.handlePhysics(entity, new Vec(0, 0, -0.4));
         entity.teleport(res.newPosition());
-        res = CollisionUtils.handlePhysics(entity, new Vec(0, 0, -0.4), res);
+        res = CollisionUtils.handlePhysics(entity, new Vec(0, 0, -0.4));
 
         assertEqualsPoint(new Pos(0.5, 42.5, 0.487), res.newPosition());
     }
 
     @Test
-    public void entityPhysicsCheckCollisionDownCache(Env env) {
+    public void entityPhysicsCheckCollisionDownRepeat(Env env) {
         var instance = env.createFlatInstance();
         instance.setBlock(0, 43, 1, Block.STONE);
 
@@ -1047,13 +1047,13 @@ public class EntityBlockPhysicsIntegrationTest {
 
         PhysicsResult res = CollisionUtils.handlePhysics(entity, new Vec(0, 0, 10));
         entity.teleport(res.newPosition());
-        res = CollisionUtils.handlePhysics(entity, new Vec(0, -10, 0), res);
+        res = CollisionUtils.handlePhysics(entity, new Vec(0, -10, 0));
 
         assertEqualsPoint(new Pos(0, 40, 0.7), res.newPosition());
     }
 
     @Test
-    public void entityPhysicsCheckGravityCached(Env env) {
+    public void entityPhysicsCheckRepeatedGravityCollision(Env env) {
         var instance = env.createFlatInstance();
         instance.setBlock(0, 43, 1, Block.STONE);
 
@@ -1067,17 +1067,12 @@ public class EntityBlockPhysicsIntegrationTest {
 
         PhysicsResult res = CollisionUtils.handlePhysics(entity, new Vec(0, 0, 10));
         entity.teleport(res.newPosition());
-        res = CollisionUtils.handlePhysics(entity, new Vec(0, -10, 0), res);
+        res = CollisionUtils.handlePhysics(entity, new Vec(0, -10, 0));
         entity.teleport(res.newPosition());
 
-        PhysicsResult lastPhysicsResult;
-
         for (int x = 0; x < 50; ++x) {
-            lastPhysicsResult = res;
-            res = CollisionUtils.handlePhysics(entity, new Vec(0, -1.7, 0), res);
+            res = CollisionUtils.handlePhysics(entity, new Vec(0, -1.7, 0));
             entity.teleport(res.newPosition());
-
-            if (x > 10) assertSame(lastPhysicsResult, res, "Physics result not cached");
         }
 
         assertEqualsPoint(new Pos(0, 40, 0.7), res.newPosition());
@@ -1092,7 +1087,7 @@ public class EntityBlockPhysicsIntegrationTest {
         entity.setInstance(instance, new Pos(0, 43.00001, 0));
 
         var deltaPos = new Vec(0.0, -10, 0.0);
-        var physicsResult = CollisionUtils.handlePhysics(entity, deltaPos, null);
+        var physicsResult = CollisionUtils.handlePhysics(entity, deltaPos);
 
         var newPos = physicsResult.newPosition();
         assertEquals(43, newPos.blockY());
@@ -1107,36 +1102,10 @@ public class EntityBlockPhysicsIntegrationTest {
         entity.setInstance(instance, new Pos(0, 43.5, 0));
 
         var deltaPos = new Vec(0.0, -10, 0.0);
-        var physicsResult = CollisionUtils.handlePhysics(entity, deltaPos, null);
+        var physicsResult = CollisionUtils.handlePhysics(entity, deltaPos);
 
         var newPos = physicsResult.newPosition();
         assertEquals(43, newPos.blockY());
     }
 
-    @Test
-    public void entityPhysicsCacheTest(Env env) {
-        var instance = env.createFlatInstance();
-        instance.setBlock(0, 42, 0, Block.STONE);
-
-        var entity = new Entity(EntityType.ZOMBIE);
-        entity.setInstance(instance, new Pos(0, 43.5, 0));
-
-        var deltaPos = new Vec(0.0, -10, 0.0);
-        var physicsResult = CollisionUtils.handlePhysics(entity, deltaPos, null);
-
-        var newPos = physicsResult.newPosition();
-        assertEquals(43, newPos.blockY());
-        assertEqualsPoint(new Vec(0, 0, 0), physicsResult.newVelocity());
-        assertEqualsPoint(deltaPos, physicsResult.originalDelta());
-
-        // Create a new instance of the physics result to simulate gravity or we will never cache because velocity would be zero.
-        var velocityFixedResult = new PhysicsResult(physicsResult.newPosition(), physicsResult.newVelocity().add(deltaPos), physicsResult.isOnGround(), physicsResult.collisionX(), physicsResult.collisionY(), physicsResult.collisionZ(), physicsResult.originalDelta(), physicsResult.collisionPoints(), physicsResult.collisionShapes(), physicsResult.collisionShapePositions(), physicsResult.hasCollision(), physicsResult.res(), false);
-
-        var physicsResult2 = CollisionUtils.handlePhysics(instance, entity.getChunk(),
-                entity.getBoundingBox(),
-                physicsResult.newPosition(), deltaPos,
-                velocityFixedResult, false);
-
-        assertTrue(physicsResult2.cached());
-    }
 }


### PR DESCRIPTION
LLM WARNING, not even checked in-game; just made sure tests pass.

* Removing `lastPhysicsResult` (which may skew the results, but I believe is still a necessary change either way)
* New collision JMH benchmark

Before
```
Benchmark                            (collisionCase)  Mode  Cnt     Score     Error  Units
CollisionBenchmark.blockPhysics          empty_short  avgt   20  1031.654 ± 150.371  ns/op
CollisionBenchmark.blockPhysics        floor_gravity  avgt   20   595.272 ±  17.483  ns/op
CollisionBenchmark.blockPhysics      wall_horizontal  avgt   20   593.767 ±  45.114  ns/op
CollisionBenchmark.blockPhysics      corner_diagonal  avgt   20  2628.071 ± 458.701  ns/op
CollisionBenchmark.blockPhysics     ceiling_vertical  avgt   20   493.882 ±  38.697  ns/op
CollisionBenchmark.blockPhysics           long_sweep  avgt   20  5407.780 ± 104.645  ns/op
CollisionBenchmark.blockPhysics        slab_subblock  avgt   20  2083.105 ± 245.686  ns/op
CollisionBenchmark.blockPhysics           fence_tall  avgt   20   627.776 ±  24.177  ns/op
CollisionBenchmark.entityCollision        single_hit  avgt   20   325.425 ±  52.205  ns/op
CollisionBenchmark.entityCollision         multi_hit  avgt   20   378.755 ±  41.901  ns/op
CollisionBenchmark.entityCollision           overlap  avgt   20   240.802 ±  15.987  ns/op
CollisionBenchmark.entityCollision         miss_many  avgt   20   520.569 ±  22.422  ns/op
CollisionBenchmark.entityCollision     filtered_many  avgt   20  1530.163 ±  30.224  ns/op
```

After
```
Benchmark                            (collisionCase)  Mode  Cnt     Score     Error  Units
CollisionBenchmark.blockPhysics          empty_short  avgt   20   165.562 ±   1.720  ns/op
CollisionBenchmark.blockPhysics        floor_gravity  avgt   20   385.796 ±  28.001  ns/op
CollisionBenchmark.blockPhysics      wall_horizontal  avgt   20   308.796 ±   6.413  ns/op
CollisionBenchmark.blockPhysics      corner_diagonal  avgt   20   634.990 ±  12.642  ns/op
CollisionBenchmark.blockPhysics     ceiling_vertical  avgt   20   403.559 ±  62.945  ns/op
CollisionBenchmark.blockPhysics           long_sweep  avgt   20  2853.730 ±  59.225  ns/op
CollisionBenchmark.blockPhysics        slab_subblock  avgt   20   493.879 ±   7.713  ns/op
CollisionBenchmark.blockPhysics           fence_tall  avgt   20   159.591 ±  20.303  ns/op
CollisionBenchmark.entityCollision        single_hit  avgt   20   318.110 ±  22.729  ns/op
CollisionBenchmark.entityCollision         multi_hit  avgt   20   367.949 ±   4.743  ns/op
CollisionBenchmark.entityCollision           overlap  avgt   20   243.247 ±  25.179  ns/op
CollisionBenchmark.entityCollision         miss_many  avgt   20   737.282 ± 126.019  ns/op
CollisionBenchmark.entityCollision     filtered_many  avgt   20  1530.847 ±  37.905  ns/op
```


| Benchmark | Case | Before | After | Δ | Change |
|---|---:|---:|---:|---:|---:|
| blockPhysics | `empty_short` | 1031.654 ns/op | 165.562 ns/op | -866.092 | **-83.95%** |
| blockPhysics | `floor_gravity` | 595.272 ns/op | 385.796 ns/op | -209.476 | **-35.19%** |
| blockPhysics | `wall_horizontal` | 593.767 ns/op | 308.796 ns/op | -284.971 | **-47.99%** |
| blockPhysics | `corner_diagonal` | 2628.071 ns/op | 634.990 ns/op | -1993.081 | **-75.84%** |
| blockPhysics | `ceiling_vertical` | 493.882 ns/op | 403.559 ns/op | -90.323 | **-18.29%** |
| blockPhysics | `long_sweep` | 5407.780 ns/op | 2853.730 ns/op | -2554.050 | **-47.23%** |
| blockPhysics | `slab_subblock` | 2083.105 ns/op | 493.879 ns/op | -1589.226 | **-76.29%** |
| blockPhysics | `fence_tall` | 627.776 ns/op | 159.591 ns/op | -468.185 | **-74.58%** |
| entityCollision | `single_hit` | 325.425 ns/op | 318.110 ns/op | -7.315 | -2.25% |
| entityCollision | `multi_hit` | 378.755 ns/op | 367.949 ns/op | -10.806 | -2.85% |
| entityCollision | `overlap` | 240.802 ns/op | 243.247 ns/op | +2.445 | +1.02% |
| entityCollision | `miss_many` | 520.569 ns/op | 737.282 ns/op | +216.713 | +41.63% |
| entityCollision | `filtered_many` | 1530.163 ns/op | 1530.847 ns/op | +0.684 | +0.04% |

Main bottleneck is block retrieval. I suspect that further improvements would either involve a better block batch read and/or collision batching so called once per tick instead of once per tick per entity.