### PR TITLE
Add deltaShort4096 for position packets

### DIFF
--- a/src/main/java/net/minestom/server/coordinate/CoordConversion.java
+++ b/src/main/java/net/minestom/server/coordinate/CoordConversion.java
@@ -222,6 +222,10 @@ public final class CoordConversion {
         return encodeSectionBlockChange(sectionBlockIndex(localX, localY, localZ), value);
     }
 
+    public static short deltaShort4096(double newCoordinate, double oldCoordinate) {
+        return (short) ((newCoordinate - oldCoordinate) * 4096);
+    }
+
     // HASHING
 
     private static final long PRIME_X = 0x9E37_79B9_7F4A_7C15L;  // Large prime for X axis

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityPositionAndRotationPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityPositionAndRotationPacket.java
@@ -1,5 +1,6 @@
 package net.minestom.server.network.packet.server.play;
 
+import net.minestom.server.coordinate.CoordConversion;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.NetworkBufferTemplate;
@@ -25,9 +26,9 @@ public record EntityPositionAndRotationPacket(int entityId, short deltaX, short 
     public static EntityPositionAndRotationPacket getPacket(int entityId,
                                                             Pos newPosition, Pos oldPosition,
                                                             boolean onGround) {
-        final short deltaX = (short) ((newPosition.x() * 32 - oldPosition.x() * 32) * 128);
-        final short deltaY = (short) ((newPosition.y() * 32 - oldPosition.y() * 32) * 128);
-        final short deltaZ = (short) ((newPosition.z() * 32 - oldPosition.z() * 32) * 128);
+        final short deltaX = CoordConversion.deltaShort4096(newPosition.x(), oldPosition.x());
+        final short deltaY = CoordConversion.deltaShort4096(newPosition.y(), oldPosition.y());
+        final short deltaZ = CoordConversion.deltaShort4096(newPosition.z(), oldPosition.z());
         return new EntityPositionAndRotationPacket(entityId, deltaX, deltaY, deltaZ, newPosition.yaw(), newPosition.pitch(), onGround);
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/server/play/EntityPositionPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/EntityPositionPacket.java
@@ -1,5 +1,6 @@
 package net.minestom.server.network.packet.server.play;
 
+import net.minestom.server.coordinate.CoordConversion;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.NetworkBufferTemplate;
@@ -20,9 +21,9 @@ public record EntityPositionPacket(int entityId, short deltaX, short deltaY, sho
     public static EntityPositionPacket getPacket(int entityId,
                                                  Pos newPosition, Pos oldPosition,
                                                  boolean onGround) {
-        final short deltaX = (short) ((newPosition.x() * 32 - oldPosition.x() * 32) * 128);
-        final short deltaY = (short) ((newPosition.y() * 32 - oldPosition.y() * 32) * 128);
-        final short deltaZ = (short) ((newPosition.z() * 32 - oldPosition.z() * 32) * 128);
+        final short deltaX = CoordConversion.deltaShort4096(newPosition.x(), oldPosition.x());
+        final short deltaY = CoordConversion.deltaShort4096(newPosition.y(), oldPosition.y());
+        final short deltaZ = CoordConversion.deltaShort4096(newPosition.z(), oldPosition.z());
         return new EntityPositionPacket(entityId, deltaX, deltaY, deltaZ, onGround);
     }
 }


### PR DESCRIPTION
Avoid duplicating the error-prone expression for the two position packets. Perhaps with the future goal of removing the `getPacket` methods