### PR TITLE
skip empty equipment slots (like vanilla)

### DIFF
--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -543,7 +543,8 @@ public class LivingEntity extends Entity implements EquipmentHandler {
     @Override
     public void updateNewViewer(Player player) {
         super.updateNewViewer(player);
-        player.sendPacket(this.getEquipmentsPacket());
+        final var equipmentsPacket = this.getEquipmentsPacket();
+        if (equipmentsPacket != null) player.sendPacket(equipmentsPacket);
 
         if (shouldSendAttributes())
             player.sendPacket(this.getPropertiesPacket());

--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -554,7 +554,8 @@ public class LivingEntity extends Entity implements EquipmentHandler {
     @Override
     public void updateNewViewer(Player player) {
         super.updateNewViewer(player);
-        player.sendPacket(this.getEquipmentsPacket());
+        final var equipmentsPacket = this.getEquipmentsPacket();
+        if (equipmentsPacket != null) player.sendPacket(equipmentsPacket);
 
         if (shouldSendAttributes())
             player.sendPacket(this.getPropertiesPacket());

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -1493,7 +1493,8 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
         sendPacketToViewersAndSelf(getVelocityPacket());
         sendPacketToViewersAndSelf(getMetadataPacket());
         sendPacketToViewersAndSelf(getPropertiesPacket());
-        sendPacketToViewersAndSelf(getEquipmentsPacket());
+        final var equipmentsPacket = getEquipmentsPacket();
+        if (equipmentsPacket != null) sendPacketToViewersAndSelf(equipmentsPacket);
 
         getInventory().update();
     }
@@ -2335,7 +2336,8 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
         connection.sendPacket(getSpawnPacket());
         connection.sendPacket(getVelocityPacket());
         connection.sendPacket(getMetadataPacket());
-        connection.sendPacket(getEquipmentsPacket());
+        final var equipmentsPacket = getEquipmentsPacket();
+        if (equipmentsPacket != null) connection.sendPacket(equipmentsPacket);
         if (hasPassenger()) {
             connection.sendPacket(getPassengersPacket());
         }

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -1570,7 +1570,8 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
         sendPacketToViewersAndSelf(getVelocityPacket());
         sendPacketToViewersAndSelf(getMetadataPacket());
         sendPacketToViewersAndSelf(getPropertiesPacket());
-        sendPacketToViewersAndSelf(getEquipmentsPacket());
+        final var equipmentsPacket = getEquipmentsPacket();
+        if (equipmentsPacket != null) sendPacketToViewersAndSelf(equipmentsPacket);
 
         getInventory().update();
     }
@@ -2418,7 +2419,8 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
         connection.sendPacket(getSpawnPacket());
         connection.sendPacket(getVelocityPacket());
         connection.sendPacket(getMetadataPacket());
-        connection.sendPacket(getEquipmentsPacket());
+        final var equipmentsPacket = getEquipmentsPacket();
+        if (equipmentsPacket != null) connection.sendPacket(equipmentsPacket);
         if (hasPassenger()) {
             connection.sendPacket(getPassengersPacket());
         }

--- a/src/main/java/net/minestom/server/inventory/EquipmentHandler.java
+++ b/src/main/java/net/minestom/server/inventory/EquipmentHandler.java
@@ -6,6 +6,7 @@ import net.minestom.server.entity.PlayerHand;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.network.packet.server.play.EntityEquipmentPacket;
 import net.minestom.server.utils.validate.Check;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -198,17 +199,19 @@ public interface EquipmentHandler {
     }
 
     /**
-     * Gets the packet with all the equipments.
+     * Gets the packet with the non-empty equipments.
      *
-     * @return the packet with the equipments
+     * @return the equipments packet, or {@code null} if every slot is empty
      * @throws IllegalStateException if 'this' is not an {@link Entity}
      */
-    default EntityEquipmentPacket getEquipmentsPacket() {
+    default @Nullable EntityEquipmentPacket getEquipmentsPacket() {
         Check.stateCondition(!(this instanceof Entity), "Only accessible for Entity");
         Map<EquipmentSlot, ItemStack> equipment = new HashMap<>();
         for (EquipmentSlot slot : EquipmentSlot.values()) {
-            equipment.put(slot, this.getEquipment(slot));
+            ItemStack stack = this.getEquipment(slot);
+            if (!stack.isAir()) equipment.put(slot, stack);
         }
+        if (equipment.isEmpty()) return null;
         return new EntityEquipmentPacket(((Entity) this).getEntityId(), equipment);
     }
 

--- a/src/main/java/net/minestom/server/inventory/PlayerInventory.java
+++ b/src/main/java/net/minestom/server/inventory/PlayerInventory.java
@@ -35,9 +35,6 @@ public non-sealed class PlayerInventory extends AbstractInventory {
     public synchronized void clear() {
         cursorItem = ItemStack.AIR;
         super.clear();
-
-        // Update equipments
-        viewers.forEach(viewer -> viewer.sendPacketToViewersAndSelf(viewer.getEquipmentsPacket()));
     }
 
     @Override

--- a/src/main/java/net/minestom/server/inventory/PlayerInventory.java
+++ b/src/main/java/net/minestom/server/inventory/PlayerInventory.java
@@ -42,9 +42,6 @@ public non-sealed class PlayerInventory extends AbstractInventory {
     public synchronized void clear() {
         cursorItem = ItemStack.AIR;
         super.clear();
-
-        // Update equipments
-        viewers.forEach(viewer -> viewer.sendPacketToViewersAndSelf(viewer.getEquipmentsPacket()));
     }
 
     @Override

--- a/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java
+++ b/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java
@@ -145,8 +145,8 @@ public class InventoryIntegrationTest {
         // Make sure WindowItemsPacket is empty
         updateWindowTracker.assertSingle(windowItemsPacket -> assertEquals(ItemStack.AIR, windowItemsPacket.carriedItem()));
 
-        // Make sure EntityEquipmentPacket is sent
-        equipmentTracker.assertSingle();
+        // Make sure no EntityEquipmentPacket is sent (nothing was equipped)
+        equipmentTracker.assertEmpty();
     }
 
     @Test

--- a/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java
+++ b/src/test/java/net/minestom/server/inventory/InventoryIntegrationTest.java
@@ -152,8 +152,8 @@ public class InventoryIntegrationTest {
         // Make sure WindowItemsPacket is empty
         updateWindowTracker.assertSingle(windowItemsPacket -> assertEquals(ItemStack.AIR, windowItemsPacket.carriedItem()));
 
-        // Make sure EntityEquipmentPacket is sent
-        equipmentTracker.assertSingle();
+        // Make sure no EntityEquipmentPacket is sent (nothing was equipped)
+        equipmentTracker.assertEmpty();
     }
 
     @Test

--- a/src/test/java/net/minestom/server/inventory/PlayerInventoryIntegrationTest.java
+++ b/src/test/java/net/minestom/server/inventory/PlayerInventoryIntegrationTest.java
@@ -12,7 +12,6 @@ import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -105,13 +104,8 @@ public class PlayerInventoryIntegrationTest {
             }
         });
 
-        // Make sure EntityEquipmentPacket is empty
-        equipmentTracker.assertSingle(entityEquipmentPacket -> {
-            assertEquals(EquipmentSlot.values().length, entityEquipmentPacket.equipments().size());
-            for (Map.Entry<EquipmentSlot, ItemStack> entry : entityEquipmentPacket.equipments().entrySet()) {
-                assertEquals(ItemStack.AIR, entry.getValue());
-            }
-        });
+        // Make sure no EntityEquipmentPacket is sent (nothing was equipped)
+        equipmentTracker.assertEmpty();
     }
 
     @Test
@@ -139,6 +133,22 @@ public class PlayerInventoryIntegrationTest {
         // Setting to air should send packet
         equipmentTracker = connectionViewer.trackIncoming(EntityEquipmentPacket.class);
         playerArmored.setEquipment(EquipmentSlot.HELMET, ItemStack.AIR);
+        equipmentTracker.assertSingle(entityEquipmentPacket -> assertEquals(ItemStack.AIR, entityEquipmentPacket.equipments().get(EquipmentSlot.HELMET)));
+    }
+
+    @Test
+    public void clearInventoryClearsEquipmentForViewersTest(Env env) {
+        var instance = env.createFlatInstance();
+        var connectionArmored = env.createConnection();
+        var playerArmored = connectionArmored.connect(instance, new Pos(0, 42, 0));
+        var connectionViewer = env.createConnection();
+        connectionViewer.connect(instance, new Pos(0, 42, 0));
+
+        playerArmored.setEquipment(EquipmentSlot.HELMET, MAGIC_STACK);
+
+        // Make sure clearing the inventory still clears the equipped slot for viewers
+        var equipmentTracker = connectionViewer.trackIncoming(EntityEquipmentPacket.class);
+        playerArmored.getInventory().clear();
         equipmentTracker.assertSingle(entityEquipmentPacket -> assertEquals(ItemStack.AIR, entityEquipmentPacket.equipments().get(EquipmentSlot.HELMET)));
     }
 

--- a/src/test/java/net/minestom/server/inventory/PlayerInventoryIntegrationTest.java
+++ b/src/test/java/net/minestom/server/inventory/PlayerInventoryIntegrationTest.java
@@ -16,7 +16,6 @@ import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -111,13 +110,8 @@ public class PlayerInventoryIntegrationTest {
             }
         });
 
