### PR TITLE
Fix EntityFinder sorting options

### DIFF
--- a/src/main/java/net/minestom/server/utils/entity/EntityFinder.java
+++ b/src/main/java/net/minestom/server/utils/entity/EntityFinder.java
@@ -217,21 +217,20 @@ public class EntityFinder {
         }
 
 
-        // Sort & limit
-        if (entitySort != EntitySort.ARBITRARY || limit != null) {
-            List<Entity> sorted = new ArrayList<>(result);
+        // Sort
+        if (entitySort != EntitySort.ARBITRARY) {
+            result = new ArrayList<>(result);  // mutable
 
             switch (entitySort) {
-                case NEAREST -> sorted.sort(Comparator.comparingDouble(ent -> pos.distanceSquared(ent.getPosition())));
-                case FURTHEST -> sorted.sort(Comparator.<Entity>comparingDouble(ent -> pos.distanceSquared(ent.getPosition())).reversed());
-                case RANDOM -> Collections.shuffle(sorted);
-                case ARBITRARY -> {}
+                case NEAREST -> result.sort(Comparator.comparingDouble(ent -> pos.distanceSquared(ent.getPosition())));
+                case FURTHEST -> result.sort(Comparator.<Entity>comparingDouble(ent -> pos.distanceSquared(ent.getPosition())).reversed());
+                case RANDOM -> Collections.shuffle(result);
             }
+        }
 
-            if (limit != null && limit < sorted.size())
-                sorted = sorted.subList(0, limit);
-
-            result = List.copyOf(sorted);
+        // Limit
+        if (limit != null && limit < result.size()) {
+            result = List.copyOf(result.subList(0, limit));
         }
 
         return result;

--- a/src/main/java/net/minestom/server/utils/entity/EntityFinder.java
+++ b/src/main/java/net/minestom/server/utils/entity/EntityFinder.java
@@ -219,24 +219,19 @@ public class EntityFinder {
 
         // Sort & limit
         if (entitySort != EntitySort.ARBITRARY || limit != null) {
-            result = result.stream()
-                    .sorted((ent1, ent2) -> switch (entitySort) {
-                        case ARBITRARY, RANDOM ->
-                            // RANDOM is handled below
-                                1;
-                        case FURTHEST -> Double.compare(
-                                pos.distanceSquared(ent2.getPosition()),
-                                pos.distanceSquared(ent1.getPosition()));
-                        case NEAREST -> Double.compare(
-                                pos.distanceSquared(ent1.getPosition()),
-                                pos.distanceSquared(ent2.getPosition()));
-                    })
-                    .limit(limit != null ? limit : Integer.MAX_VALUE)
-                    .toList();
+            List<Entity> sorted = new ArrayList<>(result);
 
-            if (entitySort == EntitySort.RANDOM) {
-                Collections.shuffle(result);
+            switch (entitySort) {
+                case NEAREST -> sorted.sort(Comparator.comparingDouble(ent -> pos.distanceSquared(ent.getPosition())));
+                case FURTHEST -> sorted.sort(Comparator.<Entity>comparingDouble(ent -> pos.distanceSquared(ent.getPosition())).reversed());
+                case RANDOM -> Collections.shuffle(sorted);
+                case ARBITRARY -> {}
             }
+
+            if (limit != null && limit < sorted.size())
+                sorted = sorted.subList(0, limit);
+
+            result = List.copyOf(sorted);
         }
 
         return result;

--- a/src/main/java/net/minestom/server/utils/entity/EntityFinder.java
+++ b/src/main/java/net/minestom/server/utils/entity/EntityFinder.java
@@ -224,12 +224,12 @@ public class EntityFinder {
                         case ARBITRARY, RANDOM ->
                             // RANDOM is handled below
                                 1;
-                        case FURTHEST -> pos.distanceSquared(ent1.getPosition()) >
-                                pos.distanceSquared(ent2.getPosition()) ?
-                                1 : 0;
-                        case NEAREST -> pos.distanceSquared(ent1.getPosition()) <
-                                pos.distanceSquared(ent2.getPosition()) ?
-                                1 : 0;
+                        case FURTHEST -> Double.compare(
+                                pos.distanceSquared(ent2.getPosition()),
+                                pos.distanceSquared(ent1.getPosition()));
+                        case NEAREST -> Double.compare(
+                                pos.distanceSquared(ent1.getPosition()),
+                                pos.distanceSquared(ent2.getPosition()));
                     })
                     .limit(limit != null ? limit : Integer.MAX_VALUE)
                     .toList();

--- a/src/test/java/net/minestom/server/utils/entity/EntityFinderIntegrationTest.java
+++ b/src/test/java/net/minestom/server/utils/entity/EntityFinderIntegrationTest.java
@@ -1,0 +1,103 @@
+package net.minestom.server.utils.entity;
+
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.EntityType;
+import net.minestom.server.instance.Instance;
+import net.minestom.testing.Env;
+import net.minestom.testing.EnvTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@EnvTest
+public class EntityFinderIntegrationTest {
+
+    /**
+     * Stores values related to an ongoing test
+     * @param instance The instance
+     * @param entities The created entities (in creation order, which matches ascending distance from origin)
+     */
+    private record TestContext(Instance instance, List<Entity> entities) {}
+
+    /**
+     * Sets up a test instance with a player at origin and 9 surrounding zombies
+     * @param env The environment
+     * @return The test context
+     */
+    private TestContext setupTest(Env env) {
+        Instance instance = env.createFlatInstance();
+
+        List<Entity> entities = new ArrayList<>();
+        entities.add(env.createPlayer(instance, new Pos(0, 41, 0)));
+
+        int angle = 0;
+        for (int i = 1; i < 10; i++) {
+            Entity entity = new Entity(EntityType.ZOMBIE);
+            entity.setHasPhysics(false);
+            entity.setInstance(instance, new Pos(
+                    Math.cos(angle) * i,
+                    41,
+                    Math.sin(angle) * i
+            )).join();
+
+            entities.add(entity);
+            angle += 45;
+        }
+
+        return new TestContext(instance, entities);
+    }
+
+    @Test
+    public void findNearestPlayer(Env env) {
+        TestContext ctx = setupTest(env);
+
+        EntityFinder finder = new EntityFinder()
+                .setTargetSelector(EntityFinder.TargetSelector.NEAREST_PLAYER)
+                .setStartPosition(new Pos(10, 41, 10));
+        List<Entity> results = finder.find(ctx.instance, null);
+        assertEquals(1, results.size(), "TargetSelector.NEAREST_PLAYER result should only contain the player");
+        assertEquals(ctx.entities.getFirst(), results.getFirst(), "TargetSelector.NEAREST_PLAYER resulting entity should be the player");
+    }
+
+    @Test
+    public void sortNearest(Env env) {
+        TestContext ctx = setupTest(env);
+
+        EntityFinder finder = new EntityFinder()
+                .setTargetSelector(EntityFinder.TargetSelector.ALL_ENTITIES)
+                .setStartPosition(new Pos(0, 41, 0))
+                .setEntitySort(EntityFinder.EntitySort.NEAREST);
+        List<Entity> results = finder.find(ctx.instance, null);
+        assertEquals(ctx.entities, results, "EntitySort.NEAREST result should be sorted from nearest to furthest");
+    }
+
+    @Test
+    public void sortFurthest(Env env) {
+        TestContext ctx = setupTest(env);
+
+        EntityFinder finder = new EntityFinder()
+                .setTargetSelector(EntityFinder.TargetSelector.ALL_ENTITIES)
+                .setStartPosition(new Pos(0, 41, 0))
+                .setEntitySort(EntityFinder.EntitySort.FURTHEST);
+        List<Entity> results = finder.find(ctx.instance, null);
+        assertEquals(ctx.entities.reversed(), results, "EntitySort.NEAREST result should be sorted from nearest to furthest");
+    }
+
+    @Test
+    public void sortNearestWithLimit(Env env) {
+        TestContext ctx = setupTest(env);
+
+        EntityFinder finder = new EntityFinder()
+                .setTargetSelector(EntityFinder.TargetSelector.ALL_ENTITIES)
+                .setStartPosition(new Pos(0, 41, 0))
+                .setEntitySort(EntityFinder.EntitySort.NEAREST)
+                .setLimit(4);
+        List<Entity> results = finder.find(ctx.instance, null);
+        assertEquals(ctx.entities.subList(0, 4), results, "EntitySort.NEAREST result should be sorted from nearest to furthest");
+    }
+
+}


### PR DESCRIPTION
## Proposed changes

Fixes #1918. The issues fixed are:
* The nearest and furthest sorting options of `EntityFinder` don't work.
* When sorting using `EntitySort.RANDOM`, the list of entities isn't randomised until after a limit is applied. This means that, while the ordering of the selected entities is random, the selection of entities itself is not.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

_If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc..._

This is my first PR to this repo, please lmk if I've missed any style conventions. 
I named the test class `EntityFinderIntegrationTest` as my understanding of the test class naming convention is that tests which use `Env` are considered an integration test. Please let me know if that assumption is incorrect.