### PR TITLE
feat: NetworkBuffer#copyTo(long, MemorySegment, ...)

### DIFF
--- a/src/main/java/net/minestom/server/network/NetworkBuffer.java
+++ b/src/main/java/net/minestom/server/network/NetworkBuffer.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.UnknownNullability;
 
 import javax.crypto.Cipher;
 import java.io.IOException;
+import java.lang.foreign.MemorySegment;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SocketChannel;
 import java.security.PublicKey;
@@ -137,7 +138,15 @@ public sealed interface NetworkBuffer permits NetworkBufferImpl {
 
     <T> @UnknownNullability T readAt(long index, Type<T> type) throws IndexOutOfBoundsException;
 
+    /**
+     * @deprecated Use {@link #copyTo(long, byte[], int, int)} instead, as longs can easily overflow arrays.
+     */
+    @Deprecated(forRemoval = true)
     void copyTo(long srcOffset, byte[] dest, long destOffset, long length);
+
+    void copyTo(long srcOffset, byte[] dest, int destOffset, int length);
+
+    void copyTo(long srcOffset, MemorySegment dest, long destOffset, long length);
 
     byte[] extractBytes(Consumer<NetworkBuffer> extractor);
 

--- a/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
@@ -99,6 +99,18 @@ final class NetworkBufferImpl implements NetworkBuffer {
         MemorySegment.copy(segment, srcOffset, MemorySegment.ofArray(dest), destOffset, length);
     }
 
+    @Override
+    public void copyTo(long srcOffset, byte[] dest, int destOffset, int length) {
+        assertDummy();
+        MemorySegment.copy(segment, ValueLayout.JAVA_BYTE, srcOffset, dest, destOffset, length);
+    }
+
+    @Override
+    public void copyTo(long srcOffset, MemorySegment dest, long destOffset, long length) {
+        assertDummy();
+        MemorySegment.copy(segment, srcOffset, dest, destOffset, length);
+    }
+
     public byte[] extractBytes(Consumer<NetworkBuffer> extractor) {
         assertDummy();
         final long startingPosition = readIndex();
@@ -352,12 +364,12 @@ final class NetworkBufferImpl implements NetworkBuffer {
     void _putBytes(long index, byte[] value) {
         if (isDummy()) return;
         assertReadOnly();
-        MemorySegment.copy(MemorySegment.ofArray(value), 0, segment, index, value.length);
+        MemorySegment.copy(value, 0, segment, ValueLayout.JAVA_BYTE, index, value.length);
     }
 
     void _getBytes(long index, byte[] value) {
         assertDummy();
-        MemorySegment.copy(segment, index, MemorySegment.ofArray(value), 0, value.length);
+        MemorySegment.copy(segment, ValueLayout.JAVA_BYTE, index, value, 0, value.length);
     }
 
     void _putByte(long index, byte value) {

--- a/src/test/java/net/minestom/server/network/NetworkBufferTest.java
+++ b/src/test/java/net/minestom/server/network/NetworkBufferTest.java
@@ -11,6 +11,9 @@ import org.jetbrains.annotations.UnknownNullability;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.lang.ref.WeakReference;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -418,6 +421,43 @@ public class NetworkBufferTest {
         var readArray = buffer.read(RAW_BYTES);
         assertArrayEquals(array, readArray);
         assertEquals(array.length, buffer.readIndex());
+    }
+
+    @Test
+    public void copyTo() {
+        var array = new byte[]{0x01, 0x02, 0x03, 0x04, 0x05};
+        var buffer = NetworkBuffer.wrap(array, 0, 5);
+        assertEquals(0, buffer.readIndex());
+        assertEquals(array.length, buffer.writeIndex());
+
+        byte[] dest = new byte[6];
+        buffer.copyTo(1, dest, 2, 3);
+
+        assertArrayEquals(new byte[]{0, 0, 0x02, 0x03, 0x04, 0}, dest);
+
+        assertEquals(0, buffer.readIndex());
+        assertEquals(array.length, buffer.writeIndex());
+    }
+
+    @Test
+    public void copyToSegment() {
+        var array = new byte[]{0x01, 0x02, 0x03, 0x04, 0x05};
+        var buffer = NetworkBuffer.wrap(array, 0, 5);
+        assertEquals(0, buffer.readIndex());
+        assertEquals(array.length, buffer.writeIndex());
+
+        try (var arena = Arena.ofConfined()) {
+            MemorySegment dest = arena.allocate(6);
+            buffer.copyTo(1, dest, 2, 3);
+
+            assertEquals(0, buffer.readIndex());
+            assertEquals((byte) 0x02, dest.get(ValueLayout.JAVA_BYTE, 2));
+            assertEquals((byte) 0x03, dest.get(ValueLayout.JAVA_BYTE, 3));
+            assertEquals((byte) 0x04, dest.get(ValueLayout.JAVA_BYTE, 4));
+        }
+
+        assertEquals(0, buffer.readIndex());
+        assertEquals(array.length, buffer.writeIndex());
     }
 
     @Test

--- a/src/test/java/net/minestom/server/network/SocketReadTest.java
+++ b/src/test/java/net/minestom/server/network/SocketReadTest.java
@@ -152,8 +152,8 @@ public class SocketReadTest {
         final var packet = new ClientPluginMessagePacket("ch", new byte[2000]);
         final var encoded = NetworkBuffer.resizableBuffer();
         PacketWriting.writeFramedPacket(encoded, ConnectionState.PLAY, packet, 256);
-        final long length = encoded.writeIndex();
-        final byte[] framed = new byte[(int) length];
+        final int length = (int) encoded.writeIndex();
+        final byte[] framed = new byte[length];
         encoded.copyTo(0, framed, 0, length);
 
         // Drain the pool so any buffer we inspect afterwards must have been used by the read.


### PR DESCRIPTION
## Proposed changes

Add NetworkBuffer#copyTo(long, MemorySegment, ...), and fix existing byte version into int based like wrap.

NetworkBuffer#copyTo(long, MemorySegment, ...) will have its dest read only checked by ffm instead of us, as we will phase out assertReadOnly.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Updates usages of _putBytes and _getBytes to remove the intermediate memory segment, like how copyTo is implemented now.