-        // Make sure EntityEquipmentPacket is empty
-        equipmentTracker.assertSingle(entityEquipmentPacket -> {
-            assertEquals(EquipmentSlot.values().length, entityEquipmentPacket.equipments().size());
-            for (Map.Entry<EquipmentSlot, ItemStack> entry : entityEquipmentPacket.equipments().entrySet()) {
-                assertEquals(ItemStack.AIR, entry.getValue());
-            }
-        });
+        // Make sure no EntityEquipmentPacket is sent (nothing was equipped)
+        equipmentTracker.assertEmpty();
     }
 
     @Test
@@ -145,6 +139,22 @@ public class PlayerInventoryIntegrationTest {
         // Setting to air should send packet
         equipmentTracker = connectionViewer.trackIncoming(EntityEquipmentPacket.class);
         playerArmored.setEquipment(EquipmentSlot.HELMET, ItemStack.AIR);
+        equipmentTracker.assertSingle(entityEquipmentPacket -> assertEquals(ItemStack.AIR, entityEquipmentPacket.equipments().get(EquipmentSlot.HELMET)));
+    }
+
+    @Test
+    public void clearInventoryClearsEquipmentForViewersTest(Env env) {
+        var instance = env.createFlatInstance();
+        var connectionArmored = env.createConnection();
+        var playerArmored = connectionArmored.connect(instance, new Pos(0, 42, 0));
+        var connectionViewer = env.createConnection();
+        connectionViewer.connect(instance, new Pos(0, 42, 0));
+
+        playerArmored.setEquipment(EquipmentSlot.HELMET, MAGIC_STACK);
+
+        // Make sure clearing the inventory still clears the equipped slot for viewers
+        var equipmentTracker = connectionViewer.trackIncoming(EntityEquipmentPacket.class);
+        playerArmored.getInventory().clear();
         equipmentTracker.assertSingle(entityEquipmentPacket -> assertEquals(ItemStack.AIR, entityEquipmentPacket.equipments().get(EquipmentSlot.HELMET)));
     }
 


### PR DESCRIPTION
## Proposed changes

`EquipmentHandler#getEquipmentsPacket()` built the packet from every
`EquipmentSlot.values()` entry, including empty ones, so a naked entity still
produced an 8-slot all-AIR packet on each pairing. Vanilla
(`ServerEntity#sendPairing`) only sends non-empty slots and omits the packet
entirely when there are none. This aligns Minestom with that behavior and avoids
sending empty-slot data on every entity spawn.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

`getEquipmentsPacket()` previously never returned null; it is now `@Nullable`.
This is source/binary compatible, but external callers that send the result
directly should null-check it (the in-tree callers have been updated).