### PR TITLE
Allow uuid deserialization from dashless string

### DIFF
--- a/src/main/java/net/minestom/server/codec/Codec.java
+++ b/src/main/java/net/minestom/server/codec/Codec.java
@@ -114,7 +114,7 @@ public interface Codec<T extends @UnknownNullability Object> extends Encoder<T>,
 
     Codec<UUID> UUID = Codec.INT_ARRAY.transform(UUIDUtils::intArrayToUuid, UUIDUtils::uuidToIntArray);
 
-    Codec<UUID> UUID_STRING = STRING.transform(java.util.UUID::fromString, java.util.UUID::toString);
+    Codec<UUID> UUID_STRING = STRING.transform(UUIDUtils::fromString, java.util.UUID::toString);
 
     Codec<UUID> UUID_COERCED = UUID.orElse(UUID_STRING);
 

--- a/src/main/java/net/minestom/server/listener/preplay/LoginListener.java
+++ b/src/main/java/net/minestom/server/listener/preplay/LoginListener.java
@@ -1,11 +1,11 @@
 package net.minestom.server.listener.preplay;
 
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.minestom.server.Auth;
 import net.minestom.server.MinecraftServer;
+import net.minestom.server.codec.Transcoder;
 import net.minestom.server.entity.Player;
 import net.minestom.server.extras.mojangAuth.MojangCrypt;
 import net.minestom.server.network.NetworkBuffer;
@@ -33,10 +33,7 @@ import java.net.SocketAddress;
 import java.net.UnknownHostException;
 import java.security.KeyPair;
 import java.security.SecureRandom;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
 
 import static net.minestom.server.network.NetworkBuffer.STRING;
 
@@ -137,17 +134,10 @@ public final class LoginListener {
 
             // We have verified the session, parse response.
             socketConnection.setEncryptionKey(secretKey);
-            final UUID profileUUID = UUID.fromString(gameProfileJson.get("id").getAsString()
-                    .replaceFirst("(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})", "$1-$2-$3-$4-$5"));
-            final String profileName = gameProfileJson.get("name").getAsString();
+            final GameProfile gameProfile = GameProfile.CODEC.decode(Transcoder.JSON, gameProfileJson).orElseThrow();
 
-            MinecraftServer.LOGGER.info("UUID of player {} is {}", profileName, profileUUID);
-            List<GameProfile.Property> propertyList = new ArrayList<>();
-            for (JsonElement element : gameProfileJson.get("properties").getAsJsonArray()) {
-                JsonObject object = element.getAsJsonObject();
-                propertyList.add(new GameProfile.Property(object.get("name").getAsString(), object.get("value").getAsString(), object.get("signature").getAsString()));
-            }
-            enterConfig(connection, new GameProfile(profileUUID, profileName, propertyList));
+            MinecraftServer.LOGGER.info("UUID of player {} is {}", gameProfile.name(), gameProfile.uuid());
+            enterConfig(connection, gameProfile);
         } catch (IOException e) {
             socketConnection.kick(ERROR_MOJANG_RESPONSE);
             MinecraftServer.getExceptionManager().handleException(e);

--- a/src/main/java/net/minestom/server/network/player/GameProfile.java
+++ b/src/main/java/net/minestom/server/network/player/GameProfile.java
@@ -40,7 +40,7 @@ public record GameProfile(
             Property.SERIALIZER.list(MAX_PROPERTIES), GameProfile::properties,
             GameProfile::new);
     public static final StructCodec<GameProfile> CODEC = StructCodec.struct(
-            "id", Codec.UUID, GameProfile::uuid,
+            "id", Codec.UUID_COERCED, GameProfile::uuid,
             "name", Codec.STRING, GameProfile::name,
             "properties", Property.LIST_CODEC.optional(List.of()), GameProfile::properties,
             GameProfile::new);

--- a/src/main/java/net/minestom/server/utils/UUIDUtils.java
+++ b/src/main/java/net/minestom/server/utils/UUIDUtils.java
@@ -24,15 +24,9 @@ public final class UUIDUtils {
     }
 
     /**
-     * Parses a {@link UUID} from its hexadecimal string representation, accepting both the
-     * dashed canonical form ({@code d2ac7139-76a6-435b-b659-7852d34dd7a3}) and the dashless
-     * form returned by the Mojang session server ({@code d2ac713976a6435bb6597852d34dd7a3}).
-     * <p>
-     * Parsing is done in a single pass without any allocation, making it faster than
-     * {@link UUID#fromString(String)}.
+     * Parses a {@link UUID} from its hexadecimal string, accepting both the dashed canonical
+     * form and the dashless form (e.g. as returned by the Mojang session server).
      *
-     * @param input the dashed or dashless UUID string
-     * @return the parsed {@link UUID}
      * @throws IllegalArgumentException if the input does not contain exactly 32 hex digits
      */
     public static UUID fromString(String input) {

--- a/src/main/java/net/minestom/server/utils/UUIDUtils.java
+++ b/src/main/java/net/minestom/server/utils/UUIDUtils.java
@@ -23,6 +23,35 @@ public final class UUIDUtils {
         return UNIQUE_ID_PATTERN.matcher(input).matches();
     }
 
+    /**
+     * Parses a {@link UUID} from its hexadecimal string representation, accepting both the
+     * dashed canonical form ({@code d2ac7139-76a6-435b-b659-7852d34dd7a3}) and the dashless
+     * form returned by the Mojang session server ({@code d2ac713976a6435bb6597852d34dd7a3}).
+     * <p>
+     * Parsing is done in a single pass without any allocation, making it faster than
+     * {@link UUID#fromString(String)}.
+     *
+     * @param input the dashed or dashless UUID string
+     * @return the parsed {@link UUID}
+     * @throws IllegalArgumentException if the input does not contain exactly 32 hex digits
+     */
+    public static UUID fromString(String input) {
+        long most = 0, least = 0;
+        int count = 0;
+        for (int i = 0, length = input.length(); i < length; i++) {
+            final char c = input.charAt(i);
+            if (c == '-') continue;
+            final int digit = Character.digit(c, 16);
+            if (digit < 0 || count >= 32)
+                throw new IllegalArgumentException("Invalid UUID string: " + input);
+            if (count < 16) most = most << 4 | digit;
+            else least = least << 4 | digit;
+            count++;
+        }
+        if (count != 32) throw new IllegalArgumentException("Invalid UUID string: " + input);
+        return new UUID(most, least);
+    }
+
     public static UUID fromNbt(IntArrayBinaryTag tag) {
         return intArrayToUuid(tag.value());
     }

--- a/src/test/java/net/minestom/server/codec/CodecTest.java
+++ b/src/test/java/net/minestom/server/codec/CodecTest.java
@@ -118,4 +118,29 @@ public final class CodecTest {
                              .add(intBinaryTag(24))
                              .build(), value);
     }
+
+    @Test
+    void uuidStringRoundTrip() {
+        var uuid = UUID.fromString("d2ac7139-76a6-435b-b659-7852d34dd7a3");
+        var encoded = Codec.UUID_STRING.encode(Transcoder.JSON, uuid);
+        // Encoding always produces the canonical dashed form.
+        assertEquals("d2ac7139-76a6-435b-b659-7852d34dd7a3",
+                Transcoder.JSON.getString(encoded.orElseThrow()).orElseThrow());
+        var decoded = Codec.UUID_STRING.decode(Transcoder.JSON, encoded.orElseThrow());
+        assertEquals(uuid, CodecAssertions.assertOk(decoded));
+    }
+
+    @Test
+    void uuidStringDashlessDecode() {
+        // Mojang's session server returns dashless UUIDs.
+        var uuid = UUID.fromString("ab70ecb4-2346-4c14-a52d-7a091507c24e");
+        var decoded = Codec.UUID_STRING.decode(Transcoder.JSON, Transcoder.JSON.createString("ab70ecb423464c14a52d7a091507c24e"));
+        assertEquals(uuid, CodecAssertions.assertOk(decoded));
+    }
+
+    @Test
+    void uuidStringInvalidDecode() {
+        var decoded = Codec.UUID_STRING.decode(Transcoder.JSON, Transcoder.JSON.createString("not a uuid"));
+        Assertions.assertInstanceOf(Result.Error.class, decoded);
+    }
 }

