### PR TITLE
Fix: Unformatted Mojang UUID parsing in MojangUtils

### DIFF
--- a/src/main/java/net/minestom/server/utils/mojang/MojangUtils.java
+++ b/src/main/java/net/minestom/server/utils/mojang/MojangUtils.java
@@ -41,12 +41,7 @@ public final class MojangUtils {
     public static UUID getUUID(String username) throws IOException {
         // Thanks stackoverflow: https://stackoverflow.com/a/19399768/13247146
         return UUID.fromString(
-                retrieve(String.format(FROM_USERNAME_URL, validateUsername(username))).get("id")
-                        .getAsString()
-                        .replaceFirst(
-                                "(\\p{XDigit}{8})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}+)",
-                                "$1-$2-$3-$4-$5"
-                        )
+                formatUUID(retrieve(String.format(FROM_USERNAME_URL, validateUsername(username))).get("id").getAsString())
         );
     }
 
@@ -87,7 +82,7 @@ public final class MojangUtils {
     public static @Nullable JsonObject fromUuid(String uuid) {
         final UUID parsed;
         try {
-            parsed = UUID.fromString(uuid);
+            parsed = UUID.fromString(formatUUID(uuid));
         } catch (IllegalArgumentException e) {
             return null;
         }
@@ -127,6 +122,13 @@ public final class MojangUtils {
         }
 
         return retrieve(url);
+    }
+
+    private static String formatUUID(String uuid) {
+        return uuid.replaceFirst(
+                "(\\p{XDigit}{8})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}+)",
+                "$1-$2-$3-$4-$5"
+        );
     }
 
     private static String encode(String value) {


### PR DESCRIPTION
## Proposed changes

Fixed an issue where the UUID string fetched from the Mojang API via username (`PlayerSkin.fromUsername()` method) wasn't formatted correctly. Because of this, it couldn't be parsed into a UUID, causing the method to return null.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

maybe it's overhead and can be moved directly into `PlayerSkin`