### PR TITLE
Add applyRegistryDataPacket

### DIFF
--- a/src/main/java/net/minestom/server/registry/DynamicRegistryImpl.java
+++ b/src/main/java/net/minestom/server/registry/DynamicRegistryImpl.java
@@ -246,6 +246,76 @@ final class DynamicRegistryImpl<T> implements DynamicRegistry<T> {
         return createRegistryDataPacket(registries, false);
     }
 
+    @SuppressWarnings("unchecked")
+    void applyRegistryDataPacket(Registries registries, DynamicRegistry<?> vanillaRegistry, RegistryDataPacket packet) {
+        Objects.requireNonNull(registries, "Registries cannot be null");
+        final DynamicRegistry<T> vanilla = (DynamicRegistry<T>) Objects.requireNonNull(vanillaRegistry,
+                "Vanilla registry cannot be null");
+        Objects.requireNonNull(packet, "Packet cannot be null");
+        Check.argCondition(!key.asString().equals(packet.registryId()),
+                "Cannot apply registry data packet for {0} to registry {1}", packet.registryId(), key);
+        Objects.requireNonNull(codec, "Cannot apply registry data packet to server-only registry");
+
+        final Transcoder<BinaryTag> transcoder = new RegistryTranscoder<>(Transcoder.NBT, registries);
+        final List<T> newIdToValue = new ArrayList<>(packet.entries().size());
+        final List<RegistryKey<T>> newIdToKey = new ArrayList<>(packet.entries().size());
+        final Map<RegistryKey<T>, Integer> newKeyToId = new HashMap<>(packet.entries().size());
+        final Map<Key, T> newKeyToValue = new HashMap<>(packet.entries().size());
+        final Map<T, RegistryKey<T>> newValueToKey = new HashMap<>(packet.entries().size());
+        final List<DataPack> newPackById = new ArrayList<>(packet.entries().size());
+
+        for (RegistryDataPacket.Entry entry : packet.entries()) {
+            final Key entryKey = Key.key(entry.id());
+            final RegistryKey<T> registryKey = new RegistryKeyImpl<>(entryKey);
+            final T value;
+            final DataPack pack;
+            if (entry.data() == null) {
+                value = Objects.requireNonNull(vanilla.get(entryKey),
+                        "Missing vanilla registry entry " + entryKey + " for registry " + key);
+                pack = DataPack.MINECRAFT_CORE;
+            } else {
+                final Result<T> result = codec.decode(transcoder, entry.data());
+                value = result.orElseThrow("Failed to decode registry entry " + entryKey + " for registry " + key);
+                final T vanillaValue = vanilla.get(entryKey);
+                pack = Objects.equals(vanillaValue, value) ? DataPack.MINECRAFT_CORE : DataPack.MINESTOM_UNNAMED;
+            }
+
+            Check.argCondition(newKeyToId.put(registryKey, newIdToValue.size()) != null,
+                    "Duplicate registry entry {0} in registry data packet for {1}", entryKey, key);
+            newIdToValue.add(value);
+            newIdToKey.add(registryKey);
+            newKeyToValue.put(entryKey, value);
+            newValueToKey.put(value, registryKey);
+            newPackById.add(pack);
+        }
+
+        synchronized (REGISTRY_LOCK) {
+            idToValue.clear();
+            idToValue.addAll(newIdToValue);
+            idToKey.clear();
+            idToKey.addAll(newIdToKey);
+            keyToId.clear();
+            keyToId.putAll(newKeyToId);
+            keyToValue.clear();
+            keyToValue.putAll(newKeyToValue);
+            valueToKey.clear();
+            valueToKey.putAll(newValueToKey);
+            packById.clear();
+            packById.addAll(newPackById);
+
+            for (RegistryTagImpl.Backed<T> tag : tags.values()) {
+                final List<RegistryKey<T>> tagEntries = new ArrayList<>();
+                tag.forEach(tagEntries::add);
+                for (RegistryKey<T> tagEntry : tagEntries) {
+                    if (!newKeyToId.containsKey(tagEntry))
+                        tag.remove(tagEntry);
+                }
+            }
+
+            vanillaRegistryDataPacket.invalidate();
+        }
+    }
+
     @Override
     public TagsPacket.Registry tagRegistry() {
         final List<TagsPacket.Tag> tagList = new ArrayList<>(tags.size());

--- a/src/main/java/net/minestom/server/registry/Registries.java
+++ b/src/main/java/net/minestom/server/registry/Registries.java
@@ -24,6 +24,7 @@ import net.minestom.server.item.instrument.Instrument;
 import net.minestom.server.message.ChatType;
 import net.minestom.server.network.packet.server.SendablePacket;
 import net.minestom.server.network.packet.server.common.TagsPacket;
+import net.minestom.server.network.packet.server.configuration.RegistryDataPacket;
 import net.minestom.server.potion.PotionEffect;
 import net.minestom.server.world.DimensionType;
 import net.minestom.server.world.biome.Biome;
@@ -49,6 +50,13 @@ public interface Registries {
 
     static TagsPacket tagsPacket(Registries registries) {
         return RegistriesImpl.tagsPacket(registries);
+    }
+
+    /**
+     * Applies a registry data packet to the matching dynamic registry.
+     */
+    static void applyRegistryDataPacket(Registries registries, RegistryDataPacket packet) {
+        RegistriesImpl.applyRegistryDataPacket(registries, packet);
     }
 
     // Static registries

--- a/src/main/java/net/minestom/server/registry/RegistriesImpl.java
+++ b/src/main/java/net/minestom/server/registry/RegistriesImpl.java
@@ -2,9 +2,11 @@ package net.minestom.server.registry;
 
 import net.minestom.server.network.packet.server.SendablePacket;
 import net.minestom.server.network.packet.server.common.TagsPacket;
+import net.minestom.server.network.packet.server.configuration.RegistryDataPacket;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 final class RegistriesImpl {
     private RegistriesImpl() {
@@ -24,6 +26,21 @@ final class RegistriesImpl {
             entries.add(registry.tagRegistry());
         }
         return new TagsPacket(entries);
+    }
+
+    static void applyRegistryDataPacket(Registries registries, RegistryDataPacket packet) {
+        Objects.requireNonNull(packet, "Packet cannot be null");
+        ((DynamicRegistryImpl<?>) configurationRegistry(registries, packet.registryId()))
+                .applyRegistryDataPacket(registries,
+                        configurationRegistry(VanillaHolder.REGISTRIES, packet.registryId()), packet);
+    }
+
+    static DynamicRegistry<?> configurationRegistry(Registries registries, String registryId) {
+        for (DynamicRegistry<?> registry : configurationRegistries(registries)) {
+            if (registry.key().asString().equals(registryId))
+                return registry;
+        }
+        throw new IllegalArgumentException("Unknown registry data packet registry: " + registryId);
     }
 
     private static List<DynamicRegistry<?>> configurationRegistries(Registries registries) {
@@ -68,5 +85,9 @@ final class RegistriesImpl {
         entries.add(registries.material());
         entries.addAll(configurationRegistries(registries));
         return entries;
+    }
+
+    private static final class VanillaHolder {
+        private static final Registries REGISTRIES = Registries.vanilla();
     }
 }

--- a/src/test/java/net/minestom/server/registry/RegistryIntegrationTest.java
+++ b/src/test/java/net/minestom/server/registry/RegistryIntegrationTest.java
@@ -2,6 +2,9 @@ package net.minestom.server.registry;
 
 import net.kyori.adventure.key.Key;
 import net.minestom.server.gamedata.DataPack;
+import net.minestom.server.network.ConnectionState;
+import net.minestom.server.network.packet.server.CachedPacket;
+import net.minestom.server.network.packet.server.configuration.RegistryDataPacket;
 import net.minestom.server.world.DimensionType;
 import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
@@ -35,5 +38,59 @@ public class RegistryIntegrationTest {
                 .build();
         assertDoesNotThrow(()-> dimensionRegistry.register(Key.key("toocool:fortests"), dimensionType, DataPack.MINESTOM_UNNAMED));
         assertDoesNotThrow(() -> dimensionRegistry.register(Key.key("toocool:fortests2"), dimensionType, DataPack.MINECRAFT_CORE));
+    }
+
+    @Test
+    void applyRegistryDataPacket() {
+        Registries source = Registries.vanilla();
+        Registries target = Registries.vanilla();
+        Key key = Key.key("minestom:test_dimension");
+        DimensionType dimensionType = DimensionType.builder()
+                .ambientLight(0.5f)
+                .build();
+        RegistryKey<DimensionType> sourceKey = source.dimensionType().register(key, dimensionType, DataPack.MINESTOM_UNNAMED);
+
+        RegistryDataPacket packet = (RegistryDataPacket) source.dimensionType().registryDataPacket(source, false);
+        Registries.applyRegistryDataPacket(target, packet);
+
+        assertEquals(source.dimensionType().size(), target.dimensionType().size());
+        assertEquals(source.dimensionType().getId(sourceKey), target.dimensionType().getId(RegistryKey.unsafeOf(key)));
+        assertEquals(dimensionType, target.dimensionType().get(key));
+    }
+
+    @Test
+    void applyRegistryDataPacketWithVanillaPlaceholders() {
+        Registries source = Registries.vanilla();
+        Registries target = Registries.vanilla();
+        Key key = Key.key("minestom:test_dimension");
+        DimensionType dimensionType = DimensionType.builder()
+                .ambientLight(0.75f)
+                .build();
+        source.dimensionType().register(key, dimensionType, DataPack.MINESTOM_UNNAMED);
+
+        RegistryDataPacket packet = (RegistryDataPacket) ((CachedPacket) source.dimensionType()
+                .registryDataPacket(source, true)).packet(ConnectionState.CONFIGURATION);
+        assertNull(packet.entries().getFirst().data());
+
+        Registries.applyRegistryDataPacket(target, packet);
+
+        assertEquals(source.dimensionType().size(), target.dimensionType().size());
+        assertEquals(dimensionType, target.dimensionType().get(key));
+        assertEquals(DataPack.MINECRAFT_CORE, target.dimensionType().getPack(0));
+        assertEquals(DataPack.MINESTOM_UNNAMED, target.dimensionType().getPack(RegistryKey.unsafeOf(key)));
+    }
+
+    @Test
+    void applyAllRegistryDataPackets() {
+        Registries source = Registries.vanilla();
+        Registries target = Registries.vanilla();
+
+        for (var packet : Registries.registryDataPackets(source, false)) {
+            Registries.applyRegistryDataPacket(target, (RegistryDataPacket) packet);
+        }
+
+        assertEquals(source.chatType().size(), target.chatType().size());
+        assertEquals(source.enchantment().size(), target.enchantment().size());
+        assertEquals(source.dimensionType().size(), target.dimensionType().size());
     }
 }


### PR DESCRIPTION
Add a new way to update a `Registries` from received server packet, useful when making a client or proxy.