### PR TITLE
Add EntityCollisionBenchmark

### DIFF
--- a/jmh-benchmarks/src/jmh/java/net/minestom/server/collision/EntityCollisionBenchmark.java
+++ b/jmh-benchmarks/src/jmh/java/net/minestom/server/collision/EntityCollisionBenchmark.java
@@ -1,0 +1,70 @@
+package net.minestom.server.collision;
+
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.coordinate.Vec;
+import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.EntityType;
+import net.minestom.server.instance.EntityTracker;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.Collection;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Scaling baseline for {@link EntityCollision#checkCollision}: the entity-vs-entity collision query
+ * run for every colliding entity every tick. Exercises the whole path - the {@link EntityTracker}
+ * broad-phase chunk scan plus the per-candidate sweep narrow-phase.
+ * <p>
+ * {@code entityCount} entities are packed inside the query's search range around the mover (so the
+ * broad-phase returns all of them and every one is swept) and spread across several chunks. The
+ * mover advances with a moderate velocity, giving a realistic mix of overlaps, swept hits and
+ * misses. Vary the param to see how the query scales with crowd density - the number to watch when
+ * optimizing.
+ */
+@BenchmarkMode({Mode.AverageTime, Mode.Throughput})
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 8, time = 1)
+@Fork(2)
+public class EntityCollisionBenchmark {
+    private static final BoundingBox MOVER_BB = new BoundingBox(0.6, 1.8, 0.6);
+    private static final Pos MOVER_POS = new Pos(0.5, 64.0, 0.5);
+    private static final Vec VELOCITY = new Vec(0.42, 0.0, 0.42); // ~0.6/tick forward
+    private static final double EXTEND_RADIUS = 1.51;
+    // Pack inside the broad-phase range (extendRadius + maxDistance + |velocity| ~= 3.6) so every
+    // entity is returned and swept; the disk spans ~4 chunks, exercising the multi-chunk scan.
+    private static final double PACK_RADIUS = 3.0;
+
+    @Param({"16", "128", "1024"})
+    private int entityCount;
+
+    private EntityTracker tracker;
+
+    @Setup
+    public void setup() {
+        final Random rnd = new Random(1234567);
+        tracker = EntityTracker.newTracker();
+        for (int i = 0; i < entityCount; i++) {
+            final double angle = rnd.nextDouble() * 2 * Math.PI;
+            final double dist = rnd.nextDouble() * PACK_RADIUS;
+            final Pos pos = new Pos(MOVER_POS.x() + Math.cos(angle) * dist, 64.0, MOVER_POS.z() + Math.sin(angle) * dist);
+            tracker.register(new PositionedEntity(pos), pos, EntityTracker.Target.ENTITIES, null);
+        }
+    }
+
+    @Benchmark
+    public Collection<EntityCollisionResult> checkCollisions() {
+        return EntityCollision.checkCollision(tracker, MOVER_BB, MOVER_POS, VELOCITY,
+                EXTEND_RADIUS, _ -> true, null);
+    }
+
+    private static final class PositionedEntity extends Entity {
+        PositionedEntity(Pos pos) {
+            super(EntityType.ZOMBIE);
+            this.boundingBox = MOVER_BB;
+            this.position = pos;
+        }
+    }
+}

