### PR TITLE
fix: detect eye level fluid in updatepose to enable swimming pose

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -830,8 +830,20 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
         EntityPose oldPose = getPose();
         EntityPose newPose;
 
-        // Figure out their expected state
         var meta = getEntityMeta();
+
+        if (instance != null) {
+            Pos pos = getPosition();
+            int eyeBlockX = pos.blockX();
+            int eyeBlockY = (int) Math.floor(pos.y() + getEyeHeight());
+            int eyeBlockZ = pos.blockZ();
+            Block eyeBlock = instance.getBlock(eyeBlockX, eyeBlockY, eyeBlockZ, Block.Getter.Condition.TYPE);
+            boolean eyeInWater = eyeBlock.compare(Block.WATER)
+                    || "true".equals(instance.getBlock(eyeBlockX, eyeBlockY, eyeBlockZ).getProperty("waterlogged"));
+            meta.setSwimming(eyeInWater && isSprinting() && getVehicle() == null);
+        }
+
+        // Figure out their expected state
         if (meta.isFlyingWithElytra()) {
             newPose = EntityPose.FALL_FLYING;
         } else if (meta instanceof LivingEntityMeta livingMeta && livingMeta.getBedInWhichSleepingPosition() != null) {

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -836,13 +836,12 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
             Pos pos = getPosition();
             boolean shouldSwim;
             if (meta.isSwimming()) {
-                Block feetBlock = getBlockSafe(pos.blockX(), pos.blockY(), pos.blockZ());
-                shouldSwim = isBlockInWater(feetBlock, 0.0) && isSprinting() && getVehicle() == null;
+                shouldSwim = isInWater() && isSprinting() && getVehicle() == null;
             } else {
                 double eyeY = pos.y() + getEyeHeight();
                 int eyeBlockY = (int) Math.floor(eyeY);
                 Block eyeBlock = getBlockSafe(pos.blockX(), eyeBlockY, pos.blockZ());
-                shouldSwim = isBlockInWater(eyeBlock, eyeY - eyeBlockY) && isSprinting() && getVehicle() == null;
+                shouldSwim = isBlockInWater(eyeBlock, eyeY - eyeBlockY) && isInWater() && isSprinting() && getVehicle() == null;
             }
             meta.setSwimming(shouldSwim);
         }
@@ -889,9 +888,35 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
         if (block == null) return false;
         if (block.compare(Block.WATER)) {
             int level = Integer.parseInt(block.getProperty("level"));
-            return localY < (9 - (level & 7)) / 9.0;
+            return localY <= (9 - (level & 7)) / 9.0;
         }
