### PR TITLE
feat: Add CodecBenchmark

### DIFF
--- a/jmh-benchmarks/src/jmh/java/net/minestom/server/codec/CodecBenchmark.java
+++ b/jmh-benchmarks/src/jmh/java/net/minestom/server/codec/CodecBenchmark.java
@@ -1,0 +1,107 @@
+package net.minestom.server.codec;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class CodecBenchmark {
+
+    public enum TranscoderKind {
+        NBT(Transcoder.NBT),
+        JSON(Transcoder.JSON),
+        JAVA(Transcoder.JAVA);
+
+        final Transcoder<?> transcoder;
+
+        TranscoderKind(Transcoder<?> transcoder) {
+            this.transcoder = transcoder;
+        }
+    }
+
+    public enum CodecKind {
+        INT(Codec.INT, 42),
+        STRING(Codec.STRING, "Hello, World!"),
+        OPTIONAL_PRESENT(Codec.STRING.optional(), "value"),
+        OPTIONAL_ABSENT(Codec.STRING.optional(), null),
+        ENUM(Codec.Enum(SampleEnum.class), SampleEnum.BAR),
+        LIST_INT(Codec.INT.list(), List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)),
+        MAP_STRING_INT(Codec.STRING.mapValue(Codec.INT), Map.of("a", 1, "b", 2, "c", 3, "d", 4)),
+        STRUCT_SMALL(SmallStruct.CODEC, new SmallStruct(7, "name")),
+        STRUCT_LARGE(LargeStruct.CODEC, new LargeStruct(1, 2L, 3.0f, 4.0, "five", true, List.of(6, 7), "eight", 9)),
+        STRUCT_NESTED(NestedStruct.CODEC, new NestedStruct("outer", new SmallStruct(1, "inner")));
+
+        final Codec<Object> codec;
+        final Object value;
+
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        CodecKind(Codec codec, Object value) {
+            this.codec = codec;
+            this.value = value;
+        }
+    }
+
+    @Param
+    public CodecKind codec;
+
+    @Param
+    public TranscoderKind transcoder;
+
+    private Transcoder<Object> activeTranscoder;
+    private Object encoded;
+
+    @Setup
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void setup() {
+        this.activeTranscoder = (Transcoder) transcoder.transcoder;
+        this.encoded = codec.codec.encode(activeTranscoder, codec.value).orElseThrow();
+    }
+
+    @Benchmark
+    public void encode(Blackhole blackhole) {
+        blackhole.consume(codec.codec.encode(activeTranscoder, codec.value));
+    }
+
+    @Benchmark
+    public void decode(Blackhole blackhole) {
+        blackhole.consume(codec.codec.decode(activeTranscoder, encoded));
+    }
+
+    public enum SampleEnum {FOO, BAR, BAZ}
+
+    public record SmallStruct(int id, String name) {
+        public static final StructCodec<SmallStruct> CODEC = StructCodec.struct(
+                "id", Codec.INT, SmallStruct::id,
+                "name", Codec.STRING, SmallStruct::name,
+                SmallStruct::new);
+    }
+
+    public record LargeStruct(int a, long b, float c, double d, String e, boolean f, List<Integer> g, String h, int i) {
+        public static final StructCodec<LargeStruct> CODEC = StructCodec.struct(
+                "a", Codec.INT, LargeStruct::a,
+                "b", Codec.LONG, LargeStruct::b,
+                "c", Codec.FLOAT, LargeStruct::c,
+                "d", Codec.DOUBLE, LargeStruct::d,
+                "e", Codec.STRING, LargeStruct::e,
+                "f", Codec.BOOLEAN, LargeStruct::f,
+                "g", Codec.INT.list(), LargeStruct::g,
+                "h", Codec.STRING, LargeStruct::h,
+                "i", Codec.INT, LargeStruct::i,
+                LargeStruct::new);
+    }
+
+    public record NestedStruct(String label, SmallStruct inner) {
+        public static final StructCodec<NestedStruct> CODEC = StructCodec.struct(
+                "label", Codec.STRING, NestedStruct::label,
+                "inner", SmallStruct.CODEC, NestedStruct::inner,
+                NestedStruct::new);
+    }
+}

