### PR TITLE
add new Point#asPos(yaw, pitch)

### DIFF
--- a/src/main/java/net/minestom/server/coordinate/Point.java
+++ b/src/main/java/net/minestom/server/coordinate/Point.java
@@ -751,6 +751,19 @@ public sealed interface Point permits Vec, Pos, BlockVec {
     }
 
     /**
+     * Converts this point to a {@link Pos} with the provided view angles.
+     *
+     * @param yaw   the yaw
+     * @param pitch the pitch
+     * @return the converted position
+     */
+    @Contract(pure = true, value = "_, _ -> new")
+    default Pos asPos(float yaw, float pitch) {
+        assert !(this instanceof Pos) : "Should be overridden";
+        return new Pos(x(), y(), z(), yaw, pitch);
+    }
+
+    /**
      * Converts this point to a {@link Vec}.
      *
      * @return the converted point or this if already a {@link Vec}

--- a/src/main/java/net/minestom/server/coordinate/Pos.java
+++ b/src/main/java/net/minestom/server/coordinate/Pos.java
@@ -480,6 +480,22 @@ public record Pos(double x, double y, double z, float yaw, float pitch) implemen
         return this;
     }
 
+    /**
+     * Equivalent to {@link #withView(float, float)} as this is already a {@link Pos}.
+     * <p>
+     * Marked as deprecated to warn against redundant usage.
+     *
+     * @param yaw   the yaw
+     * @param pitch the pitch
+     * @return a new position with the provided view
+     */
+    @Deprecated
+    @Override
+    @Contract(pure = true, value = "_, _ -> new")
+    public Pos asPos(float yaw, float pitch) {
+        return withView(yaw, pitch);
+    }
+
     @Override
     @Contract(pure = true, value = "-> new")
     public Pos normalize() {

--- a/src/test/java/net/minestom/server/coordinate/PosTest.java
+++ b/src/test/java/net/minestom/server/coordinate/PosTest.java
@@ -324,6 +324,17 @@ public class PosTest {
     }
 
     @Test
+    public void testAsPosWithView() {
+        Pos pos = new Pos(1, 2, 3, 45f, 30f);
+        Pos result = pos.asPos(90f, 60f);
+        assertEquals(1, result.x());
+        assertEquals(2, result.y());
+        assertEquals(3, result.z());
+        assertEquals(90f, result.yaw());
+        assertEquals(60f, result.pitch());
+    }
+
+    @Test
     public void testArithmeticPreservesView() {
         Pos base = new Pos(10, 20, 30, 45f, 30f);
 

--- a/src/test/java/net/minestom/server/coordinate/VecTest.java
+++ b/src/test/java/net/minestom/server/coordinate/VecTest.java
@@ -386,6 +386,17 @@ public class VecTest {
     }
 
     @Test
+    public void testAsPosWithView() {
+        Vec vec = new Vec(1, 2, 3);
+        Pos result = vec.asPos(45f, 30f);
+        assertEquals(1, result.x());
+        assertEquals(2, result.y());
+        assertEquals(3, result.z());
+        assertEquals(45f, result.yaw());
+        assertEquals(30f, result.pitch());
+    }
+
+    @Test
     public void testDistance() {
         Vec v1 = new Vec(0, 0, 0);
         Vec v2 = new Vec(3, 4, 0);


### PR DESCRIPTION
The `Pos(Point point, float yaw, float pitch)` constructor is deprecated, so perhaps this is not a desirable change, but it is still less code/allocation