--- a/src/test/java/net/minestom/server/codec/CodecTest.java
+++ b/src/test/java/net/minestom/server/codec/CodecTest.java
@@ -123,7 +123,6 @@ public final class CodecTest {
     void uuidStringRoundTrip() {
         var uuid = UUID.fromString("d2ac7139-76a6-435b-b659-7852d34dd7a3");
         var encoded = Codec.UUID_STRING.encode(Transcoder.JSON, uuid);
-        // Encoding always produces the canonical dashed form.
         assertEquals("d2ac7139-76a6-435b-b659-7852d34dd7a3",
                 Transcoder.JSON.getString(encoded.orElseThrow()).orElseThrow());
         var decoded = Codec.UUID_STRING.decode(Transcoder.JSON, encoded.orElseThrow());
@@ -132,7 +131,6 @@ public final class CodecTest {
 
     @Test
     void uuidStringDashlessDecode() {
-        // Mojang's session server returns dashless UUIDs.
         var uuid = UUID.fromString("ab70ecb4-2346-4c14-a52d-7a091507c24e");
         var decoded = Codec.UUID_STRING.decode(Transcoder.JSON, Transcoder.JSON.createString("ab70ecb423464c14a52d7a091507c24e"));
         assertEquals(uuid, CodecAssertions.assertOk(decoded));

--- a/src/test/java/net/minestom/server/network/player/GameProfileTest.java
+++ b/src/test/java/net/minestom/server/network/player/GameProfileTest.java
@@ -1,0 +1,49 @@
+package net.minestom.server.network.player;
+
+import com.google.gson.JsonParser;
+import net.minestom.server.codec.Transcoder;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class GameProfileTest {
+
+    @Test
+    void decodeMojangSessionResponse() {
+        final var element = JsonParser.parseString("""
+                {
+                  "id": "ab70ecb423464c14a52d7a091507c24e",
+                  "name": "Notch",
+                  "properties": [
+                    { "name": "textures", "value": "ewogICJ0aW1lc3RhbXAi", "signature": "abc123" }
+                  ]
+                }
+                """);
+        final GameProfile profile = GameProfile.CODEC.decode(Transcoder.JSON, element).orElseThrow();
+        assertEquals(UUID.fromString("ab70ecb4-2346-4c14-a52d-7a091507c24e"), profile.uuid());
+        assertEquals("Notch", profile.name());
+        assertEquals(1, profile.properties().size());
+        final GameProfile.Property property = profile.properties().getFirst();
+        assertEquals("textures", property.name());
+        assertEquals("ewogICJ0aW1lc3RhbXAi", property.value());
+        assertEquals("abc123", property.signature());
+    }
+
+    @Test
+    void decodeUnsignedProperty() {
+        final var element = JsonParser.parseString("""
+                {
+                  "id": "ab70ecb423464c14a52d7a091507c24e",
+                  "name": "Notch",
+                  "properties": [
+                    { "name": "textures", "value": "ewogICJ0aW1lc3RhbXAi" }
+                  ]
+                }
+                """);
+        final GameProfile profile = GameProfile.CODEC.decode(Transcoder.JSON, element).orElseThrow();
+        assertNull(profile.properties().getFirst().signature());
+    }
+}

--- a/src/test/java/net/minestom/server/utils/UUIDUtilsTest.java
+++ b/src/test/java/net/minestom/server/utils/UUIDUtilsTest.java
@@ -39,7 +39,6 @@ class UUIDUtilsTest {
 
     @Test
     void fromStringDashless() {
-        // The dashless form is what the Mojang session server returns.
         assertEquals(TEST_UUID, UUIDUtils.fromString("d2ac713976a6435bb6597852d34dd7a3"));
         assertEquals(UUID.fromString("ab70ecb4-2346-4c14-a52d-7a091507c24e"),
                 UUIDUtils.fromString("ab70ecb423464c14a52d7a091507c24e"));
@@ -53,11 +52,8 @@ class UUIDUtilsTest {
     @Test
     void fromStringInvalid() {
         assertThrows(IllegalArgumentException.class, () -> UUIDUtils.fromString("not a uuid"));
-        // Too few hex digits.
         assertThrows(IllegalArgumentException.class, () -> UUIDUtils.fromString("d2ac713976a6435bb6597852d34dd7a"));
-        // Too many hex digits.
         assertThrows(IllegalArgumentException.class, () -> UUIDUtils.fromString("d2ac713976a6435bb6597852d34dd7a33"));
-        // Non-hex character.
         assertThrows(IllegalArgumentException.class, () -> UUIDUtils.fromString("g2ac713976a6435bb6597852d34dd7a3"));
     }
 }

--- a/src/test/java/net/minestom/server/utils/UUIDUtilsTest.java
+++ b/src/test/java/net/minestom/server/utils/UUIDUtilsTest.java
@@ -31,4 +31,33 @@ class UUIDUtilsTest {
     void intArrayToUuid() {
         assertEquals(TEST_UUID, UUIDUtils.intArrayToUuid(TEST_INT_ARRAY));
     }
+
+    @Test
+    void fromStringDashed() {
+        assertEquals(TEST_UUID, UUIDUtils.fromString("d2ac7139-76a6-435b-b659-7852d34dd7a3"));
+    }
+
+    @Test
+    void fromStringDashless() {
+        // The dashless form is what the Mojang session server returns.
+        assertEquals(TEST_UUID, UUIDUtils.fromString("d2ac713976a6435bb6597852d34dd7a3"));
+        assertEquals(UUID.fromString("ab70ecb4-2346-4c14-a52d-7a091507c24e"),
+                UUIDUtils.fromString("ab70ecb423464c14a52d7a091507c24e"));
+    }
+
+    @Test
+    void fromStringUppercase() {
+        assertEquals(TEST_UUID, UUIDUtils.fromString("D2AC713976A6435BB6597852D34DD7A3"));
+    }
+
+    @Test
+    void fromStringInvalid() {
+        assertThrows(IllegalArgumentException.class, () -> UUIDUtils.fromString("not a uuid"));
+        // Too few hex digits.
+        assertThrows(IllegalArgumentException.class, () -> UUIDUtils.fromString("d2ac713976a6435bb6597852d34dd7a"));
+        // Too many hex digits.
+        assertThrows(IllegalArgumentException.class, () -> UUIDUtils.fromString("d2ac713976a6435bb6597852d34dd7a33"));
+        // Non-hex character.
+        assertThrows(IllegalArgumentException.class, () -> UUIDUtils.fromString("g2ac713976a6435bb6597852d34dd7a3"));
+    }
 }


### PR DESCRIPTION
Updated `Codec.UUID_STRING` (and therefore `UUID_COERCED` as well) to allow parsing dashless UUIDs, mostly relevantly provided by Mojang auth API.

Updating the existing uuid codecs is perhaps not the ideal solution given they will always serialize back with dashes. I guess the alternative would be to have a duplicate `GameProfile.CODEC_AUTH` or similar.