### PR TITLE
fix: use ItemStackTemplate for DisplayData icon in AdvancementsPacket

### DIFF
--- a/src/main/java/net/minestom/server/network/packet/server/play/AdvancementsPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/play/AdvancementsPacket.java
@@ -4,6 +4,7 @@ import net.kyori.adventure.text.Component;
 import net.minestom.server.advancements.FrameType;
 import net.minestom.server.adventure.ComponentHolder;
 import net.minestom.server.item.ItemStack;
+import net.minestom.server.item.ItemStackTemplate;
 import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.NetworkBufferTemplate;
 import net.minestom.server.network.packet.server.ServerPacket;
@@ -134,7 +135,7 @@ public record AdvancementsPacket(
             public void write(NetworkBuffer buffer, DisplayData value) {
                 buffer.write(NetworkBuffer.COMPONENT, value.title);
                 buffer.write(NetworkBuffer.COMPONENT, value.description);
-                buffer.write(ItemStack.NETWORK_TYPE, value.icon);
+                buffer.write(ItemStackTemplate.NETWORK_TYPE, value.icon);
                 buffer.write(NetworkBuffer.Enum(FrameType.class), value.frameType);
                 buffer.write(NetworkBuffer.INT, value.flags);
                 if ((value.flags & 0x1) != 0) {
@@ -149,7 +150,7 @@ public record AdvancementsPacket(
             public DisplayData read(NetworkBuffer buffer) {
                 var title = buffer.read(NetworkBuffer.COMPONENT);
                 var description = buffer.read(NetworkBuffer.COMPONENT);
-                var icon = buffer.read(ItemStack.NETWORK_TYPE);
+                var icon = buffer.read(ItemStackTemplate.NETWORK_TYPE);
                 var frameType = FrameType.values()[buffer.read(NetworkBuffer.VAR_INT)];
                 var flags = buffer.read(NetworkBuffer.INT);
                 var backgroundTexture = (flags & 0x1) != 0 ? buffer.read(NetworkBuffer.STRING) : null;


### PR DESCRIPTION
## Proposed changes

As described in #3243, the sent varint ordering was wrong for advancement packets. This fixes it by using ItemStackTemplate network type as vanilla is doing as well. (see https://mcsrc.dev/1/26.1.2/net/minecraft/advancements/DisplayInfo#L110 for confirmation)

closing  #3243

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works (how? this is client packet parsing logic for e2e which would be preferred here and I think we don't have such a setup right now)
- [ ] I have added necessary documentation (if appropriate)