--- a/src/main/java/net/minestom/server/collision/CollisionUtils.java
+++ b/src/main/java/net/minestom/server/collision/CollisionUtils.java
@@ -51,7 +51,7 @@ public final class CollisionUtils {
      *                     For players this is (0.3^2 + 0.3^2 + 1.8^2) ^ (1/3) ~= 1.51
      */
     public static Collection<EntityCollisionResult> checkEntityCollisions(Instance instance, BoundingBox boundingBox, Point pos, Vec velocity, double extendRadius, Function<Entity, Boolean> entityFilter, @Nullable PhysicsResult physicsResult) {
-        return EntityCollision.checkCollision(instance, boundingBox, pos, velocity, extendRadius, entityFilter, physicsResult);
+        return EntityCollision.checkCollision(instance.getEntityTracker(), boundingBox, pos, velocity, extendRadius, entityFilter, physicsResult);
     }
 
     /**
@@ -65,7 +65,7 @@ public final class CollisionUtils {
      * @return the entity collision results
      */
     public static Collection<EntityCollisionResult> checkEntityCollisions(Entity entity, Vec velocity, double extendRadius, Function<Entity, Boolean> entityFilter, @Nullable PhysicsResult physicsResult) {
-        return EntityCollision.checkCollision(entity.getInstance(), entity.getBoundingBox(), entity.getPosition(), velocity, extendRadius, entityFilter, physicsResult);
+        return EntityCollision.checkCollision(entity.getInstance().getEntityTracker(), entity.getBoundingBox(), entity.getPosition(), velocity, extendRadius, entityFilter, physicsResult);
     }
 
     /**

--- a/src/main/java/net/minestom/server/collision/EntityCollision.java
+++ b/src/main/java/net/minestom/server/collision/EntityCollision.java
@@ -3,7 +3,7 @@ package net.minestom.server.collision;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Entity;
-import net.minestom.server.instance.Instance;
+import net.minestom.server.instance.EntityTracker;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -11,7 +11,11 @@ import java.util.List;
 import java.util.function.Function;
 
 final class EntityCollision {
-    static List<EntityCollisionResult> checkCollision(Instance instance, BoundingBox boundingBox, Point point, Vec entityVelocity, double extendRadius, Function<Entity, Boolean> entityFilter, @Nullable PhysicsResult physicsResult) {
+    static List<EntityCollisionResult> checkCollision(
+            EntityTracker entityTracker,
+            BoundingBox boundingBox, Point point, Vec entityVelocity,
+            double extendRadius, Function<Entity, Boolean> entityFilter, @Nullable PhysicsResult physicsResult
+    ) {
         double minimumRes = physicsResult != null ? physicsResult.res().res : Double.MAX_VALUE;
 
         List<EntityCollisionResult> result = new ArrayList<>();
@@ -19,20 +23,19 @@ final class EntityCollision {
         var maxDistance = Math.pow(boundingBox.height() * boundingBox.height() + boundingBox.depth() / 2 * boundingBox.depth() / 2 + boundingBox.width() / 2 * boundingBox.width() / 2, 1 / 3.0);
         double projectileDistance = entityVelocity.length();
 
-        for (Entity e : instance.getNearbyEntities(point, extendRadius + maxDistance + projectileDistance)) {
-            SweepResult sweepResult = new SweepResult(minimumRes, 0, 0, 0, null, 0, 0, 0, 0, 0, 0);
-
-            if (!entityFilter.apply(e)) continue;
-            if (!e.hasEntityCollision()) continue;
+        entityTracker.nearbyEntities(point, extendRadius + maxDistance + projectileDistance, EntityTracker.Target.ENTITIES, e -> {
+            if (!entityFilter.apply(e)) return;
+            if (!e.hasEntityCollision()) return;
 
             // Overlapping with entity, math can't be done we return the entity
             if (e.getBoundingBox().intersectBox(e.getPosition().sub(point), boundingBox)) {
                 var p = point.asPos();
                 result.add(new EntityCollisionResult(p, e, Vec.ZERO, 0));
-                continue;
+                return;
             }
 
             // Check collisions with entity
+            SweepResult sweepResult = new SweepResult(minimumRes, 0, 0, 0, null, 0, 0, 0, 0, 0, 0);
             boolean intersected = e.getBoundingBox().intersectBoxSwept(point, entityVelocity, e.getPosition(), boundingBox, sweepResult);
 
             if (intersected && sweepResult.res < 1) {
@@ -40,7 +43,7 @@ final class EntityCollision {
                 Vec direction = new Vec(sweepResult.collidedPositionX, sweepResult.collidedPositionY, sweepResult.collidedPositionZ);
                 result.add(new EntityCollisionResult(p, e, direction, sweepResult.res));
             }
-        }
+        });
 
         return result;
     }


### PR DESCRIPTION
Basic entity collision stress test, necessary if #3194 is to go anywhere.
Additionally removed `checkCollision` dependency on `Instance` but didn't focus on performance improvement.