### PR TITLE
Expose blocksMotion

### DIFF
--- a/src/main/java/net/minestom/server/instance/block/Block.java
+++ b/src/main/java/net/minestom/server/instance/block/Block.java
@@ -256,6 +256,11 @@ public sealed interface Block extends StaticProtocolObject<Block>, TagReadable, 
         return registry().isSolid();
     }
 
+    /** Whether this block stops entity movement (motion-blocking collision); unlike {@link #isSolid()}, e.g. cobweb is solid but does not block motion. */
+    default boolean blocksMotion() {
+        return registry().blocksMotion();
+    }
+
     default boolean isLiquid() {
         return registry().isLiquid();
     }

--- a/src/main/java/net/minestom/server/registry/RegistryData.java
+++ b/src/main/java/net/minestom/server/registry/RegistryData.java
@@ -261,6 +261,9 @@ public final class RegistryData {
         private final float jumpFactor;
         private final int mapColorId;
         private final byte packedFlags;
+        // standalone field rather than a packedFlags bit: that byte is already full (8 flags; SIGNAL_SOURCE uses bit 7).
+        // fold into a wider flags field if the flag set ever grows - changed here if needed.
+        private final boolean blocksMotion;
         private final byte lightEmission;
         private final byte lightBlocked;
         private final @Nullable BlockEntityType blockEntityType;
@@ -283,6 +286,7 @@ public final class RegistryData {
             this.mapColorId = fromParent(parent, BlockEntry::mapColorId, main, "mapColorId", Properties::getInt, 0);
             var air = fromParent(parent, BlockEntry::isAir, main, "air", Properties::getBoolean, false);
             var solid = fromParent(parent, BlockEntry::isSolid, main, "solid", Properties::getBoolean, null);
+            this.blocksMotion = fromParent(parent, BlockEntry::blocksMotion, main, "blocksMotion", Properties::getBoolean, false);
             var liquid = fromParent(parent, BlockEntry::isLiquid, main, "liquid", Properties::getBoolean, false);
             var occludes = fromParent(parent, BlockEntry::occludes, main, "occludes", Properties::getBoolean, true);
             var requiresTool = fromParent(parent, BlockEntry::requiresTool, main, "requiresTool", Properties::getBoolean, true);
@@ -406,6 +410,10 @@ public final class RegistryData {
 
         public boolean isSolid() {
             return (packedFlags & SOLID_OFFSET) != 0;
+        }
+
+        public boolean blocksMotion() {
+            return blocksMotion;
         }
 
         public boolean isLiquid() {


### PR DESCRIPTION
## Proposed changes

Exposes the block registry's blocksMotion flag via Block#blocksMotion(). It's already parsed from the data but had no accessor, It correctly distinguishes blocks that stop movement (cobweb is solid but doesn't block motion).

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
did and what alternatives you considered, etc...