-        return "true".equals(block.getProperty("waterlogged"));
+        if ("true".equals(block.getProperty("waterlogged"))) {
+            return localY <= 8.0 / 9.0;
+        }
+        return false;
+    }
+
+    private boolean isInWater() {
+        Pos pos = getPosition();
+        double absMinY = pos.y() + boundingBox.minY();
+        var iter = boundingBox.getBlocks(pos);
+        while (iter.hasNext()) {
+            var blockPos = iter.next();
+            int by = blockPos.blockY();
+            Block block = getBlockSafe(blockPos.blockX(), by, blockPos.blockZ());
+            if (block == null) continue;
+            double fluidHeight;
+            if (block.compare(Block.WATER)) {
+                int level = Integer.parseInt(block.getProperty("level"));
+                fluidHeight = (9 - (level & 7)) / 9.0;
+            } else if ("true".equals(block.getProperty("waterlogged"))) {
+                fluidHeight = 8.0 / 9.0;
+            } else {
+                continue;
+            }
+            if (by + fluidHeight >= absMinY) return true;
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -888,8 +888,7 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
     private boolean isBlockInWater(@Nullable Block block, double localY) {
         if (block == null) return false;
         if (block.compare(Block.WATER)) {
-            String levelStr = block.getProperty("level");
-            int level = levelStr != null ? Integer.parseInt(levelStr) : 0;
+            int level = Integer.parseInt(block.getProperty("level"));
             return localY < (9 - (level & 7)) / 9.0;
         }
         return "true".equals(block.getProperty("waterlogged"));

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -834,14 +834,16 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
 
         if (instance != null) {
             Pos pos = getPosition();
-            boolean shouldSwim;
-            if (meta.isSwimming()) {
-                shouldSwim = isInWater() && isSprinting() && getVehicle() == null;
-            } else {
-                double eyeY = pos.y() + getEyeHeight();
-                int eyeBlockY = (int) Math.floor(eyeY);
-                Block eyeBlock = getBlockSafe(pos.blockX(), eyeBlockY, pos.blockZ());
-                shouldSwim = isBlockInWater(eyeBlock, eyeY - eyeBlockY) && isInWater() && isSprinting() && getVehicle() == null;
+            boolean shouldSwim = false;
+            if (isSprinting() && getVehicle() == null && !isFlying() && getGameMode() != GameMode.SPECTATOR) {
+                if (meta.isSwimming()) {
+                    shouldSwim = isInWater();
+                } else {
+                    double eyeY = pos.y() + getEyeHeight();
+                    int eyeBlockY = (int) Math.floor(eyeY);
+                    Block eyeBlock = getBlockSafe(pos.blockX(), eyeBlockY, pos.blockZ());
+                    shouldSwim = isBlockInWater(eyeBlock, pos.blockX(), eyeBlockY, pos.blockZ(), eyeY - eyeBlockY) && isInWater();
+                }
             }
             meta.setSwimming(shouldSwim);
         }
@@ -884,39 +886,39 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
         }
     }
 
-    private boolean isBlockInWater(@Nullable Block block, double localY) {
+    private boolean isBlockInWater(@Nullable Block block, int x, int y, int z, double localY) {
         if (block == null) return false;
-        if (block.compare(Block.WATER)) {
-            int level = Integer.parseInt(block.getProperty("level"));
-            return localY <= (9 - (level & 7)) / 9.0;
-        }
-        if ("true".equals(block.getProperty("waterlogged"))) {
-            return localY <= 8.0 / 9.0;
-        }
-        return false;
+        return localY <= getFluidHeight(block, x, y, z);
     }
 
     private boolean isInWater() {
         Pos pos = getPosition();
-        double absMinY = pos.y() + boundingBox.minY();
-        var iter = boundingBox.getBlocks(pos);
+        BoundingBox box = getBoundingBox();
+        double absMinY = pos.y() + box.minY();
+        var iter = box.getBlocks(pos);
         while (iter.hasNext()) {
             var blockPos = iter.next();
-            int by = blockPos.blockY();
-            Block block = getBlockSafe(blockPos.blockX(), by, blockPos.blockZ());
+            int bx = blockPos.blockX(), by = blockPos.blockY(), bz = blockPos.blockZ();
+            Block block = getBlockSafe(bx, by, bz);
             if (block == null) continue;
-            double fluidHeight;
-            if (block.compare(Block.WATER)) {
-                int level = Integer.parseInt(block.getProperty("level"));
-                fluidHeight = (9 - (level & 7)) / 9.0;
-            } else if ("true".equals(block.getProperty("waterlogged"))) {
-                fluidHeight = 8.0 / 9.0;
-            } else {
-                continue;
-            }
-            if (by + fluidHeight >= absMinY) return true;
+            double h = getFluidHeight(block, bx, by, bz);
+            if (h >= 0 && by + h >= absMinY) return true;
         }
         return false;
+    }
+
+    private double getFluidHeight(@Nullable Block block, int x, int y, int z) {
+        if (block == null) return -1;
+        boolean isWater = block.compare(Block.WATER);
+        boolean isWaterlogged = !isWater && "true".equals(block.getProperty("waterlogged"));
+        if (!isWater && !isWaterlogged) return -1;
+        Block above = getBlockSafe(x, y + 1, z);
+        if (above != null && (above.compare(Block.WATER) || "true".equals(above.getProperty("waterlogged")))) return 1.0;
+        if (isWater) {
+            int level = Integer.parseInt(block.getProperty("level"));
+            return (8 - (level & 7)) / 9.0;
+        }
+        return 8.0 / 9.0;
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -834,13 +834,17 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
 
         if (instance != null) {
             Pos pos = getPosition();
-            int eyeBlockX = pos.blockX();
-            int eyeBlockY = (int) Math.floor(pos.y() + getEyeHeight());
-            int eyeBlockZ = pos.blockZ();
-            Block eyeBlock = instance.getBlock(eyeBlockX, eyeBlockY, eyeBlockZ, Block.Getter.Condition.TYPE);
-            boolean eyeInWater = eyeBlock.compare(Block.WATER)
-                    || "true".equals(instance.getBlock(eyeBlockX, eyeBlockY, eyeBlockZ).getProperty("waterlogged"));
-            meta.setSwimming(eyeInWater && isSprinting() && getVehicle() == null);
+            boolean shouldSwim;
+            if (meta.isSwimming()) {
+                Block feetBlock = getBlockSafe(pos.blockX(), pos.blockY(), pos.blockZ());
+                shouldSwim = isBlockInWater(feetBlock, 0.0) && isSprinting() && getVehicle() == null;
+            } else {
+                double eyeY = pos.y() + getEyeHeight();
+                int eyeBlockY = (int) Math.floor(eyeY);
+                Block eyeBlock = getBlockSafe(pos.blockX(), eyeBlockY, pos.blockZ());
+                shouldSwim = isBlockInWater(eyeBlock, eyeY - eyeBlockY) && isSprinting() && getVehicle() == null;
+            }
+            meta.setSwimming(shouldSwim);
         }
 
         // Figure out their expected state
@@ -871,6 +875,24 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
         }
 
         if (newPose != oldPose) setPose(newPose);
+    }
+
+    private @Nullable Block getBlockSafe(int x, int y, int z) {
+        try {
+            return instance.getBlock(x, y, z);
+        } catch (NullPointerException ignored) {
+            return null;
+        }
+    }
+
+    private boolean isBlockInWater(@Nullable Block block, double localY) {
+        if (block == null) return false;
+        if (block.compare(Block.WATER)) {
+            String levelStr = block.getProperty("level");
+            int level = levelStr != null ? Integer.parseInt(levelStr) : 0;
+            return localY < (9 - (level & 7)) / 9.0;
+        }
+        return "true".equals(block.getProperty("waterlogged"));
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -842,7 +842,10 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
                     double eyeY = pos.y() + getEyeHeight();
                     int eyeBlockY = (int) Math.floor(eyeY);
                     Block eyeBlock = getBlockSafe(pos.blockX(), eyeBlockY, pos.blockZ());
-                    shouldSwim = isBlockInWater(eyeBlock, pos.blockX(), eyeBlockY, pos.blockZ(), eyeY - eyeBlockY) && isInWater();
+                    Block feetBlock = getBlockSafe(pos.blockX(), pos.blockY(), pos.blockZ());
+                    shouldSwim = isBlockInWater(eyeBlock, pos.blockX(), eyeBlockY, pos.blockZ(), eyeY - eyeBlockY)
+                            && isInWater()
+                            && getFluidHeight(feetBlock, pos.blockX(), pos.blockY(), pos.blockZ()) >= 0;
                 }
             }
             meta.setSwimming(shouldSwim);
@@ -888,7 +891,7 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
 
     private boolean isBlockInWater(@Nullable Block block, int x, int y, int z, double localY) {
         if (block == null) return false;
-        return localY <= getFluidHeight(block, x, y, z);
+        return localY < getFluidHeight(block, x, y, z);
     }
 
     private boolean isInWater() {
@@ -916,7 +919,8 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
         if (above != null && (above.compare(Block.WATER) || "true".equals(above.getProperty("waterlogged")))) return 1.0;
         if (isWater) {
             int level = Integer.parseInt(block.getProperty("level"));
-            return (8 - (level & 7)) / 9.0;
+            if (level >= 8) return 1.0;
+            return (8 - level) / 9.0;
         }
         return 8.0 / 9.0;
     }

--- a/src/test/java/net/minestom/server/entity/PlayerSwimmingPoseTest.java
+++ b/src/test/java/net/minestom/server/entity/PlayerSwimmingPoseTest.java
@@ -116,4 +116,19 @@ public class PlayerSwimmingPoseTest {
 
         assertNotEquals(EntityPose.SWIMMING, player.getPose(), "Player should not swim when eyes are above flowing water surface");
     }
+
+    @Test
+    public void noSwimWhenFeetAboveShallowWaterSurface(Env env) {
+        var instance = env.createFlatInstance();
+        instance.setBlock(0, 40, 0, Block.WATER.withProperty("level", "7"));
+        instance.setBlock(0, 41, 0, Block.WATER.withProperty("level", "7"));
+
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0.5, 40.2, 0.5));
+
+        player.setSprinting(true);
+        env.tick();
+
+        assertNotEquals(EntityPose.SWIMMING, player.getPose(), "Player should not be in water when feet are above the shallow fluid surface");
+    }
 }

