### PR TITLE
Set NetworkBuffer registries while parsing

### DIFF
--- a/src/main/java/net/minestom/server/network/NetworkBuffer.java
+++ b/src/main/java/net/minestom/server/network/NetworkBuffer.java
@@ -190,6 +190,8 @@ public sealed interface NetworkBuffer permits NetworkBufferImpl {
 
     @Nullable Registries registries();
 
+    void registries(@Nullable Registries registries);
+
     interface Type<T extends @UnknownNullability Object> {
         void write(NetworkBuffer buffer, T value);
 

--- a/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
@@ -39,7 +39,7 @@ final class NetworkBufferImpl implements NetworkBuffer {
     private BinaryTagReader nbtReader;
 
     final @Nullable AutoResize autoResize;
-    final @Nullable Registries registries;
+    @Nullable Registries registries;
 
     ByteBuffer nioBuffer = null;
 
@@ -339,6 +339,11 @@ final class NetworkBufferImpl implements NetworkBuffer {
     @Override
     public @Nullable Registries registries() {
         return registries;
+    }
+
+    @Override
+    public void registries(@Nullable Registries registries) {
+        this.registries = registries;
     }
 
     private ByteBuffer bufferSlice(int position, int length) {

--- a/src/main/java/net/minestom/server/network/packet/PacketReading.java
+++ b/src/main/java/net/minestom/server/network/packet/PacketReading.java
@@ -198,6 +198,7 @@ public final class PacketReading {
         NetworkBuffer decompressed = PacketVanilla.PACKET_POOL.get();
         try {
             if (decompressed.capacity() < dataLength) decompressed.resize(dataLength);
+            decompressed.registries(buffer.registries());
             buffer.decompress(buffer.readIndex(), buffer.readableBytes(), decompressed);
             return readPayload(decompressed, registry);
         } finally {

--- a/src/test/java/net/minestom/server/network/SocketReadTest.java
+++ b/src/test/java/net/minestom/server/network/SocketReadTest.java
@@ -5,6 +5,8 @@ import net.minestom.server.network.packet.PacketVanilla;
 import net.minestom.server.network.packet.PacketWriting;
 import net.minestom.server.network.packet.client.ClientPacket;
 import net.minestom.server.network.packet.client.common.ClientPluginMessagePacket;
+import net.minestom.server.registry.Registries;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -12,6 +14,7 @@ import java.util.List;
 import java.util.zip.DataFormatException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class SocketReadTest {
 
@@ -140,6 +143,33 @@ public class SocketReadTest {
         }
         // 5 = max var-int size
         assertEquals(5, requiredCapacity);
+    }
+
+    @Test
+    public void compressedReadInheritsSourceBufferRegistries() throws DataFormatException {
+        // Encode a framed packet large enough to actually compress (threshold = 256), keeping
+        // the pool untouched by the test setup so the read is the only relevant consumer.
+        final var packet = new ClientPluginMessagePacket("ch", new byte[2000]);
+        final var encoded = NetworkBuffer.resizableBuffer();
+        PacketWriting.writeFramedPacket(encoded, ConnectionState.PLAY, packet, 256);
+        final long length = encoded.writeIndex();
+        final byte[] framed = new byte[(int) length];
+        encoded.copyTo(0, framed, 0, length);
+
+        // Drain the pool so any buffer we inspect afterwards must have been used by the read.
+        while (PacketVanilla.PACKET_POOL.count() > 0) PacketVanilla.PACKET_POOL.get();
+
+        final Registries sourceRegistries = Registries.vanilla();
+        final var source = NetworkBuffer.wrap(framed, 0, framed.length, sourceRegistries);
+        PacketReading.readClients(source, ConnectionState.PLAY, true);
+
+        final NetworkBuffer pooled = PacketVanilla.PACKET_POOL.get();
+        try {
+            assertSame(sourceRegistries, pooled.registries(),
+                    "Decompressed pool buffer must inherit the source buffer's registries");
+        } finally {
+            PacketVanilla.PACKET_POOL.add(pooled);
+        }
     }
 
     private static int getVarIntSize(int input) {


### PR DESCRIPTION
With compression enabled, packet blob ended up in a pooled buffer that has no registries