### PR TITLE
Add Packet interface

### DIFF
--- a/src/main/java/net/minestom/server/network/packet/Packet.java
+++ b/src/main/java/net/minestom/server/network/packet/Packet.java
@@ -1,0 +1,7 @@
+package net.minestom.server.network.packet;
+
+import net.minestom.server.network.packet.client.ClientPacket;
+import net.minestom.server.network.packet.server.ServerPacket;
+
+public sealed interface Packet permits ClientPacket, ServerPacket {
+}

--- a/src/main/java/net/minestom/server/network/packet/client/ClientPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/ClientPacket.java
@@ -1,9 +1,11 @@
 package net.minestom.server.network.packet.client;
 
+import net.minestom.server.network.packet.Packet;
+
 /**
  * Represents a packet received from a client.
  * <p>
  * Packets are value-based, and should therefore not be reliant on identity.
  */
-public interface ClientPacket {
+public non-sealed interface ClientPacket extends Packet {
 }

--- a/src/main/java/net/minestom/server/network/packet/server/ServerPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/ServerPacket.java
@@ -1,6 +1,7 @@
 package net.minestom.server.network.packet.server;
 
 import net.minestom.server.adventure.ComponentHolder;
+import net.minestom.server.network.packet.Packet;
 import net.minestom.server.network.player.PlayerConnection;
 
 /**
@@ -8,7 +9,7 @@ import net.minestom.server.network.player.PlayerConnection;
  * <p>
  * Packets are value-based, and should therefore not be reliant on identity.
  */
-public sealed interface ServerPacket extends SendablePacket permits ServerPacket.Configuration, ServerPacket.Login, ServerPacket.Play, ServerPacket.Status {
+public sealed interface ServerPacket extends Packet, SendablePacket permits ServerPacket.Configuration, ServerPacket.Login, ServerPacket.Play, ServerPacket.Status {
 
     non-sealed interface Configuration extends ServerPacket {
     }


### PR DESCRIPTION
Useful when you need to write a function that accept inbound and outbound packets. Which currently require using an `Object` parameter or make use of method overloading.