### PR TITLE
Metadata fixes

### DIFF
--- a/src/main/java/net/minestom/server/entity/MetadataDef.java
+++ b/src/main/java/net/minestom/server/entity/MetadataDef.java
@@ -394,7 +394,7 @@ public sealed class MetadataDef {
     public static final class Frog extends AgeableMob {
         public static final Entry<RegistryKey<FrogVariant>> VARIANT = index(0, Metadata::FrogVariant,
                                                                             FrogVariant.TEMPERATE);
-        public static final Entry<@Nullable Integer> TONGUE_TARGET = index(1, Metadata::OptVarInt, 0);
+        public static final Entry<@Nullable Integer> TONGUE_TARGET = index(1, Metadata::OptVarInt, null);
     }
 
     public static final class Ocelot extends AgeableMob {

--- a/src/main/java/net/minestom/server/entity/MetadataDef.java
+++ b/src/main/java/net/minestom/server/entity/MetadataDef.java
@@ -310,7 +310,7 @@ public sealed class MetadataDef {
     }
 
     public static final class Salmon extends AbstractFish {
-        public static final Entry<Integer> SIZE = index(0, Metadata::VarInt, SalmonMeta.Size.SMALL.ordinal());
+        public static final Entry<Integer> SIZE = index(0, Metadata::VarInt, SalmonMeta.Size.MEDIUM.ordinal());
     }
 
     public static final class TropicalFish extends AbstractFish {

--- a/src/main/java/net/minestom/server/entity/MetadataDef.java
+++ b/src/main/java/net/minestom/server/entity/MetadataDef.java
@@ -121,7 +121,7 @@ public sealed class MetadataDef {
     public static final class AreaEffectCloud extends MetadataDef {
         public static final Entry<Float> RADIUS = index(0, Metadata::Float, 3f);
         public static final Entry<Boolean> WAITING = index(1, Metadata::Boolean, false);
-        public static final Entry<Particle> PARTICLE = index(2, Metadata::Particle, Particle.EFFECT);
+        public static final Entry<Particle> PARTICLE = index(2, Metadata::Particle, Particle.ENTITY_EFFECT);
     }
 
     public static final class FishingHook extends MetadataDef {

--- a/src/main/java/net/minestom/server/entity/MetadataDef.java
+++ b/src/main/java/net/minestom/server/entity/MetadataDef.java
@@ -119,7 +119,7 @@ public sealed class MetadataDef {
     }
 
     public static final class AreaEffectCloud extends MetadataDef {
-        public static final Entry<Float> RADIUS = index(0, Metadata::Float, 0.5f);
+        public static final Entry<Float> RADIUS = index(0, Metadata::Float, 3f);
         public static final Entry<Boolean> WAITING = index(1, Metadata::Boolean, false);
         public static final Entry<Particle> PARTICLE = index(2, Metadata::Particle, Particle.EFFECT);
     }

--- a/src/main/java/net/minestom/server/entity/MetadataDef.java
+++ b/src/main/java/net/minestom/server/entity/MetadataDef.java
@@ -296,10 +296,9 @@ public sealed class MetadataDef {
         public static final Entry<Boolean> IS_HANGING = bitMask(0, (byte) 0x01, false);
     }
 
-    public static final class Dolphin extends Mob {
-        public static final Entry<Point> TREASURE_POSITION = index(0, Metadata::BlockPosition, Vec.ZERO);
-        public static final Entry<Boolean> HAS_FISH = index(1, Metadata::Boolean, false);
-        public static final Entry<Integer> MOISTURE_LEVEL = index(2, Metadata::VarInt, 2400);
+    public static final class Dolphin extends AgeableMob {
+        public static final Entry<Boolean> HAS_FISH = index(0, Metadata::Boolean, false);
+        public static final Entry<Integer> MOISTURE_LEVEL = index(1, Metadata::VarInt, 2400);
     }
 
     public static sealed class AbstractFish extends Mob {

--- a/src/main/java/net/minestom/server/entity/metadata/water/DolphinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/DolphinMeta.java
@@ -1,6 +1,5 @@
 package net.minestom.server.entity.metadata.water;
 
-import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.MetadataDef;
 import net.minestom.server.entity.MetadataHolder;
@@ -9,14 +8,6 @@ import org.jetbrains.annotations.Nullable;
 public class DolphinMeta extends AgeableWaterAnimalMeta {
     public DolphinMeta(@Nullable Entity entity, MetadataHolder metadata) {
         super(entity, metadata);
-    }
-
-    public Point getTreasurePosition() {
-        return metadata.get(MetadataDef.Dolphin.TREASURE_POSITION);
-    }
-
-    public void setTreasurePosition(Point value) {
-        metadata.set(MetadataDef.Dolphin.TREASURE_POSITION, value);
     }
 
     public boolean isHasFish() {

--- a/src/main/java/net/minestom/server/entity/metadata/water/GlowSquidMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/GlowSquidMeta.java
@@ -10,11 +10,11 @@ public class GlowSquidMeta extends AgeableWaterAnimalMeta {
         super(entity, metadata);
     }
 
-    private int getDarkTicksRemaining() {
+    public int getDarkTicksRemaining() {
         return metadata.get(MetadataDef.GlowSquid.DARK_TICKS_REMAINING);
     }
 
-    private void setDarkTicksRemaining(int ticks) {
+    public void setDarkTicksRemaining(int ticks) {
         metadata.set(MetadataDef.GlowSquid.DARK_TICKS_REMAINING, ticks);
     }
 


### PR DESCRIPTION
- Fixed vanilla drift
  - Dolphin treasure position was removed in 25w07a (1.21.5) and is now handled server-side
  - Dolphin was made ageable in 24w33a (1.21.2)
  - Area effect cloud radius changed from 0.5 to 3.0 in 22w43a (1.19.3)
- Fixed some other incorrect stuff

Breaking