### PR TITLE
WIP PointIndex API

### DIFF
--- a/jcstress-tests/src/jcstress/java/net/minestom/server/coordinate/PointIndexAddReadTest.java
+++ b/jcstress-tests/src/jcstress/java/net/minestom/server/coordinate/PointIndexAddReadTest.java
@@ -1,0 +1,34 @@
+package net.minestom.server.coordinate;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Description;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.I_Result;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+import static org.openjdk.jcstress.annotations.Expect.FORBIDDEN;
+
+@JCStressTest
+@Description("Concurrent add + chunk read yields a consistent snapshot.")
+@Outcome(id = "0", expect = ACCEPTABLE, desc = "Reader scanned before add was published")
+@Outcome(id = "1", expect = ACCEPTABLE, desc = "Reader scanned after add was published")
+@Outcome(id = "2", expect = FORBIDDEN, desc = "Duplicate entry - bucket snapshot corruption")
+@State
+public class PointIndexAddReadTest {
+
+    private final PointIndex idx = PointIndex.createConcurrent();
+
+    @Actor
+    public void adder() {
+        idx.add(1, new Vec(0, 64, 0)); // chunk (0, 0)
+    }
+
+    @Actor
+    public void reader(I_Result r) {
+        final int[] count = {0};
+        idx.forEachInChunk(0, 0, id -> count[0]++);
+        r.r1 = count[0];
+    }
+}

--- a/jcstress-tests/src/jcstress/java/net/minestom/server/coordinate/PointIndexAddTest.java
+++ b/jcstress-tests/src/jcstress/java/net/minestom/server/coordinate/PointIndexAddTest.java
@@ -1,0 +1,38 @@
+package net.minestom.server.coordinate;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.Description;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.I_Result;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+import static org.openjdk.jcstress.annotations.Expect.FORBIDDEN;
+
+@JCStressTest
+@Description("Concurrent adds of different ids to the same chunk preserve both entries.")
+@Outcome(id = "2", expect = ACCEPTABLE, desc = "Both adds completed and are visible")
+@Outcome(id = "0", expect = FORBIDDEN)
+@Outcome(id = "1", expect = FORBIDDEN, desc = "One add was lost - concurrency bug")
+@State
+public class PointIndexAddTest {
+
+    private final PointIndex idx = PointIndex.createConcurrent();
+
+    @Actor
+    public void actor1() {
+        idx.add(1, new Vec(0, 64, 0)); // chunk (0, 0)
+    }
+
+    @Actor
+    public void actor2() {
+        idx.add(2, new Vec(4, 64, 4)); // chunk (0, 0)
+    }
+
+    @Arbiter
+    public void arbiter(I_Result r) {
+        r.r1 = idx.size();
+    }
+}

--- a/jcstress-tests/src/jcstress/java/net/minestom/server/coordinate/PointIndexCrossChunkMovesTest.java
+++ b/jcstress-tests/src/jcstress/java/net/minestom/server/coordinate/PointIndexCrossChunkMovesTest.java
@@ -1,0 +1,45 @@
+package net.minestom.server.coordinate;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.Description;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.I_Result;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+import static org.openjdk.jcstress.annotations.Expect.FORBIDDEN;
+
+@JCStressTest
+@Description("Cross-chunk moves of two ids over the same chunk pair complete without deadlock and leave both entries intact.")
+@Outcome(id = "2", expect = ACCEPTABLE, desc = "Both moves completed, two ids tracked")
+@Outcome(id = "0", expect = FORBIDDEN)
+@Outcome(id = "1", expect = FORBIDDEN, desc = "An entry was lost during concurrent moves")
+@State
+public class PointIndexCrossChunkMovesTest {
+
+    private final PointIndex idx = PointIndex.createConcurrent();
+    private static final Vec CHUNK_A = new Vec(0, 64, 0);    // chunk (0, 0)
+    private static final Vec CHUNK_B = new Vec(32, 64, 0);   // chunk (2, 0)
+
+    public PointIndexCrossChunkMovesTest() {
+        idx.add(1, CHUNK_A);
+        idx.add(2, CHUNK_B);
+    }
+
+    @Actor
+    public void mover1() {
+        idx.move(1, CHUNK_B);
+    }
+
+    @Actor
+    public void mover2() {
+        idx.move(2, CHUNK_A);
+    }
+
+    @Arbiter
+    public void arbiter(I_Result r) {
+        r.r1 = idx.size();
+    }
+}

--- a/jcstress-tests/src/jcstress/java/net/minestom/server/coordinate/PointIndexMoveVisibilityTest.java
+++ b/jcstress-tests/src/jcstress/java/net/minestom/server/coordinate/PointIndexMoveVisibilityTest.java
@@ -1,0 +1,38 @@
+package net.minestom.server.coordinate;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Description;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.I_Result;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+import static org.openjdk.jcstress.annotations.Expect.FORBIDDEN;
+
+@JCStressTest
+@Description("Cross-chunk move keeps the entity visible in exactly one chunk to a concurrent reader.")
+@Outcome(id = "1", expect = ACCEPTABLE, desc = "Reader saw the entity in exactly one chunk")
+@Outcome(id = "0", expect = FORBIDDEN, desc = "Entity briefly invisible - visibility invariant violated")
+@Outcome(id = "2", expect = FORBIDDEN, desc = "Entity briefly visible in both chunks - exact-once invariant violated")
+@State
+public class PointIndexMoveVisibilityTest {
+
+    private final PointIndex idx = PointIndex.createConcurrent();
+
+    public PointIndexMoveVisibilityTest() {
+        idx.add(1, new Vec(0, 64, 0)); // chunk (0, 0)
+    }
+
+    @Actor
+    public void mover() {
+        idx.move(1, new Vec(32, 64, 0)); // chunk (2, 0)
+    }
+
+    @Actor
+    public void reader(I_Result r) {
+        final int[] count = {0};
+        idx.forEachInChunkRange(new Vec(16, 64, 0), 2, id -> count[0]++);
+        r.r1 = count[0];
+    }
+}

--- a/jcstress-tests/src/jcstress/java/net/minestom/server/coordinate/PointIndexRemoveReadTest.java
+++ b/jcstress-tests/src/jcstress/java/net/minestom/server/coordinate/PointIndexRemoveReadTest.java
@@ -1,0 +1,38 @@
+package net.minestom.server.coordinate;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Description;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.I_Result;
+
+import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
+import static org.openjdk.jcstress.annotations.Expect.FORBIDDEN;
+
+@JCStressTest
+@Description("Concurrent remove + read yields 0 or 1, never a corrupt bucket.")
+@Outcome(id = "0", expect = ACCEPTABLE, desc = "Reader saw post-remove state")
+@Outcome(id = "1", expect = ACCEPTABLE, desc = "Reader saw pre-remove state")
+@Outcome(id = "2", expect = FORBIDDEN, desc = "Duplicate entry - bucket snapshot corruption")
+@State
+public class PointIndexRemoveReadTest {
+
+    private final PointIndex idx = PointIndex.createConcurrent();
+
+    public PointIndexRemoveReadTest() {
+        idx.add(1, new Vec(0, 64, 0)); // chunk (0, 0)
+    }
+
+    @Actor
+    public void remover() {
+        idx.remove(1);
+    }
+
+    @Actor
+    public void reader(I_Result r) {
+        final int[] count = {0};
+        idx.forEachInChunk(0, 0, id -> count[0]++);
+        r.r1 = count[0];
+    }
+}

--- a/jmh-benchmarks/src/jmh/java/net/minestom/server/coordinate/PointIndexBenchmark.java
+++ b/jmh-benchmarks/src/jmh/java/net/minestom/server/coordinate/PointIndexBenchmark.java
@@ -1,0 +1,79 @@
+package net.minestom.server.coordinate;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class PointIndexBenchmark {
+
+    @Param({"100", "1000", "10000"})
+    int size;
+
+    @Param({"16", "64"})
+    double radius;
+
+    private PointIndex index;
+    private Point[] points;
+    private int cursor;
+
+    @Setup
+    public void setup() {
+        index = PointIndex.create();
+        Random r = new Random(42);
+        points = new Point[size];
+        for (int i = 0; i < size; i++) {
+            points[i] = randomPoint(r);
+            index.add(i, points[i]);
+        }
+    }
+
+    @Benchmark
+    public int nearest() {
+        Point p = points[Math.floorMod(cursor++, size)];
+        return index.nearest(p);
+    }
+
+    @Benchmark
+    public int countWithin() {
+        Point p = points[Math.floorMod(cursor++, size)];
+        return index.count(p, radius);
+    }
+
+    @Benchmark
+    public void forEachWithin(Blackhole bh) {
+        Point p = points[Math.floorMod(cursor++, size)];
+        index.forEachWithin(p, radius, bh::consume);
+    }
+
+    @Benchmark
+    public void forEachInChunkRange(Blackhole bh) {
+        Point p = points[Math.floorMod(cursor++, size)];
+        index.forEachInChunkRange(p, 4, bh::consume);
+    }
+
+    @Benchmark
+    public void moveCycle(Blackhole bh) {
+        int i = Math.floorMod(cursor++, size);
+        Point newPoint = new Vec(
+                (cursor * 13L) % 1024 - 512,
+                (cursor * 7L) % 256,
+                (cursor * 17L) % 1024 - 512);
+        bh.consume(index.move(i, newPoint));
+        points[i] = newPoint;
+    }
+
+    private static Point randomPoint(Random r) {
+        return new Vec(
+                r.nextDouble(-512, 512),
+                r.nextDouble(0, 256),
+                r.nextDouble(-512, 512));
+    }
+}

--- a/src/main/java/net/minestom/server/coordinate/PointIndex.java
+++ b/src/main/java/net/minestom/server/coordinate/PointIndex.java
@@ -1,0 +1,84 @@
+package net.minestom.server.coordinate;
+
+import it.unimi.dsi.fastutil.ints.IntCollection;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
+
+import java.util.function.IntConsumer;
+
+public interface PointIndex {
+
+    void add(int id, Point point);
+
+    /**
+     * Removes {@code id}.
+     *
+     * @return the last known position, or {@code null} if {@code id} was not present
+     */
+    @Nullable Point remove(int id);
+
+    /**
+     * Updates the position of {@code id}.
+     *
+     * @return the previous position, or {@code null} if {@code id} was not present
+     */
+    @Nullable Point move(int id, Point newPoint);
+
+    /**
+     * @return the current position of {@code id}, or {@code null} if not present
+     */
+    @Nullable Point get(int id);
+
+    default boolean contains(int id) {
+        return get(id) != null;
+    }
+
+    int size();
+
+    @Unmodifiable IntCollection all();
+
+    /**
+     * Returns the id closest to {@code point}, or {@code -1} if the index is empty.
+     */
+    int nearest(Point point);
+
+    /**
+     * Invokes {@code consumer} for every id within {@code radius} of {@code point}.
+     */
+    void forEachWithin(Point point, double radius, IntConsumer consumer);
+
+    default int count(Point point, double radius) {
+        int[] n = {0};
+        forEachWithin(point, radius, id -> n[0]++);
+        return n[0];
+    }
+
+    void forEachInChunk(int chunkX, int chunkZ, IntConsumer consumer);
+
+    /**
+     * Live, unmodifiable view of the ids in chunk {@code (chunkX, chunkZ)}.
+     * The collection reflects mutations to the index.
+     */
+    @Unmodifiable IntCollection inChunk(int chunkX, int chunkZ);
+
+    default void forEachInChunkRange(Point point, int chunkRange, IntConsumer consumer) {
+        final int centerX = point.chunkX();
+        final int centerZ = point.chunkZ();
+        for (int x = centerX - chunkRange; x <= centerX + chunkRange; x++) {
+            for (int z = centerZ - chunkRange; z <= centerZ + chunkRange; z++) {
+                forEachInChunk(x, z, consumer);
+            }
+        }
+    }
+
+    void forEachInChunkRangeDiffering(Point oldPoint, Point newPoint, int chunkRange,
+                                      IntConsumer added, IntConsumer removed);
+
+    static PointIndex create() {
+        return new PointIndexImpl();
+    }
+
+    static PointIndex createConcurrent() {
+        return new PointIndexConcurrentImpl();
+    }
+}

