### PR TITLE
feat: Add 26.1 support for AnvilLoader

### DIFF
--- a/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
+++ b/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
@@ -5,6 +5,7 @@ import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.*;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.adventure.MinestomAdventure;
@@ -27,10 +28,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
+import java.nio.file.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
@@ -40,6 +38,7 @@ import static net.minestom.server.instance.Chunk.CHUNK_SIZE_X;
 import static net.minestom.server.instance.Chunk.CHUNK_SIZE_Z;
 
 public class AnvilLoader implements ChunkLoader {
+    private final static Key DEFAULT_DIMENSION = Key.key("minecraft", "overworld");
     private final static Logger LOGGER = LoggerFactory.getLogger(AnvilLoader.class);
     private static final DynamicRegistry<Biome> BIOME_REGISTRY = MinecraftServer.getBiomeRegistry();
     private final static int PLAINS_ID = BIOME_REGISTRY.getId(Biome.PLAINS);
@@ -59,14 +58,45 @@ public class AnvilLoader implements ChunkLoader {
     private final Long2ObjectOpenHashMap<LongSet> perRegionLoadedChunks = new Long2ObjectOpenHashMap<>();
     private final ReentrantLock perRegionLoadedChunksLock = new ReentrantLock();
 
-    public AnvilLoader(Path path) {
+
+    private static Path resolveDimensionPath(Path worldPath, String namespace, String dimension) {
+        final Path newPath = worldPath.resolve("dimensions").resolve(namespace).resolve(dimension);
+
+        // 26.1+ layout
+        if (Files.exists(newPath)) {
+            return newPath;
+        }
+
+        // Backwards-compatible loading for old vanilla layouts
+        if ("minecraft".equals(namespace)) {
+            return switch (dimension) {
+                case "overworld" -> worldPath;
+                case "the_nether" -> worldPath.resolve("DIM-1");
+                case "the_end" -> worldPath.resolve("DIM1");
+                default -> newPath;
+            };
+        }
+
+        // New custom dimension layout
+        return newPath;
+    }
+
+    public AnvilLoader(Path path, Key dimension) {
         this.path = path;
         this.levelPath = path.resolve("level.dat");
-        this.regionPath = path.resolve("region");
+        this.regionPath = resolveDimensionPath(path, dimension.namespace(), dimension.value()).resolve("region");
+    }
+
+    public AnvilLoader(String path, Key dimension) {
+        this(Path.of(path), dimension);
+    }
+
+    public AnvilLoader(Path path) {
+        this(path, DEFAULT_DIMENSION);
     }
 
     public AnvilLoader(String path) {
-        this(Path.of(path));
+        this(Path.of(path), DEFAULT_DIMENSION);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
+++ b/src/main/java/net/minestom/server/instance/anvil/AnvilLoader.java
@@ -20,6 +20,7 @@ import net.minestom.server.registry.DynamicRegistry;
 import net.minestom.server.registry.RegistryKey;
 import net.minestom.server.utils.MathUtils;
 import net.minestom.server.utils.validate.Check;
+import net.minestom.server.world.DimensionType;
 import net.minestom.server.world.biome.Biome;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -28,7 +29,10 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
@@ -38,7 +42,6 @@ import static net.minestom.server.instance.Chunk.CHUNK_SIZE_X;
 import static net.minestom.server.instance.Chunk.CHUNK_SIZE_Z;
 
 public class AnvilLoader implements ChunkLoader {
-    private final static Key DEFAULT_DIMENSION = Key.key("minecraft", "overworld");
     private final static Logger LOGGER = LoggerFactory.getLogger(AnvilLoader.class);
     private static final DynamicRegistry<Biome> BIOME_REGISTRY = MinecraftServer.getBiomeRegistry();
     private final static int PLAINS_ID = BIOME_REGISTRY.getId(Biome.PLAINS);
@@ -58,45 +61,35 @@ public class AnvilLoader implements ChunkLoader {
     private final Long2ObjectOpenHashMap<LongSet> perRegionLoadedChunks = new Long2ObjectOpenHashMap<>();
     private final ReentrantLock perRegionLoadedChunksLock = new ReentrantLock();
 
-
-    private static Path resolveDimensionPath(Path worldPath, String namespace, String dimension) {
-        final Path newPath = worldPath.resolve("dimensions").resolve(namespace).resolve(dimension);
-
-        // 26.1+ layout
-        if (Files.exists(newPath)) {
-            return newPath;
-        }
-
-        // Backwards-compatible loading for old vanilla layouts
-        if ("minecraft".equals(namespace)) {
-            return switch (dimension) {
-                case "overworld" -> worldPath;
-                case "the_nether" -> worldPath.resolve("DIM-1");
-                case "the_end" -> worldPath.resolve("DIM1");
-                default -> newPath;
-            };
-        }
-
-        // New custom dimension layout
-        return newPath;
-    }
-
+    /**
+     * Creates a new AnvilLoader for the given world path and dimension.
+     * @param path The path to the world
+     * @param dimension The key for the dimension. Use {@link DimensionType} for getting vanilla keys for dimensions.
+     */
     public AnvilLoader(Path path, Key dimension) {
         this.path = path;
         this.levelPath = path.resolve("level.dat");
-        this.regionPath = resolveDimensionPath(path, dimension.namespace(), dimension.value()).resolve("region");
+        this.regionPath = path.resolve("dimensions").resolve(dimension.namespace()).resolve(dimension.value()).resolve("region");
     }
 
-    public AnvilLoader(String path, Key dimension) {
-        this(Path.of(path), dimension);
-    }
-
+    /**
+     * @deprecated This creates the AnvilLoader for worlds created before 26.1. Use {@link #AnvilLoader(Path, Key)} instead.
+     * @param path The path to the world
+     */
+    @Deprecated(forRemoval = true)
     public AnvilLoader(Path path) {
-        this(path, DEFAULT_DIMENSION);
+        this.path = path;
+        this.levelPath = path.resolve("level.dat");
+        this.regionPath = path.resolve("region");
     }
 
+    /**
+     * @deprecated This creates the AnvilLoader for worlds created before 26.1. Use {@link #AnvilLoader(Path, Key)} instead.
+     * @param path The path to the world
+     */
+    @Deprecated(forRemoval = true)
     public AnvilLoader(String path) {
-        this(Path.of(path), DEFAULT_DIMENSION);
+        this(Path.of(path));
     }
 
     @Override


### PR DESCRIPTION
## Proposed changes

This PR updates the Anvil chunk loader to support the new Minecraft Java 26.1 world storage layout.

Minecraft 26.1 stores dimension data in namespaced folders under `dimensions/<namespace>/<dimension>/`, so the loader now resolves region files from the correct dimension path instead of always assuming the legacy root-level `region` folder.

The default constructor continues to load the Overworld, while additional constructors allow loading other vanilla or custom dimensions. The implementation also keeps backwards compatibility with older world layouts such as root `region`, `DIM-1`, and `DIM1`.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

The main goal of this change is to make the Anvil loader dimension-aware while preserving the existing behavior for older worlds.

Instead of hardcoding the region path to `<world>/region`, the loader now resolves the dimension path first. For Minecraft 26.1+ worlds this means loading from paths like:

```text
<world>/dimensions/minecraft/overworld/region