### PR TITLE
refactor: Make Material components bind with vanilla registries

### DIFF
--- a/src/main/java/net/minestom/server/registry/RegistryData.java
+++ b/src/main/java/net/minestom/server/registry/RegistryData.java
@@ -516,26 +516,37 @@ public final class RegistryData {
         }
 
         public DataComponentMap prototype() {
-            if (prototype instanceof Either.Left(var components)) {
-                final Transcoder<Object> coder = new RegistryTranscoder<>(Transcoder.JAVA, MinecraftServer.process());
-                DataComponentMap.Builder builder = DataComponentMap.builder();
-                for (Map.Entry<String, Object> entry : components) {
-                    //noinspection unchecked
-                    DataComponent<Object> component = (DataComponent<Object>) DataComponent.fromKey(entry.getKey());
-                    Check.notNull(component, "Unknown component {0} in {1}", entry.getKey(), key);
+            return switch (prototype) {
+                case Either.Left(_) -> throw new IllegalStateException("Should have been bound");
+                case Either.Right(var dataComponentMap) -> dataComponentMap;
+                case null -> DataComponentMap.EMPTY;
+            };
+        }
 
-                    final Result<Object> result = component.decode(coder, entry.getValue());
-                    switch (result) {
-                        case Result.Ok(Object ok) -> builder.set(component, ok);
-                        case Result.Error(String message) ->
-                                throw new IllegalStateException("Failed to decode component " + entry.getKey() + " in " + key + ": " + message);
-                    }
+        /**
+         * Attempts the bind the current prototype using the registries provided.
+         *
+         * @param registries the registries used during decode
+         */
+        @ApiStatus.Internal
+        void bindComponents(Registries registries) {
+            if (!(prototype instanceof Either.Left(var components))) return;
+            final Transcoder<Object> coder = new RegistryTranscoder<>(Transcoder.JAVA, registries);
+            DataComponentMap.Builder builder = DataComponentMap.builder();
+            for (Map.Entry<String, Object> entry : components) {
+                //noinspection unchecked
+                DataComponent<Object> component = (DataComponent<Object>) DataComponent.fromKey(entry.getKey());
+                Check.notNull(component, "Unknown component {0} in {1}", entry.getKey(), key);
+
+                final Result<Object> result = component.decode(coder, entry.getValue());
+                switch (result) {
+                    case Result.Ok(Object ok) -> builder.set(component, ok);
+                    case Result.Error(String message) ->
+                            throw new IllegalStateException("Failed to decode component " + entry.getKey() + " in " + key + ": " + message);
                 }
-                final DataComponentMap prototype = builder.build();
-                this.prototype = !prototype.isEmpty() ? Either.right(prototype) : null;
             }
-
-            return prototype instanceof Either.Right(var dataComponentMap) ? dataComponentMap : DataComponentMap.EMPTY;
+            final DataComponentMap prototype = builder.build();
+            this.prototype = prototype.isEmpty() ? null : Either.right(prototype); // null is essential for EMPTY
         }
 
         public boolean isArmor() {

--- a/src/main/java/net/minestom/server/registry/VanillaRegistries.java
+++ b/src/main/java/net/minestom/server/registry/VanillaRegistries.java
@@ -90,6 +90,12 @@ final class VanillaRegistries implements Registries {
         this.worldClock = WorldClock.createDefaultRegistry();
         this.timeline = Timeline.createDefaultRegistry(this);
         this.dimensionType = DimensionType.createDefaultRegistry(this); // depends on timelines
+
+        // Quite a hack because materials are a static registry, and can be loaded before but are cyclic on components.
+        // So we break the loop and bind them here
+        for (var entry: material().values()) {
+            entry.registry().bindComponents(this);
+        }
     }
 
     @Override

--- a/src/test/java/net/minestom/server/registry/RegistriesTest.java
+++ b/src/test/java/net/minestom/server/registry/RegistriesTest.java
@@ -1,0 +1,22 @@
+package net.minestom.server.registry;
+
+import net.minestom.server.component.DataComponentMap;
+import net.minestom.testing.EnvTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@EnvTest
+public class RegistriesTest {
+
+    @Test
+    void testMaterialPrototypes() {
+        var registries = Registries.vanilla();
+        for (var entry : registries.material().values()) {
+            var prototype = entry.prototype();
+            Assertions.assertNotNull(prototype);
+            if (prototype.isEmpty()) {
+                Assertions.assertSame(DataComponentMap.EMPTY, prototype);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

Drops the dependency on MinecraftServer for this direct use case. #3210 should be solved (for now)

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
There is likely better ways to bind these "correctly". Id assume in a future update this prototype might become a separate registry like block entity's.
