### PR TITLE
Optimize block collisions

### DIFF
--- a/jmh-benchmarks/src/jmh/java/net/minestom/server/collision/BlockPhysicsBenchmark.java
+++ b/jmh-benchmarks/src/jmh/java/net/minestom/server/collision/BlockPhysicsBenchmark.java
@@ -1,0 +1,215 @@
+package net.minestom.server.collision;
+
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.coordinate.Vec;
+import net.minestom.server.instance.WorldBorder;
+import net.minestom.server.instance.block.Block;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Benchmarks the block-physics hot path ({@link CollisionUtils#handlePhysics} /
+ * {@link PhysicsUtils#simulateMovement}) which runs for every entity every tick.
+ * <p>
+ * Each benchmark method is crafted to exercise a distinct branch of the physics code:
+ * <ul>
+ *     <li>{@link #zeroVelocity()} - the {@code velocity.isZero()} early return</li>
+ *     <li>{@link #cachedStanding()} - the {@code cachedPhysics} fast-exit (resting on ground)</li>
+ *     <li>{@link #fallThroughAir()} - {@code fastPhysics}, no collision (face traversal only)</li>
+ *     <li>{@link #fallIntoFloor()} - {@code fastPhysics}, vertical collision</li>
+ *     <li>{@link #walkOnFloor()} - {@code fastPhysics}, horizontal move + gravity into floor</li>
+ *     <li>{@link #diagonalMove()} - {@code fastPhysics} diagonal special-case</li>
+ *     <li>{@link #largeMoveSlow()} - {@code slowPhysics} ray-cast (velocity length &gt; 1)</li>
+ *     <li>{@link #fenceCollision()} - multi-box shape + tall-below ({@code shouldCheckLower}) path</li>
+ *     <li>{@link #denseCollision()} - collisions on all axes, multiple step-physics iterations</li>
+ *     <li>{@link #simulateOnGround()} - full movement incl. friction lookup + velocity update</li>
+ *     <li>{@link #simulateFalling()} - full movement incl. gravity velocity update</li>
+ * </ul>
+ */
+@BenchmarkMode({Mode.AverageTime, Mode.Throughput})
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 8, time = 1)
+@Fork(2)
+public class BlockPhysicsBenchmark {
+
+    // Player-sized bounding box (0.6 x 1.8 x 0.6)
+    private static final BoundingBox PLAYER_BB = new BoundingBox(0.6, 1.8, 0.6);
+    // Representative player aerodynamics (gravity, horizontal drag, vertical drag)
+    private static final Aerodynamics AERO = new Aerodynamics(0.08, 0.91, 0.98);
+    private static final WorldBorder BORDER = WorldBorder.DEFAULT_BORDER;
+
+    // --- In-memory block getters ---
+
+    /** Everything is air: exercises face traversal with no collisions. */
+    private static final Block.Getter AIR_GETTER = condGetter((x, y, z) -> Block.AIR);
+
+    /** Stone floor with its top surface at y=64 (block layer y<=63), air above. */
+    private static final Block.Getter FLOOR_GETTER = condGetter((x, y, z) -> y <= 63 ? Block.STONE : Block.AIR);
+
+    /** Solid stone everywhere: maximal collision on every axis. */
+    private static final Block.Getter DENSE_GETTER = condGetter((x, y, z) -> Block.STONE);
+
+    /**
+     * Stone floor (y<=62) topped by a layer of fences at y=63. Fences are multi-box, 1.5 tall shapes,
+     * so this drives {@link ShapeImpl#intersectBoxSwept} over several boxes and the tall-below branch.
+     */
+    private static final Block.Getter FENCE_GETTER = condGetter((x, y, z) -> {
+        if (y <= 62) return Block.STONE;
+        if (y == 63) return Block.OAK_FENCE;
+        return Block.AIR;
+    });
+
+    // Getters that take a read lock per block lookup, mimicking the real ChunkCache cost (which the
+    // plain lambda getters above do not capture). Used to measure the benefit of fewer/deduplicated
+    // block lookups in the physics paths.
+    private static final Block.Getter LOCKING_FLOOR_GETTER = lockingGetter((x, y, z) -> y <= 63 ? Block.STONE : Block.AIR);
+    private static final Block.Getter LOCKING_DENSE_GETTER = lockingGetter((x, y, z) -> Block.STONE);
+    private static final Block.Getter LOCKING_AIR_GETTER = lockingGetter((x, y, z) -> Block.AIR);
+
+    // Cached "standing on the ground" physics result, primed in setup.
+    private Pos restPos;
+    private Vec restVelocity;
+    private PhysicsResult cachedResult;
+
+    @Setup
+    public void setup() {
+        // Prime the cached-physics fast path: rest an entity on the floor and feed the result
+        // back until it stabilizes into a cacheable state.
+        restPos = new Pos(0.5, 64.0, 0.5);
+        restVelocity = new Vec(0, -AERO.gravity() * AERO.verticalAirResistance(), 0);
+        PhysicsResult result = null;
+        for (int i = 0; i < 8; i++) {
+            result = CollisionUtils.handlePhysics(FLOOR_GETTER, PLAYER_BB, restPos, restVelocity, result, false);
+            restPos = result.newPosition();
+        }
+        this.cachedResult = result;
+        if (!cachedResult.collisionY()) {
+            throw new IllegalStateException("Failed to prime resting state; collisionY expected to be true");
+        }
+    }
+
+    // --- handlePhysics paths ---
+
+    @Benchmark
+    public PhysicsResult zeroVelocity() {
+        return CollisionUtils.handlePhysics(FLOOR_GETTER, PLAYER_BB, restPos, Vec.ZERO, cachedResult, false);
+    }
+
+    @Benchmark
+    public PhysicsResult cachedStanding() {
+        return CollisionUtils.handlePhysics(FLOOR_GETTER, PLAYER_BB, restPos, restVelocity, cachedResult, false);
+    }
+
+    @Benchmark
+    public PhysicsResult fallThroughAir() {
+        return CollisionUtils.handlePhysics(AIR_GETTER, PLAYER_BB, new Pos(0.5, 100.0, 0.5),
+                new Vec(0, -0.4, 0), null, false);
+    }
+
+    @Benchmark
+    public PhysicsResult fallIntoFloor() {
+        return CollisionUtils.handlePhysics(FLOOR_GETTER, PLAYER_BB, new Pos(0.5, 64.3, 0.5),
+                new Vec(0, -0.4, 0), null, false);
+    }
+
+    @Benchmark
+    public PhysicsResult walkOnFloor() {
+        return CollisionUtils.handlePhysics(FLOOR_GETTER, PLAYER_BB, new Pos(0.5, 64.0, 0.5),
+                new Vec(0.2, -0.08, 0.15), null, false);
+    }
+
+    @Benchmark
+    public PhysicsResult diagonalMove() {
+        return CollisionUtils.handlePhysics(FLOOR_GETTER, PLAYER_BB, new Pos(0.5, 64.0, 0.5),
+                new Vec(1, 0, 1), null, false);
+    }
+
+    @Benchmark
+    public PhysicsResult largeMoveSlow() {
+        // length ~3.3, not diagonal -> slowPhysics ray-cast that crosses the floor
+        return CollisionUtils.handlePhysics(FLOOR_GETTER, PLAYER_BB, new Pos(0.5, 67.0, 0.5),
+                new Vec(1.5, -2.5, 1.5), null, false);
+    }
+
+    @Benchmark
+    public PhysicsResult fenceCollision() {
+        // Standing atop the fence layer (top at y=64.5), walking into the adjacent fences.
+        return CollisionUtils.handlePhysics(FENCE_GETTER, PLAYER_BB, new Pos(0.5, 64.5, 0.5),
+                new Vec(0.3, -0.08, 0.0), null, false);
+    }
+
+    @Benchmark
+    public PhysicsResult denseCollision() {
+        // Embedded in solid stone with a small velocity: collisions on all three axes,
+        // multiple iterations of the stepPhysics while-loop.
+        return CollisionUtils.handlePhysics(DENSE_GETTER, PLAYER_BB, new Pos(0.5, 64.5, 0.5),
+                new Vec(0.3, -0.3, 0.3), null, false);
+    }
+
+    // --- locking-getter variants: measure block-lookup cost (dedup benefit) ---
+
+    @Benchmark
+    public PhysicsResult walkOnFloorLocking() {
+        return CollisionUtils.handlePhysics(LOCKING_FLOOR_GETTER, PLAYER_BB, new Pos(0.5, 64.0, 0.5),
+                new Vec(0.2, -0.08, 0.15), null, false);
+    }
+
+    @Benchmark
+    public PhysicsResult denseCollisionLocking() {
+        return CollisionUtils.handlePhysics(LOCKING_DENSE_GETTER, PLAYER_BB, new Pos(0.5, 64.5, 0.5),
+                new Vec(0.3, -0.3, 0.3), null, false);
+    }
+
+    @Benchmark
+    public PhysicsResult fallThroughAirLocking() {
+        return CollisionUtils.handlePhysics(LOCKING_AIR_GETTER, PLAYER_BB, new Pos(0.5, 100.0, 0.5),
+                new Vec(0, -0.4, 0), null, false);
+    }
+
+    @Benchmark
+    public PhysicsResult largeMoveSlowLocking() {
+        return CollisionUtils.handlePhysics(LOCKING_FLOOR_GETTER, PLAYER_BB, new Pos(0.5, 67.0, 0.5),
+                new Vec(1.5, -2.5, 1.5), null, false);
+    }
+
+    // --- simulateMovement paths (handlePhysics + world border + velocity update) ---
+
+    @Benchmark
+    public PhysicsResult simulateOnGround() {
+        return PhysicsUtils.simulateMovement(new Pos(0.5, 64.0, 0.5), new Vec(0.1, 0, 0.1), PLAYER_BB,
+                BORDER, FLOOR_GETTER, AERO, false, true, true, false, null);
+    }
+
+    @Benchmark
+    public PhysicsResult simulateFalling() {
+        return PhysicsUtils.simulateMovement(new Pos(0.5, 100.0, 0.5), new Vec(0.1, -0.4, 0.1), PLAYER_BB,
+                BORDER, AIR_GETTER, AERO, false, true, false, false, null);
+    }
+
+    // --- helpers ---
+
+    @FunctionalInterface
+    private interface BlockAt {
+        Block get(int x, int y, int z);
+    }
+
+    private static Block.Getter condGetter(BlockAt fn) {
+        return (x, y, z, condition) -> fn.get(x, y, z);
+    }
+
+    private static Block.Getter lockingGetter(BlockAt fn) {
+        final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+        return (x, y, z, condition) -> {
+            lock.readLock().lock();
+            try {
+                return fn.get(x, y, z);
+            } finally {
+                lock.readLock().unlock();
+            }
+        };
+    }
+}

--- a/src/main/java/net/minestom/server/collision/BlockCollision.java
+++ b/src/main/java/net/minestom/server/collision/BlockCollision.java
@@ -7,10 +7,13 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.Player;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.utils.block.BlockIterator;
 import org.jetbrains.annotations.Nullable;
 
 final class BlockCollision {
+    static final Point[] NO_COLLISION_POINTS = new Point[3];
+    static final Shape[] NO_COLLISION_SHAPES = new Shape[3];
+    static final Point[] NO_COLLISION_SHAPE_POSITIONS = new Point[3];
+
     /**
      * Moves an entity with physics applied (ie checking against blocks)
      * <p>
@@ -23,9 +26,8 @@ final class BlockCollision {
                                        @Nullable PhysicsResult lastPhysicsResult,
                                        boolean singleCollision) {
         if (velocity.isZero()) {
-            // TODO should return a constant
             return new PhysicsResult(entityPosition, Vec.ZERO, false, false, false, false,
-                    velocity, new Point[3], new Shape[3], new Point[3], false, SweepResult.NO_COLLISION);
+                    velocity, NO_COLLISION_POINTS, NO_COLLISION_SHAPES, NO_COLLISION_SHAPE_POSITIONS, false, SweepResult.NO_COLLISION);
         }
         // Fast-exit using cache
         final PhysicsResult cachedResult = cachedPhysics(velocity, entityPosition, getter, lastPhysicsResult);
@@ -87,187 +89,115 @@ final class BlockCollision {
     private static PhysicsResult stepPhysics(BoundingBox boundingBox,
                                              Vec velocity, Pos entityPosition,
                                              Block.Getter getter, boolean singleCollision) {
-        // Allocate once and update values
-        SweepResult finalResult = new SweepResult(1 - Vec.EPSILON, 0, 0, 0, null, 0, 0, 0, 0, 0, 0);
+        final SweepResult finalResult = new SweepResult(1 - Vec.EPSILON, 0, 0, 0, null, 0, 0, 0, 0, 0, 0);
 
-        boolean foundCollisionX = false, foundCollisionY = false, foundCollisionZ = false;
+        // Start as the shared (all-null) arrays; only allocate real ones on the first collision.
+        Point[] collidedPoints = NO_COLLISION_POINTS;
+        Shape[] collisionShapes = NO_COLLISION_SHAPES;
+        Point[] collisionShapePositions = NO_COLLISION_SHAPE_POSITIONS;
 
-        Point[] collidedPoints = new Point[3];
-        Shape[] collisionShapes = new Shape[3];
-        Point[] collisionShapePositions = new Point[3];
+        Pos position = entityPosition;
+        Vec remaining = velocity;
+        // Each sweep advances along `remaining` until the first hit, zeroes the
+        // collided axis, then repeats so the entity slides along the others.
+        while (true) {
+            sweepBlocks(boundingBox, remaining, position, getter, finalResult);
+            double dx = finalResult.res * remaining.x();
+            double dy = finalResult.res * remaining.y();
+            double dz = finalResult.res * remaining.z();
+            if (Math.abs(dx) < Vec.EPSILON) dx = 0;
+            if (Math.abs(dy) < Vec.EPSILON) dy = 0;
+            if (Math.abs(dz) < Vec.EPSILON) dz = 0;
+            position = position.add(dx, dy, dz);
 
-        boolean hasCollided = false;
+            // The slab method records the entry face as a single non-zero normal.
+            final int axis;
+            if (finalResult.normalX != 0) axis = 0;
+            else if (finalResult.normalY != 0) axis = 1;
+            else if (finalResult.normalZ != 0) axis = 2;
+            else break; // no collision this pass
 
-        // Query faces to get the points needed for collision
-        final Vec[] allFaces = calculateFaces(velocity, boundingBox);
-        PhysicsResult result = computePhysics(boundingBox, velocity, entityPosition, getter, allFaces, finalResult);
-        // Loop until no collisions are found.
-        // When collisions are found, the collision axis is set to 0
-        // Looping until there are no collisions will allow the entity to move in axis other than the collision axis after a collision.
-        while (result.collisionX() || result.collisionY() || result.collisionZ()) {
-            // Reset final result
+            if (collisionShapes == NO_COLLISION_SHAPES) {
+                collidedPoints = new Point[3];
+                collisionShapes = new Shape[3];
+                collisionShapePositions = new Point[3];
+            }
+            collisionShapes[axis] = finalResult.collidedShape;
+            collisionShapePositions[axis] = new Vec(finalResult.collidedShapeX, finalResult.collidedShapeY, finalResult.collidedShapeZ);
+            collidedPoints[axis] = new Vec(finalResult.collidedPositionX, finalResult.collidedPositionY, finalResult.collidedPositionZ);
+
+            if (singleCollision || (collisionShapes[0] != null && collisionShapes[1] != null && collisionShapes[2] != null))
+                break;
+
+            remaining = new Vec(
+                    axis == 0 ? 0 : remaining.x() - dx,
+                    axis == 1 ? 0 : remaining.y() - dy,
+                    axis == 2 ? 0 : remaining.z() - dz);
+            if (remaining.isZero()) break;
+
             finalResult.normalX = 0;
             finalResult.normalY = 0;
             finalResult.normalZ = 0;
-
-            if (result.collisionX()) {
-                foundCollisionX = true;
-                collisionShapes[0] = finalResult.collidedShape;
-                collisionShapePositions[0] = new Vec(finalResult.collidedShapeX, finalResult.collidedShapeY, finalResult.collidedShapeZ);
-                collidedPoints[0] = new Vec(finalResult.collidedPositionX, finalResult.collidedPositionY, finalResult.collidedPositionZ);
-                hasCollided = true;
-                if (singleCollision) break;
-            } else if (result.collisionZ()) {
-                foundCollisionZ = true;
-                collisionShapes[2] = finalResult.collidedShape;
-                collisionShapePositions[2] = new Vec(finalResult.collidedShapeX, finalResult.collidedShapeY, finalResult.collidedShapeZ);
-                collidedPoints[2] = new Vec(finalResult.collidedPositionX, finalResult.collidedPositionY, finalResult.collidedPositionZ);
-                hasCollided = true;
-                if (singleCollision) break;
-            } else if (result.collisionY()) {
-                foundCollisionY = true;
-                collisionShapes[1] = finalResult.collidedShape;
-                collisionShapePositions[1] = new Vec(finalResult.collidedShapeX, finalResult.collidedShapeY, finalResult.collidedShapeZ);
-                collidedPoints[1] = new Vec(finalResult.collidedPositionX, finalResult.collidedPositionY, finalResult.collidedPositionZ);
-                hasCollided = true;
-                if (singleCollision) break;
-            }
-
-            // If all axis have had collisions, break
-            if (foundCollisionX && foundCollisionY && foundCollisionZ) break;
-            // If the entity isn't moving, break
-            if (result.newVelocity().isZero()) break;
-
             finalResult.res = 1 - Vec.EPSILON;
-            result = computePhysics(boundingBox, result.newVelocity(), result.newPosition(), getter, allFaces, finalResult);
         }
 
-        finalResult.res = result.res().res;
-
-        final double newDeltaX = foundCollisionX ? 0 : velocity.x();
-        final double newDeltaY = foundCollisionY ? 0 : velocity.y();
-        final double newDeltaZ = foundCollisionZ ? 0 : velocity.z();
-
-        return new PhysicsResult(result.newPosition(), new Vec(newDeltaX, newDeltaY, newDeltaZ),
-                newDeltaY == 0 && velocity.y() < 0,
-                foundCollisionX, foundCollisionY, foundCollisionZ, velocity, collidedPoints, collisionShapes, collisionShapePositions, hasCollided, finalResult);
-    }
-
-    private static PhysicsResult computePhysics(BoundingBox boundingBox,
-                                                Vec velocity, Pos entityPosition,
-                                                Block.Getter getter,
-                                                Vec[] allFaces,
-                                                SweepResult finalResult) {
-        // If the movement is small we don't need to run the expensive ray casting.
-        // Positions of move less than one can have hardcoded blocks to check for every direction
-        // Diagonals are a special case which will work with fast physics
-        if (velocity.length() <= 1 || isDiagonal(velocity)) {
-            fastPhysics(boundingBox, velocity, entityPosition, getter, allFaces, finalResult);
+        final boolean foundX = collisionShapes[0] != null;
+        final boolean foundY = collisionShapes[1] != null;
+        final boolean foundZ = collisionShapes[2] != null;
+        final boolean anyCollision = foundX || foundY || foundZ;
+        final boolean allCollision = foundX && foundY && foundZ;
+        final Vec newDelta;
+        if (!anyCollision) {
+            newDelta = velocity;
+        } else if (allCollision) {
+            newDelta = Vec.ZERO;
         } else {
-            slowPhysics(boundingBox, velocity, entityPosition, getter, allFaces, finalResult);
+            newDelta = new Vec(foundX ? 0 : velocity.x(), foundY ? 0 : velocity.y(), foundZ ? 0 : velocity.z());
         }
-
-        final boolean collisionX = finalResult.normalX != 0;
-        final boolean collisionY = finalResult.normalY != 0;
-        final boolean collisionZ = finalResult.normalZ != 0;
-
-        double deltaX = finalResult.res * velocity.x();
-        double deltaY = finalResult.res * velocity.y();
-        double deltaZ = finalResult.res * velocity.z();
-
-        if (Math.abs(deltaX) < Vec.EPSILON) deltaX = 0;
-        if (Math.abs(deltaY) < Vec.EPSILON) deltaY = 0;
-        if (Math.abs(deltaZ) < Vec.EPSILON) deltaZ = 0;
-
-        final Pos finalPos = entityPosition.add(deltaX, deltaY, deltaZ);
-
-        final double remainingX = collisionX ? 0 : velocity.x() - deltaX;
-        final double remainingY = collisionY ? 0 : velocity.y() - deltaY;
-        final double remainingZ = collisionZ ? 0 : velocity.z() - deltaZ;
-
-        return new PhysicsResult(finalPos, new Vec(remainingX, remainingY, remainingZ),
-                collisionY, collisionX, collisionY, collisionZ,
-                Vec.ZERO, null, null, null, false, finalResult);
+        return new PhysicsResult(position, newDelta,
+                foundY && velocity.y() < 0,
+                foundX, foundY, foundZ,
+                velocity, collidedPoints, collisionShapes, collisionShapePositions,
+                anyCollision, finalResult);
     }
 
-    private static boolean isDiagonal(Vec velocity) {
-        return Math.abs(velocity.x()) == 1 && Math.abs(velocity.z()) == 1;
-    }
-
-    private static void slowPhysics(BoundingBox boundingBox,
+    /**
+     * Iterate the blocks overlapping the swept bounding box (start -> start+velocity), near-to-far
+     * along the movement so {@code finalResult.res} tightens early and farther blocks are rejected
+     * cheaply by the SweepResult distance gate. Each block is visited exactly once.
+     */
+    private static void sweepBlocks(BoundingBox boundingBox,
                                     Vec velocity, Pos entityPosition,
                                     Block.Getter getter,
-                                    Vec[] allFaces,
                                     SweepResult finalResult) {
-        BlockIterator iterator = new BlockIterator();
-        // When large moves are done we need to ray-cast to find all blocks that could intersect with the movement
-        for (Vec point : allFaces) {
-            iterator.reset(point.add(entityPosition), velocity, 0, velocity.length(), false);
-            int timer = -1;
+        final double startX = entityPosition.x();
+        final double startY = entityPosition.y();
+        final double startZ = entityPosition.z();
+        final double endX = startX + velocity.x();
+        final double endY = startY + velocity.y();
+        final double endZ = startZ + velocity.z();
 
-            while (iterator.hasNext() && timer != 0) {
-                Point p = iterator.next();
+        // Block-aligned bounds of the swept AABB.
+        final int minX = (int) Math.floor(Math.min(startX, endX) + boundingBox.minX());
+        final int minY = (int) Math.floor(Math.min(startY, endY) + boundingBox.minY());
+        final int minZ = (int) Math.floor(Math.min(startZ, endZ) + boundingBox.minZ());
+        final int maxX = (int) Math.floor(Math.max(startX, endX) + boundingBox.maxX());
+        final int maxY = (int) Math.floor(Math.max(startY, endY) + boundingBox.maxY());
+        final int maxZ = (int) Math.floor(Math.max(startZ, endZ) + boundingBox.maxZ());
 
-                // If we hit a block, there are at most 3 other blocks that could be closer
-                if (checkBoundingBox(p.blockX(), p.blockY(), p.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult))
-                    timer = 3;
+        // Walk from near to far along velocity.
+        final int stepX = velocity.x() < 0 ? -1 : 1;
+        final int stepY = velocity.y() < 0 ? -1 : 1;
+        final int stepZ = velocity.z() < 0 ? -1 : 1;
+        final int firstX = stepX > 0 ? minX : maxX, lastX = stepX > 0 ? maxX : minX;
+        final int firstY = stepY > 0 ? minY : maxY, lastY = stepY > 0 ? maxY : minY;
+        final int firstZ = stepZ > 0 ? minZ : maxZ, lastZ = stepZ > 0 ? maxZ : minZ;
 
-                timer--;
-            }
-        }
-    }
-
-    private static void fastPhysics(BoundingBox boundingBox,
-                                    Vec velocity, Pos entityPosition,
-                                    Block.Getter getter,
-                                    Vec[] allFaces,
-                                    SweepResult finalResult) {
-        for (Vec point : allFaces) {
-            final Vec pointBefore = point.add(entityPosition);
-            final Vec pointAfter = point.add(entityPosition).add(velocity);
-            // Entity can pass through up to 4 blocks. Starting block, Two intermediate blocks, and a final block.
-            // This means we must check every combination of block movements when an entity moves over an axis.
-            // 000, 001, 010, 011, etc.
-            // There are 8 of these combinations
-            // Checks can be limited by checking if we moved across an axis line
-
-            boolean needsX = pointBefore.x() != pointAfter.x();
-            boolean needsY = pointBefore.y() != pointAfter.y();
-            boolean needsZ = pointBefore.z() != pointAfter.z();
-
-            checkBoundingBox(pointBefore.blockX(), pointBefore.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-
-            if (needsX && needsY && needsZ) {
-                checkBoundingBox(pointAfter.blockX(), pointAfter.blockY(), pointAfter.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-
-                checkBoundingBox(pointAfter.blockX(), pointAfter.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-                checkBoundingBox(pointAfter.blockX(), pointBefore.blockY(), pointAfter.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-                checkBoundingBox(pointBefore.blockX(), pointAfter.blockY(), pointAfter.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-
-                checkBoundingBox(pointAfter.blockX(), pointBefore.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-                checkBoundingBox(pointBefore.blockX(), pointAfter.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-                checkBoundingBox(pointBefore.blockX(), pointBefore.blockY(), pointAfter.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-            } else if (needsX && needsY) {
-                checkBoundingBox(pointAfter.blockX(), pointAfter.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-
-                checkBoundingBox(pointAfter.blockX(), pointBefore.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-                checkBoundingBox(pointBefore.blockX(), pointAfter.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-            } else if (needsX && needsZ) {
-                checkBoundingBox(pointAfter.blockX(), pointBefore.blockY(), pointAfter.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-
-                checkBoundingBox(pointAfter.blockX(), pointBefore.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-                checkBoundingBox(pointBefore.blockX(), pointBefore.blockY(), pointAfter.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-            } else if (needsY && needsZ) {
-                checkBoundingBox(pointBefore.blockX(), pointAfter.blockY(), pointAfter.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-
-                checkBoundingBox(pointBefore.blockX(), pointAfter.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-                checkBoundingBox(pointBefore.blockX(), pointBefore.blockY(), pointAfter.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-            } else if (needsX) {
-                checkBoundingBox(pointAfter.blockX(), pointBefore.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-            } else if (needsY) {
-                checkBoundingBox(pointBefore.blockX(), pointAfter.blockY(), pointBefore.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
-            } else if (needsZ) {
-                checkBoundingBox(pointBefore.blockX(), pointBefore.blockY(), pointAfter.blockZ(), velocity, entityPosition, boundingBox, getter, finalResult);
+        for (int x = firstX; x != lastX + stepX; x += stepX) {
+            for (int y = firstY; y != lastY + stepY; y += stepY) {
+                for (int z = firstZ; z != lastZ + stepZ; z += stepZ) {
+                    checkBoundingBox(x, y, z, velocity, entityPosition, boundingBox, getter, finalResult);
+                }
             }
         }
     }
@@ -363,112 +293,5 @@ final class BlockCollision {
         corner
          */
         return m * (blockPos - pos + (m > 0 ? 1 : 0)) + entityY;
-    }
-
-    private static Vec[] calculateFaces(Vec queryVec, BoundingBox boundingBox) {
-        final int queryX = (int) Math.signum(queryVec.x());
-        final int queryY = (int) Math.signum(queryVec.y());
-        final int queryZ = (int) Math.signum(queryVec.z());
-
-        final int ceilWidth = (int) Math.ceil(boundingBox.width());
-        final int ceilHeight = (int) Math.ceil(boundingBox.height());
-        final int ceilDepth = (int) Math.ceil(boundingBox.depth());
-        Vec[] facePoints;
-        // Compute array length
-        {
-            final int ceilX = ceilWidth + 1;
-            final int ceilY = ceilHeight + 1;
-            final int ceilZ = ceilDepth + 1;
-            int pointCount = 0;
-            if (queryX != 0) pointCount += ceilY * ceilZ;
-            if (queryY != 0) pointCount += ceilX * ceilZ;
-            if (queryZ != 0) pointCount += ceilX * ceilY;
-            // Three edge reduction
-            if (queryX != 0 && queryY != 0 && queryZ != 0) {
-                pointCount -= ceilX + ceilY + ceilZ;
-                // inclusion exclusion principle
-                pointCount++;
-            } else if (queryX != 0 && queryY != 0) { // Two edge reduction
-                pointCount -= ceilZ;
-            } else if (queryY != 0 && queryZ != 0) { // Two edge reduction
-                pointCount -= ceilX;
-            } else if (queryX != 0 && queryZ != 0) { // Two edge reduction
-                pointCount -= ceilY;
-            }
-            facePoints = new Vec[pointCount];
-        }
-        int insertIndex = 0;
-        // X -> Y x Z
-        if (queryX != 0) {
-            int startIOffset = 0, endIOffset = 0, startJOffset = 0, endJOffset = 0;
-            // Y handles XY edge
-            if (queryY < 0) startJOffset = 1;
-            if (queryY > 0) endJOffset = 1;
-            // Z handles XZ edge
-            if (queryZ < 0) startIOffset = 1;
-            if (queryZ > 0) endIOffset = 1;
-
-            for (int i = startIOffset; i <= ceilDepth - endIOffset; ++i) {
-                for (int j = startJOffset; j <= ceilHeight - endJOffset; ++j) {
-                    double cellI = i;
-                    double cellJ = j;
-                    double cellK = queryX < 0 ? 0 : boundingBox.width();
-
-                    if (i >= boundingBox.depth()) cellI = boundingBox.depth();
-                    if (j >= boundingBox.height()) cellJ = boundingBox.height();
-
-                    cellI += boundingBox.minZ();
-                    cellJ += boundingBox.minY();
-                    cellK += boundingBox.minX();
-
-                    facePoints[insertIndex++] = new Vec(cellK, cellJ, cellI);
-                }
-            }
-        }
-        // Y -> X x Z
-        if (queryY != 0) {
-            int startJOffset = 0, endJOffset = 0;
-            // Z handles YZ edge
-            if (queryZ < 0) startJOffset = 1;
-            if (queryZ > 0) endJOffset = 1;
-
-            for (int i = startJOffset; i <= ceilDepth - endJOffset; ++i) {
-                for (int j = 0; j <= ceilWidth; ++j) {
-                    double cellI = i;
-                    double cellJ = j;
-                    double cellK = queryY < 0 ? 0 : boundingBox.height();
-
-                    if (i >= boundingBox.depth()) cellI = boundingBox.depth();
-                    if (j >= boundingBox.width()) cellJ = boundingBox.width();
-
-                    cellI += boundingBox.minZ();
-                    cellJ += boundingBox.minX();
-                    cellK += boundingBox.minY();
-
-                    facePoints[insertIndex++] = new Vec(cellJ, cellK, cellI);
-                }
-            }
-        }
-        // Z -> X x Y
-        if (queryZ != 0) {
-            for (int i = 0; i <= ceilHeight; ++i) {
-                for (int j = 0; j <= ceilWidth; ++j) {
-                    double cellI = i;
-                    double cellJ = j;
-                    double cellK = queryZ < 0 ? 0 : boundingBox.depth();
-
-                    if (i >= boundingBox.height()) cellI = boundingBox.height();
-                    if (j >= boundingBox.width()) cellJ = boundingBox.width();
-
-                    cellI += boundingBox.minY();
-                    cellJ += boundingBox.minX();
-                    cellK += boundingBox.minZ();
-
-                    facePoints[insertIndex++] = new Vec(cellJ, cellI, cellK);
-                }
-            }
-        }
-
-        return facePoints;
     }
 }

--- a/src/main/java/net/minestom/server/collision/CollisionUtils.java
+++ b/src/main/java/net/minestom/server/collision/CollisionUtils.java
@@ -205,7 +205,7 @@ public final class CollisionUtils {
      */
     public static PhysicsResult blocklessCollision(Pos entityPosition, Vec entityVelocity) {
         return new PhysicsResult(entityPosition.add(entityVelocity), entityVelocity, false,
-                false, false, false, entityVelocity, new Point[3],
-                new Shape[3], new Point[3], false, SweepResult.NO_COLLISION);
+                false, false, false, entityVelocity, BlockCollision.NO_COLLISION_POINTS,
+                BlockCollision.NO_COLLISION_SHAPES, BlockCollision.NO_COLLISION_SHAPE_POSITIONS, false, SweepResult.NO_COLLISION);
     }
 }

--- a/src/main/java/net/minestom/server/collision/RayUtils.java
+++ b/src/main/java/net/minestom/server/collision/RayUtils.java
@@ -15,19 +15,40 @@ final class RayUtils {
      * @return true if an intersection between the ray and the bounding box was found
      */
     public static boolean BoundingBoxIntersectionCheck(BoundingBox moving, Point rayStart, Point rayDirection, BoundingBox collidableStatic, Point staticCollidableOffset, SweepResult finalResult) {
-        Point bbCentre = new Vec(moving.minX() + moving.width() / 2, moving.minY() + moving.height() / 2, moving.minZ() + moving.depth() / 2);
-        Point rayCentre = rayStart.add(bbCentre);
+        final double halfWidth = moving.width() / 2;
+        final double halfHeight = moving.height() / 2;
+        final double halfDepth = moving.depth() / 2;
 
-        // Translate bounding box
-        Vec bbOffMin = new Vec(collidableStatic.minX() - rayCentre.x() + staticCollidableOffset.x() - moving.width() / 2, collidableStatic.minY() - rayCentre.y() + staticCollidableOffset.y() - moving.height() / 2, collidableStatic.minZ() - rayCentre.z() + staticCollidableOffset.z() - moving.depth() / 2);
-        Vec bbOffMax = new Vec(collidableStatic.maxX() - rayCentre.x() + staticCollidableOffset.x() + moving.width() / 2, collidableStatic.maxY() - rayCentre.y() + staticCollidableOffset.y() + moving.height() / 2, collidableStatic.maxZ() - rayCentre.z() + staticCollidableOffset.z() + moving.depth() / 2);
+        final double rayCentreX = rayStart.x() + moving.minX() + halfWidth;
+        final double rayCentreY = rayStart.y() + moving.minY() + halfHeight;
+        final double rayCentreZ = rayStart.z() + moving.minZ() + halfDepth;
+
+        final double rayDirX = rayDirection.x();
+        final double rayDirY = rayDirection.y();
+        final double rayDirZ = rayDirection.z();
+
+        // Static box bounds in world space (offset by the shape position)
+        final double staticMinX = collidableStatic.minX() + staticCollidableOffset.x();
+        final double staticMinY = collidableStatic.minY() + staticCollidableOffset.y();
+        final double staticMinZ = collidableStatic.minZ() + staticCollidableOffset.z();
+        final double staticMaxX = collidableStatic.maxX() + staticCollidableOffset.x();
+        final double staticMaxY = collidableStatic.maxY() + staticCollidableOffset.y();
+        final double staticMaxZ = collidableStatic.maxZ() + staticCollidableOffset.z();
+
+        // Expanded (Minkowski) bounds relative to the ray centre
+        final double bbOffMinX = staticMinX - rayCentreX - halfWidth;
+        final double bbOffMinY = staticMinY - rayCentreY - halfHeight;
+        final double bbOffMinZ = staticMinZ - rayCentreZ - halfDepth;
+        final double bbOffMaxX = staticMaxX - rayCentreX + halfWidth;
+        final double bbOffMaxY = staticMaxY - rayCentreY + halfHeight;
+        final double bbOffMaxZ = staticMaxZ - rayCentreZ + halfDepth;
 
         // This check is done in 2d. it can be visualised as a rectangle (the face we are checking), and a point.
         // If the point is within the rectangle, we know the vector intersects the face.
 
-        double signumRayX = Math.signum(rayDirection.x());
-        double signumRayY = Math.signum(rayDirection.y());
-        double signumRayZ = Math.signum(rayDirection.z());
+        double signumRayX = Math.signum(rayDirX);
+        double signumRayY = Math.signum(rayDirY);
+        double signumRayZ = Math.signum(rayDirZ);
 
         boolean isHit = false;
         double percentage = Double.MAX_VALUE;
@@ -35,19 +56,19 @@ final class RayUtils {
 
         // Intersect X
         // Left side of bounding box
-        if (rayDirection.x() > 0) {
-            double xFac = epsilon(bbOffMin.x() / rayDirection.x());
+        if (rayDirX > 0) {
+            double xFac = epsilon(bbOffMinX / rayDirX);
             if (xFac < percentage) {
-                double yix = rayDirection.y() * xFac + rayCentre.y();
-                double zix = rayDirection.z() * xFac + rayCentre.z();
+                double yix = rayDirY * xFac + rayCentreY;
+                double zix = rayDirZ * xFac + rayCentreZ;
 
                 // Check if ray passes through y/z plane
-                if (((yix - rayCentre.y()) * signumRayY) >= 0
-                        && ((zix - rayCentre.z()) * signumRayZ) >= 0
-                        && yix >= collidableStatic.minY() + staticCollidableOffset.y() - moving.height() / 2
-                        && yix <= collidableStatic.maxY() + staticCollidableOffset.y() + moving.height() / 2
-                        && zix >= collidableStatic.minZ() + staticCollidableOffset.z() - moving.depth() / 2
-                        && zix <= collidableStatic.maxZ() + staticCollidableOffset.z() + moving.depth() / 2) {
+                if (((yix - rayCentreY) * signumRayY) >= 0
+                        && ((zix - rayCentreZ) * signumRayZ) >= 0
+                        && yix >= staticMinY - halfHeight
+                        && yix <= staticMaxY + halfHeight
+                        && zix >= staticMinZ - halfDepth
+                        && zix <= staticMaxZ + halfDepth) {
                     isHit = true;
                     percentage = xFac;
                     collisionFace = 0;
@@ -55,18 +76,18 @@ final class RayUtils {
             }
         }
         // Right side of bounding box
-        if (rayDirection.x() < 0) {
-            double xFac = epsilon(bbOffMax.x() / rayDirection.x());
+        if (rayDirX < 0) {
+            double xFac = epsilon(bbOffMaxX / rayDirX);
             if (xFac < percentage) {
-                double yix = rayDirection.y() * xFac + rayCentre.y();
-                double zix = rayDirection.z() * xFac + rayCentre.z();
+                double yix = rayDirY * xFac + rayCentreY;
+                double zix = rayDirZ * xFac + rayCentreZ;
 
-                if (((yix - rayCentre.y()) * signumRayY) >= 0
-                        && ((zix - rayCentre.z()) * signumRayZ) >= 0
-                        && yix >= collidableStatic.minY() + staticCollidableOffset.y() - moving.height() / 2
-                        && yix <= collidableStatic.maxY() + staticCollidableOffset.y() + moving.height() / 2
-                        && zix >= collidableStatic.minZ() + staticCollidableOffset.z() - moving.depth() / 2
-                        && zix <= collidableStatic.maxZ() + staticCollidableOffset.z() + moving.depth() / 2) {
+                if (((yix - rayCentreY) * signumRayY) >= 0
+                        && ((zix - rayCentreZ) * signumRayZ) >= 0
+                        && yix >= staticMinY - halfHeight
+                        && yix <= staticMaxY + halfHeight
+                        && zix >= staticMinZ - halfDepth
+                        && zix <= staticMaxZ + halfDepth) {
                     isHit = true;
                     percentage = xFac;
                     collisionFace = 0;
@@ -75,36 +96,36 @@ final class RayUtils {
         }
 
         // Intersect Z
-        if (rayDirection.z() > 0) {
-            double zFac = epsilon(bbOffMin.z() / rayDirection.z());
+        if (rayDirZ > 0) {
+            double zFac = epsilon(bbOffMinZ / rayDirZ);
             if (zFac < percentage) {
-                double xiz = rayDirection.x() * zFac + rayCentre.x();
-                double yiz = rayDirection.y() * zFac + rayCentre.y();
+                double xiz = rayDirX * zFac + rayCentreX;
+                double yiz = rayDirY * zFac + rayCentreY;
 
-                if (((yiz - rayCentre.y()) * signumRayY) >= 0
-                        && ((xiz - rayCentre.x()) * signumRayX) >= 0
-                        && xiz >= collidableStatic.minX() + staticCollidableOffset.x() - moving.width() / 2
-                        && xiz <= collidableStatic.maxX() + staticCollidableOffset.x() + moving.width() / 2
-                        && yiz >= collidableStatic.minY() + staticCollidableOffset.y() - moving.height() / 2
-                        && yiz <= collidableStatic.maxY() + staticCollidableOffset.y() + moving.height() / 2) {
+                if (((yiz - rayCentreY) * signumRayY) >= 0
+                        && ((xiz - rayCentreX) * signumRayX) >= 0
+                        && xiz >= staticMinX - halfWidth
+                        && xiz <= staticMaxX + halfWidth
+                        && yiz >= staticMinY - halfHeight
+                        && yiz <= staticMaxY + halfHeight) {
                     isHit = true;
                     percentage = zFac;
                     collisionFace = 1;
                 }
             }
         }
-        if (rayDirection.z() < 0) {
-            double zFac = epsilon(bbOffMax.z() / rayDirection.z());
+        if (rayDirZ < 0) {
+            double zFac = epsilon(bbOffMaxZ / rayDirZ);
             if (zFac < percentage) {
-                double xiz = rayDirection.x() * zFac + rayCentre.x();
-                double yiz = rayDirection.y() * zFac + rayCentre.y();
+                double xiz = rayDirX * zFac + rayCentreX;
+                double yiz = rayDirY * zFac + rayCentreY;
 
-                if (((yiz - rayCentre.y()) * signumRayY) >= 0
-                        && ((xiz - rayCentre.x()) * signumRayX) >= 0
-                        && xiz >= collidableStatic.minX() + staticCollidableOffset.x() - moving.width() / 2
-                        && xiz <= collidableStatic.maxX() + staticCollidableOffset.x() + moving.width() / 2
-                        && yiz >= collidableStatic.minY() + staticCollidableOffset.y() - moving.height() / 2
-                        && yiz <= collidableStatic.maxY() + staticCollidableOffset.y() + moving.height() / 2) {
+                if (((yiz - rayCentreY) * signumRayY) >= 0
+                        && ((xiz - rayCentreX) * signumRayX) >= 0
+                        && xiz >= staticMinX - halfWidth
+                        && xiz <= staticMaxX + halfWidth
+                        && yiz >= staticMinY - halfHeight
+                        && yiz <= staticMaxY + halfHeight) {
                     isHit = true;
                     percentage = zFac;
                     collisionFace = 1;
@@ -113,18 +134,18 @@ final class RayUtils {
         }
 
         // Intersect Y
-        if (rayDirection.y() > 0) {
-            double yFac = epsilon(bbOffMin.y() / rayDirection.y());
+        if (rayDirY > 0) {
+            double yFac = epsilon(bbOffMinY / rayDirY);
             if (yFac < percentage) {
-                double xiy = rayDirection.x() * yFac + rayCentre.x();
-                double ziy = rayDirection.z() * yFac + rayCentre.z();
+                double xiy = rayDirX * yFac + rayCentreX;
+                double ziy = rayDirZ * yFac + rayCentreZ;
 
-                if (((ziy - rayCentre.z()) * signumRayZ) >= 0
-                        && ((xiy - rayCentre.x()) * signumRayX) >= 0
-                        && xiy >= collidableStatic.minX() + staticCollidableOffset.x() - moving.width() / 2
-                        && xiy <= collidableStatic.maxX() + staticCollidableOffset.x() + moving.width() / 2
-                        && ziy >= collidableStatic.minZ() + staticCollidableOffset.z() - moving.depth() / 2
-                        && ziy <= collidableStatic.maxZ() + staticCollidableOffset.z() + moving.depth() / 2) {
+                if (((ziy - rayCentreZ) * signumRayZ) >= 0
+                        && ((xiy - rayCentreX) * signumRayX) >= 0
+                        && xiy >= staticMinX - halfWidth
+                        && xiy <= staticMaxX + halfWidth
+                        && ziy >= staticMinZ - halfDepth
+                        && ziy <= staticMaxZ + halfDepth) {
                     isHit = true;
                     percentage = yFac;
                     collisionFace = 2;
@@ -132,18 +153,18 @@ final class RayUtils {
             }
         }
 
-        if (rayDirection.y() < 0) {
-            double yFac = epsilon(bbOffMax.y() / rayDirection.y());
+        if (rayDirY < 0) {
+            double yFac = epsilon(bbOffMaxY / rayDirY);
             if (yFac < percentage) {
-                double xiy = rayDirection.x() * yFac + rayCentre.x();
-                double ziy = rayDirection.z() * yFac + rayCentre.z();
+                double xiy = rayDirX * yFac + rayCentreX;
+                double ziy = rayDirZ * yFac + rayCentreZ;
 
-                if (((ziy - rayCentre.z()) * signumRayZ) >= 0
-                        && ((xiy - rayCentre.x()) * signumRayX) >= 0
-                        && xiy >= collidableStatic.minX() + staticCollidableOffset.x() - moving.width() / 2
-                        && xiy <= collidableStatic.maxX() + staticCollidableOffset.x() + moving.width() / 2
-                        && ziy >= collidableStatic.minZ() + staticCollidableOffset.z() - moving.depth() / 2
-                        && ziy <= collidableStatic.maxZ() + staticCollidableOffset.z() + moving.depth() / 2) {
+                if (((ziy - rayCentreZ) * signumRayZ) >= 0
+                        && ((xiy - rayCentreX) * signumRayX) >= 0
+                        && xiy >= staticMinX - halfWidth
+                        && xiy <= staticMaxX + halfWidth
+                        && ziy >= staticMinZ - halfDepth
+                        && ziy <= staticMaxZ + halfDepth) {
                     isHit = true;
                     percentage = yFac;
                     collisionFace = 2;


### PR DESCRIPTION
## Proposed changes

Reworks block-collision detection into a single **swept-AABB broadphase**, replacing the face-point enumeration and its separate fast/slow code paths.

The old approach enumerated points across the bounding box's leading faces and computed which cells each crossed — revisiting the same block many times (~26 `getBlock` calls to cover 6 distinct blocks for a walking entity), allocating a faces array per call, and using two separate algorithms (face combinations for short moves, a ray-cast for long ones). The new code iterates every block in the swept bounding box **exactly once**, near-to-far along the movement so the closest hit tightens the sweep result and prunes the rest. It is allocation-free (no faces array, no candidate buffer, no dedup/sort) and handles all velocities with one path.

Also keeps the no-collision constants, lazy collision arrays, and the resting-entity cache. No public API change.

## Types of changes

Performance improvement

## Physics performance: master → this PR

Interleaved, drift-cancelled. `BlockPhysicsBenchmark`.

| Scenario | master ns | now ns | Δ CPU | Δ alloc |
|---|--:|--:|--:|--:|
| idle (zero velocity) | 8 | 2 | −76% | −67% |
| walkOnFloor | 1188 | 148 | −88% | −63% |
| denseCollision | 2760 | 386 | −86% | −77% |
| simulateFalling | 613 | 46 | −92% | −58% |
| simulateOnGround | 304 | 48 | −84% | −56% |
| fallIntoFloor | 156 | 68 | −56% | −37% |
| fenceCollision | 235 | 56 | −76% | −59% |
| largeMoveSlow | 1512 | 315 | −79% | −95% |
| fallThroughAir | 97 | 39 | −59% | −47% |
| diagonalMove | 337 | 71 | −79% | −62% |

## With realistic per-block chunk locking

| Scenario | master ns | now ns | Δ CPU | Δ alloc |
|---|--:|--:|--:|--:|
| walkOnFloorLocking | 2587 | 266 | −90% | −63% |
| denseCollisionLocking | 3284 | 547 | −83% | −77% |
| fallThroughAirLocking | 218 | 85 | −61% | −47% |
| largeMoveSlowLocking | 2711 | 959 | −65% | −95% |

All collision and physics integration tests pass.