--- a/src/main/java/net/minestom/server/coordinate/PointIndexConcurrentImpl.java
+++ b/src/main/java/net/minestom/server/coordinate/PointIndexConcurrentImpl.java
@@ -1,0 +1,551 @@
+package net.minestom.server.coordinate;
+
+import it.unimi.dsi.fastutil.ints.AbstractIntCollection;
+import it.unimi.dsi.fastutil.ints.IntCollection;
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.ints.IntIterators;
+import it.unimi.dsi.fastutil.ints.IntSets;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
+import space.vectrix.flare.fastutil.Int2ObjectSyncMap;
+import space.vectrix.flare.fastutil.Long2ObjectSyncMap;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+import java.util.function.IntConsumer;
+
+import static net.minestom.server.coordinate.CoordConversion.*;
+
+final class PointIndexConcurrentImpl implements PointIndex {
+
+    private static final int LOCK_STRIPES = 64;
+    private static final int LOCK_MASK = LOCK_STRIPES - 1;
+    private static final double SECTION_SIZE_D = SECTION_SIZE;
+
+    private final Int2ObjectSyncMap<@Nullable Slot> byId = Int2ObjectSyncMap.hashmap();
+    private final Long2ObjectSyncMap<@Nullable Bucket> byChunk = Long2ObjectSyncMap.hashmap();
+    private final Object[] locks;
+    private final Object crossChunkLock = new Object();
+    private final IntCollection view = IntSets.unmodifiable(byId.keySet());
+
+    PointIndexConcurrentImpl() {
+        this.locks = new Object[LOCK_STRIPES];
+        for (int i = 0; i < LOCK_STRIPES; i++) this.locks[i] = new Object();
+    }
+
+    private static int stripeFor(long chunk) {
+        long hash = chunk;
+        hash ^= hash >>> 33;
+        hash *= 0xff51afd7ed558ccdL;
+        hash ^= hash >>> 33;
+        return (int) hash & LOCK_MASK;
+    }
+
+    private Object lockFor(long chunk) {
+        return locks[stripeFor(chunk)];
+    }
+
+    private boolean belongsToChunk(int id, long chunk) {
+        final Slot slot = byId.get(id);
+        return slot != null && slot.chunk == chunk;
+    }
+
+    @Override
+    public void add(int id, Point point) {
+        final double x = point.x(), y = point.y(), z = point.z();
+        final long chunk = chunkIndex(globalToChunk(x), globalToChunk(z));
+        synchronized (crossChunkLock) {
+            final Slot previous = byId.putIfAbsent(id, new Slot(chunk, point));
+            if (previous != null) {
+                throw new IllegalStateException("Point with id " + id + " already present");
+            }
+            synchronized (lockFor(chunk)) {
+                Bucket bucket = byChunk.get(chunk);
+                if (bucket == null) bucket = Bucket.first(id, x, y, z);
+                else bucket = bucket.withAdded(id, x, y, z);
+                byChunk.put(chunk, bucket);
+            }
+        }
+    }
+
+    @Override
+    public @Nullable Point remove(int id) {
+        final Slot removed;
+        synchronized (crossChunkLock) {
+            removed = byId.remove(id);
+            if (removed == null) return null;
+            synchronized (lockFor(removed.chunk)) {
+                final Bucket bucket = byChunk.get(removed.chunk);
+                if (bucket != null) {
+                    final int idx = bucket.indexOf(id);
+                    if (idx != -1) {
+                        final Bucket newBucket = bucket.withRemovedAt(idx);
+                        if (newBucket == null) byChunk.remove(removed.chunk);
+                        else byChunk.put(removed.chunk, newBucket);
+                    }
+                }
+            }
+        }
+        return removed.point;
+    }
+
+    @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
+    @Override
+    public @Nullable Point move(int id, Point newPoint) {
+        final Slot slot = byId.get(id);
+        if (slot == null) return null;
+        final long oldChunk = slot.chunk;
+        final Point oldPoint = slot.point;
+        final double newX = newPoint.x(), newY = newPoint.y(), newZ = newPoint.z();
+        final long newChunk = chunkIndex(globalToChunk(newX), globalToChunk(newZ));
+
+        if (oldChunk == newChunk) {
+            synchronized (lockFor(oldChunk)) {
+                final Bucket bucket = byChunk.get(oldChunk);
+                if (bucket != null) {
+                    final int idx = bucket.indexOf(id);
+                    if (idx != -1) byChunk.put(oldChunk, bucket.withUpdated(idx, newX, newY, newZ));
+                }
+                byId.put(id, new Slot(oldChunk, newPoint));
+            }
+            return oldPoint;
+        }
+
+        final int oldStripe = stripeFor(oldChunk);
+        final int newStripe = stripeFor(newChunk);
+        synchronized (crossChunkLock) {
+            if (oldStripe == newStripe) {
+                synchronized (locks[oldStripe]) {
+                    doMoveCross(id, oldChunk, newChunk, newX, newY, newZ, newPoint);
+                }
+            } else {
+                final Object firstLock = locks[Math.min(oldStripe, newStripe)];
+                final Object secondLock = locks[Math.max(oldStripe, newStripe)];
+                synchronized (firstLock) {
+                    synchronized (secondLock) {
+                        doMoveCross(id, oldChunk, newChunk, newX, newY, newZ, newPoint);
+                    }
+                }
+            }
+        }
+        return oldPoint;
+    }
+
+    private void doMoveCross(int id, long oldChunk, long newChunk,
+                             double newX, double newY, double newZ, Point newPoint) {
+        final Bucket destBucket = byChunk.get(newChunk);
+        if (destBucket == null) byChunk.put(newChunk, Bucket.first(id, newX, newY, newZ));
+        else byChunk.put(newChunk, destBucket.withAdded(id, newX, newY, newZ));
+        byId.put(id, new Slot(newChunk, newPoint));
+        final Bucket oldBucket = byChunk.get(oldChunk);
+        if (oldBucket != null) {
+            final int idx = oldBucket.indexOf(id);
+            if (idx != -1) {
+                final Bucket newOldBucket = oldBucket.withRemovedAt(idx);
+                if (newOldBucket == null) byChunk.remove(oldChunk);
+                else byChunk.put(oldChunk, newOldBucket);
+            }
+        }
+    }
+
+    @Override
+    public @Nullable Point get(int id) {
+        final Slot slot = byId.get(id);
+        return slot == null ? null : slot.point;
+    }
+
+    @Override
+    public int size() {
+        return byId.size();
+    }
+
+    @Override
+    public @Unmodifiable IntCollection all() {
+        return view;
+    }
+
+    @Override
+    public int nearest(Point point) {
+        if (byChunk.isEmpty()) return -1;
+        final double px = point.x(), py = point.y(), pz = point.z();
+        final NearestState state = new NearestState();
+
+        if (byChunk.size() <= 4) {
+            for (var entry : byChunk.long2ObjectEntrySet()) {
+                final Bucket b = entry.getValue();
+                if (b != null) scanBucketForNearest(b, entry.getLongKey(), px, py, pz, state);
+            }
+            return state.bestId;
+        }
+
+        final int qcx = globalToChunk(px), qcz = globalToChunk(pz);
+        final int maxRing = 4096;
+        for (int r = 0; r <= maxRing; r++) {
+            if (r >= 1) {
+                final double minPossibleDist = SECTION_SIZE_D * (r - 1);
+                if (state.bestSq < minPossibleDist * minPossibleDist) break;
+            }
+            if (r == 0) {
+                scanChunkForNearest(qcx, qcz, px, py, pz, state);
+                continue;
+            }
+            for (int dx = -r; dx <= r; dx++) {
+                scanChunkForNearest(qcx + dx, qcz - r, px, py, pz, state);
+                scanChunkForNearest(qcx + dx, qcz + r, px, py, pz, state);
+            }
+            for (int dz = -r + 1; dz <= r - 1; dz++) {
+                scanChunkForNearest(qcx - r, qcz + dz, px, py, pz, state);
+                scanChunkForNearest(qcx + r, qcz + dz, px, py, pz, state);
+            }
+        }
+        return state.bestId;
+    }
+
+    private void scanChunkForNearest(int cx, int cz, double px, double py, double pz, NearestState state) {
+        final double cxMin = cx * SECTION_SIZE_D, cxMax = cxMin + SECTION_SIZE_D;
+        final double czMin = cz * SECTION_SIZE_D, czMax = czMin + SECTION_SIZE_D;
+        final double dx = Math.max(0.0, Math.max(cxMin - px, px - cxMax));
+        final double dz = Math.max(0.0, Math.max(czMin - pz, pz - czMax));
+        if (dx * dx + dz * dz >= state.bestSq) return;
+        final long chunk = chunkIndex(cx, cz);
+        final Bucket b = byChunk.get(chunk);
+        if (b != null) scanBucketForNearest(b, chunk, px, py, pz, state);
+    }
+
+    private void scanBucketForNearest(Bucket b, long chunk, double px, double py, double pz, NearestState state) {
+        final int n = b.size();
+        final double[] xs = b.xs, ys = b.ys, zs = b.zs;
+        final int[] ids = b.ids;
+        double bestSq = state.bestSq;
+        int bestId = state.bestId;
+        for (int i = 0; i < n; i++) {
+            final int id = ids[i];
+            if (!belongsToChunk(id, chunk)) continue;
+            final double ex = xs[i] - px, ey = ys[i] - py, ez = zs[i] - pz;
+            final double d = ex * ex + ey * ey + ez * ez;
+            if (d < bestSq) {
+                bestSq = d;
+                bestId = id;
+            }
+        }
+        state.bestSq = bestSq;
+        state.bestId = bestId;
+    }
+
+    private static final class NearestState {
+        int bestId = -1;
+        double bestSq = Double.POSITIVE_INFINITY;
+    }
+
+    @Override
+    public void forEachWithin(Point point, double radius, IntConsumer consumer) {
+        final double px = point.x(), py = point.y(), pz = point.z();
+        final double rSq = radius * radius;
+        final int minCX = globalToChunk(px - radius);
+        final int maxCX = globalToChunk(px + radius);
+        final int minCZ = globalToChunk(pz - radius);
+        final int maxCZ = globalToChunk(pz + radius);
+
+        if (minCX == maxCX && minCZ == maxCZ) {
+            final long chunk = chunkIndex(minCX, minCZ);
+            final Bucket b = byChunk.get(chunk);
+            if (b == null) return;
+            forEachInBucketWithin(b, chunk, px, py, pz, rSq, consumer);
+            return;
+        }
+        synchronized (crossChunkLock) {
+            for (int cx = minCX; cx <= maxCX; cx++) {
+                final double cxMin = cx * SECTION_SIZE_D, cxMax = cxMin + SECTION_SIZE_D;
+                final double cdx = Math.max(0.0, Math.max(cxMin - px, px - cxMax));
+                final double cdxSq = cdx * cdx;
+                if (cdxSq >= rSq) continue;
+                for (int cz = minCZ; cz <= maxCZ; cz++) {
+                    final double czMin = cz * SECTION_SIZE_D, czMax = czMin + SECTION_SIZE_D;
+                    final double cdz = Math.max(0.0, Math.max(czMin - pz, pz - czMax));
+                    if (cdxSq + cdz * cdz >= rSq) continue;
+                    final long chunk = chunkIndex(cx, cz);
+                    final Bucket b = byChunk.get(chunk);
+                    if (b == null) continue;
+                    forEachInBucketWithin(b, px, py, pz, rSq, consumer);
+                }
+            }
+        }
+    }
+
+    private void forEachInBucketWithin(Bucket b, long chunk, double px, double py, double pz,
+                                       double rSq, IntConsumer consumer) {
+        final int n = b.size();
+        final double[] xs = b.xs, ys = b.ys, zs = b.zs;
+        final int[] ids = b.ids;
+        for (int i = 0; i < n; i++) {
+            final int id = ids[i];
+            if (!belongsToChunk(id, chunk)) continue;
+            final double dx = xs[i] - px, dy = ys[i] - py, dz = zs[i] - pz;
+            if (dx * dx + dy * dy + dz * dz <= rSq) consumer.accept(id);
+        }
+    }
+
+    private static void forEachInBucketWithin(Bucket b, double px, double py, double pz,
+                                              double rSq, IntConsumer consumer) {
+        final int n = b.size();
+        final double[] xs = b.xs, ys = b.ys, zs = b.zs;
+        final int[] ids = b.ids;
+        for (int i = 0; i < n; i++) {
+            final double dx = xs[i] - px, dy = ys[i] - py, dz = zs[i] - pz;
+            if (dx * dx + dy * dy + dz * dz <= rSq) consumer.accept(ids[i]);
+        }
+    }
+
+    @Override
+    public int count(Point point, double radius) {
+        final double px = point.x(), py = point.y(), pz = point.z();
+        final double rSq = radius * radius;
+        final int minCX = globalToChunk(px - radius);
+        final int maxCX = globalToChunk(px + radius);
+        final int minCZ = globalToChunk(pz - radius);
+        final int maxCZ = globalToChunk(pz + radius);
+        if (minCX == maxCX && minCZ == maxCZ) {
+            final long chunk = chunkIndex(minCX, minCZ);
+            final Bucket b = byChunk.get(chunk);
+            return b == null ? 0 : countInBucketWithin(b, chunk, px, py, pz, rSq);
+        }
+        int total = 0;
+        synchronized (crossChunkLock) {
+            for (int cx = minCX; cx <= maxCX; cx++) {
+                final double cxMin = cx * SECTION_SIZE_D, cxMax = cxMin + SECTION_SIZE_D;
+                final double cdx = Math.max(0.0, Math.max(cxMin - px, px - cxMax));
+                final double cdxSq = cdx * cdx;
+                if (cdxSq >= rSq) continue;
+                for (int cz = minCZ; cz <= maxCZ; cz++) {
+                    final double czMin = cz * SECTION_SIZE_D, czMax = czMin + SECTION_SIZE_D;
+                    final double cdz = Math.max(0.0, Math.max(czMin - pz, pz - czMax));
+                    if (cdxSq + cdz * cdz >= rSq) continue;
+                    final long chunk = chunkIndex(cx, cz);
+                    final Bucket b = byChunk.get(chunk);
+                    if (b == null) continue;
+                    total += countInBucketWithin(b, px, py, pz, rSq);
+                }
+            }
+        }
+        return total;
+    }
+
+    private int countInBucketWithin(Bucket b, long chunk, double px, double py, double pz, double rSq) {
+        final int n = b.size();
+        final double[] xs = b.xs, ys = b.ys, zs = b.zs;
+        final int[] ids = b.ids;
+        int total = 0;
+        for (int i = 0; i < n; i++) {
+            final int id = ids[i];
+            if (!belongsToChunk(id, chunk)) continue;
+            final double dx = xs[i] - px, dy = ys[i] - py, dz = zs[i] - pz;
+            if (dx * dx + dy * dy + dz * dz <= rSq) total++;
+        }
+        return total;
+    }
+
+    private static int countInBucketWithin(Bucket b, double px, double py, double pz, double rSq) {
+        final int n = b.size();
+        final double[] xs = b.xs, ys = b.ys, zs = b.zs;
+        int total = 0;
+        for (int i = 0; i < n; i++) {
+            final double dx = xs[i] - px, dy = ys[i] - py, dz = zs[i] - pz;
+            if (dx * dx + dy * dy + dz * dz <= rSq) total++;
+        }
+        return total;
+    }
+
+    @Override
+    public void forEachInChunk(int chunkX, int chunkZ, IntConsumer consumer) {
+        final long chunk = chunkIndex(chunkX, chunkZ);
+        final Bucket b = byChunk.get(chunk);
+        if (b == null) return;
+        final int n = b.size();
+        final int[] ids = b.ids;
+        for (int i = 0; i < n; i++) {
+            final int id = ids[i];
+            if (belongsToChunk(id, chunk)) consumer.accept(id);
+        }
+    }
+
+    @Override
+    public @Unmodifiable IntCollection inChunk(int chunkX, int chunkZ) {
+        return new ChunkView(this, chunkIndex(chunkX, chunkZ));
+    }
+
+    @Override
+    public void forEachInChunkRange(Point point, int chunkRange, IntConsumer consumer) {
+        final int centerX = point.chunkX();
+        final int centerZ = point.chunkZ();
+        final int minCX = centerX - chunkRange;
+        final int maxCX = centerX + chunkRange;
+        final int minCZ = centerZ - chunkRange;
+        final int maxCZ = centerZ + chunkRange;
+        synchronized (crossChunkLock) {
+            for (int cx = minCX; cx <= maxCX; cx++) {
+                for (int cz = minCZ; cz <= maxCZ; cz++) {
+                    final long chunk = chunkIndex(cx, cz);
+                    final Bucket b = byChunk.get(chunk);
+                    if (b == null) continue;
+                    final int n = b.size();
+                    final int[] ids = b.ids;
+                    for (int i = 0; i < n; i++) {
+                        consumer.accept(ids[i]);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void forEachInChunkRangeDiffering(Point oldPoint, Point newPoint, int chunkRange,
+                                             IntConsumer added, IntConsumer removed) {
+        final int oldCX = oldPoint.chunkX(), oldCZ = oldPoint.chunkZ();
+        final int newCX = newPoint.chunkX(), newCZ = newPoint.chunkZ();
+        synchronized (crossChunkLock) {
+            for (int cx = newCX - chunkRange; cx <= newCX + chunkRange; cx++) {
+                for (int cz = newCZ - chunkRange; cz <= newCZ + chunkRange; cz++) {
+                    if (Math.abs(cx - oldCX) <= chunkRange && Math.abs(cz - oldCZ) <= chunkRange) continue;
+                    final long chunk = chunkIndex(cx, cz);
+                    final Bucket b = byChunk.get(chunk);
+                    if (b == null) continue;
+                    final int n = b.size();
+                    final int[] ids = b.ids;
+                    for (int i = 0; i < n; i++) {
+                        added.accept(ids[i]);
+                    }
+                }
+            }
+            for (int cx = oldCX - chunkRange; cx <= oldCX + chunkRange; cx++) {
+                for (int cz = oldCZ - chunkRange; cz <= oldCZ + chunkRange; cz++) {
+                    if (Math.abs(cx - newCX) <= chunkRange && Math.abs(cz - newCZ) <= chunkRange) continue;
+                    final long chunk = chunkIndex(cx, cz);
+                    final Bucket b = byChunk.get(chunk);
+                    if (b == null) continue;
+                    final int n = b.size();
+                    final int[] ids = b.ids;
+                    for (int i = 0; i < n; i++) {
+                        removed.accept(ids[i]);
+                    }
+                }
+            }
+        }
+    }
+
+    record Slot(long chunk, Point point) {
+    }
+
+    record Bucket(double[] xs, double[] ys, double[] zs, int[] ids) {
+        static Bucket first(int id, double x, double y, double z) {
+            return new Bucket(new double[]{x}, new double[]{y}, new double[]{z}, new int[]{id});
+        }
+
+        int size() {
+            return ids.length;
+        }
+
+        int indexOf(int id) {
+            final int[] ids = this.ids;
+            for (int i = 0; i < ids.length; i++) if (ids[i] == id) return i;
+            return -1;
+        }
+
+        Bucket withAdded(int id, double x, double y, double z) {
+            final int prev = ids.length;
+            final int newSize = prev + 1;
+            final double[] nxs = Arrays.copyOf(xs, newSize);
+            nxs[prev] = x;
+            final double[] nys = Arrays.copyOf(ys, newSize);
+            nys[prev] = y;
+            final double[] nzs = Arrays.copyOf(zs, newSize);
+            nzs[prev] = z;
+            final int[] nids = Arrays.copyOf(ids, newSize);
+            nids[prev] = id;
+            return new Bucket(nxs, nys, nzs, nids);
+        }
+
+        @Nullable
+        Bucket withRemovedAt(int idx) {
+            final int newSize = ids.length - 1;
+            if (newSize == 0) return null;
+            final double[] nxs = Arrays.copyOf(xs, newSize);
+            final double[] nys = Arrays.copyOf(ys, newSize);
+            final double[] nzs = Arrays.copyOf(zs, newSize);
+            final int[] nids = Arrays.copyOf(ids, newSize);
+            if (idx != newSize) {
+                nxs[idx] = xs[newSize];
+                nys[idx] = ys[newSize];
+                nzs[idx] = zs[newSize];
+                nids[idx] = ids[newSize];
+            }
+            return new Bucket(nxs, nys, nzs, nids);
+        }
+
+        Bucket withUpdated(int idx, double x, double y, double z) {
+            final int n = ids.length;
+            final double[] nxs = Arrays.copyOf(xs, n);
+            nxs[idx] = x;
+            final double[] nys = Arrays.copyOf(ys, n);
+            nys[idx] = y;
+            final double[] nzs = Arrays.copyOf(zs, n);
+            nzs[idx] = z;
+            return new Bucket(nxs, nys, nzs, ids);
+        }
+    }
+
+    private static final class ChunkView extends AbstractIntCollection {
+        private final PointIndexConcurrentImpl index;
+        private final long chunkKey;
+
+        ChunkView(PointIndexConcurrentImpl index, long chunkKey) {
+            this.index = index;
+            this.chunkKey = chunkKey;
+        }
+
+        @Override
+        public IntIterator iterator() {
+            final Bucket b = index.byChunk.get(chunkKey);
+            if (b == null) return IntIterators.EMPTY_ITERATOR;
+            final int[] ids = b.ids;
+            final int n = b.size();
+            return new IntIterator() {
+                int i = 0;
+                int next;
+                boolean hasNext;
+
+                @Override
+                public boolean hasNext() {
+                    if (hasNext) return true;
+                    while (i < n) {
+                        final int id = ids[i++];
+                        if (index.belongsToChunk(id, chunkKey)) {
+                            next = id;
+                            hasNext = true;
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+
+                @Override
+                public int nextInt() {
+                    if (!hasNext()) throw new NoSuchElementException();
+                    hasNext = false;
+                    return next;
+                }
+            };
+        }
+
+        @Override
+        public int size() {
+            final Bucket b = index.byChunk.get(chunkKey);
+            return b == null ? 0 : b.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return index.byChunk.get(chunkKey) == null;
+        }
+    }
+
+}

--- a/src/main/java/net/minestom/server/coordinate/PointIndexImpl.java
+++ b/src/main/java/net/minestom/server/coordinate/PointIndexImpl.java
@@ -1,0 +1,414 @@
+package net.minestom.server.coordinate;
+
+import it.unimi.dsi.fastutil.ints.AbstractIntCollection;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntCollection;
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.ints.IntIterators;
+import it.unimi.dsi.fastutil.ints.IntSets;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+import java.util.function.IntConsumer;
+
+import static net.minestom.server.coordinate.CoordConversion.SECTION_SIZE;
+import static net.minestom.server.coordinate.CoordConversion.chunkIndex;
+import static net.minestom.server.coordinate.CoordConversion.globalToChunk;
+
+final class PointIndexImpl implements PointIndex {
+
+    private static final int INITIAL_BUCKET_CAPACITY = 4;
+    private static final double SECTION_SIZE_D = SECTION_SIZE;
+
+    private final Int2ObjectOpenHashMap<@Nullable Slot> byId = new Int2ObjectOpenHashMap<>();
+    private final Long2ObjectOpenHashMap<@Nullable Bucket> byChunk = new Long2ObjectOpenHashMap<>();
+    private final IntCollection view = IntSets.unmodifiable(byId.keySet());
+
+    @Override
+    public void add(int id, Point point) {
+        if (byId.get(id) != null) {
+            throw new IllegalStateException("Point with id " + id + " already present");
+        }
+        final double x = point.x(), y = point.y(), z = point.z();
+        final long chunk = chunkIndex(globalToChunk(x), globalToChunk(z));
+
+        Bucket bucket = byChunk.get(chunk);
+        if (bucket == null) {
+            bucket = new Bucket();
+            byChunk.put(chunk, bucket);
+        }
+        final int slotIndex = bucket.add(id, x, y, z);
+        byId.put(id, new Slot(chunk, slotIndex, point));
+    }
+
+    @Override
+    public @Nullable Point remove(int id) {
+        final Slot slot = byId.remove(id);
+        if (slot == null) return null;
+        final long chunk = slot.chunk;
+        final Point point = slot.point;
+        final Bucket bucket = byChunk.get(chunk);
+        assert bucket != null;
+        final int swappedId = bucket.removeAt(slot.slotIndex);
+        if (swappedId != -1) {
+            final Slot swappedSlot = byId.get(swappedId);
+            assert swappedSlot != null;
+            swappedSlot.slotIndex = slot.slotIndex;
+        }
+        if (bucket.size == 0) byChunk.remove(chunk);
+
+        return point;
+    }
+
+    @Override
+    public @Nullable Point move(int id, Point newPoint) {
+        final Slot slot = byId.get(id);
+        if (slot == null) return null;
+        final Point oldPoint = slot.point;
+        final long oldChunk = slot.chunk;
+        final double newX = newPoint.x(), newY = newPoint.y(), newZ = newPoint.z();
+        final long newChunk = chunkIndex(globalToChunk(newX), globalToChunk(newZ));
+
+        if (oldChunk == newChunk) {
+            final Bucket bucket = byChunk.get(oldChunk);
+            assert bucket != null;
+            bucket.update(slot.slotIndex, newX, newY, newZ);
+            slot.point = newPoint;
+            return oldPoint;
+        }
+
+        Bucket newBucket = byChunk.get(newChunk);
+        if (newBucket == null) {
+            newBucket = new Bucket();
+            byChunk.put(newChunk, newBucket);
+        }
+        final int newSlotIndex = newBucket.add(id, newX, newY, newZ);
+        final Bucket oldBucket = byChunk.get(oldChunk);
+        assert oldBucket != null;
+        final int swappedId = oldBucket.removeAt(slot.slotIndex);
+        if (swappedId != -1) {
+            final Slot swappedSlot = byId.get(swappedId);
+            assert swappedSlot != null;
+            swappedSlot.slotIndex = slot.slotIndex;
+        }
+        if (oldBucket.size == 0) byChunk.remove(oldChunk);
+        slot.chunk = newChunk;
+        slot.slotIndex = newSlotIndex;
+        slot.point = newPoint;
+        return oldPoint;
+    }
+
+    @Override
+    public @Nullable Point get(int id) {
+        final Slot slot = byId.get(id);
+        return slot == null ? null : slot.point;
+    }
+
+    @Override
+    public int size() {
+        return byId.size();
+    }
+
+    @Override
+    public @Unmodifiable IntCollection all() {
+        return view;
+    }
+
+    @Override
+    public int nearest(Point point) {
+        if (byChunk.isEmpty()) return -1;
+        final double px = point.x(), py = point.y(), pz = point.z();
+        final NearestState state = new NearestState();
+
+        if (byChunk.size() <= 4) {
+            for (Bucket b : byChunk.values()) scanBucketForNearest(b, px, py, pz, state);
+            return state.bestId;
+        }
+
+        final int qcx = globalToChunk(px), qcz = globalToChunk(pz);
+        final int maxRing = 4096;
+        for (int r = 0; r <= maxRing; r++) {
+            if (r >= 1) {
+                final double minPossibleDist = SECTION_SIZE_D * (r - 1);
+                if (state.bestSq < minPossibleDist * minPossibleDist) break;
+            }
+            if (r == 0) {
+                scanChunkForNearest(qcx, qcz, px, py, pz, state);
+            } else {
+                for (int dx = -r; dx <= r; dx++) {
+                    scanChunkForNearest(qcx + dx, qcz - r, px, py, pz, state);
+                    scanChunkForNearest(qcx + dx, qcz + r, px, py, pz, state);
+                }
+                for (int dz = -r + 1; dz <= r - 1; dz++) {
+                    scanChunkForNearest(qcx - r, qcz + dz, px, py, pz, state);
+                    scanChunkForNearest(qcx + r, qcz + dz, px, py, pz, state);
+                }
+            }
+        }
+        return state.bestId;
+    }
+
+    private void scanChunkForNearest(int cx, int cz, double px, double py, double pz, NearestState state) {
+        final double cxMin = cx * SECTION_SIZE_D, cxMax = cxMin + SECTION_SIZE_D;
+        final double czMin = cz * SECTION_SIZE_D, czMax = czMin + SECTION_SIZE_D;
+        final double dx = Math.max(0.0, Math.max(cxMin - px, px - cxMax));
+        final double dz = Math.max(0.0, Math.max(czMin - pz, pz - czMax));
+        if (dx * dx + dz * dz >= state.bestSq) return;
+        final Bucket b = byChunk.get(chunkIndex(cx, cz));
+        if (b != null) scanBucketForNearest(b, px, py, pz, state);
+    }
+
+    private void scanBucketForNearest(Bucket b, double px, double py, double pz, NearestState state) {
+        final int n = b.size;
+        final double[] xs = b.xs, ys = b.ys, zs = b.zs;
+        final int[] ids = b.ids;
+        double bestSq = state.bestSq;
+        int bestId = state.bestId;
+        for (int i = 0; i < n; i++) {
+            final double dx = xs[i] - px, dy = ys[i] - py, dz = zs[i] - pz;
+            final double d = dx * dx + dy * dy + dz * dz;
+            if (d < bestSq) {
+                bestSq = d;
+                bestId = ids[i];
+            }
+        }
+        state.bestSq = bestSq;
+        state.bestId = bestId;
+    }
+
+    @Override
+    public void forEachWithin(Point point, double radius, IntConsumer consumer) {
+        final double px = point.x(), py = point.y(), pz = point.z();
+        final double rSq = radius * radius;
+        final int minCX = globalToChunk(px - radius);
+        final int maxCX = globalToChunk(px + radius);
+        final int minCZ = globalToChunk(pz - radius);
+        final int maxCZ = globalToChunk(pz + radius);
+
+        if (minCX == maxCX && minCZ == maxCZ) {
+            final Bucket b = byChunk.get(chunkIndex(minCX, minCZ));
+            if (b == null) return;
+            forEachInBucketWithin(b, px, py, pz, rSq, consumer);
+            return;
+        }
+        for (int cx = minCX; cx <= maxCX; cx++) {
+            final double cxMin = cx * SECTION_SIZE_D, cxMax = cxMin + SECTION_SIZE_D;
+            final double cdx = Math.max(0.0, Math.max(cxMin - px, px - cxMax));
+            final double cdxSq = cdx * cdx;
+            if (cdxSq >= rSq) continue;
+            for (int cz = minCZ; cz <= maxCZ; cz++) {
+                final double czMin = cz * SECTION_SIZE_D, czMax = czMin + SECTION_SIZE_D;
+                final double cdz = Math.max(0.0, Math.max(czMin - pz, pz - czMax));
+                if (cdxSq + cdz * cdz >= rSq) continue;
+                final Bucket b = byChunk.get(chunkIndex(cx, cz));
+                if (b == null) continue;
+                forEachInBucketWithin(b, px, py, pz, rSq, consumer);
+            }
+        }
+    }
+
+    private static void forEachInBucketWithin(Bucket b, double px, double py, double pz,
+                                              double rSq, IntConsumer consumer) {
+        final int n = b.size;
+        final double[] xs = b.xs, ys = b.ys, zs = b.zs;
+        final int[] ids = b.ids;
+        for (int i = 0; i < n; i++) {
+            final double dx = xs[i] - px, dy = ys[i] - py, dz = zs[i] - pz;
+            if (dx * dx + dy * dy + dz * dz <= rSq) consumer.accept(ids[i]);
+        }
+    }
+
+    @Override
+    public int count(Point point, double radius) {
+        final double px = point.x(), py = point.y(), pz = point.z();
+        final double rSq = radius * radius;
+        final int minCX = globalToChunk(px - radius);
+        final int maxCX = globalToChunk(px + radius);
+        final int minCZ = globalToChunk(pz - radius);
+        final int maxCZ = globalToChunk(pz + radius);
+        if (minCX == maxCX && minCZ == maxCZ) {
+            final Bucket b = byChunk.get(chunkIndex(minCX, minCZ));
+            return b == null ? 0 : countInBucketWithin(b, px, py, pz, rSq);
+        }
+        int total = 0;
+        for (int cx = minCX; cx <= maxCX; cx++) {
+            final double cxMin = cx * SECTION_SIZE_D, cxMax = cxMin + SECTION_SIZE_D;
+            final double cdx = Math.max(0.0, Math.max(cxMin - px, px - cxMax));
+            final double cdxSq = cdx * cdx;
+            if (cdxSq >= rSq) continue;
+            for (int cz = minCZ; cz <= maxCZ; cz++) {
+                final double czMin = cz * SECTION_SIZE_D, czMax = czMin + SECTION_SIZE_D;
+                final double cdz = Math.max(0.0, Math.max(czMin - pz, pz - czMax));
+                if (cdxSq + cdz * cdz >= rSq) continue;
+                final Bucket b = byChunk.get(chunkIndex(cx, cz));
+                if (b == null) continue;
+                total += countInBucketWithin(b, px, py, pz, rSq);
+            }
+        }
+        return total;
+    }
+
+    private static int countInBucketWithin(Bucket b, double px, double py, double pz, double rSq) {
+        final int n = b.size;
+        final double[] xs = b.xs, ys = b.ys, zs = b.zs;
+        int total = 0;
+        for (int i = 0; i < n; i++) {
+            final double dx = xs[i] - px, dy = ys[i] - py, dz = zs[i] - pz;
+            if (dx * dx + dy * dy + dz * dz <= rSq) total++;
+        }
+        return total;
+    }
+
+    @Override
+    public void forEachInChunk(int chunkX, int chunkZ, IntConsumer consumer) {
+        final Bucket b = byChunk.get(chunkIndex(chunkX, chunkZ));
+        if (b == null) return;
+        forEachInBucket(b, consumer);
+    }
+
+    private static void forEachInBucket(Bucket b, IntConsumer consumer) {
+        final int n = b.size;
+        final int[] ids = b.ids;
+        for (int i = 0; i < n; i++) consumer.accept(ids[i]);
+    }
+
+    @Override
+    public @Unmodifiable IntCollection inChunk(int chunkX, int chunkZ) {
+        return new ChunkView(this, chunkIndex(chunkX, chunkZ));
+    }
+
+    @Override
+    public void forEachInChunkRangeDiffering(Point oldPoint, Point newPoint, int chunkRange,
+                                             IntConsumer added, IntConsumer removed) {
+        final int oldCX = oldPoint.chunkX(), oldCZ = oldPoint.chunkZ();
+        final int newCX = newPoint.chunkX(), newCZ = newPoint.chunkZ();
+        for (int cx = newCX - chunkRange; cx <= newCX + chunkRange; cx++) {
+            for (int cz = newCZ - chunkRange; cz <= newCZ + chunkRange; cz++) {
+                if (Math.abs(cx - oldCX) <= chunkRange && Math.abs(cz - oldCZ) <= chunkRange) continue;
+                final Bucket b = byChunk.get(chunkIndex(cx, cz));
+                if (b == null) continue;
+                forEachInBucket(b, added);
+            }
+        }
+        for (int cx = oldCX - chunkRange; cx <= oldCX + chunkRange; cx++) {
+            for (int cz = oldCZ - chunkRange; cz <= oldCZ + chunkRange; cz++) {
+                if (Math.abs(cx - newCX) <= chunkRange && Math.abs(cz - newCZ) <= chunkRange) continue;
+                final Bucket b = byChunk.get(chunkIndex(cx, cz));
+                if (b == null) continue;
+                forEachInBucket(b, removed);
+            }
+        }
+    }
+
+    private static final class NearestState {
+        int bestId = -1;
+        double bestSq = Double.POSITIVE_INFINITY;
+    }
+
+    private static final class Slot {
+        long chunk;
+        int slotIndex;
+        Point point;
+
+        Slot(long chunk, int slotIndex, Point point) {
+            this.chunk = chunk;
+            this.slotIndex = slotIndex;
+            this.point = point;
+        }
+    }
+
+    private static final class Bucket {
+        int size;
+        double[] xs, ys, zs;
+        int[] ids;
+
+        Bucket() {
+            this.xs = new double[INITIAL_BUCKET_CAPACITY];
+            this.ys = new double[INITIAL_BUCKET_CAPACITY];
+            this.zs = new double[INITIAL_BUCKET_CAPACITY];
+            this.ids = new int[INITIAL_BUCKET_CAPACITY];
+        }
+
+        int add(int id, double x, double y, double z) {
+            if (size == xs.length) grow();
+            final int i = size++;
+            xs[i] = x;
+            ys[i] = y;
+            zs[i] = z;
+            ids[i] = id;
+            return i;
+        }
+
+        void update(int idx, double x, double y, double z) {
+            xs[idx] = x;
+            ys[idx] = y;
+            zs[idx] = z;
+        }
+
+        int removeAt(int idx) {
+            final int last = --size;
+            if (idx == last) return -1;
+            xs[idx] = xs[last];
+            ys[idx] = ys[last];
+            zs[idx] = zs[last];
+            ids[idx] = ids[last];
+            return ids[idx];
+        }
+
+        private void grow() {
+            final int newCap = xs.length * 2;
+            xs = Arrays.copyOf(xs, newCap);
+            ys = Arrays.copyOf(ys, newCap);
+            zs = Arrays.copyOf(zs, newCap);
+            ids = Arrays.copyOf(ids, newCap);
+        }
+    }
+
+    private static final class ChunkView extends AbstractIntCollection {
+        private final PointIndexImpl index;
+        private final long chunkKey;
+
+        ChunkView(PointIndexImpl index, long chunkKey) {
+            this.index = index;
+            this.chunkKey = chunkKey;
+        }
+
+        @Override
+        public IntIterator iterator() {
+            final Bucket b = index.byChunk.get(chunkKey);
+            if (b == null) return IntIterators.EMPTY_ITERATOR;
+            final int[] ids = b.ids;
+            final int n = b.size;
+            return new IntIterator() {
+                int i = 0;
+
+                @Override
+                public boolean hasNext() {
+                    return i < n;
+                }
+
+                @Override
+                public int nextInt() {
+                    if (i >= n) throw new NoSuchElementException();
+                    return ids[i++];
+                }
+            };
+        }
+
+        @Override
+        public int size() {
+            final Bucket b = index.byChunk.get(chunkKey);
+            return b == null ? 0 : b.size;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            final Bucket b = index.byChunk.get(chunkKey);
+            return b == null || b.size == 0;
+        }
+    }
+
+}

--- a/src/main/java/net/minestom/server/instance/EntityTrackerImpl.java
+++ b/src/main/java/net/minestom/server/instance/EntityTrackerImpl.java
@@ -1,29 +1,26 @@
 package net.minestom.server.instance;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntCollection;
+import it.unimi.dsi.fastutil.ints.IntIterator;
 import net.minestom.server.ServerFlag;
 import net.minestom.server.Viewable;
-import net.minestom.server.coordinate.ChunkRange;
-import net.minestom.server.coordinate.CoordConversion;
+import net.minestom.server.coordinate.PointIndex;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.Player;
-import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 import org.jetbrains.annotations.UnmodifiableView;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import space.vectrix.flare.fastutil.Int2ObjectSyncMap;
-import space.vectrix.flare.fastutil.Long2ObjectSyncMap;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import static net.minestom.server.instance.Chunk.CHUNK_SIZE_X;
 import static net.minestom.server.instance.Chunk.CHUNK_SIZE_Z;
@@ -33,220 +30,220 @@ final class EntityTrackerImpl implements EntityTracker {
 
     static final AtomicInteger TARGET_COUNTER = new AtomicInteger();
 
-    // Store all data associated to a Target
-    // The array index is the Target enum ordinal
-    final TargetEntry<Entity>[] targetEntries = EntityTracker.Target.TARGETS.stream().map((Function<Target<?>, TargetEntry>) TargetEntry::new).toArray(TargetEntry[]::new);
+    private final PointIndex[] indices;
 
-    private final Int2ObjectSyncMap<EntityTrackerEntry> entriesByEntityId = Int2ObjectSyncMap.hashmap();
-    private final Map<UUID, EntityTrackerEntry> entriesByEntityUuid = new ConcurrentHashMap<>();
+    private final Int2ObjectSyncMap<@Nullable Entity> entitiesById = Int2ObjectSyncMap.hashmap();
+    private final Map<UUID, @Nullable Entity> entitiesByUuid = new ConcurrentHashMap<>();
+    private final Map<ChunkViewKey, @Nullable ChunkView> viewers = new ConcurrentHashMap<>();
+
+    EntityTrackerImpl() {
+        final int targetCount = Target.TARGETS.size();
+        this.indices = new PointIndex[targetCount];
+        for (int i = 0; i < targetCount; i++) this.indices[i] = PointIndex.createConcurrent();
+    }
 
     @Override
     public <T extends Entity> void register(Entity entity, Point point,
                                             Target<T> target, @Nullable Update<T> update) {
-        EntityTrackerEntry newEntry = new EntityTrackerEntry(entity, point);
-
-        EntityTrackerEntry prevEntryWithId = entriesByEntityId.putIfAbsent(entity.getEntityId(), newEntry);
-        Check.isTrue(prevEntryWithId == null, "There is already an entity registered with id {0}", entity.getEntityId());
-        EntityTrackerEntry prevEntryWithUuid = entriesByEntityUuid.putIfAbsent(entity.getUuid(), newEntry);
-        Check.isTrue(prevEntryWithUuid == null, "There is already an entity registered with uuid {0}", entity.getUuid());
-
-        final long index = CoordConversion.chunkIndex(point);
-        for (TargetEntry<Entity> targetEntry : targetEntries) {
-            if (targetEntry.target.type().isInstance(entity)) {
-                targetEntry.entities.add(entity);
-                targetEntry.addToChunk(index, entity);
-            }
+        final int id = entity.getEntityId();
+        final UUID uuid = entity.getUuid();
+        final Entity previousById = entitiesById.putIfAbsent(id, entity);
+        if (previousById != null) {
+            throw new IllegalStateException("There is already an entity registered with id " + id);
         }
+        final Entity previousByUuid = entitiesByUuid.putIfAbsent(uuid, entity);
+        if (previousByUuid != null) {
+            entitiesById.remove(id);
+            throw new IllegalStateException("There is already an entity registered with uuid " + uuid);
+        }
+        forEachTargetIndex(entity, index -> index.add(id, point));
         if (update != null) {
             update.referenceUpdate(point, this);
-            nearbyEntitiesByChunkRange(point, ServerFlag.ENTITY_VIEW_DISTANCE, target, newEntity -> {
-                if (newEntity == entity) return;
-                update.add(newEntity);
+            indices[target.ordinal()].forEachInChunkRange(point, ServerFlag.ENTITY_VIEW_DISTANCE, neighborId -> {
+                if (neighborId == id) return;
+                acceptEntity(neighborId, update::add);
             });
         }
     }
 
     @Override
-    public <T extends Entity> void unregister(Entity entity,
-                                              Target<T> target, @Nullable Update<T> update) {
-        EntityTrackerEntry entry = entriesByEntityId.remove(entity.getEntityId());
-        entriesByEntityUuid.remove(entity.getUuid());
-        final Point point = entry == null ? null : entry.getLastPosition();
-        if (point == null) return;
-
-        final long index = CoordConversion.chunkIndex(point);
-        for (TargetEntry<Entity> targetEntry : targetEntries) {
-            if (targetEntry.target.type().isInstance(entity)) {
-                targetEntry.entities.remove(entity);
-                targetEntry.removeFromChunk(index, entity);
-            }
+    public <T extends Entity> void unregister(Entity entity, Target<T> target, @Nullable Update<T> update) {
+        final int id = entity.getEntityId();
+        final Entity removed = entitiesById.remove(id);
+        if (removed == null) return;
+        entitiesByUuid.remove(entity.getUuid());
+        @Nullable Point lastPoint = null;
+        for (Target<? extends Entity> t : Target.TARGETS) {
+            if (!t.type().isInstance(entity)) continue;
+            final Point p = indices[t.ordinal()].remove(id);
+            if (lastPoint == null) lastPoint = p;
         }
+        if (lastPoint == null) return;
         if (update != null) {
-            update.referenceUpdate(point, null);
-            nearbyEntitiesByChunkRange(point, ServerFlag.ENTITY_VIEW_DISTANCE, target, newEntity -> {
-                if (newEntity == entity) return;
-                update.remove(newEntity);
+            update.referenceUpdate(lastPoint, null);
+            indices[target.ordinal()].forEachInChunkRange(lastPoint, ServerFlag.ENTITY_VIEW_DISTANCE, neighborId -> {
+                if (neighborId == id) return;
+                acceptEntity(neighborId, update::remove);
             });
         }
     }
 
     @Override
     public @Nullable Entity getEntityById(int id) {
-        EntityTrackerEntry entry = entriesByEntityId.get(id);
-        return entry == null ? null : entry.getEntity();
+        return entitiesById.get(id);
     }
 
     @Override
     public @Nullable Entity getEntityByUuid(UUID uuid) {
-        EntityTrackerEntry entry = entriesByEntityUuid.get(uuid);
-        return entry == null ? null : entry.getEntity();
+        return entitiesByUuid.get(uuid);
     }
 
     @Override
     public <T extends Entity> void move(Entity entity, Point newPoint,
                                         Target<T> target, @Nullable Update<T> update) {
-        EntityTrackerEntry entry = entriesByEntityId.get(entity.getEntityId());
-        if (entry == null) {
-            LOGGER.warn("Attempted to move unregistered entity {} in the entity tracker", entity.getEntityId());
+        final int id = entity.getEntityId();
+        final PointIndex entitiesIndex = indices[Target.ENTITIES.ordinal()];
+        final Point oldPoint = entitiesIndex.get(id);
+        if (oldPoint == null) {
+            LOGGER.warn("Attempted to move unregistered entity {} in the entity tracker", id);
             return;
         }
-        Point oldPoint = entry.getLastPosition();
-        entry.setLastPosition(newPoint);
-        if (oldPoint == null || oldPoint.sameChunk(newPoint)) return;
-        final long oldIndex = CoordConversion.chunkIndex(oldPoint);
-        final long newIndex = CoordConversion.chunkIndex(newPoint);
-        for (TargetEntry<Entity> targetEntry : targetEntries) {
-            if (targetEntry.target.type().isInstance(entity)) {
-                targetEntry.addToChunk(newIndex, entity);
-                targetEntry.removeFromChunk(oldIndex, entity);
-            }
-        }
+        forEachTargetIndex(entity, index -> index.move(id, newPoint));
+        if (oldPoint.sameChunk(newPoint)) return;
         if (update != null) {
-            difference(oldPoint, newPoint, target, new Update<>() {
-                @Override
-                public void add(T added) {
-                    if (entity != added) update.add(added);
-                }
-
-                @Override
-                public void remove(T removed) {
-                    if (entity != removed) update.remove(removed);
-                }
-            });
+            indices[target.ordinal()].forEachInChunkRangeDiffering(oldPoint, newPoint, ServerFlag.ENTITY_VIEW_DISTANCE,
+                    addedId -> {
+                        if (addedId == id) return;
+                        acceptEntity(addedId, update::add);
+                    },
+                    removedId -> {
+                        if (removedId == id) return;
+                        acceptEntity(removedId, update::remove);
+                    });
             update.referenceUpdate(newPoint, this);
         }
     }
 
     @Override
     public @Unmodifiable <T extends Entity> Collection<T> chunkEntities(int chunkX, int chunkZ, Target<T> target) {
-        final TargetEntry<Entity> entry = targetEntries[target.ordinal()];
-        //noinspection unchecked
-        var chunkEntities = (List<T>) entry.chunkEntities(CoordConversion.chunkIndex(chunkX, chunkZ));
-        return Collections.unmodifiableList(chunkEntities);
+        return new MappedCollection<>(indices[target.ordinal()].inChunk(chunkX, chunkZ), entitiesById);
     }
 
     @Override
-    public <T extends Entity> void nearbyEntitiesByChunkRange(Point point, int chunkRange, Target<T> target, Consumer<T> query) {
-        final Long2ObjectSyncMap<List<Entity>> entities = targetEntries[target.ordinal()].chunkEntities;
-        if (chunkRange == 0) {
-            // Single chunk
-            final var chunkEntities = (List<T>) entities.get(CoordConversion.chunkIndex(point));
-            if (chunkEntities != null && !chunkEntities.isEmpty()) {
-                chunkEntities.forEach(query);
-            }
-        } else {
-            // Multiple chunks
-            ChunkRange.chunksInRange(point, chunkRange, (chunkX, chunkZ) -> {
-                final var chunkEntities = (List<T>) entities.get(CoordConversion.chunkIndex(chunkX, chunkZ));
-                if (chunkEntities == null || chunkEntities.isEmpty()) return;
-                chunkEntities.forEach(query);
-            });
-        }
+    public <T extends Entity> void nearbyEntitiesByChunkRange(Point point, int chunkRange,
+                                                              Target<T> target, Consumer<T> query) {
+        indices[target.ordinal()].forEachInChunkRange(point, chunkRange, id -> {
+            acceptEntity(id, query);
+        });
     }
 
     @Override
-    public <T extends Entity> void nearbyEntities(Point point, double range, Target<T> target, Consumer<T> query) {
-        final Long2ObjectSyncMap<List<Entity>> entities = targetEntries[target.ordinal()].chunkEntities;
-        final int minChunkX = CoordConversion.globalToChunk(point.x() - range);
-        final int minChunkZ = CoordConversion.globalToChunk(point.z() - range);
-        final int maxChunkX = CoordConversion.globalToChunk(point.x() + range);
-        final int maxChunkZ = CoordConversion.globalToChunk(point.z() + range);
-        final double squaredRange = range * range;
-        if (minChunkX == maxChunkX && minChunkZ == maxChunkZ) {
-            // Single chunk
-            final var chunkEntities = (List<T>) entities.get(CoordConversion.chunkIndex(point));
-            if (chunkEntities != null && !chunkEntities.isEmpty()) {
-                chunkEntities.forEach(entity -> {
-                    final Point position = entriesByEntityId.get(entity.getEntityId()).getLastPosition();
-                    if (point.distanceSquared(position) <= squaredRange) query.accept(entity);
-                });
-            }
-        } else {
-            // Multiple chunks
-            final int chunkRange = (int) (range / Chunk.CHUNK_SECTION_SIZE) + 1;
-            ChunkRange.chunksInRange(point, chunkRange, (chunkX, chunkZ) -> {
-                final var chunkEntities = (List<T>) entities.get(CoordConversion.chunkIndex(chunkX, chunkZ));
-                if (chunkEntities == null || chunkEntities.isEmpty()) return;
-                chunkEntities.forEach(entity -> {
-                    final Point position = entriesByEntityId.get(entity.getEntityId()).getLastPosition();
-                    if (point.distanceSquared(position) <= squaredRange) {
-                        query.accept(entity);
-                    }
-                });
-            });
-        }
+    public <T extends Entity> void nearbyEntities(Point point, double range,
+                                                  Target<T> target, Consumer<T> query) {
+        indices[target.ordinal()].forEachWithin(point, range, id -> {
+            acceptEntity(id, query);
+        });
     }
 
     @Override
     public @UnmodifiableView <T extends Entity> Set<T> entities(Target<T> target) {
-        //noinspection unchecked
-        return (Set<T>) targetEntries[target.ordinal()].entitiesView;
+        return new MappedSet<>(indices[target.ordinal()].all(), entitiesById);
     }
 
     @Override
     public Viewable viewable(List<SharedInstance> sharedInstances, int chunkX, int chunkZ) {
-        var entry = targetEntries[Target.PLAYERS.ordinal()];
-        return entry.viewers.computeIfAbsent(new ChunkViewKey(sharedInstances, chunkX, chunkZ), ChunkView::new);
+        return viewers.computeIfAbsent(new ChunkViewKey(sharedInstances, chunkX, chunkZ), ChunkView::new);
     }
 
-    private static class EntityTrackerEntry {
-        private final Entity entity;
-        private Point lastPosition;
-
-        private EntityTrackerEntry(Entity entity, @Nullable Point lastPosition) {
-            this.entity = entity;
-            this.lastPosition = lastPosition;
-        }
-
-        public Entity getEntity() {
-            return entity;
-        }
-
-        @Nullable
-        public Point getLastPosition() {
-            return lastPosition;
-        }
-
-        public void setLastPosition(Point lastPosition) {
-            this.lastPosition = lastPosition;
+    private void forEachTargetIndex(Entity entity, Consumer<PointIndex> consumer) {
+        for (Target<? extends Entity> target : Target.TARGETS) {
+            if (target.type().isInstance(entity)) consumer.accept(indices[target.ordinal()]);
         }
     }
 
-    private <T extends Entity> void difference(Point oldPoint, Point newPoint,
-                                               Target<T> target, Update<T> update) {
-        final TargetEntry<Entity> entry = targetEntries[target.ordinal()];
-        ChunkRange.chunksInRangeDiffering(newPoint.chunkX(), newPoint.chunkZ(), oldPoint.chunkX(), oldPoint.chunkZ(),
-                ServerFlag.ENTITY_VIEW_DISTANCE, (chunkX, chunkZ) -> {
-                    // Add
-                    final List<Entity> entities = entry.chunkEntities.get(CoordConversion.chunkIndex(chunkX, chunkZ));
-                    if (entities == null || entities.isEmpty()) return;
-                    for (Entity entity : entities) update.add((T) entity);
-                }, (chunkX, chunkZ) -> {
-                    // Remove
-                    final List<Entity> entities = entry.chunkEntities.get(CoordConversion.chunkIndex(chunkX, chunkZ));
-                    if (entities == null || entities.isEmpty()) return;
-                    for (Entity entity : entities) update.remove((T) entity);
-                });
+    @SuppressWarnings("unchecked")
+    private <T extends Entity> void acceptEntity(int id, Consumer<T> consumer) {
+        final Entity entity = entitiesById.get(id);
+        if (entity != null) consumer.accept((T) entity);
+    }
+
+    private static final class MappedCollection<T extends Entity> extends AbstractCollection<T> {
+        private final IntCollection ids;
+        private final Int2ObjectSyncMap<@Nullable Entity> resolver;
+
+        MappedCollection(IntCollection ids, Int2ObjectSyncMap<@Nullable Entity> resolver) {
+            this.ids = ids;
+            this.resolver = resolver;
+        }
+
+        @Override
+        public Iterator<T> iterator() {
+            return mappingIterator(ids.intIterator(), resolver);
+        }
+
+        @Override
+        public int size() {
+            return ids.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return ids.isEmpty();
+        }
+    }
+
+    private static final class MappedSet<T extends Entity> extends AbstractSet<T> {
+        private final IntCollection ids;
+        private final Int2ObjectSyncMap<@Nullable Entity> resolver;
+
+        MappedSet(IntCollection ids, Int2ObjectSyncMap<@Nullable Entity> resolver) {
+            this.ids = ids;
+            this.resolver = resolver;
+        }
+
+        @Override
+        public Iterator<T> iterator() {
+            return mappingIterator(ids.intIterator(), resolver);
+        }
+
+        @Override
+        public int size() {
+            return ids.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return ids.isEmpty();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Entity> Iterator<T> mappingIterator(IntIterator ids,
+                                                                  Int2ObjectSyncMap<@Nullable Entity> resolver) {
+        return new Iterator<>() {
+            private @Nullable T next;
+
+            @Override
+            public boolean hasNext() {
+                if (next != null) return true;
+                while (ids.hasNext()) {
+                    final Entity entity = resolver.get(ids.nextInt());
+                    if (entity != null) {
+                        next = (T) entity;
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            @Override
+            public T next() {
+                if (!hasNext()) throw new java.util.NoSuchElementException();
+                final T value = Objects.requireNonNull(next);
+                next = null;
+                return value;
+            }
+        };
     }
 
     record ChunkViewKey(List<SharedInstance> sharedInstances, int chunkX, int chunkZ) {
@@ -260,46 +257,15 @@ final class EntityTrackerImpl implements EntityTracker {
         }
     }
 
-    static final class TargetEntry<T extends Entity> {
-        private final EntityTracker.Target<T> target;
-        private final Set<T> entities = ConcurrentHashMap.newKeySet(); // Thread-safe since exposed
-        private final Set<T> entitiesView = Collections.unmodifiableSet(entities);
-        // Chunk index -> entities inside it
-        final Long2ObjectSyncMap<List<T>> chunkEntities = Long2ObjectSyncMap.hashmap();
-        final Map<ChunkViewKey, ChunkView> viewers = new ConcurrentHashMap<>();
-
-        TargetEntry(Target<T> target) {
-            this.target = target;
-        }
-
-        List<T> chunkEntities(long index) {
-            return chunkEntities.computeIfAbsent(index, i -> (List<T>) new CopyOnWriteArrayList());
-        }
-
-        void addToChunk(long index, T entity) {
-            chunkEntities(index).add(entity);
-        }
-
-        void removeFromChunk(long index, T entity) {
-            List<T> entities = chunkEntities.get(index);
-            if (entities != null) entities.remove(entity);
-        }
-    }
-
     private final class ChunkView implements Viewable {
         private final ChunkViewKey key;
-        private final int chunkX, chunkZ;
         private final Point point;
         final Set<Player> set = new SetImpl();
         private int lastReferenceCount;
 
         private ChunkView(ChunkViewKey key) {
             this.key = key;
-
-            this.chunkX = key.chunkX;
-            this.chunkZ = key.chunkZ;
-
-            this.point = new Vec(CHUNK_SIZE_X * chunkX, 0, CHUNK_SIZE_Z * chunkZ);
+            this.point = new Vec(CHUNK_SIZE_X * key.chunkX, 0, CHUNK_SIZE_Z * key.chunkZ);
         }
 
         @Override
@@ -318,7 +284,7 @@ final class EntityTrackerImpl implements EntityTracker {
         }
 
         private Collection<Player> references() {
-            Int2ObjectOpenHashMap<Player> entityMap = new Int2ObjectOpenHashMap<>(lastReferenceCount);
+            final Int2ObjectOpenHashMap<@Nullable Player> entityMap = new Int2ObjectOpenHashMap<>(lastReferenceCount);
             collectPlayers(EntityTrackerImpl.this, entityMap);
             if (!key.sharedInstances.isEmpty()) {
                 for (SharedInstance instance : key.sharedInstances) {
@@ -329,9 +295,9 @@ final class EntityTrackerImpl implements EntityTracker {
             return entityMap.values();
         }
 
-        private void collectPlayers(EntityTracker tracker, Int2ObjectOpenHashMap<Player> map) {
-            tracker.nearbyEntitiesByChunkRange(point, ServerFlag.CHUNK_VIEW_DISTANCE,
-                    EntityTracker.Target.PLAYERS, (player) -> map.putIfAbsent(player.getEntityId(), player));
+        private void collectPlayers(EntityTracker tracker, Int2ObjectOpenHashMap<@Nullable Player> map) {
+            tracker.nearbyEntitiesByChunkRange(point, ServerFlag.CHUNK_VIEW_DISTANCE, Target.PLAYERS,
+                    (Player player) -> map.putIfAbsent(player.getEntityId(), player));
         }
 
         final class SetImpl extends AbstractSet<Player> {

--- a/src/test/java/net/minestom/server/coordinate/PointIndexTest.java
+++ b/src/test/java/net/minestom/server/coordinate/PointIndexTest.java
@@ -1,0 +1,414 @@
+package net.minestom.server.coordinate;
+
+import it.unimi.dsi.fastutil.ints.IntCollection;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PointIndexTest {
+
+    static Stream<Arguments> impls() {
+        return Stream.of(
+                Arguments.of("plain", (Supplier<PointIndex>) PointIndex::create),
+                Arguments.of("concurrent", (Supplier<PointIndex>) PointIndex::createConcurrent)
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("impls")
+    void addGetContainsSize(String name, Supplier<PointIndex> factory) {
+        PointIndex idx = factory.get();
+        assertEquals(0, idx.size());
+        assertNull(idx.get(1));
+        assertFalse(idx.contains(1));
+
+        Vec p = new Vec(0, 0, 0);
+        idx.add(1, p);
+        assertEquals(1, idx.size());
+        assertEquals(p, idx.get(1));
+        assertTrue(idx.contains(1));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("impls")
+    void addDuplicateThrows(String name, Supplier<PointIndex> factory) {
+        PointIndex idx = factory.get();
+        idx.add(1, new Vec(0, 0, 0));
+        assertThrows(IllegalStateException.class, () -> idx.add(1, new Vec(1, 0, 0)));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("impls")
+    void removeReturnsLastPointAndUpdatesSize(String name, Supplier<PointIndex> factory) {
+        PointIndex idx = factory.get();
+        Vec p = new Vec(7, 0, 3);
+        idx.add(1, p);
+        assertEquals(p, idx.remove(1));
+        assertEquals(0, idx.size());
+        assertNull(idx.remove(1));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("impls")
+    void moveReturnsOldPointAndUpdatesPosition(String name, Supplier<PointIndex> factory) {
+        PointIndex idx = factory.get();
+        Vec p0 = new Vec(0, 0, 0);
+        Vec p1 = new Vec(100, 0, 100);
+        idx.add(1, p0);
+        assertEquals(p0, idx.move(1, p1));
+        assertEquals(p1, idx.get(1));
+
+        Set<Integer> nearOrigin = new HashSet<>();
+        idx.forEachWithin(new Vec(0, 0, 0), 10, nearOrigin::add);
+        assertTrue(nearOrigin.isEmpty(), "id should have moved out of origin radius");
+
+        Set<Integer> nearTarget = new HashSet<>();
+        idx.forEachWithin(new Vec(100, 0, 100), 10, nearTarget::add);
+        assertEquals(Set.of(1), nearTarget);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("impls")
+    void moveUnknownReturnsNull(String name, Supplier<PointIndex> factory) {
+        assertNull(factory.get().move(99, new Vec(0, 0, 0)));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("impls")
+    void nearestEmptyReturnsSentinel(String name, Supplier<PointIndex> factory) {
+        assertEquals(-1, factory.get().nearest(new Vec(0, 0, 0)));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("impls")
+    void nearestPicksClosest(String name, Supplier<PointIndex> factory) {
+        PointIndex idx = factory.get();
+        idx.add(1, new Vec(100, 0, 0));
+        idx.add(2, new Vec(5, 0, 0));
+        idx.add(3, new Vec(50, 0, 0));
+        assertEquals(2, idx.nearest(new Vec(0, 0, 0)));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("impls")
+    void withinReturnsCorrectSet(String name, Supplier<PointIndex> factory) {
+        PointIndex idx = factory.get();
+        idx.add(1, new Vec(0, 0, 0));
+        idx.add(2, new Vec(5, 0, 0));
+        idx.add(3, new Vec(20, 0, 0));
+        idx.add(4, new Vec(0, 30, 0)); // Y component matters
+
+        Set<Integer> found = new HashSet<>();
+        idx.forEachWithin(new Vec(0, 0, 0), 10, found::add);
+        assertEquals(Set.of(1, 2), found);
+
+        assertEquals(2, idx.count(new Vec(0, 0, 0), 10));
+        assertEquals(3, idx.count(new Vec(0, 0, 0), 25));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("impls")
+    void withinCrossesChunkBoundaries(String name, Supplier<PointIndex> factory) {
+        PointIndex idx = factory.get();
+        idx.add(1, new Vec(-3, 0, -3));   // chunk (-1, -1)
+        idx.add(2, new Vec(3, 0, 3));     // chunk (0, 0)
+        idx.add(3, new Vec(20, 0, 20));   // chunk (1, 1)
+        idx.add(4, new Vec(60, 0, 60));
+
+        Set<Integer> found = new HashSet<>();
+        idx.forEachWithin(new Vec(0, 0, 0), 30, found::add);
+        assertEquals(Set.of(1, 2, 3), found);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("impls")
+    void allReturnsLiveView(String name, Supplier<PointIndex> factory) {
+        PointIndex idx = factory.get();
+        idx.add(1, new Vec(0, 0, 0));
+        idx.add(2, new Vec(0, 0, 0));
+        assertEquals(2, idx.all().size());
+        idx.remove(1);
+        assertEquals(1, idx.all().size());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("impls")
+    void forEachInChunkReturnsBucket(String name, Supplier<PointIndex> factory) {
+        PointIndex idx = factory.get();
+        idx.add(1, new Vec(2, 0, 2));    // chunk (0,0)
+        idx.add(2, new Vec(10, 50, 10)); // chunk (0,0)
+        idx.add(3, new Vec(20, 0, 0));   // chunk (1,0)
+
+        Set<Integer> chunk00 = new HashSet<>();
+        idx.forEachInChunk(0, 0, chunk00::add);
+        assertEquals(Set.of(1, 2), chunk00);
+
+        Set<Integer> chunk10 = new HashSet<>();
+        idx.forEachInChunk(1, 0, chunk10::add);
+        assertEquals(Set.of(3), chunk10);
+
+        Set<Integer> empty = new HashSet<>();
+        idx.forEachInChunk(99, 99, empty::add);
+        assertTrue(empty.isEmpty());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("impls")
+    void inChunkIsLiveView(String name, Supplier<PointIndex> factory) {
+        PointIndex idx = factory.get();
+        IntCollection view = idx.inChunk(0, 0);
+        assertTrue(view.isEmpty());
+        assertEquals(0, view.size());
+
+        idx.add(1, new Vec(2, 0, 2));
+        assertEquals(1, view.size());
+        assertFalse(view.isEmpty());
+
+        idx.add(2, new Vec(8, 0, 8));
+        assertEquals(2, view.size());
+
+        idx.remove(1);
+        assertEquals(1, view.size());
+
+        // Empty chunks return a live empty view too.
+        IntCollection empty = idx.inChunk(99, 99);
+        assertTrue(empty.isEmpty());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("impls")
+    void forEachInChunkRangeIgnoresDistance(String name, Supplier<PointIndex> factory) {
+        PointIndex idx = factory.get();
+        idx.add(1, new Vec(2, 0, 2));     // chunk (0,0)
+        idx.add(2, new Vec(20, 0, 20));   // chunk (1,1)
+        idx.add(3, new Vec(40, 0, 40));   // chunk (2,2)
+        idx.add(4, new Vec(100, 0, 100));
+
+        Set<Integer> range1 = new HashSet<>();
+        idx.forEachInChunkRange(new Vec(0, 0, 0), 1, range1::add);
+        assertEquals(Set.of(1, 2), range1);
+
+        Set<Integer> range2 = new HashSet<>();
+        idx.forEachInChunkRange(new Vec(0, 0, 0), 2, range2::add);
+        assertEquals(Set.of(1, 2, 3), range2);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("impls")
+    void forEachInChunkRangeDifferingReportsSymmetricDifference(String name, Supplier<PointIndex> factory) {
+        PointIndex idx = factory.get();
+        idx.add(1, new Vec(0, 0, 0));    // chunk (0,0)
+        idx.add(2, new Vec(100, 0, 0));  // chunk (6,0)
+        idx.add(3, new Vec(20, 0, 20));  // chunk (1,1)
+        idx.add(4, new Vec(80, 0, 0));   // chunk (5,0)
+
+        Set<Integer> added = new HashSet<>();
+        Set<Integer> removed = new HashSet<>();
+        idx.forEachInChunkRangeDiffering(new Vec(0, 0, 0), new Vec(100, 0, 0), 1, added::add, removed::add);
+        assertEquals(Set.of(2, 4), added);
+        assertEquals(Set.of(1, 3), removed);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("impls")
+    void forEachInChunkRangeDifferingSkipsOverlap(String name, Supplier<PointIndex> factory) {
+        PointIndex idx = factory.get();
+        idx.add(99, new Vec(20, 0, 0));
+        idx.add(1, new Vec(0, 0, 0));   // chunk (0, 0)
+        idx.add(2, new Vec(40, 0, 0));  // chunk (2, 0)
+
+        Set<Integer> added = new HashSet<>();
+        Set<Integer> removed = new HashSet<>();
+        idx.forEachInChunkRangeDiffering(new Vec(0, 0, 0), new Vec(32, 0, 0), 1, added::add, removed::add);
+        assertEquals(Set.of(2), added);
+        assertEquals(Set.of(1), removed);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("impls")
+    void singleChunkRadiusFastPath(String name, Supplier<PointIndex> factory) {
+        PointIndex idx = factory.get();
+        idx.add(1, new Vec(2, 0, 2));
+        idx.add(2, new Vec(8, 0, 8));
+        idx.add(3, new Vec(14, 0, 14));
+
+        Set<Integer> found = new HashSet<>();
+        idx.forEachWithin(new Vec(8, 0, 8), 3, found::add);
+        assertEquals(Set.of(2), found);
+        assertEquals(1, idx.count(new Vec(8, 0, 8), 3));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("impls")
+    void swapRemoveKeepsBucketConsistent(String name, Supplier<PointIndex> factory) {
+        PointIndex idx = factory.get();
+        for (int i = 1; i <= 5; i++) idx.add(i, new Vec(i, 0, 0));
+
+        idx.remove(2);
+        assertNull(idx.get(2));
+        assertEquals(4, idx.size());
+
+        idx.move(5, new Vec(5, 0, 16));
+        Set<Integer> found = new HashSet<>();
+        idx.forEachInChunk(0, 1, found::add);
+        assertEquals(Set.of(5), found);
+
+        assertNotNull(idx.get(1));
+        assertNotNull(idx.get(3));
+        assertNotNull(idx.get(4));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("impls")
+    void nearestAcrossManyChunks(String name, Supplier<PointIndex> factory) {
+        PointIndex idx = factory.get();
+        for (int x = -3; x <= 3; x++) {
+            for (int z = -3; z <= 3; z++) {
+                idx.add((x + 10) * 100 + (z + 10), new Vec(x * 16 + 8, 0, z * 16 + 8));
+            }
+        }
+        // 49 buckets; query at (50, 0, 50). Nearest is in chunk (3, 3) at (56, 0, 56).
+        int nearest = idx.nearest(new Vec(50, 0, 50));
+        assertNotEquals(-1, nearest);
+        assertEquals(new Vec(56, 0, 56), idx.get(nearest));
+    }
+
+    @Test
+    void concurrentAddMoveRemoveStaysConsistent() throws InterruptedException {
+        final PointIndex idx = PointIndex.createConcurrent();
+        final int threads = 8;
+        final int idsPerThread = 200;
+        final int movesPerId = 50;
+        final ExecutorService pool = Executors.newFixedThreadPool(threads);
+        final CountDownLatch start = new CountDownLatch(1);
+        final AtomicInteger errors = new AtomicInteger();
+        try {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int t = 0; t < threads; t++) {
+                final int threadId = t;
+                futures.add(pool.submit(() -> {
+                    try {
+                        start.await();
+                        final int base = threadId * idsPerThread;
+                        for (int i = 0; i < idsPerThread; i++) {
+                            idx.add(base + i + 1, new Vec(base + i, 64, base + i));
+                        }
+                        java.util.Random r = new java.util.Random(threadId);
+                        for (int m = 0; m < movesPerId; m++) {
+                            for (int i = 0; i < idsPerThread; i++) {
+                                idx.move(base + i + 1, new Vec(
+                                        r.nextDouble(-256, 256),
+                                        r.nextDouble(0, 256),
+                                        r.nextDouble(-256, 256)));
+                            }
+                        }
+                        for (int i = 0; i < idsPerThread; i++) {
+                            assertNotNull(idx.remove(base + i + 1), "remove " + (base + i + 1));
+                        }
+                    } catch (Throwable e) {
+                        errors.incrementAndGet();
+                        e.printStackTrace();
+                    }
+                }));
+            }
+            start.countDown();
+            for (Future<?> f : futures) {
+                try {
+                    f.get(60, TimeUnit.SECONDS);
+                } catch (Exception e) {
+                    errors.incrementAndGet();
+                    e.printStackTrace();
+                }
+            }
+        } finally {
+            pool.shutdownNow();
+            assertTrue(pool.awaitTermination(5, TimeUnit.SECONDS));
+        }
+        assertEquals(0, errors.get(), "concurrent ops threw");
+        assertEquals(0, idx.size(), "index leaked entries");
+    }
+
+    @Test
+    void concurrentReadsDuringMutationAreNonNull() throws InterruptedException {
+        final PointIndex idx = PointIndex.createConcurrent();
+        for (int i = 0; i < 500; i++) {
+            idx.add(i + 1, new Vec(i % 32, 64, i / 32));
+        }
+        final int writers = 2;
+        final int readers = 4;
+        final long durationNs = TimeUnit.MILLISECONDS.toNanos(500);
+        final ExecutorService pool = Executors.newFixedThreadPool(writers + readers);
+        final CountDownLatch start = new CountDownLatch(1);
+        final AtomicInteger errors = new AtomicInteger();
+        try {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int w = 0; w < writers; w++) {
+                final int seed = w;
+                futures.add(pool.submit(() -> {
+                    try {
+                        start.await();
+                        final long deadline = System.nanoTime() + durationNs;
+                        java.util.Random r = new java.util.Random(seed);
+                        while (System.nanoTime() < deadline) {
+                            final int id = r.nextInt(500) + 1;
+                            idx.move(id, new Vec(
+                                    r.nextDouble(-256, 256),
+                                    r.nextDouble(0, 256),
+                                    r.nextDouble(-256, 256)));
+                        }
+                    } catch (Throwable e) {
+                        errors.incrementAndGet();
+                        e.printStackTrace();
+                    }
+                }));
+            }
+            for (int r = 0; r < readers; r++) {
+                futures.add(pool.submit(() -> {
+                    try {
+                        start.await();
+                        final long deadline = System.nanoTime() + durationNs;
+                        while (System.nanoTime() < deadline) {
+                            idx.forEachWithin(new Vec(0, 64, 0), 100, id -> {
+                            });
+                            idx.count(new Vec(0, 64, 0), 50);
+                            idx.nearest(new Vec(0, 64, 0));
+                        }
+                    } catch (Throwable e) {
+                        errors.incrementAndGet();
+                        e.printStackTrace();
+                    }
+                }));
+            }
+            start.countDown();
+            for (Future<?> f : futures) {
+                try {
+                    f.get(60, TimeUnit.SECONDS);
+                } catch (Exception e) {
+                    errors.incrementAndGet();
+                    e.printStackTrace();
+                }
+            }
+        } finally {
+            pool.shutdownNow();
+            assertTrue(pool.awaitTermination(5, TimeUnit.SECONDS));
+        }
+        assertEquals(0, errors.get(), "concurrent reads/writes threw");
+    }
+
+}


### PR DESCRIPTION
Goal is to introduce a more testable backend for `EntityTracker` which could also be used standalone, and for the potential entity tracker replacement.

One note is that not directly relying on `Entity` let be a bit more creative in the data layout, currently having one array with ids and others with coordinates

Very experimental and require a lot more reviewing. No entity tracking/collision benchmark on master, may have to duplicate #3162