### PR TITLE
Misc MetadataHolder improvements

### DIFF
--- a/src/main/java/net/minestom/server/entity/MetadataHolder.java
+++ b/src/main/java/net/minestom/server/entity/MetadataHolder.java
@@ -1,7 +1,6 @@
 package net.minestom.server.entity;
 
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.entity.metadata.ambient.BatMeta;
 import net.minestom.server.entity.metadata.animal.*;
@@ -40,6 +39,7 @@ import org.jetbrains.annotations.UnknownNullability;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -60,11 +60,11 @@ public final class MetadataHolder {
     }
 
     private final Consumer<Map<Integer, Metadata.Entry<?>>> changesListener;
-    private final Int2ObjectMap<Metadata.Entry<?>> entries = new Int2ObjectOpenHashMap<>();
+    private Metadata.@Nullable Entry<?>[] entries = new Metadata.Entry<?>[0]; // indexed by metadata id, resized on demand
 
     @SuppressWarnings("FieldMayBeFinal")
     private volatile boolean notifyAboutChanges = true;
-    private final Map<Integer, Metadata.Entry<?>> notNotifiedChanges = new HashMap<>();
+    private final Int2ObjectArrayMap<Metadata.Entry<?>> notNotifiedChanges = new Int2ObjectArrayMap<>();
 
     /**
      * @deprecated Use {@link #MetadataHolder(Consumer)} instead.
@@ -83,7 +83,7 @@ public final class MetadataHolder {
     public <T extends @UnknownNullability Object> T get(MetadataDef.Entry<T> entry) {
         final int id = entry.index();
 
-        final Metadata.Entry<?> value = this.entries.get(id);
+        final Metadata.Entry<?> value = entryAt(id);
         if (value == null) return entry.defaultValue();
         return switch (entry) {
             case MetadataDef.Entry.Index<T> _ -> (T) value.value();
@@ -114,20 +114,20 @@ public final class MetadataHolder {
         Metadata.Entry<?> result = switch (entry) {
             case MetadataDef.Entry.Index<T> v -> v.function().apply(value);
             case MetadataDef.Entry.BitMask bitMask -> {
-                Metadata.Entry<?> currentEntry = this.entries.get(id);
+                Metadata.Entry<?> currentEntry = entryAt(id);
                 byte maskValue = currentEntry != null ? (byte) currentEntry.value() : 0;
                 maskValue = setMaskBit(maskValue, bitMask.bitMask(), (Boolean) value);
                 yield Metadata.Byte(maskValue);
             }
             case MetadataDef.Entry.ByteMask byteMask -> {
-                Metadata.Entry<?> currentEntry = this.entries.get(id);
+                Metadata.Entry<?> currentEntry = entryAt(id);
                 byte maskValue = currentEntry != null ? (byte) currentEntry.value() : 0;
                 maskValue = setMaskByte(maskValue, byteMask.byteMask(), byteMask.offset(), (Byte) value);
                 yield Metadata.Byte(maskValue);
             }
         };
 
-        this.entries.put(id, result);
+        putEntry(id, result);
 
         if (!this.notifyAboutChanges) {
             synchronized (this.notNotifiedChanges) {
@@ -161,183 +161,199 @@ public final class MetadataHolder {
             // Ask future metadata changes to be cached
             return;
         }
-        Map<Integer, Metadata.Entry<?>> entries;
+        Int2ObjectArrayMap<Metadata.Entry<?>> entries;
         synchronized (this.notNotifiedChanges) {
-            Map<Integer, Metadata.Entry<?>> awaitingChanges = this.notNotifiedChanges;
-            if (awaitingChanges.isEmpty()) return;
-            entries = Map.copyOf(awaitingChanges);
-            awaitingChanges.clear();
+            if (this.notNotifiedChanges.isEmpty()) return;
+            entries = new Int2ObjectArrayMap<>(this.notNotifiedChanges);
+            this.notNotifiedChanges.clear();
         }
         this.changesListener.accept(entries);
     }
 
-    public Map<Integer, Metadata.Entry<?>> getEntries() {
-        return Map.copyOf(this.entries);
+    private Metadata.@Nullable Entry<?> entryAt(int id) {
+        final var entries = this.entries;
+        return id >= 0 && id < entries.length ? entries[id] : null;
     }
 
-    static final Map<String, BiFunction<@Nullable Entity, MetadataHolder, ? extends EntityMeta>> ENTITY_META_SUPPLIER = Map.ofEntries(
-            entry("minecraft:acacia_boat", BoatMeta::new),
-            entry("minecraft:acacia_chest_boat", BoatMeta::new),
-            entry("minecraft:allay", AllayMeta::new),
-            entry("minecraft:area_effect_cloud", AreaEffectCloudMeta::new),
-            entry("minecraft:armadillo", ArmadilloMeta::new),
-            entry("minecraft:armor_stand", ArmorStandMeta::new),
-            entry("minecraft:arrow", ArrowMeta::new),
-            entry("minecraft:axolotl", AxolotlMeta::new),
-            entry("minecraft:bamboo_raft", BoatMeta::new),
-            entry("minecraft:bamboo_chest_raft", BoatMeta::new),
-            entry("minecraft:bat", BatMeta::new),
-            entry("minecraft:bee", BeeMeta::new),
-            entry("minecraft:birch_boat", BoatMeta::new),
-            entry("minecraft:birch_chest_boat", BoatMeta::new),
-            entry("minecraft:blaze", BlazeMeta::new),
-            entry("minecraft:block_display", BlockDisplayMeta::new),
-            entry("minecraft:bogged", BoggedMeta::new),
-            entry("minecraft:breeze", BreezeMeta::new),
-            entry("minecraft:breeze_wind_charge", BreezeWindChargeMeta::new),
-            entry("minecraft:camel", CamelMeta::new),
-            entry("minecraft:camel_husk", CamelHuskMeta::new),
-            entry("minecraft:cat", CatMeta::new),
-            entry("minecraft:cave_spider", CaveSpiderMeta::new),
-            entry("minecraft:cherry_boat", BoatMeta::new),
-            entry("minecraft:cherry_chest_boat", BoatMeta::new),
-            entry("minecraft:chicken", ChickenMeta::new),
-            entry("minecraft:cod", CodMeta::new),
-            entry("minecraft:copper_golem", CopperGolemMeta::new),
-            entry("minecraft:cow", CowMeta::new),
-            entry("minecraft:creaking", CreakingMeta::new),
-            entry("minecraft:creeper", CreeperMeta::new),
-            entry("minecraft:dark_oak_boat", BoatMeta::new),
-            entry("minecraft:dark_oak_chest_boat", BoatMeta::new),
-            entry("minecraft:dolphin", DolphinMeta::new),
-            entry("minecraft:donkey", DonkeyMeta::new),
-            entry("minecraft:dragon_fireball", DragonFireballMeta::new),
-            entry("minecraft:drowned", DrownedMeta::new),
-            entry("minecraft:elder_guardian", ElderGuardianMeta::new),
-            entry("minecraft:end_crystal", EndCrystalMeta::new),
-            entry("minecraft:ender_dragon", EnderDragonMeta::new),
-            entry("minecraft:enderman", EndermanMeta::new),
-            entry("minecraft:endermite", EndermiteMeta::new),
-            entry("minecraft:evoker", EvokerMeta::new),
-            entry("minecraft:evoker_fangs", EvokerFangsMeta::new),
-            entry("minecraft:experience_orb", ExperienceOrbMeta::new),
-            entry("minecraft:eye_of_ender", EyeOfEnderMeta::new),
-            entry("minecraft:falling_block", FallingBlockMeta::new),
-            entry("minecraft:fireball", FireballMeta::new),
-            entry("minecraft:firework_rocket", FireworkRocketMeta::new),
-            entry("minecraft:fox", FoxMeta::new),
-            entry("minecraft:frog", FrogMeta::new),
-            entry("minecraft:ghast", GhastMeta::new),
-            entry("minecraft:giant", GiantMeta::new),
-            entry("minecraft:glow_item_frame", GlowItemFrameMeta::new),
-            entry("minecraft:glow_squid", GlowSquidMeta::new),
-            entry("minecraft:goat", GoatMeta::new),
-            entry("minecraft:guardian", GuardianMeta::new),
-            entry("minecraft:happy_ghast", HappyGhastMeta::new),
-            entry("minecraft:hoglin", HoglinMeta::new),
-            entry("minecraft:horse", HorseMeta::new),
-            entry("minecraft:husk", HuskMeta::new),
-            entry("minecraft:illusioner", IllusionerMeta::new),
-            entry("minecraft:interaction", InteractionMeta::new),
-            entry("minecraft:iron_golem", IronGolemMeta::new),
-            entry("minecraft:item", ItemEntityMeta::new),
-            entry("minecraft:item_display", ItemDisplayMeta::new),
-            entry("minecraft:item_frame", ItemFrameMeta::new),
-            entry("minecraft:jungle_boat", BoatMeta::new),
-            entry("minecraft:jungle_chest_boat", BoatMeta::new),
-            entry("minecraft:leash_knot", LeashKnotMeta::new),
-            entry("minecraft:lightning_bolt", LightningBoltMeta::new),
-            entry("minecraft:lingering_potion", LingeringPotionMeta::new),
-            entry("minecraft:llama", LlamaMeta::new),
-            entry("minecraft:llama_spit", LlamaSpitMeta::new),
-            entry("minecraft:magma_cube", MagmaCubeMeta::new),
-            entry("minecraft:mangrove_boat", BoatMeta::new),
-            entry("minecraft:mangrove_chest_boat", BoatMeta::new),
-            entry("minecraft:mannequin", MannequinMeta::new),
-            entry("minecraft:marker", MarkerMeta::new),
-            entry("minecraft:minecart", MinecartMeta::new),
-            entry("minecraft:nautilus", NautilusMeta::new),
-            entry("minecraft:chest_minecart", ChestMinecartMeta::new),
-            entry("minecraft:command_block_minecart", CommandBlockMinecartMeta::new),
-            entry("minecraft:furnace_minecart", FurnaceMinecartMeta::new),
-            entry("minecraft:hopper_minecart", HopperMinecartMeta::new),
-            entry("minecraft:spawner_minecart", SpawnerMinecartMeta::new),
-            entry("minecraft:text_display", TextDisplayMeta::new),
-            entry("minecraft:tnt_minecart", TntMinecartMeta::new),
-            entry("minecraft:mooshroom", MooshroomMeta::new),
-            entry("minecraft:mule", MuleMeta::new),
-            entry("minecraft:oak_boat", BoatMeta::new),
-            entry("minecraft:oak_chest_boat", BoatMeta::new),
-            entry("minecraft:ocelot", OcelotMeta::new),
-            entry("minecraft:ominous_item_spawner", OminousItemSpawnerMeta::new),
-            entry("minecraft:painting", PaintingMeta::new),
-            entry("minecraft:pale_oak_boat", BoatMeta::new),
-            entry("minecraft:pale_oak_chest_boat", BoatMeta::new),
-            entry("minecraft:panda", PandaMeta::new),
-            entry("minecraft:parrot", ParrotMeta::new),
-            entry("minecraft:parched", ParchedMeta::new),
-            entry("minecraft:phantom", PhantomMeta::new),
-            entry("minecraft:pig", PigMeta::new),
-            entry("minecraft:piglin", PiglinMeta::new),
-            entry("minecraft:piglin_brute", PiglinBruteMeta::new),
-            entry("minecraft:pillager", PillagerMeta::new),
-            entry("minecraft:polar_bear", PolarBearMeta::new),
-            entry("minecraft:tnt", PrimedTntMeta::new),
-            entry("minecraft:pufferfish", PufferfishMeta::new),
-            entry("minecraft:rabbit", RabbitMeta::new),
-            entry("minecraft:ravager", RavagerMeta::new),
-            entry("minecraft:salmon", SalmonMeta::new),
-            entry("minecraft:sheep", SheepMeta::new),
-            entry("minecraft:shulker", ShulkerMeta::new),
-            entry("minecraft:shulker_bullet", ShulkerBulletMeta::new),
-            entry("minecraft:silverfish", SilverfishMeta::new),
-            entry("minecraft:skeleton", SkeletonMeta::new),
-            entry("minecraft:skeleton_horse", SkeletonHorseMeta::new),
-            entry("minecraft:slime", SlimeMeta::new),
-            entry("minecraft:small_fireball", SmallFireballMeta::new),
-            entry("minecraft:sniffer", SnifferMeta::new),
-            entry("minecraft:snow_golem", SnowGolemMeta::new),
-            entry("minecraft:snowball", SnowballMeta::new),
-            entry("minecraft:spectral_arrow", SpectralArrowMeta::new),
-            entry("minecraft:spider", SpiderMeta::new),
-            entry("minecraft:splash_potion", SplashPotionMeta::new),
-            entry("minecraft:spruce_boat", BoatMeta::new),
-            entry("minecraft:spruce_chest_boat", BoatMeta::new),
-            entry("minecraft:squid", SquidMeta::new),
-            entry("minecraft:stray", StrayMeta::new),
-            entry("minecraft:strider", StriderMeta::new),
-            entry("minecraft:tadpole", TadpoleMeta::new),
-            entry("minecraft:egg", ThrownEggMeta::new),
-            entry("minecraft:ender_pearl", ThrownEnderPearlMeta::new),
-            entry("minecraft:experience_bottle", ThrownExperienceBottleMeta::new),
-            entry("minecraft:potion", SplashPotionMeta::new),
-            entry("minecraft:trident", ThrownTridentMeta::new),
-            entry("minecraft:trader_llama", TraderLlamaMeta::new),
-            entry("minecraft:tropical_fish", TropicalFishMeta::new),
-            entry("minecraft:turtle", TurtleMeta::new),
-            entry("minecraft:vex", VexMeta::new),
-            entry("minecraft:villager", VillagerMeta::new),
-            entry("minecraft:vindicator", VindicatorMeta::new),
-            entry("minecraft:wandering_trader", WanderingTraderMeta::new),
-            entry("minecraft:warden", WardenMeta::new),
-            entry("minecraft:wind_charge", WindChargeMeta::new),
-            entry("minecraft:witch", WitchMeta::new),
-            entry("minecraft:wither", WitherMeta::new),
-            entry("minecraft:wither_skeleton", WitherSkeletonMeta::new),
-            entry("minecraft:wither_skull", WitherSkullMeta::new),
-            entry("minecraft:wolf", WolfMeta::new),
-            entry("minecraft:zoglin", ZoglinMeta::new),
-            entry("minecraft:zombie", ZombieMeta::new),
-            entry("minecraft:zombie_horse", ZombieHorseMeta::new),
-            entry("minecraft:zombie_nautilus", ZombieNautilusMeta::new),
-            entry("minecraft:zombie_villager", ZombieVillagerMeta::new),
-            entry("minecraft:zombified_piglin", ZombifiedPiglinMeta::new),
-            entry("minecraft:player", PlayerMeta::new),
-            entry("minecraft:fishing_bobber", FishingHookMeta::new)
+    private void putEntry(int id, Metadata.Entry<?> entry) {
+        var entries = this.entries;
+        if (id >= entries.length) this.entries = entries = Arrays.copyOf(entries, id + 1);
+        entries[id] = entry;
+    }
+
+    public Map<Integer, Metadata.Entry<?>> getEntries() {
+        final var entries = this.entries;
+        Map<Integer, Metadata.Entry<?>> map = new HashMap<>();
+        for (int id = 0; id < entries.length; id++) {
+            final var entry = entries[id];
+            if (entry != null) map.put(id, entry);
+        }
+        return Map.copyOf(map);
+    }
+
+    @SuppressWarnings("JavacQuirks")
+    static final Map<EntityType, BiFunction<@Nullable Entity, MetadataHolder, ? extends EntityMeta>> ENTITY_META_SUPPLIER = Map.ofEntries(
+            entry(EntityType.ACACIA_BOAT, BoatMeta::new),
+            entry(EntityType.ACACIA_CHEST_BOAT, BoatMeta::new),
+            entry(EntityType.ALLAY, AllayMeta::new),
+            entry(EntityType.AREA_EFFECT_CLOUD, AreaEffectCloudMeta::new),
+            entry(EntityType.ARMADILLO, ArmadilloMeta::new),
+            entry(EntityType.ARMOR_STAND, ArmorStandMeta::new),
+            entry(EntityType.ARROW, ArrowMeta::new),
+            entry(EntityType.AXOLOTL, AxolotlMeta::new),
+            entry(EntityType.BAMBOO_RAFT, BoatMeta::new),
+            entry(EntityType.BAMBOO_CHEST_RAFT, BoatMeta::new),
+            entry(EntityType.BAT, BatMeta::new),
+            entry(EntityType.BEE, BeeMeta::new),
+            entry(EntityType.BIRCH_BOAT, BoatMeta::new),
+            entry(EntityType.BIRCH_CHEST_BOAT, BoatMeta::new),
+            entry(EntityType.BLAZE, BlazeMeta::new),
+            entry(EntityType.BLOCK_DISPLAY, BlockDisplayMeta::new),
+            entry(EntityType.BOGGED, BoggedMeta::new),
+            entry(EntityType.BREEZE, BreezeMeta::new),
+            entry(EntityType.BREEZE_WIND_CHARGE, BreezeWindChargeMeta::new),
+            entry(EntityType.CAMEL, CamelMeta::new),
+            entry(EntityType.CAMEL_HUSK, CamelHuskMeta::new),
+            entry(EntityType.CAT, CatMeta::new),
+            entry(EntityType.CAVE_SPIDER, CaveSpiderMeta::new),
+            entry(EntityType.CHERRY_BOAT, BoatMeta::new),
+            entry(EntityType.CHERRY_CHEST_BOAT, BoatMeta::new),
+            entry(EntityType.CHICKEN, ChickenMeta::new),
+            entry(EntityType.COD, CodMeta::new),
+            entry(EntityType.COPPER_GOLEM, CopperGolemMeta::new),
+            entry(EntityType.COW, CowMeta::new),
+            entry(EntityType.CREAKING, CreakingMeta::new),
+            entry(EntityType.CREEPER, CreeperMeta::new),
+            entry(EntityType.DARK_OAK_BOAT, BoatMeta::new),
+            entry(EntityType.DARK_OAK_CHEST_BOAT, BoatMeta::new),
+            entry(EntityType.DOLPHIN, DolphinMeta::new),
+            entry(EntityType.DONKEY, DonkeyMeta::new),
+            entry(EntityType.DRAGON_FIREBALL, DragonFireballMeta::new),
+            entry(EntityType.DROWNED, DrownedMeta::new),
+            entry(EntityType.ELDER_GUARDIAN, ElderGuardianMeta::new),
+            entry(EntityType.END_CRYSTAL, EndCrystalMeta::new),
+            entry(EntityType.ENDER_DRAGON, EnderDragonMeta::new),
+            entry(EntityType.ENDERMAN, EndermanMeta::new),
+            entry(EntityType.ENDERMITE, EndermiteMeta::new),
+            entry(EntityType.EVOKER, EvokerMeta::new),
+            entry(EntityType.EVOKER_FANGS, EvokerFangsMeta::new),
+            entry(EntityType.EXPERIENCE_ORB, ExperienceOrbMeta::new),
+            entry(EntityType.EYE_OF_ENDER, EyeOfEnderMeta::new),
+            entry(EntityType.FALLING_BLOCK, FallingBlockMeta::new),
+            entry(EntityType.FIREBALL, FireballMeta::new),
+            entry(EntityType.FIREWORK_ROCKET, FireworkRocketMeta::new),
+            entry(EntityType.FOX, FoxMeta::new),
+            entry(EntityType.FROG, FrogMeta::new),
+            entry(EntityType.GHAST, GhastMeta::new),
+            entry(EntityType.GIANT, GiantMeta::new),
+            entry(EntityType.GLOW_ITEM_FRAME, GlowItemFrameMeta::new),
+            entry(EntityType.GLOW_SQUID, GlowSquidMeta::new),
+            entry(EntityType.GOAT, GoatMeta::new),
+            entry(EntityType.GUARDIAN, GuardianMeta::new),
+            entry(EntityType.HAPPY_GHAST, HappyGhastMeta::new),
+            entry(EntityType.HOGLIN, HoglinMeta::new),
+            entry(EntityType.HORSE, HorseMeta::new),
+            entry(EntityType.HUSK, HuskMeta::new),
+            entry(EntityType.ILLUSIONER, IllusionerMeta::new),
+            entry(EntityType.INTERACTION, InteractionMeta::new),
+            entry(EntityType.IRON_GOLEM, IronGolemMeta::new),
+            entry(EntityType.ITEM, ItemEntityMeta::new),
+            entry(EntityType.ITEM_DISPLAY, ItemDisplayMeta::new),
+            entry(EntityType.ITEM_FRAME, ItemFrameMeta::new),
+            entry(EntityType.JUNGLE_BOAT, BoatMeta::new),
+            entry(EntityType.JUNGLE_CHEST_BOAT, BoatMeta::new),
+            entry(EntityType.LEASH_KNOT, LeashKnotMeta::new),
+            entry(EntityType.LIGHTNING_BOLT, LightningBoltMeta::new),
+            entry(EntityType.LINGERING_POTION, LingeringPotionMeta::new),
+            entry(EntityType.LLAMA, LlamaMeta::new),
+            entry(EntityType.LLAMA_SPIT, LlamaSpitMeta::new),
+            entry(EntityType.MAGMA_CUBE, MagmaCubeMeta::new),
+            entry(EntityType.MANGROVE_BOAT, BoatMeta::new),
+            entry(EntityType.MANGROVE_CHEST_BOAT, BoatMeta::new),
+            entry(EntityType.MANNEQUIN, MannequinMeta::new),
+            entry(EntityType.MARKER, MarkerMeta::new),
+            entry(EntityType.MINECART, MinecartMeta::new),
+            entry(EntityType.NAUTILUS, NautilusMeta::new),
+            entry(EntityType.CHEST_MINECART, ChestMinecartMeta::new),
+            entry(EntityType.COMMAND_BLOCK_MINECART, CommandBlockMinecartMeta::new),
+            entry(EntityType.FURNACE_MINECART, FurnaceMinecartMeta::new),
+            entry(EntityType.HOPPER_MINECART, HopperMinecartMeta::new),
+            entry(EntityType.SPAWNER_MINECART, SpawnerMinecartMeta::new),
+            entry(EntityType.TEXT_DISPLAY, TextDisplayMeta::new),
+            entry(EntityType.TNT_MINECART, TntMinecartMeta::new),
+            entry(EntityType.MOOSHROOM, MooshroomMeta::new),
+            entry(EntityType.MULE, MuleMeta::new),
+            entry(EntityType.OAK_BOAT, BoatMeta::new),
+            entry(EntityType.OAK_CHEST_BOAT, BoatMeta::new),
+            entry(EntityType.OCELOT, OcelotMeta::new),
+            entry(EntityType.OMINOUS_ITEM_SPAWNER, OminousItemSpawnerMeta::new),
+            entry(EntityType.PAINTING, PaintingMeta::new),
+            entry(EntityType.PALE_OAK_BOAT, BoatMeta::new),
+            entry(EntityType.PALE_OAK_CHEST_BOAT, BoatMeta::new),
+            entry(EntityType.PANDA, PandaMeta::new),
+            entry(EntityType.PARROT, ParrotMeta::new),
+            entry(EntityType.PARCHED, ParchedMeta::new),
+            entry(EntityType.PHANTOM, PhantomMeta::new),
+            entry(EntityType.PIG, PigMeta::new),
+            entry(EntityType.PIGLIN, PiglinMeta::new),
+            entry(EntityType.PIGLIN_BRUTE, PiglinBruteMeta::new),
+            entry(EntityType.PILLAGER, PillagerMeta::new),
+            entry(EntityType.POLAR_BEAR, PolarBearMeta::new),
+            entry(EntityType.TNT, PrimedTntMeta::new),
+            entry(EntityType.PUFFERFISH, PufferfishMeta::new),
+            entry(EntityType.RABBIT, RabbitMeta::new),
+            entry(EntityType.RAVAGER, RavagerMeta::new),
+            entry(EntityType.SALMON, SalmonMeta::new),
+            entry(EntityType.SHEEP, SheepMeta::new),
+            entry(EntityType.SHULKER, ShulkerMeta::new),
+            entry(EntityType.SHULKER_BULLET, ShulkerBulletMeta::new),
+            entry(EntityType.SILVERFISH, SilverfishMeta::new),
+            entry(EntityType.SKELETON, SkeletonMeta::new),
+            entry(EntityType.SKELETON_HORSE, SkeletonHorseMeta::new),
+            entry(EntityType.SLIME, SlimeMeta::new),
+            entry(EntityType.SMALL_FIREBALL, SmallFireballMeta::new),
+            entry(EntityType.SNIFFER, SnifferMeta::new),
+            entry(EntityType.SNOW_GOLEM, SnowGolemMeta::new),
+            entry(EntityType.SNOWBALL, SnowballMeta::new),
+            entry(EntityType.SPECTRAL_ARROW, SpectralArrowMeta::new),
+            entry(EntityType.SPIDER, SpiderMeta::new),
+            entry(EntityType.SPLASH_POTION, SplashPotionMeta::new),
+            entry(EntityType.SPRUCE_BOAT, BoatMeta::new),
+            entry(EntityType.SPRUCE_CHEST_BOAT, BoatMeta::new),
+            entry(EntityType.SQUID, SquidMeta::new),
+            entry(EntityType.STRAY, StrayMeta::new),
+            entry(EntityType.STRIDER, StriderMeta::new),
+            entry(EntityType.TADPOLE, TadpoleMeta::new),
+            entry(EntityType.EGG, ThrownEggMeta::new),
+            entry(EntityType.ENDER_PEARL, ThrownEnderPearlMeta::new),
+            entry(EntityType.EXPERIENCE_BOTTLE, ThrownExperienceBottleMeta::new),
+            entry(EntityType.TRIDENT, ThrownTridentMeta::new),
+            entry(EntityType.TRADER_LLAMA, TraderLlamaMeta::new),
+            entry(EntityType.TROPICAL_FISH, TropicalFishMeta::new),
+            entry(EntityType.TURTLE, TurtleMeta::new),
+            entry(EntityType.VEX, VexMeta::new),
+            entry(EntityType.VILLAGER, VillagerMeta::new),
+            entry(EntityType.VINDICATOR, VindicatorMeta::new),
+            entry(EntityType.WANDERING_TRADER, WanderingTraderMeta::new),
+            entry(EntityType.WARDEN, WardenMeta::new),
+            entry(EntityType.WIND_CHARGE, WindChargeMeta::new),
+            entry(EntityType.WITCH, WitchMeta::new),
+            entry(EntityType.WITHER, WitherMeta::new),
+            entry(EntityType.WITHER_SKELETON, WitherSkeletonMeta::new),
+            entry(EntityType.WITHER_SKULL, WitherSkullMeta::new),
+            entry(EntityType.WOLF, WolfMeta::new),
+            entry(EntityType.ZOGLIN, ZoglinMeta::new),
+            entry(EntityType.ZOMBIE, ZombieMeta::new),
+            entry(EntityType.ZOMBIE_HORSE, ZombieHorseMeta::new),
+            entry(EntityType.ZOMBIE_NAUTILUS, ZombieNautilusMeta::new),
+            entry(EntityType.ZOMBIE_VILLAGER, ZombieVillagerMeta::new),
+            entry(EntityType.ZOMBIFIED_PIGLIN, ZombifiedPiglinMeta::new),
+            entry(EntityType.PLAYER, PlayerMeta::new),
+            entry(EntityType.FISHING_BOBBER, FishingHookMeta::new)
     );
 
     @ApiStatus.Internal
     public static EntityMeta createMeta(EntityType entityType, @Nullable Entity entity, MetadataHolder metadata) {
-        return ENTITY_META_SUPPLIER.get(entityType.name()).apply(entity, metadata);
+        return ENTITY_META_SUPPLIER.get(entityType).apply(entity, metadata);
     }
 }

--- a/src/main/java/net/minestom/server/entity/MetadataHolder.java
+++ b/src/main/java/net/minestom/server/entity/MetadataHolder.java
@@ -40,7 +40,6 @@ import org.jetbrains.annotations.UnknownNullability;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiFunction;
@@ -183,12 +182,17 @@ public final class MetadataHolder {
 
     public Map<Integer, Metadata.Entry<?>> getEntries() {
         final var entries = this.entries;
-        Map<Integer, Metadata.Entry<?>> map = HashMap.newHashMap(entries.length);
+        int[] ids = new int[entries.length];
+        Metadata.Entry<?>[] values = new Metadata.Entry<?>[entries.length];
+        int count = 0;
         for (int id = 0; id < entries.length; id++) {
             final var entry = entries[id];
-            if (entry != null) map.put(id, entry);
+            if (entry == null) continue; // skip gaps between metadata ids
+            ids[count] = id;
+            values[count] = entry;
+            count++;
         }
-        return Map.copyOf(map);
+        return Map.copyOf(new Int2ObjectArrayMap<>(ids, values, count));
     }
 
     @SuppressWarnings("JavacQuirks")

--- a/src/main/java/net/minestom/server/entity/MetadataHolder.java
+++ b/src/main/java/net/minestom/server/entity/MetadataHolder.java
@@ -183,7 +183,7 @@ public final class MetadataHolder {
 
     public Map<Integer, Metadata.Entry<?>> getEntries() {
         final var entries = this.entries;
-        Map<Integer, Metadata.Entry<?>> map = new HashMap<>();
+        Map<Integer, Metadata.Entry<?>> map = HashMap.newHashMap(entries.length);
         for (int id = 0; id < entries.length; id++) {
             final var entry = entries[id];
             if (entry != null) map.put(id, entry);

--- a/src/main/java/net/minestom/server/entity/metadata/AbstractVehicleMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/AbstractVehicleMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class AbstractVehicleMeta extends EntityMeta {
-    public AbstractVehicleMeta(Entity entity, MetadataHolder metadata) {
+    public AbstractVehicleMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/AgeableMobMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/AgeableMobMeta.java
@@ -4,9 +4,10 @@ import net.minestom.server.collision.BoundingBox;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class AgeableMobMeta extends PathfinderMobMeta {
-    protected AgeableMobMeta(Entity entity, MetadataHolder metadata) {
+    protected AgeableMobMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/LivingEntityMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/LivingEntityMeta.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class LivingEntityMeta extends EntityMeta {
-    protected LivingEntityMeta(Entity entity, MetadataHolder metadata) {
+    protected LivingEntityMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/MobMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/MobMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class MobMeta extends LivingEntityMeta {
-    protected MobMeta(Entity entity, MetadataHolder metadata) {
+    protected MobMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/PathfinderMobMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/PathfinderMobMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class PathfinderMobMeta extends MobMeta {
-    protected PathfinderMobMeta(Entity entity, MetadataHolder metadata) {
+    protected PathfinderMobMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/ambient/AmbientCreatureMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/ambient/AmbientCreatureMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.ambient;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.MobMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class AmbientCreatureMeta extends MobMeta {
-    protected AmbientCreatureMeta(Entity entity, MetadataHolder metadata) {
+    protected AmbientCreatureMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/ambient/BatMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/ambient/BatMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.ambient;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class BatMeta extends AmbientCreatureMeta {
-    public BatMeta(Entity entity, MetadataHolder metadata) {
+    public BatMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/AbstractHorseMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/AbstractHorseMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.animal;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class AbstractHorseMeta extends AnimalMeta {
-    protected AbstractHorseMeta(Entity entity, MetadataHolder metadata) {
+    protected AbstractHorseMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/AbstractNautilusMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/AbstractNautilusMeta.java
@@ -4,9 +4,10 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.animal.tameable.TameableAnimalMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class AbstractNautilusMeta extends TameableAnimalMeta {
-    public AbstractNautilusMeta(Entity entity, MetadataHolder metadata) {
+    public AbstractNautilusMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/AnimalMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/AnimalMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.animal;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.AgeableMobMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class AnimalMeta extends AgeableMobMeta {
-    protected AnimalMeta(Entity entity, MetadataHolder metadata) {
+    protected AnimalMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/ArmadilloMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/ArmadilloMeta.java
@@ -4,9 +4,10 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.network.NetworkBuffer;
+import org.jetbrains.annotations.Nullable;
 
 public class ArmadilloMeta extends AnimalMeta {
-    public ArmadilloMeta(Entity entity, MetadataHolder metadata) {
+    public ArmadilloMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/BeeMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/BeeMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.animal;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class BeeMeta extends AnimalMeta {
-    public BeeMeta(Entity entity, MetadataHolder metadata) {
+    public BeeMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/CamelHuskMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/CamelHuskMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.animal;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class CamelHuskMeta extends CamelMeta {
-    public CamelHuskMeta(Entity entity, MetadataHolder metadata) {
+    public CamelHuskMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/CamelMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/CamelMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.animal;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class CamelMeta extends AbstractHorseMeta {
-    public CamelMeta(Entity entity, MetadataHolder metadata) {
+    public CamelMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/ChestedHorseMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/ChestedHorseMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.animal;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class ChestedHorseMeta extends AbstractHorseMeta {
-    protected ChestedHorseMeta(Entity entity, MetadataHolder metadata) {
+    protected ChestedHorseMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/ChickenMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/ChickenMeta.java
@@ -9,7 +9,7 @@ import net.minestom.server.registry.RegistryKey;
 import org.jetbrains.annotations.Nullable;
 
 public class ChickenMeta extends AnimalMeta {
-    public ChickenMeta(Entity entity, MetadataHolder metadata) {
+    public ChickenMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/CowMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/CowMeta.java
@@ -9,7 +9,7 @@ import net.minestom.server.registry.RegistryKey;
 import org.jetbrains.annotations.Nullable;
 
 public class CowMeta extends AnimalMeta {
-    public CowMeta(Entity entity, MetadataHolder metadata) {
+    public CowMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/DonkeyMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/DonkeyMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.animal;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class DonkeyMeta extends ChestedHorseMeta {
-    public DonkeyMeta(Entity entity, MetadataHolder metadata) {
+    public DonkeyMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/FoxMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/FoxMeta.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.UUID;
 
 public class FoxMeta extends AnimalMeta {
-    public FoxMeta(Entity entity, MetadataHolder metadata) {
+    public FoxMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/FrogMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/FrogMeta.java
@@ -9,7 +9,7 @@ import net.minestom.server.registry.RegistryKey;
 import org.jetbrains.annotations.Nullable;
 
 public class FrogMeta extends AnimalMeta {
-    public FrogMeta(Entity entity, MetadataHolder metadata) {
+    public FrogMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/GoatMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/GoatMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.animal;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class GoatMeta extends AnimalMeta {
-    public GoatMeta(Entity entity, MetadataHolder metadata) {
+    public GoatMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/HappyGhastMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/HappyGhastMeta.java
@@ -3,10 +3,11 @@ package net.minestom.server.entity.metadata.animal;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class HappyGhastMeta extends AnimalMeta {
 
-    public HappyGhastMeta(Entity entity, MetadataHolder metadata) {
+    public HappyGhastMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/HoglinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/HoglinMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.animal;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class HoglinMeta extends AnimalMeta {
-    public HoglinMeta(Entity entity, MetadataHolder metadata) {
+    public HoglinMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/HorseMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/HorseMeta.java
@@ -10,7 +10,7 @@ import net.minestom.server.network.NetworkBuffer;
 import org.jetbrains.annotations.Nullable;
 
 public class HorseMeta extends AbstractHorseMeta {
-    public HorseMeta(Entity entity, MetadataHolder metadata) {
+    public HorseMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/LlamaMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/LlamaMeta.java
@@ -10,7 +10,7 @@ import net.minestom.server.network.NetworkBuffer;
 import org.jetbrains.annotations.Nullable;
 
 public class LlamaMeta extends ChestedHorseMeta {
-    public LlamaMeta(Entity entity, MetadataHolder metadata) {
+    public LlamaMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/MooshroomMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/MooshroomMeta.java
@@ -10,7 +10,7 @@ import net.minestom.server.network.NetworkBuffer;
 import org.jetbrains.annotations.Nullable;
 
 public class MooshroomMeta extends AnimalMeta {
-    public MooshroomMeta(Entity entity, MetadataHolder metadata) {
+    public MooshroomMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/MuleMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/MuleMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.animal;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class MuleMeta extends ChestedHorseMeta {
-    public MuleMeta(Entity entity, MetadataHolder metadata) {
+    public MuleMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/NautilusMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/NautilusMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.animal;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class NautilusMeta extends AbstractNautilusMeta {
-    public NautilusMeta(Entity entity, MetadataHolder metadata) {
+    public NautilusMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/OcelotMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/OcelotMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.animal;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class OcelotMeta extends AnimalMeta {
-    public OcelotMeta(Entity entity, MetadataHolder metadata) {
+    public OcelotMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/PandaMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/PandaMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.animal;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class PandaMeta extends AnimalMeta {
-    public PandaMeta(Entity entity, MetadataHolder metadata) {
+    public PandaMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/PigMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/PigMeta.java
@@ -9,7 +9,7 @@ import net.minestom.server.registry.RegistryKey;
 import org.jetbrains.annotations.Nullable;
 
 public class PigMeta extends AnimalMeta {
-    public PigMeta(Entity entity, MetadataHolder metadata) {
+    public PigMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/PolarBearMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/PolarBearMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.animal;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class PolarBearMeta extends AnimalMeta {
-    public PolarBearMeta(Entity entity, MetadataHolder metadata) {
+    public PolarBearMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/RabbitMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/RabbitMeta.java
@@ -10,7 +10,7 @@ import net.minestom.server.network.NetworkBuffer;
 import org.jetbrains.annotations.Nullable;
 
 public class RabbitMeta extends AnimalMeta {
-    public RabbitMeta(Entity entity, MetadataHolder metadata) {
+    public RabbitMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/SheepMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/SheepMeta.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.Nullable;
 public class SheepMeta extends AnimalMeta {
     private static final DyeColor[] DYE_VALUES = DyeColor.values();
 
-    public SheepMeta(Entity entity, MetadataHolder metadata) {
+    public SheepMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/SkeletonHorseMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/SkeletonHorseMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.animal;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class SkeletonHorseMeta extends AbstractHorseMeta {
-    public SkeletonHorseMeta(Entity entity, MetadataHolder metadata) {
+    public SkeletonHorseMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/SnifferMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/SnifferMeta.java
@@ -4,9 +4,10 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.network.NetworkBuffer;
+import org.jetbrains.annotations.Nullable;
 
 public class SnifferMeta extends AnimalMeta {
-    public SnifferMeta(Entity entity, MetadataHolder metadata) {
+    public SnifferMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/StriderMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/StriderMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.animal;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class StriderMeta extends AnimalMeta {
-    public StriderMeta(Entity entity, MetadataHolder metadata) {
+    public StriderMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/TurtleMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/TurtleMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.animal;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class TurtleMeta extends AnimalMeta {
-    public TurtleMeta(Entity entity, MetadataHolder metadata) {
+    public TurtleMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/ZombieHorseMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/ZombieHorseMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.animal;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class ZombieHorseMeta extends AbstractHorseMeta {
-    public ZombieHorseMeta(Entity entity, MetadataHolder metadata) {
+    public ZombieHorseMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/ZombieNautilusMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/ZombieNautilusMeta.java
@@ -9,7 +9,7 @@ import net.minestom.server.registry.RegistryKey;
 import org.jetbrains.annotations.Nullable;
 
 public class ZombieNautilusMeta extends AbstractNautilusMeta {
-    public ZombieNautilusMeta(Entity entity, MetadataHolder metadata) {
+    public ZombieNautilusMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/tameable/CatMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/tameable/CatMeta.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
 public class CatMeta extends TameableAnimalMeta {
     private static final DyeColor[] DYE_VALUES = DyeColor.values();
 
-    public CatMeta(Entity entity, MetadataHolder metadata) {
+    public CatMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/tameable/ParrotMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/tameable/ParrotMeta.java
@@ -10,7 +10,7 @@ import net.minestom.server.network.NetworkBuffer;
 import org.jetbrains.annotations.Nullable;
 
 public class ParrotMeta extends TameableAnimalMeta {
-    public ParrotMeta(Entity entity, MetadataHolder metadata) {
+    public ParrotMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/tameable/TameableAnimalMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/tameable/TameableAnimalMeta.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.UUID;
 
 public class TameableAnimalMeta extends AnimalMeta {
-    protected TameableAnimalMeta(Entity entity, MetadataHolder metadata) {
+    protected TameableAnimalMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/tameable/WolfMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/tameable/WolfMeta.java
@@ -10,7 +10,7 @@ import net.minestom.server.registry.RegistryKey;
 import org.jetbrains.annotations.Nullable;
 
 public class WolfMeta extends TameableAnimalMeta {
-    public WolfMeta(Entity entity, MetadataHolder metadata) {
+    public WolfMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/avatar/AvatarMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/avatar/AvatarMeta.java
@@ -5,10 +5,11 @@ import net.minestom.server.entity.MainHand;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.LivingEntityMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class AvatarMeta extends LivingEntityMeta {
 
-    protected AvatarMeta(Entity entity, MetadataHolder metadata) {
+    protected AvatarMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
     

--- a/src/main/java/net/minestom/server/entity/metadata/avatar/MannequinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/avatar/MannequinMeta.java
@@ -8,7 +8,7 @@ import net.minestom.server.network.player.ResolvableProfile;
 import org.jetbrains.annotations.Nullable;
 
 public class MannequinMeta extends AvatarMeta {
-    public MannequinMeta(Entity entity, MetadataHolder metadata) {
+    public MannequinMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/avatar/PlayerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/avatar/PlayerMeta.java
@@ -6,7 +6,7 @@ import net.minestom.server.entity.MetadataHolder;
 import org.jetbrains.annotations.Nullable;
 
 public class PlayerMeta extends AvatarMeta {
-    public PlayerMeta(Entity entity, MetadataHolder metadata) {
+    public PlayerMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/display/AbstractDisplayMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/display/AbstractDisplayMeta.java
@@ -6,9 +6,10 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class AbstractDisplayMeta extends EntityMeta {
-    protected AbstractDisplayMeta(Entity entity, MetadataHolder metadata) {
+    protected AbstractDisplayMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/display/BlockDisplayMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/display/BlockDisplayMeta.java
@@ -4,9 +4,10 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.instance.block.Block;
+import org.jetbrains.annotations.Nullable;
 
 public class BlockDisplayMeta extends AbstractDisplayMeta {
-    public BlockDisplayMeta(Entity entity, MetadataHolder metadata) {
+    public BlockDisplayMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/display/ItemDisplayMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/display/ItemDisplayMeta.java
@@ -4,9 +4,10 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
 
 public class ItemDisplayMeta extends AbstractDisplayMeta {
-    public ItemDisplayMeta(Entity entity, MetadataHolder metadata) {
+    public ItemDisplayMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/display/TextDisplayMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/display/TextDisplayMeta.java
@@ -4,9 +4,10 @@ import net.kyori.adventure.text.Component;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class TextDisplayMeta extends AbstractDisplayMeta {
-    public TextDisplayMeta(Entity entity, MetadataHolder metadata) {
+    public TextDisplayMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/flying/FlyingMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/flying/FlyingMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.flying;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.MobMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class FlyingMeta extends MobMeta {
-    protected FlyingMeta(Entity entity, MetadataHolder metadata) {
+    protected FlyingMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/flying/GhastMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/flying/GhastMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.flying;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class GhastMeta extends FlyingMeta {
-    public GhastMeta(Entity entity, MetadataHolder metadata) {
+    public GhastMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/flying/PhantomMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/flying/PhantomMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.flying;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class PhantomMeta extends FlyingMeta {
-    public PhantomMeta(Entity entity, MetadataHolder metadata) {
+    public PhantomMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/golem/AbstractGolemMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/golem/AbstractGolemMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.golem;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.PathfinderMobMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class AbstractGolemMeta extends PathfinderMobMeta {
-    protected AbstractGolemMeta(Entity entity, MetadataHolder metadata) {
+    protected AbstractGolemMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/golem/CopperGolemMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/golem/CopperGolemMeta.java
@@ -5,10 +5,11 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.network.NetworkBuffer;
+import org.jetbrains.annotations.Nullable;
 
 public class CopperGolemMeta extends AbstractGolemMeta {
 
-    public CopperGolemMeta(Entity entity, MetadataHolder metadata) {
+    public CopperGolemMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/golem/IronGolemMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/golem/IronGolemMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.golem;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class IronGolemMeta extends AbstractGolemMeta {
-    public IronGolemMeta(Entity entity, MetadataHolder metadata) {
+    public IronGolemMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/golem/ShulkerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/golem/ShulkerMeta.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
 public class ShulkerMeta extends AbstractGolemMeta {
     private static final DyeColor[] DYE_VALUES = DyeColor.values();
 
-    public ShulkerMeta(Entity entity, MetadataHolder metadata) {
+    public ShulkerMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/golem/SnowGolemMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/golem/SnowGolemMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.golem;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class SnowGolemMeta extends AbstractGolemMeta {
-    public SnowGolemMeta(Entity entity, MetadataHolder metadata) {
+    public SnowGolemMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/item/EyeOfEnderMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/EyeOfEnderMeta.java
@@ -5,9 +5,10 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
 
 public class EyeOfEnderMeta extends EntityMeta {
-    public EyeOfEnderMeta(Entity entity, MetadataHolder metadata) {
+    public EyeOfEnderMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/item/FireballMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/FireballMeta.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
 public class FireballMeta extends EntityMeta implements ObjectDataProvider, ProjectileMeta {
     private Entity shooter;
 
-    public FireballMeta(Entity entity, MetadataHolder metadata) {
+    public FireballMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/item/ItemEntityMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/ItemEntityMeta.java
@@ -6,9 +6,10 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.entity.metadata.ObjectDataProvider;
 import net.minestom.server.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
 
 public class ItemEntityMeta extends EntityMeta implements ObjectDataProvider {
-    public ItemEntityMeta(Entity entity, MetadataHolder metadata) {
+    public ItemEntityMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/item/LingeringPotionMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/LingeringPotionMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.item;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class LingeringPotionMeta extends ThrownItemProjectileMeta {
-    public LingeringPotionMeta(Entity entity, MetadataHolder metadata) {
+    public LingeringPotionMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/item/SmallFireballMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/SmallFireballMeta.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
 public class SmallFireballMeta extends EntityMeta implements ObjectDataProvider, ProjectileMeta {
     private @Nullable Entity shooter;
 
-    public SmallFireballMeta(Entity entity, MetadataHolder metadata) {
+    public SmallFireballMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/item/SnowballMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/SnowballMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.item;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class SnowballMeta extends ThrownItemProjectileMeta {
-    public SnowballMeta(Entity entity, MetadataHolder metadata) {
+    public SnowballMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/item/SplashPotionMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/SplashPotionMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.item;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class SplashPotionMeta extends ThrownItemProjectileMeta {
-    public SplashPotionMeta(Entity entity, MetadataHolder metadata) {
+    public SplashPotionMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/item/ThrownEggMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/ThrownEggMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.item;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class ThrownEggMeta extends ThrownItemProjectileMeta {
-    public ThrownEggMeta(Entity entity, MetadataHolder metadata) {
+    public ThrownEggMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/item/ThrownEnderPearlMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/ThrownEnderPearlMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.item;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class ThrownEnderPearlMeta extends ThrownItemProjectileMeta {
-    public ThrownEnderPearlMeta(Entity entity, MetadataHolder metadata) {
+    public ThrownEnderPearlMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/item/ThrownExperienceBottleMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/ThrownExperienceBottleMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.item;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class ThrownExperienceBottleMeta extends ThrownItemProjectileMeta {
-    public ThrownExperienceBottleMeta(Entity entity, MetadataHolder metadata) {
+    public ThrownExperienceBottleMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/item/ThrownItemProjectileMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/item/ThrownItemProjectileMeta.java
@@ -5,9 +5,10 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
 
 class ThrownItemProjectileMeta extends EntityMeta {
-    protected ThrownItemProjectileMeta(Entity entity, MetadataHolder metadata) {
+    protected ThrownItemProjectileMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/AbstractMinecartContainerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/AbstractMinecartContainerMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.minecart;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class AbstractMinecartContainerMeta extends AbstractMinecartMeta {
-    protected AbstractMinecartContainerMeta(Entity entity, MetadataHolder metadata) {
+    protected AbstractMinecartContainerMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/AbstractMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/AbstractMinecartMeta.java
@@ -8,7 +8,7 @@ import net.minestom.server.instance.block.Block;
 import org.jetbrains.annotations.Nullable;
 
 public abstract class AbstractMinecartMeta extends AbstractVehicleMeta {
-    protected AbstractMinecartMeta(Entity entity, MetadataHolder metadata) {
+    protected AbstractMinecartMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/ChestMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/ChestMinecartMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.minecart;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class ChestMinecartMeta extends AbstractMinecartContainerMeta {
-    public ChestMinecartMeta(Entity entity, MetadataHolder metadata) {
+    public ChestMinecartMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/CommandBlockMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/CommandBlockMinecartMeta.java
@@ -4,9 +4,10 @@ import net.kyori.adventure.text.Component;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class CommandBlockMinecartMeta extends AbstractMinecartMeta {
-    public CommandBlockMinecartMeta(Entity entity, MetadataHolder metadata) {
+    public CommandBlockMinecartMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/FurnaceMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/FurnaceMinecartMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.minecart;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class FurnaceMinecartMeta extends AbstractMinecartMeta {
-    public FurnaceMinecartMeta(Entity entity, MetadataHolder metadata) {
+    public FurnaceMinecartMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/HopperMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/HopperMinecartMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.minecart;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class HopperMinecartMeta extends AbstractMinecartContainerMeta {
-    public HopperMinecartMeta(Entity entity, MetadataHolder metadata) {
+    public HopperMinecartMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/MinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/MinecartMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.minecart;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class MinecartMeta extends AbstractMinecartMeta {
-    public MinecartMeta(Entity entity, MetadataHolder metadata) {
+    public MinecartMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/SpawnerMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/SpawnerMinecartMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.minecart;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class SpawnerMinecartMeta extends AbstractMinecartMeta {
-    public SpawnerMinecartMeta(Entity entity, MetadataHolder metadata) {
+    public SpawnerMinecartMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/minecart/TntMinecartMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/minecart/TntMinecartMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.minecart;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class TntMinecartMeta extends AbstractMinecartMeta {
-    public TntMinecartMeta(Entity entity, MetadataHolder metadata) {
+    public TntMinecartMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/BasePiglinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/BasePiglinMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.monster;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class BasePiglinMeta extends MonsterMeta {
-    protected BasePiglinMeta(Entity entity, MetadataHolder metadata) {
+    protected BasePiglinMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/BlazeMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/BlazeMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.monster;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class BlazeMeta extends MonsterMeta {
-    public BlazeMeta(Entity entity, MetadataHolder metadata) {
+    public BlazeMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/BreezeMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/BreezeMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.monster;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class BreezeMeta extends MonsterMeta {
-    public BreezeMeta(Entity entity, MetadataHolder metadata) {
+    public BreezeMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/CaveSpiderMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/CaveSpiderMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.monster;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class CaveSpiderMeta extends SpiderMeta {
-    public CaveSpiderMeta(Entity entity, MetadataHolder metadata) {
+    public CaveSpiderMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/CreakingMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/CreakingMeta.java
@@ -7,7 +7,7 @@ import net.minestom.server.entity.MetadataHolder;
 import org.jetbrains.annotations.Nullable;
 
 public class CreakingMeta extends MonsterMeta {
-    public CreakingMeta(Entity entity, MetadataHolder metadata) {
+    public CreakingMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/CreeperMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/CreeperMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.monster;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class CreeperMeta extends MonsterMeta {
-    public CreeperMeta(Entity entity, MetadataHolder metadata) {
+    public CreeperMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/ElderGuardianMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/ElderGuardianMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.monster;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class ElderGuardianMeta extends GuardianMeta {
-    public ElderGuardianMeta(Entity entity, MetadataHolder metadata) {
+    public ElderGuardianMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/EndermanMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/EndermanMeta.java
@@ -7,7 +7,7 @@ import net.minestom.server.instance.block.Block;
 import org.jetbrains.annotations.Nullable;
 
 public class EndermanMeta extends MonsterMeta {
-    public EndermanMeta(Entity entity, MetadataHolder metadata) {
+    public EndermanMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/EndermiteMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/EndermiteMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.monster;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class EndermiteMeta extends MonsterMeta {
-    public EndermiteMeta(Entity entity, MetadataHolder metadata) {
+    public EndermiteMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/GiantMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/GiantMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.monster;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class GiantMeta extends MonsterMeta {
-    public GiantMeta(Entity entity, MetadataHolder metadata) {
+    public GiantMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/GuardianMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/GuardianMeta.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.Nullable;
 public class GuardianMeta extends MonsterMeta {
     private @Nullable Entity target;
 
-    public GuardianMeta(Entity entity, MetadataHolder metadata) {
+    public GuardianMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/MonsterMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/MonsterMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.monster;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.PathfinderMobMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class MonsterMeta extends PathfinderMobMeta {
-    protected MonsterMeta(Entity entity, MetadataHolder metadata) {
+    protected MonsterMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/PiglinBruteMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/PiglinBruteMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.monster;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class PiglinBruteMeta extends BasePiglinMeta {
-    public PiglinBruteMeta(Entity entity, MetadataHolder metadata) {
+    public PiglinBruteMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/PiglinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/PiglinMeta.java
@@ -4,9 +4,10 @@ import net.minestom.server.collision.BoundingBox;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class PiglinMeta extends BasePiglinMeta {
-    public PiglinMeta(Entity entity, MetadataHolder metadata) {
+    public PiglinMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/SilverfishMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/SilverfishMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.monster;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class SilverfishMeta extends MonsterMeta {
-    public SilverfishMeta(Entity entity, MetadataHolder metadata) {
+    public SilverfishMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/SpiderMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/SpiderMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.monster;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class SpiderMeta extends MonsterMeta {
-    public SpiderMeta(Entity entity, MetadataHolder metadata) {
+    public SpiderMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/VexMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/VexMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.monster;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class VexMeta extends MonsterMeta {
-    public VexMeta(Entity entity, MetadataHolder metadata) {
+    public VexMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/WardenMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/WardenMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.monster;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class WardenMeta extends MonsterMeta {
-    public WardenMeta(Entity entity, MetadataHolder metadata) {
+    public WardenMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/WitherMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/WitherMeta.java
@@ -11,7 +11,7 @@ public class WitherMeta extends MonsterMeta {
     private @Nullable Entity leftHead;
     private @Nullable Entity rightHead;
 
-    public WitherMeta(Entity entity, MetadataHolder metadata) {
+    public WitherMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/ZoglinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/ZoglinMeta.java
@@ -4,9 +4,10 @@ import net.minestom.server.collision.BoundingBox;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class ZoglinMeta extends MonsterMeta {
-    public ZoglinMeta(Entity entity, MetadataHolder metadata) {
+    public ZoglinMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/AbstractIllagerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/AbstractIllagerMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.monster.raider;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class AbstractIllagerMeta extends RaiderMeta {
-    protected AbstractIllagerMeta(Entity entity, MetadataHolder metadata) {
+    protected AbstractIllagerMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/EvokerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/EvokerMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.monster.raider;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class EvokerMeta extends SpellcasterIllagerMeta {
-    public EvokerMeta(Entity entity, MetadataHolder metadata) {
+    public EvokerMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/IllusionerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/IllusionerMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.monster.raider;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class IllusionerMeta extends SpellcasterIllagerMeta {
-    public IllusionerMeta(Entity entity, MetadataHolder metadata) {
+    public IllusionerMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/PillagerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/PillagerMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.monster.raider;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class PillagerMeta extends AbstractIllagerMeta {
-    public PillagerMeta(Entity entity, MetadataHolder metadata) {
+    public PillagerMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/RaiderMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/RaiderMeta.java
@@ -4,9 +4,10 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.monster.MonsterMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class RaiderMeta extends MonsterMeta {
-    protected RaiderMeta(Entity entity, MetadataHolder metadata) {
+    protected RaiderMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/RavagerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/RavagerMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.monster.raider;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class RavagerMeta extends RaiderMeta {
-    public RavagerMeta(Entity entity, MetadataHolder metadata) {
+    public RavagerMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/SpellcasterIllagerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/SpellcasterIllagerMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.monster.raider;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class SpellcasterIllagerMeta extends AbstractIllagerMeta {
-    protected SpellcasterIllagerMeta(Entity entity, MetadataHolder metadata) {
+    protected SpellcasterIllagerMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/VindicatorMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/VindicatorMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.monster.raider;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class VindicatorMeta extends AbstractIllagerMeta {
-    public VindicatorMeta(Entity entity, MetadataHolder metadata) {
+    public VindicatorMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/WitchMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/WitchMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.monster.raider;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class WitchMeta extends RaiderMeta {
-    public WitchMeta(Entity entity, MetadataHolder metadata) {
+    public WitchMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/AbstractSkeletonMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/AbstractSkeletonMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.monster.skeleton;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.monster.MonsterMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class AbstractSkeletonMeta extends MonsterMeta {
-    protected AbstractSkeletonMeta(Entity entity, MetadataHolder metadata) {
+    protected AbstractSkeletonMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/BoggedMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/BoggedMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.monster.skeleton;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class BoggedMeta extends AbstractSkeletonMeta {
-    public BoggedMeta(Entity entity, MetadataHolder metadata) {
+    public BoggedMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/ParchedMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/ParchedMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.monster.skeleton;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class ParchedMeta extends AbstractSkeletonMeta {
-    public ParchedMeta(Entity entity, MetadataHolder metadata) {
+    public ParchedMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/SkeletonMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/SkeletonMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.monster.skeleton;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class SkeletonMeta extends AbstractSkeletonMeta {
-    public SkeletonMeta(Entity entity, MetadataHolder metadata) {
+    public SkeletonMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/StrayMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/StrayMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.monster.skeleton;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class StrayMeta extends AbstractSkeletonMeta {
-    public StrayMeta(Entity entity, MetadataHolder metadata) {
+    public StrayMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/WitherSkeletonMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/skeleton/WitherSkeletonMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.monster.skeleton;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class WitherSkeletonMeta extends AbstractSkeletonMeta {
-    public WitherSkeletonMeta(Entity entity, MetadataHolder metadata) {
+    public WitherSkeletonMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/zombie/DrownedMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/zombie/DrownedMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.monster.zombie;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class DrownedMeta extends ZombieMeta {
-    public DrownedMeta(Entity entity, MetadataHolder metadata) {
+    public DrownedMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/zombie/HuskMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/zombie/HuskMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.monster.zombie;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class HuskMeta extends ZombieMeta {
-    public HuskMeta(Entity entity, MetadataHolder metadata) {
+    public HuskMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/zombie/ZombieMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/zombie/ZombieMeta.java
@@ -5,9 +5,10 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.monster.MonsterMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class ZombieMeta extends MonsterMeta {
-    public ZombieMeta(Entity entity, MetadataHolder metadata) {
+    public ZombieMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/zombie/ZombieVillagerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/zombie/ZombieVillagerMeta.java
@@ -10,7 +10,7 @@ import net.minestom.server.entity.metadata.villager.VillagerMeta;
 import org.jetbrains.annotations.Nullable;
 
 public class ZombieVillagerMeta extends ZombieMeta {
-    public ZombieVillagerMeta(Entity entity, MetadataHolder metadata) {
+    public ZombieVillagerMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/monster/zombie/ZombifiedPiglinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/zombie/ZombifiedPiglinMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.monster.zombie;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class ZombifiedPiglinMeta extends ZombieMeta {
-    public ZombifiedPiglinMeta(Entity entity, MetadataHolder metadata) {
+    public ZombifiedPiglinMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/AllayMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/AllayMeta.java
@@ -4,9 +4,10 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.PathfinderMobMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class AllayMeta extends PathfinderMobMeta {
-    public AllayMeta(Entity entity, MetadataHolder metadata) {
+    public AllayMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/AreaEffectCloudMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/AreaEffectCloudMeta.java
@@ -5,9 +5,10 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.particle.Particle;
+import org.jetbrains.annotations.Nullable;
 
 public class AreaEffectCloudMeta extends EntityMeta {
-    public AreaEffectCloudMeta(Entity entity, MetadataHolder metadata) {
+    public AreaEffectCloudMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/ArmorStandMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/ArmorStandMeta.java
@@ -5,9 +5,10 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.LivingEntityMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class ArmorStandMeta extends LivingEntityMeta {
-    public ArmorStandMeta(Entity entity, MetadataHolder metadata) {
+    public ArmorStandMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/BoatMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/BoatMeta.java
@@ -4,9 +4,10 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.AbstractVehicleMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class BoatMeta extends AbstractVehicleMeta {
-    public BoatMeta(Entity entity, MetadataHolder metadata) {
+    public BoatMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/EndCrystalMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/EndCrystalMeta.java
@@ -8,7 +8,7 @@ import net.minestom.server.entity.metadata.EntityMeta;
 import org.jetbrains.annotations.Nullable;
 
 public class EndCrystalMeta extends EntityMeta {
-    public EndCrystalMeta(Entity entity, MetadataHolder metadata) {
+    public EndCrystalMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/EnderDragonMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/EnderDragonMeta.java
@@ -4,9 +4,10 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.MobMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class EnderDragonMeta extends MobMeta {
-    public EnderDragonMeta(Entity entity, MetadataHolder metadata) {
+    public EnderDragonMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/EvokerFangsMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/EvokerFangsMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.other;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class EvokerFangsMeta extends EntityMeta {
-    public EvokerFangsMeta(Entity entity, MetadataHolder metadata) {
+    public EvokerFangsMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/ExperienceOrbMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/ExperienceOrbMeta.java
@@ -4,10 +4,11 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class ExperienceOrbMeta extends EntityMeta {
 
-    public ExperienceOrbMeta(Entity entity, MetadataHolder metadata) {
+    public ExperienceOrbMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/FallingBlockMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/FallingBlockMeta.java
@@ -7,11 +7,12 @@ import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.entity.metadata.ObjectDataProvider;
 import net.minestom.server.instance.block.Block;
+import org.jetbrains.annotations.Nullable;
 
 public class FallingBlockMeta extends EntityMeta implements ObjectDataProvider {
     private Block block = Block.STONE;
 
-    public FallingBlockMeta(Entity entity, MetadataHolder metadata) {
+    public FallingBlockMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/FishingHookMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/FishingHookMeta.java
@@ -12,7 +12,7 @@ public class FishingHookMeta extends EntityMeta implements ObjectDataProvider {
     private Entity hooked;
     private Entity owner;
 
-    public FishingHookMeta(Entity entity, MetadataHolder metadata) {
+    public FishingHookMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/GlowItemFrameMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/GlowItemFrameMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.other;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class GlowItemFrameMeta extends ItemFrameMeta {
-    public GlowItemFrameMeta(Entity entity, MetadataHolder metadata) {
+    public GlowItemFrameMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/other/ItemFrameMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/ItemFrameMeta.java
@@ -5,9 +5,10 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.utils.Rotation;
+import org.jetbrains.annotations.Nullable;
 
 public class ItemFrameMeta extends HangingMeta {
-    public ItemFrameMeta(Entity entity, MetadataHolder metadata) {
+    public ItemFrameMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/LeashKnotMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/LeashKnotMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.other;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class LeashKnotMeta extends EntityMeta {
-    public LeashKnotMeta(Entity entity, MetadataHolder metadata) {
+    public LeashKnotMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/LightningBoltMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/LightningBoltMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.other;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class LightningBoltMeta extends EntityMeta {
-    public LightningBoltMeta(Entity entity, MetadataHolder metadata) {
+    public LightningBoltMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/LlamaSpitMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/LlamaSpitMeta.java
@@ -4,9 +4,10 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.entity.metadata.ObjectDataProvider;
+import org.jetbrains.annotations.Nullable;
 
 public class LlamaSpitMeta extends EntityMeta implements ObjectDataProvider {
-    public LlamaSpitMeta(Entity entity, MetadataHolder metadata) {
+    public LlamaSpitMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/MagmaCubeMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/MagmaCubeMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.other;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class MagmaCubeMeta extends SlimeMeta {
-    public MagmaCubeMeta(Entity entity, MetadataHolder metadata) {
+    public MagmaCubeMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/MarkerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/MarkerMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.other;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class MarkerMeta extends EntityMeta {
-    public MarkerMeta(Entity entity, MetadataHolder metadata) {
+    public MarkerMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/other/OminousItemSpawnerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/OminousItemSpawnerMeta.java
@@ -5,9 +5,10 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
 
 public class OminousItemSpawnerMeta extends EntityMeta {
-    public OminousItemSpawnerMeta(Entity entity, MetadataHolder metadata) {
+    public OminousItemSpawnerMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/PaintingMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/PaintingMeta.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class PaintingMeta extends HangingMeta {
 
-    public PaintingMeta(Entity entity, MetadataHolder metadata) {
+    public PaintingMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/PrimedTntMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/PrimedTntMeta.java
@@ -5,9 +5,10 @@ import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.instance.block.Block;
+import org.jetbrains.annotations.Nullable;
 
 public class PrimedTntMeta extends EntityMeta {
-    public PrimedTntMeta(Entity entity, MetadataHolder metadata) {
+    public PrimedTntMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/ShulkerBulletMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/ShulkerBulletMeta.java
@@ -4,9 +4,10 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
 import net.minestom.server.entity.metadata.ObjectDataProvider;
+import org.jetbrains.annotations.Nullable;
 
 public class ShulkerBulletMeta extends EntityMeta implements ObjectDataProvider {
-    public ShulkerBulletMeta(Entity entity, MetadataHolder metadata) {
+    public ShulkerBulletMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/SlimeMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/SlimeMeta.java
@@ -4,9 +4,10 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.MobMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class SlimeMeta extends MobMeta {
-    public SlimeMeta(Entity entity, MetadataHolder metadata) {
+    public SlimeMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/other/TraderLlamaMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/TraderLlamaMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.other;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.animal.LlamaMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class TraderLlamaMeta extends LlamaMeta {
-    public TraderLlamaMeta(Entity entity, MetadataHolder metadata) {
+    public TraderLlamaMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/AbstractArrowMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/AbstractArrowMeta.java
@@ -4,9 +4,10 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.EntityMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class AbstractArrowMeta extends EntityMeta {
-    protected AbstractArrowMeta(Entity entity, MetadataHolder metadata) {
+    protected AbstractArrowMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/ArrowMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/ArrowMeta.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.Nullable;
 public class ArrowMeta extends AbstractArrowMeta implements ObjectDataProvider, ProjectileMeta {
     private Entity shooter;
 
-    public ArrowMeta(Entity entity, MetadataHolder metadata) {
+    public ArrowMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/BreezeWindChargeMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/BreezeWindChargeMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.projectile;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class BreezeWindChargeMeta extends AbstractWindChargeMeta {
-    public BreezeWindChargeMeta(Entity entity, MetadataHolder metadata) {
+    public BreezeWindChargeMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/DragonFireballMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/DragonFireballMeta.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.Nullable;
 public class DragonFireballMeta extends EntityMeta implements ObjectDataProvider, ProjectileMeta {
     private @Nullable Entity shooter;
 
-    public DragonFireballMeta(Entity entity, MetadataHolder metadata) {
+    public DragonFireballMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/FireworkRocketMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/FireworkRocketMeta.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.Nullable;
 public class FireworkRocketMeta extends EntityMeta implements ProjectileMeta {
     private Entity shooter;
 
-    public FireworkRocketMeta(Entity entity, MetadataHolder metadata) {
+    public FireworkRocketMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/SpectralArrowMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/SpectralArrowMeta.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.Nullable;
 public class SpectralArrowMeta extends AbstractArrowMeta implements ObjectDataProvider, ProjectileMeta {
     private @Nullable Entity shooter;
 
-    public SpectralArrowMeta(Entity entity, MetadataHolder metadata) {
+    public SpectralArrowMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/ThrownTridentMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/ThrownTridentMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.projectile;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class ThrownTridentMeta extends AbstractArrowMeta {
-    public ThrownTridentMeta(Entity entity, MetadataHolder metadata) {
+    public ThrownTridentMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/WindChargeMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/WindChargeMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.projectile;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class WindChargeMeta extends AbstractWindChargeMeta {
-    public WindChargeMeta(Entity entity, MetadataHolder metadata) {
+    public WindChargeMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/projectile/WitherSkullMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/projectile/WitherSkullMeta.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
 public class WitherSkullMeta extends EntityMeta implements ObjectDataProvider, ProjectileMeta {
     private @Nullable Entity shooter;
 
-    public WitherSkullMeta(Entity entity, MetadataHolder metadata) {
+    public WitherSkullMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/villager/AbstractVillagerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/villager/AbstractVillagerMeta.java
@@ -4,9 +4,10 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.AgeableMobMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class AbstractVillagerMeta extends AgeableMobMeta {
-    protected AbstractVillagerMeta(Entity entity, MetadataHolder metadata) {
+    protected AbstractVillagerMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/villager/VillagerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/villager/VillagerMeta.java
@@ -8,7 +8,7 @@ import net.minestom.server.network.NetworkBufferTemplate;
 import org.jetbrains.annotations.Nullable;
 
 public class VillagerMeta extends AbstractVillagerMeta {
-    public VillagerMeta(Entity entity, MetadataHolder metadata) {
+    public VillagerMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/villager/WanderingTraderMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/villager/WanderingTraderMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.villager;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class WanderingTraderMeta extends VillagerMeta {
-    public WanderingTraderMeta(Entity entity, MetadataHolder metadata) {
+    public WanderingTraderMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/water/AgeableWaterAnimalMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/AgeableWaterAnimalMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.water;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.AgeableMobMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class AgeableWaterAnimalMeta extends AgeableMobMeta {
-    public AgeableWaterAnimalMeta(Entity entity, MetadataHolder metadata) {
+    public AgeableWaterAnimalMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/water/AxolotlMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/AxolotlMeta.java
@@ -11,7 +11,7 @@ import net.minestom.server.network.NetworkBuffer;
 import org.jetbrains.annotations.Nullable;
 
 public class AxolotlMeta extends AnimalMeta {
-    public AxolotlMeta(Entity entity, MetadataHolder metadata) {
+    public AxolotlMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/water/DolphinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/DolphinMeta.java
@@ -4,9 +4,10 @@ import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class DolphinMeta extends AgeableWaterAnimalMeta {
-    public DolphinMeta(Entity entity, MetadataHolder metadata) {
+    public DolphinMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/water/GlowSquidMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/GlowSquidMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.water;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class GlowSquidMeta extends AgeableWaterAnimalMeta {
-    public GlowSquidMeta(Entity entity, MetadataHolder metadata) {
+    public GlowSquidMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/water/SquidMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/SquidMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.water;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class SquidMeta extends AgeableWaterAnimalMeta {
-    public SquidMeta(Entity entity, MetadataHolder metadata) {
+    public SquidMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/water/WaterAnimalMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/WaterAnimalMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.water;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.PathfinderMobMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class WaterAnimalMeta extends PathfinderMobMeta {
-    protected WaterAnimalMeta(Entity entity, MetadataHolder metadata) {
+    protected WaterAnimalMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/water/fish/AbstractFishMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/fish/AbstractFishMeta.java
@@ -4,9 +4,10 @@ import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
 import net.minestom.server.entity.metadata.water.WaterAnimalMeta;
+import org.jetbrains.annotations.Nullable;
 
 public class AbstractFishMeta extends WaterAnimalMeta {
-    protected AbstractFishMeta(Entity entity, MetadataHolder metadata) {
+    protected AbstractFishMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/water/fish/CodMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/fish/CodMeta.java
@@ -2,9 +2,10 @@ package net.minestom.server.entity.metadata.water.fish;
 
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class CodMeta extends AbstractFishMeta {
-    public CodMeta(Entity entity, MetadataHolder metadata) {
+    public CodMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/water/fish/PufferfishMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/fish/PufferfishMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.water.fish;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class PufferfishMeta extends AbstractFishMeta {
-    public PufferfishMeta(Entity entity, MetadataHolder metadata) {
+    public PufferfishMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
         updateBoundingBox(State.UNPUFFED);
     }

--- a/src/main/java/net/minestom/server/entity/metadata/water/fish/SalmonMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/fish/SalmonMeta.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class SalmonMeta extends AbstractFishMeta {
-    public SalmonMeta(Entity entity, MetadataHolder metadata) {
+    public SalmonMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/water/fish/TadpoleMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/fish/TadpoleMeta.java
@@ -3,9 +3,10 @@ package net.minestom.server.entity.metadata.water.fish;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
+import org.jetbrains.annotations.Nullable;
 
 public class TadpoleMeta extends AbstractFishMeta {
-    public TadpoleMeta(Entity entity, MetadataHolder metadata) {
+    public TadpoleMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/main/java/net/minestom/server/entity/metadata/water/fish/TropicalFishMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/fish/TropicalFishMeta.java
@@ -11,7 +11,7 @@ import net.minestom.server.network.NetworkBuffer;
 import org.jetbrains.annotations.Nullable;
 
 public class TropicalFishMeta extends AbstractFishMeta {
-    public TropicalFishMeta(Entity entity, MetadataHolder metadata) {
+    public TropicalFishMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
     }
 

--- a/src/test/java/net/minestom/server/entity/EntityMetaTest.java
+++ b/src/test/java/net/minestom/server/entity/EntityMetaTest.java
@@ -14,9 +14,8 @@ public class EntityMetaTest {
         List<String> list = new ArrayList<>();
         for (var field : EntityTypes.class.getDeclaredFields()) {
             final EntityType entityType = (EntityType) field.get(this);
-            final String name = entityType.name();
-            if (MetadataHolder.ENTITY_META_SUPPLIER.get(name) == null) {
-                list.add(name);
+            if (MetadataHolder.ENTITY_META_SUPPLIER.get(entityType) == null) {
+                list.add(entityType.name());
             }
         }
         assertTrue(list.isEmpty(), "Missing meta for: " + list);

--- a/src/test/java/net/minestom/server/entity/MetadataHolderTest.java
+++ b/src/test/java/net/minestom/server/entity/MetadataHolderTest.java
@@ -54,6 +54,41 @@ public class MetadataHolderTest {
         assertTrue(received.isEmpty());
     }
 
+    @Test
+    public void getEntriesReflectsSets() {
+        MetadataHolder holder = new MetadataHolder(_ -> {
+        });
+
+        assertTrue(holder.getEntries().isEmpty(), "No entries before any set");
+
+        // AIR_TICKS sits at a higher index than CUSTOM_NAME_VISIBLE, exercising the sparse/resized array
+        holder.set(MetadataDef.CUSTOM_NAME_VISIBLE, true);
+        holder.set(MetadataDef.AIR_TICKS, 42);
+
+        Map<Integer, Metadata.Entry<?>> entries = holder.getEntries();
+        assertEquals(2, entries.size(), "Only set ids are present, gaps excluded");
+        assertEquals(true, entries.get(MetadataDef.CUSTOM_NAME_VISIBLE.index()).value());
+        assertEquals(42, entries.get(MetadataDef.AIR_TICKS.index()).value());
+
+        // Overwriting an id keeps the map size and reflects the new value
+        holder.set(MetadataDef.AIR_TICKS, 7);
+        entries = holder.getEntries();
+        assertEquals(2, entries.size());
+        assertEquals(7, entries.get(MetadataDef.AIR_TICKS.index()).value());
+    }
+
+    @Test
+    public void getEntriesIsSnapshot() {
+        MetadataHolder holder = new MetadataHolder(_ -> {
+        });
+        holder.set(MetadataDef.CUSTOM_NAME_VISIBLE, true);
+
+        Map<Integer, Metadata.Entry<?>> snapshot = holder.getEntries();
+        holder.set(MetadataDef.AIR_TICKS, 42);
+
+        assertEquals(1, snapshot.size(), "Previously returned map must not see later sets");
+    }
+
     @SuppressWarnings({"ConstantConditions", "removal"})
     @Test
     public void testNullCtor() {


### PR DESCRIPTION
* Update `#entries` to an array, using its index as a key. Avoid the various `Map` fields, but there is a risk of oversized array, with most metadata definitions holding between 20-40 potential entries. Improving performance at the cost of memory (metadata retrieval can take about 40% of entity collision resolution)
* Change `ENTITY_META_SUPPLIER` to store `EntityType` as key instead of namespace. It caused `minecraft:potion` to be removed, unsure if this was forgotten from a previous version.
* The supplier change required updating most specialized entity meta classes to take a nullable entity (as specified in super constructor)