### PR TITLE
fix: Unintentional ABI regression in NetworkBufferTemplate

### DIFF
--- a/src/main/java/net/minestom/server/network/NetworkBufferTemplate.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferTemplate.java
@@ -189,7 +189,7 @@ public final class NetworkBufferTemplate {
      * @param <R>  the type of the value
      * @return the new template
      */
-    public static <P1 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(Type<P1> p1, Function<? super R, ? extends P1> g1, Function<? super P1, ? extends R> ctor) {
+    public static <P1 extends @UnknownNullability Object, R extends @UnknownNullability Object> Type<R> template(Type<P1> p1, Function<? super R, ? extends P1> g1, F1<? super P1, ? extends R> ctor) {
         Objects.requireNonNull(p1, "p1");
         Objects.requireNonNull(g1, "g1");
         Objects.requireNonNull(ctor, "ctor");


### PR DESCRIPTION
## Proposed changes

Fixes an ABI bug introduced by #3043, will not be back ported to 1.21.11

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Technically rebreaks the ABI for versions targeting [2026.05.17b-26.1.1](https://github.com/Minestom/Minestom/releases/tag/2026.05.17b-26.1.1) and [2026.05.17-1.21.11](https://github.com/Minestom/Minestom/releases/tag/2026.05.17-1.21.11)