### PR TITLE
fix: avoid full chunk resends for localized block changes

### DIFF
--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -1,6 +1,8 @@
 package net.minestom.server.instance;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongList;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.CompoundBinaryTag;
 import net.minestom.server.MinecraftServer;
@@ -25,6 +27,7 @@ import net.minestom.server.instance.generator.GeneratorImpl;
 import net.minestom.server.instance.palette.Palette;
 import net.minestom.server.monitoring.EventsJFR;
 import net.minestom.server.network.packet.server.play.BlockChangePacket;
+import net.minestom.server.network.packet.server.play.MultiBlockChangePacket;
 import net.minestom.server.network.packet.server.play.BlockEntityDataPacket;
 import net.minestom.server.network.packet.server.play.UnloadChunkPacket;
 import net.minestom.server.network.packet.server.play.WorldEventPacket;
@@ -237,8 +240,8 @@ public class InstanceContainer extends Instance {
         final int y = blockPosition.blockY();
         final int z = blockPosition.blockZ();
         if (block.isAir()) {
-            // The player probably have a wrong version of this chunk section, send it
-            chunk.sendChunk(player);
+            // The player has a wrong version of this block; correct just that block instead of resending the chunk.
+            player.sendPacket(new BlockChangePacket(blockPosition, block));
             return false;
         }
         PlayerBlockBreakEvent blockBreakEvent = new PlayerBlockBreakEvent(player, this, block, Block.AIR, blockPosition.asBlockVec(), blockFace);
@@ -439,9 +442,9 @@ public class InstanceContainer extends Instance {
                         final Chunk forkChunk = start.chunkX() == chunkX && start.chunkZ() == chunkZ ? chunk : getChunkAt(start);
                         if (forkChunk != null) {
                             applyFork(forkChunk, sectionModifier);
-                            // Update players
+                            // Refresh the cached chunk packet, then push the fork's changes as a per-section update instead of a chunk resend.
                             forkChunk.invalidate();
-                            forkChunk.sendChunk();
+                            sendForkSectionUpdate(forkChunk, sectionModifier);
                         } else {
                             final long index = CoordConversion.chunkIndex(start);
                             this.generationForks.compute(index, (i, sectionModifiers) -> {
@@ -485,6 +488,25 @@ public class InstanceContainer extends Instance {
         } finally {
             chunk.unlockWriteLock();
         }
+    }
+
+    // Sends a fork's section changes to viewers as a single multi-block update instead of a full chunk resend.
+    private void sendForkSectionUpdate(Chunk forkChunk, GeneratorImpl.SectionModifierImpl sectionModifier) {
+        final int section = CoordConversion.globalToChunk(sectionModifier.start().blockY());
+        final LongList packed = new LongArrayList();
+        sectionModifier.genSection().blocks().getAllPresent((x, y, z, value) ->
+                packed.add(CoordConversion.encodeSectionBlockChange(CoordConversion.sectionBlockIndex(x, y, z), value - 1)));
+        Int2ObjectMaps.fastForEach(sectionModifier.genSection().specials(), entry -> {
+            final int index = entry.getIntKey();
+            final int sectionBlockIndex = CoordConversion.sectionBlockIndex(
+                    CoordConversion.chunkBlockIndexGetX(index),
+                    CoordConversion.chunkBlockIndexGetY(index),
+                    CoordConversion.chunkBlockIndexGetZ(index));
+            packed.add(CoordConversion.encodeSectionBlockChange(sectionBlockIndex, entry.getValue().stateId()));
+        });
+        if (packed.isEmpty()) return;
+        forkChunk.sendPacketToViewers(new MultiBlockChangePacket(
+                forkChunk.getChunkX(), section, forkChunk.getChunkZ(), packed.toLongArray()));
     }
 
     private void applyGenerationData(Chunk chunk, GeneratorImpl.SectionModifierImpl section) {

--- a/src/main/java/net/minestom/server/instance/batch/ChunkBatch.java
+++ b/src/main/java/net/minestom/server/instance/batch/ChunkBatch.java
@@ -4,11 +4,14 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntArraySet;
 import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongList;
 import net.minestom.server.coordinate.CoordConversion;
 import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.InstanceContainer;
 import net.minestom.server.instance.block.Block;
+import net.minestom.server.network.packet.server.play.MultiBlockChangePacket;
 import net.minestom.server.utils.callback.OptionalCallback;
 import net.minestom.server.utils.chunk.ChunkCallback;
 import org.jetbrains.annotations.Nullable;
@@ -228,8 +231,12 @@ public class ChunkBatch implements Batch<ChunkCallback> {
     private void updateChunk(Instance instance, Chunk chunk, IntSet updatedSections, @Nullable ChunkCallback callback, boolean safeCallback) {
         // Refresh chunk for viewers
         if (options.shouldSendUpdate()) {
-            // TODO update all sections from `updatedSections`
-            chunk.sendChunk();
+            if (options.isFullChunk()) {
+                chunk.sendChunk();
+            } else {
+                // Send only the changed blocks per section instead of resending the whole chunk.
+                sendSectionUpdates(chunk);
+            }
         }
 
         if (instance instanceof InstanceContainer) {
@@ -243,6 +250,27 @@ public class ChunkBatch implements Batch<ChunkCallback> {
             } else {
                 callback.accept(chunk);
             }
+        }
+    }
+
+    // Sends the batch's changed blocks to viewers as per-section multi-block updates instead of a full chunk resend.
+    private void sendSectionUpdates(Chunk chunk) {
+        final int chunkX = chunk.getChunkX();
+        final int chunkZ = chunk.getChunkZ();
+        final Int2ObjectMap<LongList> bySection = new Int2ObjectOpenHashMap<>();
+        synchronized (blocks) {
+            for (var entry : blocks.int2ObjectEntrySet()) {
+                final int index = entry.getIntKey();
+                final int x = CoordConversion.chunkBlockIndexGetX(index);
+                final int y = CoordConversion.chunkBlockIndexGetY(index);
+                final int z = CoordConversion.chunkBlockIndexGetZ(index);
+                final long packed = CoordConversion.encodeSectionBlockChange(
+                        x, CoordConversion.globalToSectionRelative(y), z, entry.getValue().stateId());
+                bySection.computeIfAbsent(CoordConversion.globalToChunk(y), s -> new LongArrayList()).add(packed);
+            }
+        }
+        for (var entry : bySection.int2ObjectEntrySet()) {
+            chunk.sendPacketToViewers(new MultiBlockChangePacket(chunkX, entry.getIntKey(), chunkZ, entry.getValue().toLongArray()));
         }
     }
 }

--- a/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
+++ b/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
@@ -130,6 +130,7 @@ public class BlockPlacementListener {
             // after rapid invalid block placements
             final Block block = instance.getBlock(placementPosition);
             player.sendPacket(new BlockChangePacket(placementPosition, block));
+            player.sendPacket(new AcknowledgeBlockChangePacket(packet.sequence()));
             return;
         }
 
@@ -137,7 +138,7 @@ public class BlockPlacementListener {
         Check.stateCondition(!ChunkUtils.isLoaded(chunk),
                 "A player tried to place a block in the border of a loaded chunk {0}", placementPosition);
         if (chunk.isReadOnly()) {
-            refresh(player, chunk);
+            rollback(player, instance, placementPosition, packet.sequence());
             return;
         }
 
@@ -149,10 +150,12 @@ public class BlockPlacementListener {
             // If a player is trying to place a block on themselves, the client will send a block change but will not set the block on the client
             // For this reason, the block doesn't need to be updated for the client
 
-            // Client also doesn't predict placement of blocks on entities, but we need to refresh for cases where bounding boxes on the server don't match the client
-            if (collisionEntity != player)
-                refresh(player, chunk);
-
+            // Otherwise correct the block where the server and client bounding boxes differ, with a targeted block change instead of a chunk resend.
+            if (collisionEntity != player) {
+                player.getInventory().update();
+                player.sendPacket(new BlockChangePacket(placementPosition, instance.getBlock(placementPosition)));
+            }
+            player.sendPacket(new AcknowledgeBlockChangePacket(packet.sequence()));
             return;
         }
 
@@ -162,7 +165,7 @@ public class BlockPlacementListener {
         playerBlockPlaceEvent.setDoBlockUpdates(blockState.equals(useMaterial.prototype().get(DataComponents.BLOCK_STATE, ItemBlockState.EMPTY)));
         EventDispatcher.call(playerBlockPlaceEvent);
         if (playerBlockPlaceEvent.isCancelled()) {
-            refresh(player, chunk);
+            rollback(player, instance, placementPosition, packet.sequence());
             return;
         }
 
@@ -182,8 +185,10 @@ public class BlockPlacementListener {
         }
     }
 
-    private static void refresh(Player player, Chunk chunk) {
+    // Corrects a cancelled placement with a targeted block change instead of resending the whole chunk.
+    private static void rollback(Player player, Instance instance, Point placementPosition, int sequence) {
         player.getInventory().update();
-        chunk.sendChunk(player);
+        player.sendPacket(new BlockChangePacket(placementPosition, instance.getBlock(placementPosition)));
+        player.sendPacket(new AcknowledgeBlockChangePacket(sequence));
     }
 }


### PR DESCRIPTION
Cancelled block placements, breaking a block the server already sees as air, partial ChunkBatch applies, and generation forks merged into an already-loaded neighbour all corrected a localized change by resending the entire chunk to viewers.

Send targeted updates instead: a single block change (+ block-change ack) for the placement-cancel and break corrections, and per-section multi-block updates for partial batches and generation forks. Full-chunk batches and full-chunk regeneration still resend, as every section genuinely changes there.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...