--- a/src/test/java/net/minestom/server/entity/PlayerSwimmingPoseTest.java
+++ b/src/test/java/net/minestom/server/entity/PlayerSwimmingPoseTest.java
@@ -1,6 +1,7 @@
 package net.minestom.server.entity;
 
 import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.GameMode;
 import net.minestom.server.instance.block.Block;
 import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
@@ -115,6 +116,76 @@ public class PlayerSwimmingPoseTest {
         env.tick();
 
         assertNotEquals(EntityPose.SWIMMING, player.getPose(), "Player should not swim when eyes are above flowing water surface");
+    }
+
+    @Test
+    public void stopSwimmingWhenFlying(Env env) {
+        var instance = env.createFlatInstance();
+        instance.setBlock(0, 40, 0, Block.WATER);
+        instance.setBlock(0, 41, 0, Block.WATER);
+
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0.5, 40, 0.5));
+
+        player.setSprinting(true);
+        env.tick();
+        assertEquals(EntityPose.SWIMMING, player.getPose());
+
+        player.setFlying(true);
+        env.tick();
+
+        assertNotEquals(EntityPose.SWIMMING, player.getPose(), "Player should be forced out of swimming when flying");
+    }
+
+    @Test
+    public void stopSwimmingInSpectator(Env env) {
+        var instance = env.createFlatInstance();
+        instance.setBlock(0, 40, 0, Block.WATER);
+        instance.setBlock(0, 41, 0, Block.WATER);
+
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0.5, 40, 0.5));
+
+        player.setSprinting(true);
+        env.tick();
+        assertEquals(EntityPose.SWIMMING, player.getPose());
+
+        player.setGameMode(GameMode.SPECTATOR);
+        env.tick();
+
+        assertNotEquals(EntityPose.SWIMMING, player.getPose(), "Player should be forced out of swimming in spectator mode");
+    }
+
+    @Test
+    public void noSwimWhenFlying(Env env) {
+        var instance = env.createFlatInstance();
+        instance.setBlock(0, 40, 0, Block.WATER);
+        instance.setBlock(0, 41, 0, Block.WATER);
+
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0.5, 40, 0.5));
+
+        player.setSprinting(true);
+        player.setFlying(true);
+        env.tick();
+
+        assertNotEquals(EntityPose.SWIMMING, player.getPose(), "Player should not swim when flying");
+    }
+
+    @Test
+    public void noSwimInSpectator(Env env) {
+        var instance = env.createFlatInstance();
+        instance.setBlock(0, 40, 0, Block.WATER);
+        instance.setBlock(0, 41, 0, Block.WATER);
+
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0.5, 40, 0.5));
+
+        player.setSprinting(true);
+        player.setGameMode(GameMode.SPECTATOR);
+        env.tick();
+
+        assertNotEquals(EntityPose.SWIMMING, player.getPose(), "Player should not swim in spectator mode");
     }
 
     @Test

