### PR TITLE
feat: Port NetworkBuffer.wrap(MemorySegment, ...)

### DIFF
--- a/src/main/java/net/minestom/server/network/NetworkBuffer.java
+++ b/src/main/java/net/minestom/server/network/NetworkBuffer.java
@@ -292,6 +292,9 @@ public sealed interface NetworkBuffer permits NetworkBufferImpl {
     }
 
     static NetworkBuffer wrap(byte[] bytes, int readIndex, int writeIndex, @Nullable Registries registries) {
+        /* TODO(next) remove me for zero copy. The old behavior didnt actually modify the underlying array.
+            quite unfortunate and will require until waiting for the next release to change this behavior. */
+        bytes = bytes.clone();
         return wrap(MemorySegment.ofArray(bytes), readIndex, writeIndex, registries);
     }
 

--- a/src/main/java/net/minestom/server/network/NetworkBuffer.java
+++ b/src/main/java/net/minestom/server/network/NetworkBuffer.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.UnknownNullability;
 
 import javax.crypto.Cipher;
 import java.io.IOException;
+import java.lang.foreign.MemorySegment;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SocketChannel;
 import java.security.PublicKey;
@@ -282,8 +283,16 @@ public sealed interface NetworkBuffer permits NetworkBufferImpl {
         return resizableBuffer(null);
     }
 
+    static NetworkBuffer wrap(MemorySegment segment, long readIndex, long writeIndex, @Nullable Registries registries) {
+        return NetworkBufferImpl.wrap(segment, readIndex, writeIndex, registries);
+    }
+
+    static NetworkBuffer wrap(MemorySegment segment, long readIndex, long writeIndex) {
+        return wrap(segment, readIndex, writeIndex, null);
+    }
+
     static NetworkBuffer wrap(byte[] bytes, int readIndex, int writeIndex, @Nullable Registries registries) {
-        return NetworkBufferImpl.wrap(bytes, readIndex, writeIndex, registries);
+        return wrap(MemorySegment.ofArray(bytes), readIndex, writeIndex, registries);
     }
 
     static NetworkBuffer wrap(byte[] bytes, int readIndex, int writeIndex) {

--- a/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
@@ -426,11 +426,8 @@ final class NetworkBufferImpl implements NetworkBuffer {
         return segment.get(DOUBLE_LAYOUT, index);
     }
 
-    static NetworkBuffer wrap(byte[] bytes, long readIndex, long writeIndex, @Nullable Registries registries) {
-        var buffer = new Builder(bytes.length).registry(registries).build();
-        buffer.writeAt(0, NetworkBuffer.RAW_BYTES, bytes);
-        buffer.index(readIndex, writeIndex);
-        return buffer;
+    static NetworkBuffer wrap(MemorySegment segment, long readIndex, long writeIndex, @Nullable Registries registries) {
+        return new NetworkBufferImpl(segment, readIndex, writeIndex, null, registries);
     }
 
     static void copy(NetworkBuffer srcBuffer, long srcOffset,

--- a/src/test/java/net/minestom/server/network/NetworkBufferTest.java
+++ b/src/test/java/net/minestom/server/network/NetworkBufferTest.java
@@ -11,6 +11,8 @@ import org.jetbrains.annotations.UnknownNullability;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
 import java.lang.ref.WeakReference;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -232,6 +234,60 @@ public class NetworkBufferTest {
         assertEquals(50L, buffer.read(LONG));
 
         assertEquals(9, buffer.readIndex());
+    }
+
+    @Test
+    public void segmentWrap() {
+        try (var arena = Arena.ofConfined()) {
+            final MemorySegment segment = arena.allocate(512);
+            var buffer = NetworkBuffer.wrap(segment, 0L, 0L);
+            assertEquals(0, buffer.writeIndex());
+            assertEquals(0, buffer.readIndex());
+            assertEquals(512,  buffer.capacity());
+            assertFalse(buffer.isReadOnly());
+
+            buffer.write(BYTE, (byte) 1);
+            buffer.write(LONG, 50L);
+            buffer.write(FLOAT, 3.5f);
+
+            assertEquals(0, buffer.readIndex());
+            assertEquals(13, buffer.writeIndex());
+
+            assertEquals((byte) 1, buffer.read(BYTE));
+            assertEquals(50L, buffer.read(LONG));
+            assertEquals(3.5f, buffer.read(FLOAT));
+
+            assertEquals(13, buffer.readIndex());
+            assertEquals(13, buffer.writeIndex());
+
+            // Rewrapping shouldn't carry anything except the data
+            var buffer2 = NetworkBuffer.wrap(segment.asReadOnly(), 0L, 0L);
+            assertEquals(0, buffer2.writeIndex());
+            assertEquals(0, buffer2.readIndex());
+            assertTrue(buffer2.isReadOnly());
+
+            assertFalse(buffer.isReadOnly(), "OG buffer should still be writeable");
+
+            buffer2.writeIndex(buffer.writeIndex());
+            assertEquals(13,  buffer2.writeIndex());
+
+            assertEquals((byte) 1, buffer2.read(BYTE));
+            assertEquals(50L, buffer2.read(LONG));
+            assertEquals(3.5f, buffer2.read(FLOAT));
+
+            assertEquals(13, buffer2.readIndex());
+        }
+    }
+
+    @Test
+    public void segmentWrapScope() {
+        NetworkBuffer buffer;
+        try (var arena = Arena.ofConfined()) {
+            final MemorySegment segment = arena.allocate(512);
+            buffer = NetworkBuffer.wrap(segment, 0L, 0L);
+            buffer.write(BYTE, (byte) 1);
+        }
+        assertThrows(Exception.class, () -> buffer.read(BYTE));
     }
 
     @Test
@@ -526,7 +582,6 @@ public class NetworkBufferTest {
 
         assertBufferType(STRING_IO_UTF8, "Hello", stream.toByteArray());
     }
-
 
     @Test
     public void testStringUtf8ModifiedRead() throws IOException {


### PR DESCRIPTION
## Proposed changes
Adds NetworkBuffer#wrap(MemorySegment, ...), ported from #2958, javadoc is excluded for these ports as it will be likely need a pass on how the current implementation works.

Also changes wrap behavior to be zero copy, which means for arrays it should still allow on heap saving of a wrapped segment, but for regular offheap/mapped segments it will require their scope to still be active.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
More PRS to come, #2958 will likely never be merged as it gets broken apart now.