--- a/jmh-benchmarks/src/jmh/java/net/minestom/server/codec/CodecBenchmark.java
+++ b/jmh-benchmarks/src/jmh/java/net/minestom/server/codec/CodecBenchmark.java
@@ -42,9 +42,9 @@ public class CodecBenchmark {
         final Codec<Object> codec;
         final Object value;
 
-        @SuppressWarnings({"rawtypes", "unchecked"})
-        CodecKind(Codec codec, Object value) {
-            this.codec = codec;
+        @SuppressWarnings("unchecked")
+        <T> CodecKind(Codec<T> codec, T value) {
+            this.codec = (Codec<Object>) codec;
             this.value = value;
         }
     }


### PR DESCRIPTION
Basic encode/decode benchmark

Unnecessary run:
```
Benchmark                       (codec)  (transcoder)  Mode  Cnt    Score    Error  Units
CodecBenchmark.decode               INT           NBT  avgt   15    3.247 ±  0.262  ns/op
CodecBenchmark.decode               INT          JSON  avgt   15    5.244 ±  2.613  ns/op
CodecBenchmark.decode               INT          JAVA  avgt   15    3.833 ±  0.714  ns/op
CodecBenchmark.decode            STRING           NBT  avgt   15    2.529 ±  0.305  ns/op
CodecBenchmark.decode            STRING          JSON  avgt   15    3.031 ±  0.231  ns/op
CodecBenchmark.decode            STRING          JAVA  avgt   15    2.389 ±  0.138  ns/op
CodecBenchmark.decode  OPTIONAL_PRESENT           NBT  avgt   15    3.047 ±  0.077  ns/op
CodecBenchmark.decode  OPTIONAL_PRESENT          JSON  avgt   15    3.228 ±  0.021  ns/op
CodecBenchmark.decode  OPTIONAL_PRESENT          JAVA  avgt   15    3.109 ±  0.350  ns/op
CodecBenchmark.decode   OPTIONAL_ABSENT           NBT  avgt   15   31.883 ±  2.854  ns/op
CodecBenchmark.decode   OPTIONAL_ABSENT          JSON  avgt   15   20.153 ±  0.814  ns/op
CodecBenchmark.decode   OPTIONAL_ABSENT          JAVA  avgt   15    2.899 ±  0.101  ns/op
CodecBenchmark.decode              ENUM           NBT  avgt   15   18.770 ±  0.154  ns/op
CodecBenchmark.decode              ENUM          JSON  avgt   15   18.868 ±  0.183  ns/op
CodecBenchmark.decode              ENUM          JAVA  avgt   15   18.471 ±  0.127  ns/op
CodecBenchmark.decode          LIST_INT           NBT  avgt   15   79.276 ±  2.230  ns/op
CodecBenchmark.decode          LIST_INT          JSON  avgt   15   81.747 ±  0.603  ns/op
CodecBenchmark.decode          LIST_INT          JAVA  avgt   15   68.180 ±  2.112  ns/op
CodecBenchmark.decode    MAP_STRING_INT           NBT  avgt   15  244.845 ±  7.847  ns/op
CodecBenchmark.decode    MAP_STRING_INT          JSON  avgt   15  257.515 ±  4.019  ns/op
CodecBenchmark.decode    MAP_STRING_INT          JAVA  avgt   15  216.101 ±  3.889  ns/op
CodecBenchmark.decode      STRUCT_SMALL           NBT  avgt   15   19.425 ±  0.095  ns/op
CodecBenchmark.decode      STRUCT_SMALL          JSON  avgt   15   24.095 ±  0.558  ns/op
CodecBenchmark.decode      STRUCT_SMALL          JAVA  avgt   15   26.392 ±  2.077  ns/op
CodecBenchmark.decode      STRUCT_LARGE           NBT  avgt   15  216.850 ± 87.001  ns/op
CodecBenchmark.decode      STRUCT_LARGE          JSON  avgt   15  244.289 ±  9.919  ns/op
CodecBenchmark.decode      STRUCT_LARGE          JAVA  avgt   15  126.426 ±  1.145  ns/op
CodecBenchmark.decode     STRUCT_NESTED           NBT  avgt   15   46.066 ±  2.283  ns/op
CodecBenchmark.decode     STRUCT_NESTED          JSON  avgt   15   52.516 ±  1.238  ns/op
CodecBenchmark.decode     STRUCT_NESTED          JAVA  avgt   15   63.183 ±  0.140  ns/op
CodecBenchmark.encode               INT           NBT  avgt   15    3.425 ±  0.023  ns/op
CodecBenchmark.encode               INT          JSON  avgt   15    4.166 ±  0.148  ns/op
CodecBenchmark.encode               INT          JAVA  avgt   15    3.496 ±  0.908  ns/op
CodecBenchmark.encode            STRING           NBT  avgt   15    3.425 ±  0.088  ns/op
CodecBenchmark.encode            STRING          JSON  avgt   15    3.417 ±  0.098  ns/op
CodecBenchmark.encode            STRING          JAVA  avgt   15    2.615 ±  0.005  ns/op
CodecBenchmark.encode  OPTIONAL_PRESENT           NBT  avgt   15    4.118 ±  0.154  ns/op
CodecBenchmark.encode  OPTIONAL_PRESENT          JSON  avgt   15    4.077 ±  0.021  ns/op
CodecBenchmark.encode  OPTIONAL_PRESENT          JAVA  avgt   15    3.742 ±  0.799  ns/op
CodecBenchmark.encode   OPTIONAL_ABSENT           NBT  avgt   15    2.335 ±  0.072  ns/op
CodecBenchmark.encode   OPTIONAL_ABSENT          JSON  avgt   15    2.449 ±  0.428  ns/op
CodecBenchmark.encode   OPTIONAL_ABSENT          JAVA  avgt   15    2.389 ±  0.209  ns/op
CodecBenchmark.encode              ENUM           NBT  avgt   15   16.025 ±  6.181  ns/op
CodecBenchmark.encode              ENUM          JSON  avgt   15   22.982 ± 19.242  ns/op
CodecBenchmark.encode              ENUM          JAVA  avgt   15   18.490 ± 18.346  ns/op
CodecBenchmark.encode          LIST_INT           NBT  avgt   15   70.064 ±  7.190  ns/op
CodecBenchmark.encode          LIST_INT          JSON  avgt   15   65.896 ±  7.022  ns/op
CodecBenchmark.encode          LIST_INT          JAVA  avgt   15   80.484 ± 39.726  ns/op
CodecBenchmark.encode    MAP_STRING_INT           NBT  avgt   15  110.716 ± 11.094  ns/op
CodecBenchmark.encode    MAP_STRING_INT          JSON  avgt   15   80.841 ±  3.350  ns/op
CodecBenchmark.encode    MAP_STRING_INT          JAVA  avgt   15  123.541 ± 43.119  ns/op
CodecBenchmark.encode      STRUCT_SMALL           NBT  avgt   15   55.471 ±  8.851  ns/op
CodecBenchmark.encode      STRUCT_SMALL          JSON  avgt   15   30.877 ±  0.307  ns/op
CodecBenchmark.encode      STRUCT_SMALL          JAVA  avgt   15   50.622 ±  0.286  ns/op
CodecBenchmark.encode      STRUCT_LARGE           NBT  avgt   15  190.700 ±  7.452  ns/op
CodecBenchmark.encode      STRUCT_LARGE          JSON  avgt   15  233.334 ±  9.407  ns/op
CodecBenchmark.encode      STRUCT_LARGE          JAVA  avgt   15  194.855 ±  1.103  ns/op
CodecBenchmark.encode     STRUCT_NESTED           NBT  avgt   15  123.359 ±  4.869  ns/op
CodecBenchmark.encode     STRUCT_NESTED          JSON  avgt   15   73.208 ±  0.572  ns/op
CodecBenchmark.encode     STRUCT_NESTED          JAVA  avgt   15  135.495 ± 18.997  ns/op
```