### PR TITLE
feat(command): add ArgumentHexColor for the minecraft:hex_color parser

### DIFF
--- a/src/main/java/net/minestom/server/command/builder/arguments/ArgumentType.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/ArgumentType.java
@@ -116,6 +116,13 @@ public class ArgumentType {
     }
 
     /**
+     * @see ArgumentHexColor
+     */
+    public static ArgumentHexColor HexColor(String id) {
+        return new ArgumentHexColor(id);
+    }
+
+    /**
      * @see ArgumentTime
      */
     public static ArgumentTime Time(String id) {

--- a/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentHexColor.java
+++ b/src/main/java/net/minestom/server/command/builder/arguments/minecraft/ArgumentHexColor.java
@@ -1,0 +1,50 @@
+package net.minestom.server.command.builder.arguments.minecraft;
+
+import net.kyori.adventure.text.format.TextColor;
+import net.minestom.server.command.ArgumentParserType;
+import net.minestom.server.command.CommandSender;
+import net.minestom.server.command.builder.arguments.Argument;
+import net.minestom.server.command.builder.exception.ArgumentSyntaxException;
+
+/**
+ * Represents an argument which will give you a {@link TextColor} parsed from a
+ * 6-digit hex string prefixed with {@code #}.
+ * <p>
+ * Example: {@code #ff8800}, {@code #FFFFFF}
+ * <p>
+ * The vanilla {@code minecraft:hex_color} parser was added in 1.21.6.
+ */
+public class ArgumentHexColor extends Argument<TextColor> {
+
+    public static final int INVALID_HEX_COLOR = -3;
+
+    public ArgumentHexColor(String id) {
+        super(id);
+    }
+
+    @Override
+    public TextColor parse(CommandSender sender, String input) throws ArgumentSyntaxException {
+        if (input == null || input.length() != 7 || input.charAt(0) != '#') {
+            throw new ArgumentSyntaxException("Invalid hex color", input, INVALID_HEX_COLOR);
+        }
+        for (int i = 1; i < 7; i++) {
+            final char c = input.charAt(i);
+            final boolean isHexDigit = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+            if (!isHexDigit) {
+                throw new ArgumentSyntaxException("Invalid hex color", input, INVALID_HEX_COLOR);
+            }
+        }
+        final int rgb = Integer.parseInt(input, 1, 7, 16);
+        return TextColor.color(rgb);
+    }
+
+    @Override
+    public ArgumentParserType parser() {
+        return ArgumentParserType.HEX_COLOR;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("HexColor<%s>", getId());
+    }
+}

--- a/src/test/java/net/minestom/server/command/ArgumentHexColorTest.java
+++ b/src/test/java/net/minestom/server/command/ArgumentHexColorTest.java
@@ -1,0 +1,63 @@
+package net.minestom.server.command;
+
+import net.kyori.adventure.text.format.TextColor;
+import net.minestom.server.command.builder.arguments.ArgumentType;
+import net.minestom.server.command.builder.arguments.minecraft.ArgumentHexColor;
+import net.minestom.server.command.builder.exception.ArgumentSyntaxException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ArgumentHexColorTest {
+
+    private final CommandSender sender = new ServerSender();
+
+    @Test
+    public void parsesValidHexColors() {
+        ArgumentHexColor arg = ArgumentType.HexColor("color");
+
+        assertEquals(TextColor.color(0xFF8800),
+                assertDoesNotThrow(() -> arg.parse(sender, "#ff8800")));
+        assertEquals(TextColor.color(0xFFFFFF),
+                assertDoesNotThrow(() -> arg.parse(sender, "#FFFFFF")));
+        assertEquals(TextColor.color(0x000000),
+                assertDoesNotThrow(() -> arg.parse(sender, "#000000")));
+        assertEquals(TextColor.color(0xABCDEF),
+                assertDoesNotThrow(() -> arg.parse(sender, "#aBcDeF")));
+    }
+
+    @Test
+    public void rejectsMissingHashPrefix() {
+        ArgumentHexColor arg = ArgumentType.HexColor("color");
+        assertThrows(ArgumentSyntaxException.class, () -> arg.parse(sender, "ff8800"));
+    }
+
+    @Test
+    public void rejectsWrongLength() {
+        ArgumentHexColor arg = ArgumentType.HexColor("color");
+        assertThrows(ArgumentSyntaxException.class, () -> arg.parse(sender, "#fff"));
+        assertThrows(ArgumentSyntaxException.class, () -> arg.parse(sender, "#ff88000"));
+        assertThrows(ArgumentSyntaxException.class, () -> arg.parse(sender, "#"));
+        assertThrows(ArgumentSyntaxException.class, () -> arg.parse(sender, ""));
+    }
+
+    @Test
+    public void rejectsNonHexCharacters() {
+        ArgumentHexColor arg = ArgumentType.HexColor("color");
+        assertThrows(ArgumentSyntaxException.class, () -> arg.parse(sender, "#gg0000"));
+        assertThrows(ArgumentSyntaxException.class, () -> arg.parse(sender, "#ff 800"));
+        assertThrows(ArgumentSyntaxException.class, () -> arg.parse(sender, "#zzzzzz"));
+    }
+
+    @Test
+    public void usesHexColorParserType() {
+        ArgumentHexColor arg = ArgumentType.HexColor("color");
+        assertEquals(ArgumentParserType.HEX_COLOR, arg.parser());
+    }
+
+    @Test
+    public void toStringIncludesId() {
+        ArgumentHexColor arg = ArgumentType.HexColor("myColor");
+        assertEquals("HexColor<myColor>", arg.toString());
+    }
+}


### PR DESCRIPTION
Closes #3199

## Summary
The vanilla \`minecraft:hex_color\` argument parser was added in 1.21.6 and the \`ArgumentParserType.HEX_COLOR\` enum entry already exists, but no \`Argument\` subclass was exposed for it. This PR fills the gap.

## Changes
- **\`ArgumentHexColor\`** — new class in \`net.minestom.server.command.builder.arguments.minecraft\`, modelled on \`ArgumentColor\`. Parses a 6-digit hex string prefixed with \`#\` (e.g. \`#ff8800\`, \`#FFFFFF\`) and returns a kyori \`TextColor\`. Throws \`ArgumentSyntaxException\` with code \`INVALID_HEX_COLOR\` (-3) for: wrong length, missing \`#\` prefix, or non-hex characters.
- **\`ArgumentType.HexColor(id)\`** — factory method matching the existing \`Color(id)\` style.

## Test plan
6 unit tests in \`ArgumentHexColorTest\` — all pass:
- \`parsesValidHexColors\` — happy path, lower/upper/mixed casing
- \`rejectsMissingHashPrefix\` — \`ff8800\` (no \`#\`)
- \`rejectsWrongLength\` — \`#fff\`, \`#ff88000\`, \`#\`, empty
- \`rejectsNonHexCharacters\` — \`#gg0000\`, embedded space, \`#zzzzzz\`
- \`usesHexColorParserType\` — confirms \`parser() == HEX_COLOR\`
- \`toStringIncludesId\` — \`HexColor<myColor>\`

\`\`\`
tests=6 failures=0 errors=0 skipped=0
\`\`\`