--- a/src/test/java/net/minestom/server/entity/PlayerSwimmingPoseTest.java
+++ b/src/test/java/net/minestom/server/entity/PlayerSwimmingPoseTest.java
@@ -93,6 +93,7 @@ public class PlayerSwimmingPoseTest {
     @Test
     public void swimInWaterloggedBlock(Env env) {
         var instance = env.createFlatInstance();
+        instance.setBlock(0, 40, 0, Block.WATER);
         instance.setBlock(0, 41, 0, Block.OAK_SLAB.withProperty("waterlogged", "true"));
 
         var connection = env.createConnection();
@@ -186,6 +187,20 @@ public class PlayerSwimmingPoseTest {
         env.tick();
 
         assertNotEquals(EntityPose.SWIMMING, player.getPose(), "Player should not swim in spectator mode");
+    }
+
+    @Test
+    public void noSwimWhenFeetNotInWater(Env env) {
+        var instance = env.createFlatInstance();
+        instance.setBlock(0, 41, 0, Block.WATER);
+
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0.5, 40, 0.5));
+
+        player.setSprinting(true);
+        env.tick();
+
+        assertNotEquals(EntityPose.SWIMMING, player.getPose(), "Player should not swim when feet block has no water");
     }
 
     @Test

--- a/src/test/java/net/minestom/server/entity/PlayerSwimmingPoseTest.java
+++ b/src/test/java/net/minestom/server/entity/PlayerSwimmingPoseTest.java
@@ -1,0 +1,105 @@
+package net.minestom.server.entity;
+
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.instance.block.Block;
+import net.minestom.testing.Env;
+import net.minestom.testing.EnvTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@EnvTest
+public class PlayerSwimmingPoseTest {
+
+    @Test
+    public void swimWhenSprintingWithEyesInWater(Env env) {
+        var instance = env.createFlatInstance();
+        instance.setBlock(0, 40, 0, Block.WATER);
+        instance.setBlock(0, 41, 0, Block.WATER);
+
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0.5, 40, 0.5));
+
+        player.setSprinting(true);
+        env.tick();
+
+        assertEquals(EntityPose.SWIMMING, player.getPose(), "Player should be SWIMMING when sprinting with eyes in water");
+    }
+
+    @Test
+    public void noSwimInShallowWater(Env env) {
+        var instance = env.createFlatInstance();
+        instance.setBlock(0, 40, 0, Block.WATER);
+
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0.5, 40, 0.5));
+
+        player.setSprinting(true);
+        env.tick();
+
+        assertNotEquals(EntityPose.SWIMMING, player.getPose(), "Player should not swim when eyes are above water");
+    }
+
+    @Test
+    public void noSwimOnDryLand(Env env) {
+        var instance = env.createFlatInstance();
+
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0, 42, 0));
+
+        player.setSprinting(true);
+        env.tick();
+
+        assertNotEquals(EntityPose.SWIMMING, player.getPose(), "Player should not swim on dry land");
+    }
+
+    @Test
+    public void noSwimWithoutSprinting(Env env) {
+        var instance = env.createFlatInstance();
+        instance.setBlock(0, 40, 0, Block.WATER);
+        instance.setBlock(0, 41, 0, Block.WATER);
+
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0.5, 40, 0.5));
+
+        player.setSprinting(false);
+        env.tick();
+
+        assertNotEquals(EntityPose.SWIMMING, player.getPose(), "Player should not swim when not sprinting");
+    }
+
+    @Test
+    public void stopSwimmingOnLeaveWater(Env env) {
+        var instance = env.createFlatInstance();
+        instance.setBlock(0, 40, 0, Block.WATER);
+        instance.setBlock(0, 41, 0, Block.WATER);
+
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0.5, 40, 0.5));
+
+        player.setSprinting(true);
+        env.tick();
+        assertEquals(EntityPose.SWIMMING, player.getPose());
+
+        instance.setBlock(0, 40, 0, Block.AIR);
+        instance.setBlock(0, 41, 0, Block.AIR);
+        env.tick();
+
+        assertNotEquals(EntityPose.SWIMMING, player.getPose(), "Player should stop swimming after leaving water");
+    }
+
+    @Test
+    public void swimInWaterloggedBlock(Env env) {
+        var instance = env.createFlatInstance();
+        instance.setBlock(0, 41, 0, Block.OAK_SLAB.withProperty("waterlogged", "true"));
+
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0.5, 40, 0.5));
+
+        player.setSprinting(true);
+        env.tick();
+
+        assertEquals(EntityPose.SWIMMING, player.getPose(), "Player should swim with eyes in a waterlogged block");
+    }
+}

--- a/src/test/java/net/minestom/server/entity/PlayerSwimmingPoseTest.java
+++ b/src/test/java/net/minestom/server/entity/PlayerSwimmingPoseTest.java
@@ -102,4 +102,18 @@ public class PlayerSwimmingPoseTest {
 
         assertEquals(EntityPose.SWIMMING, player.getPose(), "Player should swim with eyes in a waterlogged block");
     }
+
+    @Test
+    public void noSwimWhenEyesAboveFlowingWaterSurface(Env env) {
+        var instance = env.createFlatInstance();
+        instance.setBlock(0, 41, 0, Block.WATER.withProperty("level", "7"));
+
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0.5, 40, 0.5));
+
+        player.setSprinting(true);
+        env.tick();
+
+        assertNotEquals(EntityPose.SWIMMING, player.getPose(), "Player should not swim when eyes are above flowing water surface");
+    }
 }


### PR DESCRIPTION
## Proposed changes

`player.getPose()` never returns `EntityPose.SWIMMING` because
`setSwimming()` was never called anywhere. Fixed by checking sprint
state + eye level fluid in `updatePose()`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works