### PR TITLE
Support generic number types in Transcoder, nbt arrays coercion

### DIFF
--- a/src/main/java/net/minestom/server/codec/Transcoder.java
+++ b/src/main/java/net/minestom/server/codec/Transcoder.java
@@ -129,6 +129,32 @@ public interface Transcoder<D> {
     D createDouble(double value);
 
     /**
+     * Attempts to unwrap a number from the value {@link D}
+     *
+     * @param value the value to unwrap
+     * @return the result
+     */
+    Result<Number> getNumber(D value);
+
+    /**
+     * Creates a number representation of {@link D}
+     *
+     * @param value the number primitive
+     * @return the representation of value in {@link D}
+     */
+    default D createNumber(Number value) {
+        return switch (value) {
+            case Byte n -> createByte(n);
+            case Short n -> createShort(n);
+            case Integer n -> createInt(n);
+            case Long n -> createLong(n);
+            case Double n -> createDouble(n);
+            case Float n -> createFloat(n);
+            default -> createDouble(value.doubleValue());
+        };
+    }
+
+    /**
      * Attempts to unwrap a string from the value {@link D}
      * @param value the value to unwrap
      * @return the result
@@ -202,10 +228,10 @@ public interface Transcoder<D> {
             return listResult.cast();
         final byte[] byteArray = new byte[list.size()];
         for (int i = 0; i < list.size(); i++) {
-            final Result<Byte> byteResult = getByte(list.get(i));
-            if (!(byteResult instanceof Result.Ok(Byte byteValue)))
-                return byteResult.cast();
-            byteArray[i] = byteValue;
+            final Result<Number> numberResult = getNumber(list.get(i));
+            if (!(numberResult instanceof Result.Ok(Number number)))
+                return new Result.Error<>("Not a byte: " + value);
+            byteArray[i] = number.byteValue();
         }
         return new Result.Ok<>(byteArray);
     }
@@ -232,10 +258,10 @@ public interface Transcoder<D> {
             return listResult.cast();
         final int[] intArray = new int[list.size()];
         for (int i = 0; i < list.size(); i++) {
-            final Result<Integer> intResult = getInt(list.get(i));
-            if (!(intResult instanceof Result.Ok(Integer intValue)))
-                return intResult.cast();
-            intArray[i] = intValue;
+            final Result<Number> numberResult = getNumber(list.get(i));
+            if (!(numberResult instanceof Result.Ok(Number number)))
+                return new Result.Error<>("Not an int: " + value);
+            intArray[i] = number.intValue();
         }
         return new Result.Ok<>(intArray);
     }
@@ -262,10 +288,10 @@ public interface Transcoder<D> {
             return listResult.cast();
         final long[] longArray = new long[list.size()];
         for (int i = 0; i < list.size(); i++) {
-            final Result<Long> longResult = getLong(list.get(i));
-            if (!(longResult instanceof Result.Ok(Long longValue)))
-                return longResult.cast();
-            longArray[i] = longValue;
+            final Result<Number> numberResult = getNumber(list.get(i));
+            if (!(numberResult instanceof Result.Ok(Number number)))
+                return new Result.Error<>("Not a long: " + value);
+            longArray[i] = number.longValue();
         }
         return new Result.Ok<>(longArray);
     }

--- a/src/main/java/net/minestom/server/codec/TranscoderCrc32Impl.java
+++ b/src/main/java/net/minestom/server/codec/TranscoderCrc32Impl.java
@@ -206,6 +206,11 @@ final class TranscoderCrc32Impl implements Transcoder<Integer> {
     }
 
     @Override
+    public Result<Number> getNumber(Integer value) {
+        return writeOnly();
+    }
+
+    @Override
     public Result<String> getString(Integer value) {
         return writeOnly();
     }

--- a/src/main/java/net/minestom/server/codec/TranscoderJavaImpl.java
+++ b/src/main/java/net/minestom/server/codec/TranscoderJavaImpl.java
@@ -98,6 +98,18 @@ final class TranscoderJavaImpl implements Transcoder<Object> {
     }
 
     @Override
+    public Object createNumber(Number value) {
+        return value;
+    }
+
+    @Override
+    public Result<Number> getNumber(Object value) {
+        if (!(value instanceof Number n))
+            return new Result.Error<>("Not a number: " + value);
+        return new Result.Ok<>(n);
+    }
+
+    @Override
     public Result<String> getString(Object value) {
         if (!(value instanceof String s))
             return new Result.Error<>("Not a string: " + value);

--- a/src/main/java/net/minestom/server/codec/TranscoderJsonImpl.java
+++ b/src/main/java/net/minestom/server/codec/TranscoderJsonImpl.java
@@ -102,6 +102,18 @@ final class TranscoderJsonImpl implements Transcoder<JsonElement> {
     }
 
     @Override
+    public Result<Number> getNumber(JsonElement value) {
+        if (value instanceof JsonPrimitive primitive && primitive.isNumber())
+            return new Result.Ok<>(primitive.getAsNumber());
+        return new Result.Error<>("Not a number: " + value);
+    }
+
+    @Override
+    public JsonElement createNumber(Number value) {
+        return new JsonPrimitive(value);
+    }
+
+    @Override
     public Result<String> getString(JsonElement value) {
         if (!(value instanceof JsonPrimitive primitive))
             return new Result.Error<>("Not a string: " + value);

--- a/src/main/java/net/minestom/server/codec/TranscoderNbtImpl.java
+++ b/src/main/java/net/minestom/server/codec/TranscoderNbtImpl.java
@@ -104,6 +104,13 @@ final class TranscoderNbtImpl implements Transcoder<BinaryTag> {
     }
 
     @Override
+    public Result<Number> getNumber(BinaryTag value) {
+        return value instanceof NumberBinaryTag number
+                ? new Result.Ok<>(number.numberValue())
+                : new Result.Error<>("Not a number: " + value);
+    }
+
+    @Override
     public Result<String> getString(BinaryTag value) {
         return value instanceof StringBinaryTag string
                 ? new Result.Ok<>(string.value())
@@ -218,7 +225,7 @@ final class TranscoderNbtImpl implements Transcoder<BinaryTag> {
     public Result<byte[]> getByteArray(BinaryTag value) {
         return value instanceof ByteArrayBinaryTag byteArray
                 ? new Result.Ok<>(byteArray.value())
-                : new Result.Error<>("Not a byte array: " + value);
+                : Transcoder.super.getByteArray(value);
     }
 
     @Override
@@ -230,7 +237,7 @@ final class TranscoderNbtImpl implements Transcoder<BinaryTag> {
     public Result<int[]> getIntArray(BinaryTag value) {
         return value instanceof IntArrayBinaryTag intArray
                 ? new Result.Ok<>(intArray.value())
-                : new Result.Error<>("Not an int array: " + value);
+                : Transcoder.super.getIntArray(value);
     }
 
     @Override
@@ -242,7 +249,7 @@ final class TranscoderNbtImpl implements Transcoder<BinaryTag> {
     public Result<long[]> getLongArray(BinaryTag value) {
         return value instanceof LongArrayBinaryTag longArray
                 ? new Result.Ok<>(longArray.value())
-                : new Result.Error<>("Not a long array: " + value);
+                : Transcoder.super.getLongArray(value);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/codec/TranscoderProxy.java
+++ b/src/main/java/net/minestom/server/codec/TranscoderProxy.java
@@ -106,6 +106,16 @@ public interface TranscoderProxy<D> extends Transcoder<D> {
     }
 
     @Override
+    default Result<Number> getNumber(D value) {
+        return delegate().getNumber(value);
+    }
+
+    @Override
+    default D createNumber(Number value) {
+        return delegate().createNumber(value);
+    }
+
+    @Override
     default Result<String> getString(D value) {
         return delegate().getString(value);
     }

--- a/src/test/java/net/minestom/server/codec/TranscoderTest.java
+++ b/src/test/java/net/minestom/server/codec/TranscoderTest.java
@@ -1,0 +1,154 @@
+package net.minestom.server.codec;
+
+import net.kyori.adventure.nbt.ByteArrayBinaryTag;
+import net.kyori.adventure.nbt.IntArrayBinaryTag;
+import net.kyori.adventure.nbt.IntBinaryTag;
+import net.kyori.adventure.nbt.ListBinaryTag;
+import net.kyori.adventure.nbt.LongArrayBinaryTag;
+import net.kyori.adventure.nbt.LongBinaryTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+
+import static net.minestom.server.codec.CodecAssertions.assertOk;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+public class TranscoderTest {
+
+    private static List<Transcoder<?>> nonDestructiveTranscoders() {
+        return List.of(Transcoder.NBT, Transcoder.JSON, Transcoder.JAVA);
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonDestructiveTranscoders")
+    <D> void createNumberDispatchesOnRuntimeType(Transcoder<D> transcoder) {
+        assertEquals((byte) 7, assertOk(transcoder.getNumber(transcoder.createNumber((byte) 7))).byteValue());
+        assertEquals((short) 9, assertOk(transcoder.getNumber(transcoder.createNumber((short) 9))).shortValue());
+        assertEquals(42, assertOk(transcoder.getNumber(transcoder.createNumber(42))).intValue());
+        assertEquals(42L, assertOk(transcoder.getNumber(transcoder.createNumber(42L))).longValue());
+        assertEquals(1.5f, assertOk(transcoder.getNumber(transcoder.createNumber(1.5f))).floatValue());
+        assertEquals(1.5d, assertOk(transcoder.getNumber(transcoder.createNumber(1.5d))).doubleValue());
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonDestructiveTranscoders")
+    <D> void getNumberReadsPrimitiveCreators(Transcoder<D> transcoder) {
+        assertEquals(5, assertOk(transcoder.getNumber(transcoder.createInt(5))).intValue());
+        assertEquals(5L, assertOk(transcoder.getNumber(transcoder.createLong(5L))).longValue());
+        assertEquals((byte) 5, assertOk(transcoder.getNumber(transcoder.createByte((byte) 5))).byteValue());
+        assertEquals((short) 5, assertOk(transcoder.getNumber(transcoder.createShort((short) 5))).shortValue());
+        assertEquals(2.5f, assertOk(transcoder.getNumber(transcoder.createFloat(2.5f))).floatValue());
+        assertEquals(2.5d, assertOk(transcoder.getNumber(transcoder.createDouble(2.5d))).doubleValue());
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonDestructiveTranscoders")
+    <D> void getNumberRejectsNonNumber(Transcoder<D> transcoder) {
+        assertInstanceOf(Result.Error.class, transcoder.getNumber(transcoder.createString("not a number")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonDestructiveTranscoders")
+    <D> void byteArrayCoercesAndNarrowsFromIntList(Transcoder<D> transcoder) {
+        final D list = transcoder.createList(3)
+                .add(transcoder.createInt(1))
+                .add(transcoder.createInt(2))
+                .add(transcoder.createInt(300))
+                .build();
+        assertArrayEquals(new byte[]{1, 2, (byte) 300}, assertOk(transcoder.getByteArray(list)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonDestructiveTranscoders")
+    <D> void intArrayCoercesAndNarrowsFromLongList(Transcoder<D> transcoder) {
+        final D list = transcoder.createList(2)
+                .add(transcoder.createLong(1L))
+                .add(transcoder.createLong(0x1_0000_0001L))
+                .build();
+        assertArrayEquals(new int[]{1, 1}, assertOk(transcoder.getIntArray(list)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonDestructiveTranscoders")
+    <D> void longArrayCoercesFromIntList(Transcoder<D> transcoder) {
+        final D list = transcoder.createList(2)
+                .add(transcoder.createInt(1))
+                .add(transcoder.createInt(-5))
+                .build();
+        assertArrayEquals(new long[]{1L, -5L}, assertOk(transcoder.getLongArray(list)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonDestructiveTranscoders")
+    <D> void intArrayRejectsNonNumberElement(Transcoder<D> transcoder) {
+        final D list = transcoder.createList(2)
+                .add(transcoder.createInt(1))
+                .add(transcoder.createString("nope"))
+                .build();
+        assertInstanceOf(Result.Error.class, transcoder.getIntArray(list));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonDestructiveTranscoders")
+    <D> void byteArrayRoundTrip(Transcoder<D> transcoder) {
+        final byte[] data = {1, -5, 127, 0};
+        final D encoded = assertOk(Codec.BYTE_ARRAY.encode(transcoder, data));
+        assertArrayEquals(data, assertOk(Codec.BYTE_ARRAY.decode(transcoder, encoded)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonDestructiveTranscoders")
+    <D> void intArrayRoundTrip(Transcoder<D> transcoder) {
+        final int[] data = {1, -5, 1000, Integer.MAX_VALUE};
+        final D encoded = assertOk(Codec.INT_ARRAY.encode(transcoder, data));
+        assertArrayEquals(data, assertOk(Codec.INT_ARRAY.decode(transcoder, encoded)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonDestructiveTranscoders")
+    <D> void longArrayRoundTrip(Transcoder<D> transcoder) {
+        final long[] data = {1L, -5L, Long.MAX_VALUE};
+        final D encoded = assertOk(Codec.LONG_ARRAY.encode(transcoder, data));
+        assertArrayEquals(data, assertOk(Codec.LONG_ARRAY.decode(transcoder, encoded)));
+    }
+
+    @Test
+    void nbtReadsNativeArrayTags() {
+        assertArrayEquals(new byte[]{1, 2, 3},
+                assertOk(Transcoder.NBT.getByteArray(ByteArrayBinaryTag.byteArrayBinaryTag((byte) 1, (byte) 2, (byte) 3))));
+        assertArrayEquals(new int[]{1, 2, 3},
+                assertOk(Transcoder.NBT.getIntArray(IntArrayBinaryTag.intArrayBinaryTag(1, 2, 3))));
+        assertArrayEquals(new long[]{1L, 2L, 3L},
+                assertOk(Transcoder.NBT.getLongArray(LongArrayBinaryTag.longArrayBinaryTag(1L, 2L, 3L))));
+    }
+
+    @Test
+    void nbtEncodesArraysToNativeTags() {
+        assertInstanceOf(ByteArrayBinaryTag.class, assertOk(Codec.BYTE_ARRAY.encode(Transcoder.NBT, new byte[]{1, 2})));
+        assertInstanceOf(IntArrayBinaryTag.class, assertOk(Codec.INT_ARRAY.encode(Transcoder.NBT, new int[]{1, 2})));
+        assertInstanceOf(LongArrayBinaryTag.class, assertOk(Codec.LONG_ARRAY.encode(Transcoder.NBT, new long[]{1, 2})));
+    }
+
+    @Test
+    void nbtIntArrayFallsBackToListTag() {
+        final ListBinaryTag list = ListBinaryTag.builder()
+                .add(IntBinaryTag.intBinaryTag(1))
+                .add(IntBinaryTag.intBinaryTag(2))
+                .add(IntBinaryTag.intBinaryTag(3))
+                .build();
+        assertArrayEquals(new int[]{1, 2, 3}, assertOk(Transcoder.NBT.getIntArray(list)));
+    }
+
+    @Test
+    void nbtLongArrayFallsBackToListTag() {
+        final ListBinaryTag list = ListBinaryTag.builder()
+                .add(LongBinaryTag.longBinaryTag(1L))
+                .add(LongBinaryTag.longBinaryTag(2L))
+                .build();
+        assertArrayEquals(new long[]{1L, 2L}, assertOk(Transcoder.NBT.getLongArray(list)));
+    }
+}


### PR DESCRIPTION
Breaks the Transcoder api so targeting next.

Adds `Transcoder#createNumber` and `Transcoder#getNumber`, and changes the NBT transcoder to try to coerce a list of numbers into a byte/short/int array.

This is a fix to match vanilla behavior where byte/int/long arrays can be coerced from number (falls back to the DynamicOps impl from DFU: https://github.com/Mojang/DataFixerUpper/blob/master/src/main/java/com/mojang/serialization/DynamicOps.java#L147)