### PR TITLE
Perform next changes in NetworkBuffer

### DIFF
--- a/src/main/java/net/minestom/server/network/ComponentNetworkBufferTypeImpl.java
+++ b/src/main/java/net/minestom/server/network/ComponentNetworkBufferTypeImpl.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.util.*;
 
 import static net.minestom.server.network.NetworkBuffer.*;
-import static net.minestom.server.network.NetworkBufferImpl.impl;
 
 record ComponentNetworkBufferTypeImpl() implements NetworkBufferTypeImpl<Component> {
 

--- a/src/main/java/net/minestom/server/network/NetworkBuffer.java
+++ b/src/main/java/net/minestom/server/network/NetworkBuffer.java
@@ -170,7 +170,8 @@ public sealed interface NetworkBuffer permits NetworkBufferImpl {
 
     long capacity();
 
-    void readOnly();
+    @Contract(pure = true, value = "-> new")
+    NetworkBuffer readOnly();
 
     boolean isReadOnly();
 

--- a/src/main/java/net/minestom/server/network/NetworkBuffer.java
+++ b/src/main/java/net/minestom/server/network/NetworkBuffer.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.lang.foreign.MemorySegment;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SocketChannel;
+import java.nio.channels.WritableByteChannel;
 import java.security.PublicKey;
 import java.time.Instant;
 import java.util.*;
@@ -191,7 +192,7 @@ public sealed interface NetworkBuffer permits NetworkBufferImpl {
 
     int readChannel(ReadableByteChannel channel) throws IOException;
 
-    boolean writeChannel(SocketChannel channel) throws IOException;
+    boolean writeChannel(WritableByteChannel channel) throws IOException;
 
     void cipher(Cipher cipher, long start, long length);
 

--- a/src/main/java/net/minestom/server/network/NetworkBuffer.java
+++ b/src/main/java/net/minestom/server/network/NetworkBuffer.java
@@ -142,12 +142,6 @@ public sealed interface NetworkBuffer permits NetworkBufferImpl {
 
     <T> @UnknownNullability T readAt(long index, Type<T> type) throws IndexOutOfBoundsException;
 
-    /**
-     * @deprecated Use {@link #copyTo(long, byte[], int, int)} instead, as longs can easily overflow arrays.
-     */
-    @Deprecated(forRemoval = true)
-    void copyTo(long srcOffset, byte[] dest, long destOffset, long length);
-
     void copyTo(long srcOffset, byte[] dest, int destOffset, int length);
 
     void copyTo(long srcOffset, MemorySegment dest, long destOffset, long length);

--- a/src/main/java/net/minestom/server/network/NetworkBuffer.java
+++ b/src/main/java/net/minestom/server/network/NetworkBuffer.java
@@ -317,9 +317,6 @@ public sealed interface NetworkBuffer permits NetworkBufferImpl {
     }
 
     static NetworkBuffer wrap(byte[] bytes, int readIndex, int writeIndex, @Nullable Registries registries) {
-        /* TODO(next) remove me for zero copy. The old behavior didnt actually modify the underlying array.
-            quite unfortunate and will require until waiting for the next release to change this behavior. */
-        bytes = bytes.clone();
         return wrap(MemorySegment.ofArray(bytes), readIndex, writeIndex, registries);
     }
 

--- a/src/main/java/net/minestom/server/network/NetworkBuffer.java
+++ b/src/main/java/net/minestom/server/network/NetworkBuffer.java
@@ -134,14 +134,13 @@ public sealed interface NetworkBuffer permits NetworkBufferImpl {
         return Tagged(discriminator, discriminatorFromValue, serializerMap, null);
     }
 
-    <T>
-    void write(Type<T> type, @UnknownNullability T value) throws IndexOutOfBoundsException;
+    <T extends @UnknownNullability Object> void write(Type<T> type, T value) throws IndexOutOfBoundsException;
 
-    <T> @UnknownNullability T read(Type<T> type) throws IndexOutOfBoundsException;
+    <T extends @UnknownNullability Object> T read(Type<T> type) throws IndexOutOfBoundsException;
 
-    <T> void writeAt(long index, Type<T> type, @UnknownNullability T value) throws IndexOutOfBoundsException;
+    <T extends @UnknownNullability Object> void writeAt(long index, Type<T> type, T value) throws IndexOutOfBoundsException;
 
-    <T> @UnknownNullability T readAt(long index, Type<T> type) throws IndexOutOfBoundsException;
+    <T extends @UnknownNullability Object> T readAt(long index, Type<T> type) throws IndexOutOfBoundsException;
 
     void copyTo(long srcOffset, byte[] dest, int destOffset, int length);
 

--- a/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
@@ -166,9 +166,8 @@ final class NetworkBufferImpl implements NetworkBuffer {
     }
 
     @Override
-    public void readOnly() {
-        final MemorySegment segment = this.segment;
-        if (segment != null) this.segment = segment.asReadOnly();
+    public NetworkBuffer readOnly() {
+        return new NetworkBufferImpl(this.segment.asReadOnly(), this.readIndex, this.writeIndex, null, this.registries);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
@@ -481,7 +481,6 @@ final class NetworkBufferImpl implements NetworkBuffer {
         assertDummy(impl1);
         assertDummy(impl2);
         if (impl1.byteSize() != impl2.byteSize()) return false;
-        if (impl1.address() != impl2.address()) return false;
         return impl1.mismatch(impl2) == -1;
     }
 

--- a/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
@@ -98,13 +98,14 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     @Override
     public byte[] extractBytes(Consumer<NetworkBuffer> extractor) {
-        assertDummy(segment); // See below why it's not hoisted
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
         final long startingPosition = readIndex();
         extractor.accept(this);
         final long endingPosition = readIndex();
         final long length = endingPosition - startingPosition;
         byte[] output = new byte[Math.toIntExact(length)];
-        copyTo(startingPosition, output, 0, output.length); // Use copyTo because MemorySegement.copy is force inline
+        MemorySegment.copy(segment, ValueLayout.JAVA_BYTE, startingPosition, output, 0, output.length);
         return output;
     }
 
@@ -158,12 +159,12 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     @Override
     public long readableBytes() {
-        return writeIndex - readIndex;
+        return readableBytes(writeIndex, readIndex);
     }
 
     @Override
     public long writableBytes() {
-        return capacity() - writeIndex;
+        return writableBytes(capacity(), writeIndex);
     }
 
     @Override
@@ -205,7 +206,7 @@ final class NetworkBufferImpl implements NetworkBuffer {
         if (isDummy(segment)) return; // dummy's have infinite write length
         assertReadOnly(segment);
         final long capacity = segment.byteSize();
-        if (capacity - writeIndex >= length) return;
+        if (writableBytes(capacity, writeIndex) >= length) return;
         final long newCapacity = newCapacity(length, capacity);
         resize(newCapacity);
     }
@@ -235,7 +236,7 @@ final class NetworkBufferImpl implements NetworkBuffer {
         assertDummy(segment);
         final long readIndex = readIndex();
         if (readIndex == 0) return;
-        MemorySegment.copy(segment, readIndex, segment, 0, readableBytes());
+        MemorySegment.copy(segment, readIndex, segment, 0, readableBytes(writeIndex, readIndex));
         this.writeIndex -= readIndex;
         this.readIndex = 0;
     }
@@ -255,7 +256,8 @@ final class NetworkBufferImpl implements NetworkBuffer {
         Objects.requireNonNull(channel);
         final MemorySegment segment = this.segment;
         assertDummy(segment);
-        var buffer = bufferSlice(segment, writeIndex, writableBytes());
+        final long writeIndex = this.writeIndex;
+        var buffer = bufferSlice(segment, writeIndex, writableBytes(segment.byteSize(), writeIndex));
         final int count = channel.read(buffer);
         if (count == -1) throw new EOFException("Disconnected");
         advanceWrite(count);
@@ -267,7 +269,8 @@ final class NetworkBufferImpl implements NetworkBuffer {
         Objects.requireNonNull(channel);
         final MemorySegment segment = this.segment;
         assertDummy(segment);
-        final long readableBytes = readableBytes();
+        final long readIndex = this.readIndex;
+        final long readableBytes = readableBytes(writeIndex, readIndex);
         if (readableBytes == 0) return true; // Nothing to write
         var buffer = bufferSlice(segment, readIndex, readableBytes);
         if (!buffer.hasRemaining())
@@ -503,8 +506,16 @@ final class NetworkBufferImpl implements NetworkBuffer {
         if (segment.isReadOnly()) throwReadOnly();
     }
 
-    private static ByteBuffer bufferSlice(MemorySegment segment, long position, long length) {
+    static ByteBuffer bufferSlice(MemorySegment segment, long position, long length) {
         return segment.asSlice(position, length).asByteBuffer().order(BIG_ENDIAN);
+    }
+
+    static long readableBytes(long writeIndex, long readIndex) {
+        return writeIndex - readIndex;
+    }
+
+    static long writableBytes(long capacity, long writeIndex) {
+        return capacity - writeIndex;
     }
 
     static final class Builder implements NetworkBuffer.Builder {

--- a/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
@@ -49,13 +49,14 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     @Override
     public <T> void write(Type<T> type, @UnknownNullability T value) {
-        assertReadOnly();
+        final MemorySegment segment = this.segment;
+        if (segment != null) assertReadOnly(segment);
         type.write(this, value);
     }
 
     @Override
     public <T> @UnknownNullability T read(Type<T> type) {
-        assertDummy();
+        assertDummy(this.segment);
         return type.read(this);
     }
 
@@ -367,10 +368,6 @@ final class NetworkBufferImpl implements NetworkBuffer {
                 readIndex, writeIndex, capacity(), registries != null, autoResize != null, isReadOnly());
     }
 
-    private boolean isDummy() {
-        return segment == null;
-    }
-
     // Internal writing methods
     void _putBytes(long index, byte[] value) {
         final MemorySegment segment = this.segment;
@@ -475,7 +472,7 @@ final class NetworkBufferImpl implements NetworkBuffer {
         MemorySegment.copy(src, srcOffset, dst, dstOffset, length);
     }
 
-    public static boolean equals(NetworkBuffer buffer1, NetworkBuffer buffer2) {
+    static boolean equals(NetworkBuffer buffer1, NetworkBuffer buffer2) {
         var impl1 = impl(buffer1).segment;
         var impl2 = impl(buffer2).segment;
         assertDummy(impl1);
@@ -483,14 +480,6 @@ final class NetworkBufferImpl implements NetworkBuffer {
         if (impl1.byteSize() != impl2.byteSize()) return false;
         if (impl1.address() != impl2.address()) return false;
         return impl1.mismatch(impl2) == -1;
-    }
-
-    void assertReadOnly() {
-        if (isReadOnly()) throw new UnsupportedOperationException("Buffer is read-only");
-    }
-
-    void assertDummy() {
-        if (isDummy()) throw new UnsupportedOperationException("Buffer is a dummy buffer");
     }
 
     static void throwDummy() {

--- a/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
@@ -84,18 +84,6 @@ final class NetworkBufferImpl implements NetworkBuffer {
     }
 
     @Override
-    public void copyTo(long srcOffset, byte[] dest, long destOffset, long length) {
-        assertDummy();
-        assertOverflow(srcOffset + length);
-        assertOverflow(destOffset + length);
-        if (length == 0) return;
-        if (dest.length < destOffset + length) {
-            throw new IndexOutOfBoundsException("Destination array is too small: " + dest.length + " < " + (destOffset + length));
-        }
-        MemorySegment.copy(segment, srcOffset, MemorySegment.ofArray(dest), destOffset, length);
-    }
-
-    @Override
     public void copyTo(long srcOffset, byte[] dest, int destOffset, int length) {
         assertDummy();
         MemorySegment.copy(segment, ValueLayout.JAVA_BYTE, srcOffset, dest, destOffset, length);

--- a/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
@@ -50,7 +50,7 @@ final class NetworkBufferImpl implements NetworkBuffer {
     @Override
     public <T> void write(Type<T> type, @UnknownNullability T value) {
         final MemorySegment segment = this.segment;
-        if (segment != null) assertReadOnly(segment);
+        if (!isDummy(segment)) assertReadOnly(segment);
         type.write(this, value);
     }
 
@@ -234,6 +234,7 @@ final class NetworkBufferImpl implements NetworkBuffer {
     public void compact() {
         final MemorySegment segment = this.segment;
         assertDummy(segment);
+        assertReadOnly(segment);
         final long readIndex = readIndex();
         if (readIndex == 0) return;
         MemorySegment.copy(segment, readIndex, segment, 0, readableBytes(writeIndex, readIndex));
@@ -488,12 +489,12 @@ final class NetworkBufferImpl implements NetworkBuffer {
         throw new UnsupportedOperationException("Buffer is a dummy buffer");
     }
 
-    static boolean isDummy(@UnknownNullability MemorySegment segment) {
+    static boolean isDummy(@Nullable MemorySegment segment) {
         return segment == null;
     }
 
     @Contract("null -> fail")
-    static void assertDummy(@UnknownNullability MemorySegment segment) {
+    static void assertDummy(@Nullable MemorySegment segment) {
         if (isDummy(segment)) throwDummy();
     }
 

--- a/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
@@ -199,6 +199,7 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     @Override
     public void ensureWritable(long length) {
+        if (length < 0) throw new IllegalArgumentException("Length cannot be negative");
         final MemorySegment segment = this.segment;
         if (isDummy(segment)) return; // dummy's have infinite write length
         assertReadOnly(segment);

--- a/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
@@ -546,7 +546,7 @@ final class NetworkBufferImpl implements NetworkBuffer {
         }
     }
 
-    static NetworkBufferImpl dummy(Registries registries) {
+    static NetworkBufferImpl dummy(@Nullable Registries registries) {
         // Dummy buffer with no memory allocated
         // Useful for size calculations
         return new NetworkBufferImpl(null, 0, 0, null, registries);

--- a/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
@@ -2,6 +2,7 @@ package net.minestom.server.network;
 
 import net.minestom.server.registry.Registries;
 import net.minestom.server.utils.ObjectPool;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
 
@@ -13,8 +14,7 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
-import java.nio.channels.SocketChannel;
-import java.util.Arrays;
+import java.nio.channels.WritableByteChannel;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.zip.DataFormatException;
@@ -30,13 +30,13 @@ final class NetworkBufferImpl implements NetworkBuffer {
     private static final ValueLayout.OfFloat FLOAT_LAYOUT = ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(BIG_ENDIAN);
     private static final ValueLayout.OfDouble DOUBLE_LAYOUT = ValueLayout.JAVA_DOUBLE_UNALIGNED.withOrder(BIG_ENDIAN);
 
-    private @UnknownNullability MemorySegment segment; // null for dummy buffers
+    private @Nullable MemorySegment segment; // null for dummy buffers
     private long readIndex, writeIndex;
 
     private final @Nullable AutoResize autoResize;
     private @Nullable Registries registries;
 
-    NetworkBufferImpl(@UnknownNullability MemorySegment segment,
+    NetworkBufferImpl(@Nullable MemorySegment segment,
                       long readIndex, long writeIndex,
                       @Nullable AutoResize autoResize,
                       @Nullable Registries registries) {
@@ -61,7 +61,6 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     @Override
     public <T> void writeAt(long index, Type<T> type, @UnknownNullability T value) {
-        assertReadOnly();
         final long oldWriteIndex = writeIndex;
         writeIndex = index;
         try {
@@ -73,7 +72,6 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     @Override
     public <T> @UnknownNullability T readAt(long index, Type<T> type) {
-        assertDummy();
         final long oldReadIndex = readIndex;
         readIndex = index;
         try {
@@ -85,45 +83,52 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     @Override
     public void copyTo(long srcOffset, byte[] dest, int destOffset, int length) {
-        assertDummy();
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
         MemorySegment.copy(segment, ValueLayout.JAVA_BYTE, srcOffset, dest, destOffset, length);
     }
 
     @Override
     public void copyTo(long srcOffset, MemorySegment dest, long destOffset, long length) {
-        assertDummy();
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
         MemorySegment.copy(segment, srcOffset, dest, destOffset, length);
     }
 
+    @Override
     public byte[] extractBytes(Consumer<NetworkBuffer> extractor) {
-        assertDummy();
+        assertDummy(segment); // See below why it's not hoisted
         final long startingPosition = readIndex();
         extractor.accept(this);
         final long endingPosition = readIndex();
         final long length = endingPosition - startingPosition;
-        assertOverflow(length);
-        byte[] output = new byte[(int) length];
-        copyTo(startingPosition, output, 0, output.length);
+        byte[] output = new byte[Math.toIntExact(length)];
+        copyTo(startingPosition, output, 0, output.length); // Use copyTo because MemorySegement.copy is force inline
         return output;
     }
 
+    @Override
     public NetworkBuffer clear() {
         return index(0, 0);
     }
 
+    @Override
     public long writeIndex() {
         return writeIndex;
     }
 
+    @Override
     public long readIndex() {
         return readIndex;
     }
 
+    @Override
     public NetworkBuffer writeIndex(long writeIndex) {
         this.writeIndex = writeIndex;
         return this;
     }
 
+    @Override
     public NetworkBuffer readIndex(long readIndex) {
         this.readIndex = readIndex;
         return this;
@@ -136,6 +141,7 @@ final class NetworkBufferImpl implements NetworkBuffer {
         return this;
     }
 
+    @Override
     public long advanceWrite(long length) {
         final long oldWriteIndex = writeIndex;
         writeIndex = oldWriteIndex + length;
@@ -167,7 +173,8 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     @Override
     public NetworkBuffer readOnly() {
-        assertDummy();
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
         return new NetworkBufferImpl(segment.asReadOnly(), this.readIndex, this.writeIndex, null, this.registries);
     }
 
@@ -179,8 +186,9 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     @Override
     public void resize(long newSize) {
-        assertDummy();
-        assertReadOnly();
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
+        assertReadOnly(segment);
         final long capacity = capacity();
         if (newSize < capacity) throw new IllegalArgumentException("New size is smaller than the current size");
         if (newSize == capacity) throw new IllegalArgumentException("New size is the same as the current size");
@@ -191,9 +199,12 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     @Override
     public void ensureWritable(long length) {
-        assertReadOnly();
-        if (writableBytes() >= length) return;
-        final long newCapacity = newCapacity(length, capacity());
+        final MemorySegment segment = this.segment;
+        if (isDummy(segment)) return; // dummy's have infinite write length
+        assertReadOnly(segment);
+        final long capacity = segment.byteSize();
+        if (capacity - writeIndex >= length) return;
+        final long newCapacity = newCapacity(length, capacity);
         resize(newCapacity);
     }
 
@@ -218,11 +229,10 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     @Override
     public void compact() {
-        assertDummy();
-        assertReadOnly();
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
         final long readIndex = readIndex();
         if (readIndex == 0) return;
-        final MemorySegment segment = this.segment;
         MemorySegment.copy(segment, readIndex, segment, 0, readableBytes());
         this.writeIndex -= readIndex;
         this.readIndex = 0;
@@ -230,7 +240,8 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     @Override
     public NetworkBuffer copy(long index, long length, long readIndex, long writeIndex) {
-        assertDummy();
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
         Objects.checkFromIndexSize(index, length, capacity());
         final MemorySegment newSegment = Arena.ofAuto().allocate(length);
         MemorySegment.copy(segment, index, newSegment, 0, length);
@@ -239,10 +250,10 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     @Override
     public int readChannel(ReadableByteChannel channel) throws IOException {
-        assertDummy();
-        assertReadOnly();
-        assertOverflow(writeIndex + writableBytes());
-        var buffer = bufferSlice(writeIndex, writableBytes());
+        Objects.requireNonNull(channel);
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
+        var buffer = bufferSlice(segment, writeIndex, writableBytes());
         final int count = channel.read(buffer);
         if (count == -1) throw new EOFException("Disconnected");
         advanceWrite(count);
@@ -250,12 +261,13 @@ final class NetworkBufferImpl implements NetworkBuffer {
     }
 
     @Override
-    public boolean writeChannel(SocketChannel channel) throws IOException {
-        assertDummy();
+    public boolean writeChannel(WritableByteChannel channel) throws IOException {
+        Objects.requireNonNull(channel);
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
         final long readableBytes = readableBytes();
         if (readableBytes == 0) return true; // Nothing to write
-        assertOverflow(readIndex + readableBytes);
-        var buffer = bufferSlice(readIndex, readableBytes);
+        var buffer = bufferSlice(segment, readIndex, readableBytes);
         if (!buffer.hasRemaining())
             return true; // Nothing to write
         final int count = channel.write(buffer);
@@ -266,9 +278,10 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     @Override
     public void cipher(Cipher cipher, long start, long length) {
-        assertDummy();
-        assertOverflow(start + length);
-        ByteBuffer input = bufferSlice(start, length);
+        Objects.requireNonNull(cipher);
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
+        ByteBuffer input = bufferSlice(segment, start, length);
         try {
             cipher.update(input, input.duplicate());
         } catch (ShortBufferException e) {
@@ -284,12 +297,14 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     @Override
     public long compress(long start, long length, NetworkBuffer output) {
-        assertDummy();
-        impl(output).assertReadOnly();
-        assertOverflow(start + length);
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
+        final MemorySegment outputSegment = impl(output).segment;
+        assertDummy(outputSegment);
+        assertReadOnly(outputSegment);
 
-        ByteBuffer input = bufferSlice(start, length);
-        ByteBuffer outputBuffer = impl(output).bufferSlice(output.writeIndex(), output.writableBytes());
+        ByteBuffer input = bufferSlice(segment, start, length);
+        ByteBuffer outputBuffer = bufferSlice(outputSegment, output.writeIndex(), output.writableBytes());
 
         Deflater deflater = CompressionHolder.DEFLATER_POOL.get();
         try {
@@ -306,12 +321,14 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     @Override
     public long decompress(long start, long length, NetworkBuffer output) throws DataFormatException {
-        assertDummy();
-        impl(output).assertReadOnly();
-        assertOverflow(start + length);
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
+        final MemorySegment outputSegment = impl(output).segment;
+        assertDummy(outputSegment);
+        assertReadOnly(outputSegment);
 
-        ByteBuffer input = bufferSlice(start, length);
-        ByteBuffer outputBuffer = impl(output).bufferSlice(output.writeIndex(), output.writableBytes());
+        ByteBuffer input = bufferSlice(segment, start, length);
+        ByteBuffer outputBuffer = bufferSlice(outputSegment, output.writeIndex(), output.writableBytes());
 
         Inflater inflater = CompressionHolder.INFLATER_POOL.get();
         try {
@@ -343,10 +360,6 @@ final class NetworkBufferImpl implements NetworkBuffer {
         return new IOView(this);
     }
 
-    private ByteBuffer bufferSlice(long position, long length) {
-        return segment.asSlice(position, length).asByteBuffer().order(BIG_ENDIAN);
-    }
-
     @Override
     public String toString() {
         return String.format("NetworkBuffer{r%d|w%d->%d, registries=%s, autoResize=%s, readOnly=%s}",
@@ -359,85 +372,92 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     // Internal writing methods
     void _putBytes(long index, byte[] value) {
-        if (isDummy()) return;
-        assertReadOnly();
+        final MemorySegment segment = this.segment;
+        if (isDummy(segment)) return;
         MemorySegment.copy(value, 0, segment, ValueLayout.JAVA_BYTE, index, value.length);
     }
 
     void _putBytes(long index, byte[] value, int offset, int length) {
-        if (isDummy()) return;
-        assertReadOnly();
+        final MemorySegment segment = this.segment;
+        if (isDummy(segment)) return;
         MemorySegment.copy(value, offset, segment, ValueLayout.JAVA_BYTE, index, length);
     }
 
     void _getBytes(long index, byte[] value) {
-        assertDummy();
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
         MemorySegment.copy(segment, ValueLayout.JAVA_BYTE, index, value, 0, value.length);
     }
 
     void _putByte(long index, byte value) {
-        if (isDummy()) return;
-        assertReadOnly();
+        final MemorySegment segment = this.segment;
+        if (isDummy(segment)) return;
         segment.set(ValueLayout.JAVA_BYTE, index, value);
     }
 
     byte _getByte(long index) {
-        assertDummy();
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
         return segment.get(ValueLayout.JAVA_BYTE, index);
     }
 
     void _putShort(long index, short value) {
-        if (isDummy()) return;
-        assertReadOnly();
+        final MemorySegment segment = this.segment;
+        if (isDummy(segment)) return;
         segment.set(SHORT_LAYOUT, index, value);
     }
 
     short _getShort(long index) {
-        assertDummy();
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
         return segment.get(SHORT_LAYOUT, index);
     }
 
     void _putInt(long index, int value) {
-        if (isDummy()) return;
-        assertReadOnly();
+        final MemorySegment segment = this.segment;
+        if (isDummy(segment)) return;
         segment.set(INT_LAYOUT, index, value);
     }
 
     int _getInt(long index) {
-        assertDummy();
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
         return segment.get(INT_LAYOUT, index);
     }
 
     void _putLong(long index, long value) {
-        if (isDummy()) return;
-        assertReadOnly();
+        final MemorySegment segment = this.segment;
+        if (isDummy(segment)) return;
         segment.set(LONG_LAYOUT, index, value);
     }
 
     long _getLong(long index) {
-        assertDummy();
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
         return segment.get(LONG_LAYOUT, index);
     }
 
     void _putFloat(long index, float value) {
-        if (isDummy()) return;
-        assertReadOnly();
+        final MemorySegment segment = this.segment;
+        if (isDummy(segment)) return;
         segment.set(FLOAT_LAYOUT, index, value);
     }
 
     float _getFloat(long index) {
-        assertDummy();
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
         return segment.get(FLOAT_LAYOUT, index);
     }
 
     void _putDouble(long index, double value) {
-        if (isDummy()) return;
-        assertReadOnly();
+        final MemorySegment segment = this.segment;
+        if (isDummy(segment)) return;
         segment.set(DOUBLE_LAYOUT, index, value);
     }
 
     double _getDouble(long index) {
-        assertDummy();
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
         return segment.get(DOUBLE_LAYOUT, index);
     }
 
@@ -447,17 +467,21 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     static void copy(NetworkBuffer srcBuffer, long srcOffset,
                      NetworkBuffer dstBuffer, long dstOffset, long length) {
-        var src = impl(srcBuffer);
-        var dst = impl(dstBuffer);
-        dst.assertReadOnly();
-        MemorySegment.copy(src.segment, srcOffset, dst.segment, dstOffset, length);
+        var src = impl(srcBuffer).segment;
+        var dst = impl(dstBuffer).segment;
+        assertDummy(src);
+        assertDummy(dst);
+        MemorySegment.copy(src, srcOffset, dst, dstOffset, length);
     }
 
     public static boolean equals(NetworkBuffer buffer1, NetworkBuffer buffer2) {
-        var impl1 = impl(buffer1);
-        var impl2 = impl(buffer2);
-        if (impl1.capacity() != impl2.capacity()) return false;
-        return impl1.segment.mismatch(impl2.segment) == -1;
+        var impl1 = impl(buffer1).segment;
+        var impl2 = impl(buffer2).segment;
+        assertDummy(impl1);
+        assertDummy(impl2);
+        if (impl1.byteSize() != impl2.byteSize()) return false;
+        if (impl1.address() != impl2.address()) return false;
+        return impl1.mismatch(impl2) == -1;
     }
 
     void assertReadOnly() {
@@ -466,6 +490,31 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     void assertDummy() {
         if (isDummy()) throw new UnsupportedOperationException("Buffer is a dummy buffer");
+    }
+
+    static void throwDummy() {
+        throw new UnsupportedOperationException("Buffer is a dummy buffer");
+    }
+
+    static boolean isDummy(@UnknownNullability MemorySegment segment) {
+        return segment == null;
+    }
+
+    @Contract("null -> fail")
+    static void assertDummy(@UnknownNullability MemorySegment segment) {
+        if (isDummy(segment)) throwDummy();
+    }
+
+    static void throwReadOnly() {
+        throw new UnsupportedOperationException("Buffer is read-only");
+    }
+
+    static void assertReadOnly(MemorySegment segment) {
+        if (segment.isReadOnly()) throwReadOnly();
+    }
+
+    private static ByteBuffer bufferSlice(MemorySegment segment, long position, long length) {
+        return segment.asSlice(position, length).asByteBuffer().order(BIG_ENDIAN);
     }
 
     static final class Builder implements NetworkBuffer.Builder {
@@ -504,15 +553,6 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     static NetworkBufferImpl impl(NetworkBuffer buffer) {
         return (NetworkBufferImpl) buffer;
-    }
-
-    private static void assertOverflow(long value) {
-        try {
-            //noinspection ResultOfMethodCallIgnored
-            Math.toIntExact(value); // Check if long is within the bounds of an int
-        } catch (ArithmeticException e) {
-            throw new RuntimeException("Method does not support long values: " + value);
-        }
     }
 
     // Use a record for final field trusting, hopefully better scalar replacement, to avoid caching IOView

--- a/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
@@ -167,8 +167,7 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     @Override
     public NetworkBuffer readOnly() {
-        final MemorySegment segment = this.segment;
-        if (segment == null) return new NetworkBufferImpl(null, this.readIndex, this.writeIndex, null, this.registries);
+        assertDummy();
         return new NetworkBufferImpl(segment.asReadOnly(), this.readIndex, this.writeIndex, null, this.registries);
     }
 

--- a/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
@@ -486,7 +486,7 @@ final class NetworkBufferImpl implements NetworkBuffer {
     }
 
     static void throwDummy() {
-        throw new UnsupportedOperationException("Buffer is a dummy buffer");
+        throw new IllegalArgumentException("Buffer is a dummy buffer");
     }
 
     static boolean isDummy(@Nullable MemorySegment segment) {
@@ -499,7 +499,7 @@ final class NetworkBufferImpl implements NetworkBuffer {
     }
 
     static void throwReadOnly() {
-        throw new UnsupportedOperationException("Buffer is read-only");
+        throw new IllegalArgumentException("Buffer is read-only");
     }
 
     static void assertReadOnly(MemorySegment segment) {

--- a/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
@@ -167,7 +167,9 @@ final class NetworkBufferImpl implements NetworkBuffer {
 
     @Override
     public NetworkBuffer readOnly() {
-        return new NetworkBufferImpl(this.segment.asReadOnly(), this.readIndex, this.writeIndex, null, this.registries);
+        final MemorySegment segment = this.segment;
+        if (segment == null) return new NetworkBufferImpl(null, this.readIndex, this.writeIndex, null, this.registries);
+        return new NetworkBufferImpl(segment.asReadOnly(), this.readIndex, this.writeIndex, null, this.registries);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/network/NetworkBufferTypeImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferTypeImpl.java
@@ -1168,7 +1168,7 @@ interface NetworkBufferTypeImpl<T> extends NetworkBuffer.Type<T> {
         }
     }
 
-    static <T> long sizeOf(Type<T> type, T value, Registries registries) {
+    static <T> long sizeOf(Type<T> type, T value, @Nullable Registries registries) {
         NetworkBuffer buffer = NetworkBufferImpl.dummy(registries);
         type.write(buffer, value);
         return buffer.writeIndex();

--- a/src/main/java/net/minestom/server/network/packet/server/BufferedPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/BufferedPacket.java
@@ -12,6 +12,6 @@ import org.jetbrains.annotations.ApiStatus;
 public record BufferedPacket(NetworkBuffer buffer,
                              long index, long length) implements SendablePacket {
     public BufferedPacket {
-        buffer.readOnly();
+        buffer = buffer.readOnly();
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/server/FramedPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/FramedPacket.java
@@ -11,7 +11,6 @@ import org.jetbrains.annotations.ApiStatus;
 public record FramedPacket(ServerPacket packet,
                            NetworkBuffer body) implements SendablePacket {
     public FramedPacket {
-        body.readIndex(0);
-        body.readOnly();
+        body = body.readOnly().readIndex(0);
     }
 }

--- a/src/main/java/net/minestom/server/utils/PacketViewableUtils.java
+++ b/src/main/java/net/minestom/server/utils/PacketViewableUtils.java
@@ -95,8 +95,7 @@ public final class PacketViewableUtils {
 
         private synchronized void process(Viewable viewable) {
             if (buffer.writeIndex() == 0) return;
-            NetworkBuffer copy = buffer.copy(0, buffer.writeIndex());
-            copy.readOnly();
+            NetworkBuffer copy = buffer.copy(0, buffer.writeIndex()).readOnly();
             viewable.getViewers().forEach(player -> processPlayer(player, copy));
             this.buffer.clear();
             this.entityIdMap.clear();

--- a/src/test/java/net/minestom/server/network/NetworkBufferTest.java
+++ b/src/test/java/net/minestom/server/network/NetworkBufferTest.java
@@ -235,6 +235,12 @@ public class NetworkBufferTest {
         assertEquals(50L, buffer.read(LONG));
 
         assertEquals(9, buffer.readIndex());
+
+        // Ensure that the backing array gets modified
+        buffer.writeIndex(0);
+        buffer.write(LONG, 0L);
+        buffer.write(BYTE, (byte) 0);
+        assertArrayEquals(new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0}, array);
     }
 
     @Test

--- a/src/test/java/net/minestom/server/network/NetworkBufferTest.java
+++ b/src/test/java/net/minestom/server/network/NetworkBufferTest.java
@@ -15,6 +15,7 @@ import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.ref.WeakReference;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.function.Consumer;
@@ -295,6 +296,86 @@ public class NetworkBufferTest {
             buffer.write(BYTE, (byte) 1);
         }
         assertThrows(Exception.class, () -> buffer.read(BYTE));
+    }
+
+    @Test
+    public void readOnlyResizable() {
+        var buffer = NetworkBuffer.resizableBuffer(16);
+        buffer.write(INT, 42);
+
+        var readOnly = buffer.readOnly();
+        assertNotSame(buffer, readOnly);
+        assertTrue(readOnly.isReadOnly());
+        assertFalse(buffer.isReadOnly());
+
+        // Check that data is readable and identical
+        assertEquals(42, readOnly.read(INT));
+
+        // Mutating operations on read-only buffer should fail
+        assertThrows(UnsupportedOperationException.class, () -> readOnly.write(INT, 24));
+        assertThrows(UnsupportedOperationException.class, () -> readOnly.writeAt(0, INT, 24));
+        assertThrows(UnsupportedOperationException.class, () -> readOnly.ensureWritable(4));
+        assertThrows(UnsupportedOperationException.class, () -> readOnly.resize(32));
+        assertThrows(UnsupportedOperationException.class, readOnly::compact);
+
+        // Verify that the original buffer's indices/content are unaffected by readOnly read
+        assertEquals(4, buffer.writeIndex());
+        assertEquals(0, buffer.readIndex());
+        assertEquals(42, buffer.read(INT));
+    }
+
+    @Test
+    public void readOnlyStatic() {
+        var buffer = NetworkBuffer.staticBuffer(16);
+        buffer.write(INT, 100);
+
+        var readOnly = buffer.readOnly();
+        assertTrue(readOnly.isReadOnly());
+        assertEquals(100, readOnly.read(INT));
+
+        assertThrows(UnsupportedOperationException.class, () -> readOnly.write(INT, 200));
+    }
+
+    @Test
+    public void readOnlyWrappedWritableSegment() {
+        try (var arena = Arena.ofConfined()) {
+            final MemorySegment segment = arena.allocate(16);
+            var buffer = NetworkBuffer.wrap(segment, 0L, 0L);
+            buffer.write(INT, 500);
+
+            var readOnly = buffer.readOnly();
+            assertTrue(readOnly.isReadOnly());
+            assertEquals(500, readOnly.read(INT));
+
+            // Verify mutating backing segment through readOnly throws
+            assertThrows(UnsupportedOperationException.class, () -> readOnly.write(INT, 600));
+            assertThrows(UnsupportedOperationException.class, () -> readOnly.writeAt(0, INT, 600));
+
+            // Verify the backing segment was not modified by the failed writes
+            assertEquals(500, buffer.readAt(0, INT));
+
+            // Verify original writeable buffer is still modifiable and modifies backing segment
+            buffer.writeAt(0, INT, 600);
+            assertEquals(600, buffer.readAt(0, INT));
+        }
+    }
+
+    @Test
+    public void readOnlyWrappedReadOnlySegment() {
+        try (var arena = Arena.ofConfined()) {
+            final MemorySegment segment = arena.allocate(16);
+            segment.set(ValueLayout.JAVA_INT_UNALIGNED.withOrder(ByteOrder.BIG_ENDIAN), 0, 777);
+
+            final MemorySegment readOnlySegment = segment.asReadOnly();
+            var buffer = NetworkBuffer.wrap(readOnlySegment, 0L, 4L);
+            assertTrue(buffer.isReadOnly());
+
+            var readOnly = buffer.readOnly();
+            assertTrue(readOnly.isReadOnly());
+            assertEquals(777, readOnly.read(INT));
+
+            assertThrows(UnsupportedOperationException.class, () -> readOnly.write(INT, 888));
+        }
     }
 
     @Test

--- a/src/test/java/net/minestom/server/network/NetworkBufferTest.java
+++ b/src/test/java/net/minestom/server/network/NetworkBufferTest.java
@@ -312,11 +312,11 @@ public class NetworkBufferTest {
         assertEquals(42, readOnly.read(INT));
 
         // Mutating operations on read-only buffer should fail
-        assertThrows(UnsupportedOperationException.class, () -> readOnly.write(INT, 24));
-        assertThrows(UnsupportedOperationException.class, () -> readOnly.writeAt(0, INT, 24));
-        assertThrows(UnsupportedOperationException.class, () -> readOnly.ensureWritable(4));
-        assertThrows(UnsupportedOperationException.class, () -> readOnly.resize(32));
-        assertThrows(UnsupportedOperationException.class, readOnly::compact);
+        assertThrows(IllegalArgumentException.class, () -> readOnly.write(INT, 24));
+        assertThrows(IllegalArgumentException.class, () -> readOnly.writeAt(0, INT, 24));
+        assertThrows(IllegalArgumentException.class, () -> readOnly.ensureWritable(4));
+        assertThrows(IllegalArgumentException.class, () -> readOnly.resize(32));
+        assertThrows(IllegalArgumentException.class, readOnly::compact);
 
         // Verify that the original buffer's indices/content are unaffected by readOnly read
         assertEquals(4, buffer.writeIndex());
@@ -333,7 +333,7 @@ public class NetworkBufferTest {
         assertTrue(readOnly.isReadOnly());
         assertEquals(100, readOnly.read(INT));
 
-        assertThrows(UnsupportedOperationException.class, () -> readOnly.write(INT, 200));
+        assertThrows(IllegalArgumentException.class, () -> readOnly.write(INT, 200));
     }
 
     @Test
@@ -348,8 +348,8 @@ public class NetworkBufferTest {
             assertEquals(500, readOnly.read(INT));
 
             // Verify mutating backing segment through readOnly throws
-            assertThrows(UnsupportedOperationException.class, () -> readOnly.write(INT, 600));
-            assertThrows(UnsupportedOperationException.class, () -> readOnly.writeAt(0, INT, 600));
+            assertThrows(IllegalArgumentException.class, () -> readOnly.write(INT, 600));
+            assertThrows(IllegalArgumentException.class, () -> readOnly.writeAt(0, INT, 600));
 
             // Verify the backing segment was not modified by the failed writes
             assertEquals(500, buffer.readAt(0, INT));
@@ -374,7 +374,7 @@ public class NetworkBufferTest {
             assertTrue(readOnly.isReadOnly());
             assertEquals(777, readOnly.read(INT));
 
-            assertThrows(UnsupportedOperationException.class, () -> readOnly.write(INT, 888));
+            assertThrows(IllegalArgumentException.class, () -> readOnly.write(INT, 888));
         }
     }
 
@@ -420,11 +420,11 @@ public class NetworkBufferTest {
             }
         };
 
-        assertThrows(UnsupportedOperationException.class, () -> fn.apply(buffer -> buffer.resize(2)).sizeOf(1));
-        assertThrows(UnsupportedOperationException.class, () -> fn.apply(buffer -> buffer.read(INT)).sizeOf(1));
-        assertThrows(UnsupportedOperationException.class, () -> fn.apply(buffer -> buffer.readAt(0, INT)).sizeOf(1));
-        assertThrows(UnsupportedOperationException.class, () -> fn.apply(NetworkBuffer::compact).sizeOf(1));
-        assertThrows(UnsupportedOperationException.class, () -> fn.apply(buffer -> buffer.copy(0, 0, 0, 0)).sizeOf(1));
+        assertThrows(IllegalArgumentException.class, () -> fn.apply(buffer -> buffer.resize(2)).sizeOf(1));
+        assertThrows(IllegalArgumentException.class, () -> fn.apply(buffer -> buffer.read(INT)).sizeOf(1));
+        assertThrows(IllegalArgumentException.class, () -> fn.apply(buffer -> buffer.readAt(0, INT)).sizeOf(1));
+        assertThrows(IllegalArgumentException.class, () -> fn.apply(NetworkBuffer::compact).sizeOf(1));
+        assertThrows(IllegalArgumentException.class, () -> fn.apply(buffer -> buffer.copy(0, 0, 0, 0)).sizeOf(1));
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

- `NetworkBuffer#wrap(byte[], ...)` deleted copy on wrap (Now mutates param1)
- `NetworkBuffer#copyTo(long, byte[], long, long)` deleted in favor of `NetworkBuffer#copyTo(long, byte[], int, int)`
- `NetworkBuffer#readOnly` now returns a read only view instead of setting a flag. They share the same memory region, so changes from the parent should show on the child when it comes to writing to the buffer. Dummy buffers that are read only will throw.
- `NetworkBuffer#writeChannel(SocketChannel)` now uses `WritableByteChannel`
- `NetworkBuffer#ensureWritable(long)` now requires lengths to be positive
- `NetworkBufferImpl` assertReadOnly may no longer throw UnsupportedOperation and can throw IllegalArgumentException instead for read only checks.
- `NetworkBufferImpl` dummy and read checks have been moved to be more hoisted.
- Some write and read operations that threw `UnsupportedOperationException` now throw `IllegalArgumentException` to align with MemorySegment read only exceptions.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
Currently targeting master, as it may be an idea to switch the head nearing the merge window (merge queue)