### PR TITLE
feat: Update the ABI checker

### DIFF
--- a/.github/workflows/binary-compat-comment.yml
+++ b/.github/workflows/binary-compat-comment.yml
@@ -42,7 +42,7 @@ jobs:
             exit 0
           fi
 
-          VIOLATIONS=$(gh run view "${{ github.event.workflow_run.id }}" --job "$JOB_ID" --log | grep -E "removed|changed|marked as internal/experimental" | sed -E 's/^.*[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+Z[[:space:]]+//g' || true)
+          VIOLATIONS=$(gh run view "${{ github.event.workflow_run.id }}" --job "$JOB_ID" --log | grep "::error" | sed -E 's/^.*[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+Z[[:space:]]+//g' | sed -E 's/::error file=([^,]+),line=([0-9]+)::/\1:\2 - /' || true)
 
           if [ -z "$VIOLATIONS" ]; then
             exit 0

--- a/build-src/src/main/kotlin/CheckAbiTask.kt
+++ b/build-src/src/main/kotlin/CheckAbiTask.kt
@@ -1,27 +1,46 @@
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.*
 import java.io.File
 import java.lang.classfile.*
+import java.lang.constant.ConstantDescs
 import java.lang.reflect.AccessFlag
-import java.util.jar.JarFile
+import java.util.zip.ZipFile
+import kotlin.jvm.optionals.getOrNull
 
+/**
+ * Simple dependency free ABI checker for Java code.
+ */
 abstract class CheckAbiTask : DefaultTask() {
 
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
     @get:Optional
     abstract val oldJar: RegularFileProperty
 
     @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
     abstract val newJar: RegularFileProperty
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val sourceDirectories: ConfigurableFileCollection
+
+    @get:Internal
+    abstract val rootProjectDir: Property<File>
+
+    @get:Classpath
+    @get:Optional
+    abstract val classpath: ConfigurableFileCollection
 
     @TaskAction
     fun run() {
         if (!oldJar.isPresent) {
-            logger.lifecycle("Skipping ABI check: Baseline JAR is not specified or could not be resolved (this is normal for new/unpublished modules).")
+            logger.lifecycle("Skipping ABI check: Baseline JAR is not specified or could not be resolved.")
             return
         }
         val oldFile = oldJar.get().asFile
@@ -34,136 +53,106 @@ abstract class CheckAbiTask : DefaultTask() {
         val oldApis = extractPublicApi(oldFile)
         val newApis = extractPublicApi(newFile)
 
+        val dependencyCache = mutableMapOf<String, ClassApi>()
         var violations = 0
 
         // Check if any old public API is missing or modified in the new build
         for ((className, oldClass) in oldApis) {
             val newClass = newApis[className]
-            if (newClass == null) {
-                if (oldClass.internal) {
-                    logger.warn("Ignored experimental/internal class removal: $className")
-                } else {
-                    logger.error("Class removed or made package-private: $className")
+
+            fun check(condition: Boolean, message: String, line: Int = newClass?.line ?: oldClass.line) {
+                if (condition) {
+                    logger.error(message)
+                    val sourceFile = newClass?.sourceFile ?: oldClass.sourceFile
+                    if (System.getenv("CI") != null && sourceFile != null) {
+                        println("::error file=$sourceFile,line=$line::$message")
+                    }
                     violations++
                 }
-                continue
             }
 
-            if (oldClass.internal) {
-                logger.warn("Ignored experimental/internal class changes: $className")
+            if (newClass == null) {
+                check(true, "Class removed, made package-private or considered internal: $className")
                 continue
             }
 
             // Check class level changes
-            if (oldClass.`interface` != newClass.`interface`) {
-                logger.error("Class type changed (class <-> interface): $className")
-                violations++
-            }
-            if (!oldClass.final && newClass.final) {
-                logger.error("Class made final: $className (breaks subclasses)")
-                violations++
-            }
-            if (!oldClass.abstract && newClass.abstract) {
-                logger.error("Class made abstract: $className (breaks instantiation)")
-                violations++
-            }
-            if (!oldClass.protected && newClass.protected) {
-                logger.error("Class visibility narrowed to protected: $className")
-                violations++
-            }
+            check(oldClass.`interface` != newClass.`interface`, "Class type changed (class <-> interface): $className")
+            check(oldClass.enum != newClass.enum, "Class type changed (enum status modified): $className")
+            check(oldClass.annotation != newClass.annotation, "Class type changed (annotation status modified): $className")
+            check(!oldClass.final && newClass.final, "Class made final: $className (breaks subclasses)")
+            check(!oldClass.abstract && newClass.abstract, "Class made abstract: $className (breaks instantiation)")
+            check(!oldClass.protected && newClass.protected, "Class visibility narrowed to protected: $className")
+            check(!oldClass.nonExtendable && newClass.nonExtendable, "Class made non-extendable (sealed or @NonExtendable): $className")
+
             for (supertype in oldClass.supertypes) {
-                if (supertype !in newClass.supertypes) {
-                    logger.error("Class no longer implements/extends $supertype: $className")
-                    violations++
-                }
+                check(!isSubtypeOf(className, supertype, newApis, dependencyCache), "Class no longer implements/extends $supertype: $className")
             }
 
             // Check methods
-            for ((methodName, oldMethod) in oldClass.methods) {
-                val newMethod = newClass.methods[methodName]
+            for ((methodKey, oldMethod) in oldClass.methods) {
+                val newMethod = newClass.methods[methodKey] ?: if (methodKey.startsWith(ConstantDescs.INIT_NAME)) null else lookupMethod(className, methodKey, newApis, dependencyCache)
                 if (newMethod == null) {
-                    if (oldMethod.internal) {
-                        logger.warn("Ignored experimental/internal method removal/change: $className#$methodName")
-                    } else {
-                        logger.error("Public/protected method removed or signature changed: $className#$methodName")
-                        violations++
-                    }
+                    check(true, "Public/protected method removed or signature changed: $className#$methodKey")
                     continue
                 }
 
-                if (oldMethod.internal) continue
-
-                if (!oldMethod.protected && newMethod.protected) {
-                    logger.error("Method visibility narrowed to protected: $className#$methodName")
-                    violations++
+                check(!oldMethod.protected && newMethod.protected, "Method visibility narrowed to protected: $className#$methodKey", newMethod.line)
+                check(oldMethod.static != newMethod.static, "Method static status changed: $className#$methodKey", newMethod.line)
+                if (!newClass.final) {
+                    check(!oldMethod.final && newMethod.final, "Method made final: $className#$methodKey (breaks subclasses)", newMethod.line)
                 }
-                if (oldMethod.static != newMethod.static) {
-                    logger.error("Method static status changed: $className#$methodName")
-                    violations++
-                }
-                if (!oldMethod.final && newMethod.final) {
-                    logger.error("Method made final: $className#$methodName (breaks subclasses)")
-                    violations++
-                }
-                if (!oldMethod.abstract && newMethod.abstract) {
-                    logger.error("Method made abstract: $className#$methodName (breaks implementing classes/subclasses)")
-                    violations++
-                }
+                check(!oldMethod.abstract && newMethod.abstract, "Method made abstract: $className#$methodKey (breaks implementing classes/subclasses)", newMethod.line)
             }
 
             // Check fields
-            for ((fieldName, oldField) in oldClass.fields) {
-                val newField = newClass.fields[fieldName]
+            for ((fieldKey, oldField) in oldClass.fields) {
+                val newField = newClass.fields[fieldKey] ?: lookupField(className, fieldKey, newApis, dependencyCache)
                 if (newField == null) {
-                    if (oldField.internal) {
-                        logger.warn("Ignored experimental/internal field removal/change: $className#$fieldName")
-                    } else {
-                        logger.error("Public/protected field removed or type changed: $className#$fieldName")
-                        violations++
-                    }
+                    check(true, "Public/protected field removed or type changed: $className#$fieldKey")
                     continue
                 }
 
-                if (oldField.internal) continue
-
-                if (!oldField.protected && newField.protected) {
-                    logger.error("Field visibility narrowed to protected: $className#$fieldName")
-                    violations++
-                }
-                if (oldField.static != newField.static) {
-                    logger.error("Field static status changed: $className#$fieldName")
-                    violations++
-                }
-                if (!oldField.final && newField.final) {
-                    logger.error("Field made final: $className#$fieldName")
-                    violations++
-                }
+                check(!oldField.protected && newField.protected, "Field visibility narrowed to protected: $className#$fieldKey", newField.line)
+                check(oldField.static != newField.static, "Field static status changed: $className#$fieldKey", newField.line)
+                check(!oldField.final && newField.final, "Field made final: $className#$fieldKey", newField.line)
+                check(oldField.constantValue != newField.constantValue, "Constant field value changed: $className#$fieldKey (old: ${oldField.constantValue}, new: ${newField.constantValue})", newField.line)
             }
         }
 
         // Check for newly added abstract methods in interfaces and non final classes
         for ((className, newClass) in newApis) {
             val oldClass = oldApis[className] ?: continue // New classes are always compatible
-            if (newClass.internal || oldClass.internal) continue
+
+            fun check(condition: Boolean, message: String, line: Int = newClass.line) {
+                if (condition) {
+                    logger.error(message)
+                    val sourceFile = newClass.sourceFile ?: oldClass.sourceFile
+                    if (System.getenv("CI") != null && sourceFile != null) {
+                        println("::error file=$sourceFile,line=$line::$message")
+                    }
+                    violations++
+                }
+            }
 
             // Determine if we need to check this class/interface
             val checkInterface = newClass.`interface` && !newClass.nonExtendable
-            val checkClass = !newClass.`interface` && !newClass.final
+            val checkClass = !newClass.`interface` && !newClass.final && !newClass.nonExtendable
 
             if (!checkInterface && !checkClass) continue
 
-            for ((methodName, newMethod) in newClass.methods) {
+            for ((methodKey, newMethod) in newClass.methods) {
                 // If the new method is abstract, not internal, and did not exist in the baseline version
                 if (!newMethod.abstract) continue
-                if (newMethod.internal) continue
-                if (oldClass.methods.containsKey(methodName)) continue
-
-                if (newClass.`interface`) {
-                    logger.error("New abstract method added to interface: $className#$methodName (breaks implementing classes)")
-                } else {
-                    logger.error("New abstract method added to extendable class: $className#$methodName (breaks subclasses)")
+                val oldMethod = lookupMethod(className, methodKey, oldApis, dependencyCache)
+                if (oldMethod != null) {
+                    check(!oldMethod.abstract, "Inherited concrete method made abstract: $className#$methodKey (breaks subclasses)", newMethod.line)
+                    continue
                 }
-                violations++
+
+                val entityType = if (newClass.`interface`) "interface" else "extendable class"
+                val breaksWho = if (newClass.`interface`) "implementing classes" else "subclasses"
+                check(true, "New abstract method added to $entityType: $className#$methodKey (breaks $breaksWho)", newMethod.line)
             }
         }
 
@@ -172,122 +161,188 @@ abstract class CheckAbiTask : DefaultTask() {
         }
     }
 
-    private data class ElementApi(
-            val descriptor: String,
-            val internal: Boolean,
-            val abstract: Boolean,
-            val static: Boolean,
-            val final: Boolean,
-            val protected: Boolean
-    )
+    private data class ElementApi(val descriptor: String, val abstract: Boolean, val static: Boolean, val final: Boolean, val protected: Boolean, val line: Int, val constantValue: String? = null)
 
-    private data class ClassApiDump(
-            val internal: Boolean,
-            val `interface`: Boolean, // Annoying reserved keyword ugh
-            val final: Boolean,
-            val abstract: Boolean,
-            val nonExtendable: Boolean,
-            val protected: Boolean,
-            val supertypes: Set<String>,
-            val methods: Map<String, ElementApi>,
-            val fields: Map<String, ElementApi>
-    )
+    private data class ClassApi(val `interface`: Boolean, // Annoying reserved keyword ugh
+                                val enum: Boolean, val annotation: Boolean, val final: Boolean, val abstract: Boolean, val nonExtendable: Boolean, val protected: Boolean, val supertypes: Set<String>, val methods: Map<String, ElementApi>, val fields: Map<String, ElementApi>, val outerClassName: String?, val sourceFile: String?, val line: Int)
 
-    private fun extractPublicApi(jarFile: File): Map<String, ClassApiDump> {
-        val apis = mutableMapOf<String, ClassApiDump>()
-        val classFileParser = ClassFile.of()
+    @get:Internal
+    val classIndex: Provider<Map<String, Pair<File, String>>> = classpath.elements.map { elements ->
+        buildMap {
+            for (element in elements) {
+                val file = element.asFile
+                if (!file.exists()) continue
+                val isJmod = file.extension == "jmod"
+                if (!isJmod && file.extension != "jar") continue
+                try {
+                    ZipFile(file).use { zip ->
+                        for (entry in zip.entries().asSequence()) {
+                            val className = when {
+                                isJmod && entry.name.startsWith("classes/") && entry.name.endsWith(".class") ->
+                                    entry.name.removePrefix("classes/").removeSuffix(".class")
 
-        JarFile(jarFile).use { jar ->
-            for (entry in jar.entries().asSequence()) {
-                if (!entry.name.endsWith(".class")) continue
+                                !isJmod && entry.name.endsWith(".class") ->
+                                    entry.name.removeSuffix(".class")
 
-                jar.getInputStream(entry).use { stream ->
-                    val bytes = stream.readAllBytes()
-                    val classModel: ClassModel = classFileParser.parse(bytes)
-
-                    val classFlags = classModel.flags().flags()
-                    // Skip non-public / non-protected classes
-                    if (!isPublicOrProtected(classFlags)) return@use
-
-                    val className = classModel.thisClass().asInternalName()
-                    val isClassInternal = isInternal(classModel)
-                    val isClassInterface = AccessFlag.INTERFACE in classFlags
-                    val isClassFinal = AccessFlag.FINAL in classFlags
-                    val isClassAbstract = AccessFlag.ABSTRACT in classFlags
-                    val isClassNonExtendable = isNonExtendable(classModel)
-                    val isClassProtected = AccessFlag.PROTECTED in classFlags
-
-                    val supertypes = mutableSetOf<String>()
-                    classModel.superclass().ifPresent { supertypes.add(it.asInternalName()) }
-                    classModel.interfaces().forEach { supertypes.add(it.asInternalName()) }
-
-                    val methods = mutableMapOf<String, ElementApi>()
-                    val fields = mutableMapOf<String, ElementApi>()
-
-                    // Inspect methods
-                    for (method: MethodModel in classModel.methods()) {
-                        val flags = method.flags().flags()
-                        if (!isPublicOrProtected(flags)) continue
-
-                        val methodName = method.methodName().stringValue()
-                        val descriptor = method.methodType().stringValue()
-                        val isMethodInternal = isInternal(method)
-                        val isMethodAbstract = AccessFlag.ABSTRACT in flags
-                        val isMethodStatic = AccessFlag.STATIC in flags
-                        val isMethodFinal = AccessFlag.FINAL in flags
-                        val isMethodProtected = AccessFlag.PROTECTED in flags
-                        methods["$methodName$descriptor"] = ElementApi(descriptor, isMethodInternal, isMethodAbstract, isMethodStatic, isMethodFinal, isMethodProtected)
+                                else -> continue
+                            }
+                            putIfAbsent(className, file to entry.name)
+                        }
                     }
-
-                    // Inspect fields
-                    for (field: FieldModel in classModel.fields()) {
-                        val flags = field.flags().flags()
-                        if (!isPublicOrProtected(flags)) continue
-
-                        val fieldName = field.fieldName().stringValue()
-                        val descriptor = field.fieldType().stringValue()
-                        val isFieldInternal = isInternal(field)
-                        val isFieldStatic = AccessFlag.STATIC in flags
-                        val isFieldFinal = AccessFlag.FINAL in flags
-                        val isFieldProtected = AccessFlag.PROTECTED in flags
-                        fields["$fieldName:$descriptor"] = ElementApi(descriptor, isFieldInternal, false, isFieldStatic, isFieldFinal, isFieldProtected)
-                    }
-
-                    apis[className] = ClassApiDump(
-                            isClassInternal, isClassInterface, isClassFinal, isClassAbstract, isClassNonExtendable, isClassProtected, supertypes, methods, fields
-                    )
+                } catch (_: Exception) {
                 }
             }
         }
-        return apis
     }
 
-    private fun isPublicOrProtected(flags: Set<AccessFlag>): Boolean {
-        return AccessFlag.PUBLIC in flags || AccessFlag.PROTECTED in flags
+    private fun loadClassBytes(className: String): ByteArray? {
+        val (archive, entryPath) = classIndex.get()[className] ?: return null
+        return try {
+            ZipFile(archive).use { zip ->
+                zip.getInputStream(zip.getEntry(entryPath) ?: return null).readAllBytes()
+            }
+        } catch (_: Exception) {
+            null
+        }
     }
 
-    // We don't care about internal or experimental marked methods
-    private fun isInternal(element: AttributedElement): Boolean {
-        return hasAnnotation(element, $$"Lorg/jetbrains/annotations/ApiStatus$Internal;", $$"Lorg/jetbrains/annotations/ApiStatus$Experimental;")
+    private fun resolveClass(className: String, apis: Map<String, ClassApi>, cache: MutableMap<String, ClassApi>): ClassApi? {
+        val existing = apis[className] ?: cache[className]
+        if (existing != null) return existing
+
+        val bytes = loadClassBytes(className) ?: return null
+        val classModel = ClassFile.of().parse(bytes)
+        val api = parseClassApi(classModel)
+        cache[className] = api
+        return api
     }
 
-    private fun isNonExtendable(element: AttributedElement): Boolean {
-        if (hasAnnotation(element, $$"Lorg/jetbrains/annotations/ApiStatus$NonExtendable;")) return true
-        if (element !is ClassModel) return false
-        return element.findAttribute(Attributes.permittedSubclasses()).isPresent
+    private fun parseClassApi(classModel: ClassModel): ClassApi {
+        val flags = classModel.flags()
+        val isClassInterface = flags.has(AccessFlag.INTERFACE)
+        val isClassEnum = flags.has(AccessFlag.ENUM)
+        val isClassAnnotation = flags.has(AccessFlag.ANNOTATION)
+        val isClassFinal = flags.has(AccessFlag.FINAL)
+        val isClassAbstract = flags.has(AccessFlag.ABSTRACT)
+        val isClassNonExtendable = isNonExtendable(classModel)
+        val isClassProtected = flags.has(AccessFlag.PROTECTED)
+
+        val supertypes = buildSet {
+            classModel.superclass().getOrNull()?.let { add(it.asInternalName()) }
+            classModel.interfaces().forEach { add(it.asInternalName()) }
+        }
+
+        val className = classModel.thisClass().asInternalName()
+        val outerClassName = classModel.findAttribute(Attributes.innerClasses()).getOrNull()
+                ?.classes()?.firstOrNull { it.innerClass().name().stringValue() == className }
+                ?.outerClass()?.getOrNull()?.name()?.stringValue()
+
+        // Reconstruct source file path
+        val sourceFileName = classModel.findAttribute(Attributes.sourceFile()).getOrNull()?.sourceFile()?.stringValue()
+        val fullSourcePath = if (sourceFileName != null) {
+            val packagePath = className.substringBeforeLast('/', "")
+            val path = if (packagePath.isEmpty()) sourceFileName else "$packagePath/$sourceFileName"
+            val file = sourceDirectories.files.asSequence().map { File(it, path) }.firstOrNull { it.exists() }
+                ?: sourceDirectories.files.firstOrNull()?.let { File(it, path) }
+            file?.relativeToOrNull(rootProjectDir.get())?.path
+        } else null
+
+        // Find class declaration line (minimum line of any method)
+        val classLine = classModel.methods().asSequence()
+                .mapNotNull { it.code().getOrNull()?.findAttribute(Attributes.lineNumberTable())?.getOrNull() }
+                .flatMap { it.lineNumbers() }.minOfOrNull { it.lineNumber() } ?: 1
+
+        val methods = classModel.methods().asSequence().mapNotNull { method ->
+            val flags = method.flags()
+            if (hasPrivateAccess(flags) || isInternal(method)) return@mapNotNull null
+            val name = method.methodName().stringValue()
+            if (name == ConstantDescs.CLASS_INIT_NAME) return@mapNotNull null
+            val descriptor = method.methodType().stringValue()
+            val line = method.code().getOrNull()?.findAttribute(Attributes.lineNumberTable())?.getOrNull()
+                ?.lineNumbers()?.firstOrNull()?.lineNumber() ?: classLine
+            "$name$descriptor" to ElementApi(
+                descriptor,
+                flags.has(AccessFlag.ABSTRACT),
+                flags.has(AccessFlag.STATIC),
+                flags.has(AccessFlag.FINAL),
+                flags.has(AccessFlag.PROTECTED),
+                line
+            )
+        }.toMap()
+
+        val fields = classModel.fields().asSequence().mapNotNull { field ->
+            val flags = field.flags()
+            if (hasPrivateAccess(flags) || isInternal(field)) return@mapNotNull null
+            val name = field.fieldName().stringValue()
+            val descriptor = field.fieldType().stringValue()
+            val constantValue = field.findAttribute(Attributes.constantValue()).getOrNull()?.constant()?.constantValue()?.toString()
+            "$name:$descriptor" to ElementApi(
+                descriptor,
+                false,
+                flags.has(AccessFlag.STATIC),
+                flags.has(AccessFlag.FINAL),
+                flags.has(AccessFlag.PROTECTED),
+                classLine,
+                constantValue
+            )
+        }.toMap()
+
+        return ClassApi(
+                isClassInterface, isClassEnum, isClassAnnotation, isClassFinal, isClassAbstract,
+                isClassNonExtendable, isClassProtected, supertypes, methods, fields, outerClassName, fullSourcePath, classLine
+        )
     }
+
+    private fun extractPublicApi(jarFile: File): Map<String, ClassApi> {
+        val classFileParser = ClassFile.of()
+        val apis = ZipFile(jarFile).use { jar ->
+            jar.entries().asSequence()
+                .filter { it.name.endsWith(".class") }
+                .mapNotNull { entry ->
+                    jar.getInputStream(entry).use { stream ->
+                        val classModel = classFileParser.parse(stream.readAllBytes())
+                        if (hasPrivateAccess(classModel.flags()) || isInternal(classModel)) null
+                        else classModel.thisClass().asInternalName() to parseClassApi(classModel)
+                    }
+                }.toMap()
+        }
+        return apis.filterValues { hasPublicEnclosure(it, apis) }
+    }
+
+    private fun hasPrivateAccess(flags: AccessFlags): Boolean {
+        return !flags.has(AccessFlag.PUBLIC) && !flags.has(AccessFlag.PROTECTED)
+    }
+
+    private fun isInternal(element: AttributedElement): Boolean =
+        hasAnnotation(element, $$"Lorg/jetbrains/annotations/ApiStatus$Internal;", $$"Lorg/jetbrains/annotations/ApiStatus$Experimental;")
+
+    private fun isNonExtendable(element: AttributedElement): Boolean =
+        hasAnnotation(element, $$"Lorg/jetbrains/annotations/ApiStatus$NonExtendable;") ||
+                (element is ClassModel && element.findAttribute(Attributes.permittedSubclasses()).isPresent)
 
     private fun hasAnnotation(element: AttributedElement, vararg descriptors: String): Boolean {
-        val visible = element.findAttribute(Attributes.runtimeVisibleAnnotations()).orElse(null)
-        val invisible = element.findAttribute(Attributes.runtimeInvisibleAnnotations()).orElse(null)
+        val visible = element.findAttribute(Attributes.runtimeVisibleAnnotations()).getOrNull()
+        if (visible?.annotations()?.any { it.classSymbol().descriptorString() in descriptors } == true) return true
+        val invisible = element.findAttribute(Attributes.runtimeInvisibleAnnotations()).getOrNull()
+        return invisible?.annotations()?.any { it.classSymbol().descriptorString() in descriptors } == true
+    }
 
-        val annotations = (visible?.annotations() ?: emptyList()) + (invisible?.annotations() ?: emptyList())
-        for (anno in annotations) {
-            val desc = anno.classSymbol().descriptorString()
-            if (desc in descriptors) {
-                return true
-            }
+    private fun hasPublicEnclosure(classApi: ClassApi, apis: Map<String, ClassApi>): Boolean =
+        classApi.outerClassName?.let { apis[it]?.let { parent -> hasPublicEnclosure(parent, apis) } ?: false } ?: true
+
+    private fun lookupMethod(className: String, key: String, apis: Map<String, ClassApi>, cache: MutableMap<String, ClassApi>): ElementApi? =
+        resolveClass(className, apis, cache)?.let { api ->
+            api.methods[key] ?: api.supertypes.firstNotNullOfOrNull { lookupMethod(it, key, apis, cache) }
         }
-        return false
+
+    private fun lookupField(className: String, key: String, apis: Map<String, ClassApi>, cache: MutableMap<String, ClassApi>): ElementApi? =
+        resolveClass(className, apis, cache)?.let { api ->
+            api.fields[key] ?: api.supertypes.firstNotNullOfOrNull { lookupField(it, key, apis, cache) }
+        }
+
+    private fun isSubtypeOf(className: String, supertype: String, apis: Map<String, ClassApi>, cache: MutableMap<String, ClassApi>): Boolean {
+        if (className == supertype) return true
+        val api = resolveClass(className, apis, cache) ?: return false
+        return supertype in api.supertypes || api.supertypes.any { isSubtypeOf(it, supertype, apis, cache) }
     }
 }

--- a/build-src/src/main/kotlin/minestom.publishing.gradle.kts
+++ b/build-src/src/main/kotlin/minestom.publishing.gradle.kts
@@ -71,12 +71,27 @@ tasks.register<CheckAbiTask>("checkBinaryCompatibility") {
     group = "verification"
     description = "Checks binary compatibility against the baseline released version."
 
-    oldJar = layout.file(provider {
-        project.findProperty("baselineJarDir")?.toString()
-                ?.let { dir -> project.rootProject.file("$dir/${project.name}.jar") }
-                ?.takeIf { it.exists() }
+    val baselineJarDir = providers.gradleProperty("baselineJarDir")
+    oldJar = layout.file(baselineJarDir.flatMap { dir ->
+        val file = project.rootProject.layout.projectDirectory.file("$dir/${project.name}.jar")
+        providers.provider { if (file.asFile.exists()) file.asFile else null }
     })
 
     newJar = tasks.named<Jar>("jar").flatMap { it.archiveFile }
-}
 
+    rootProjectDir.set(project.rootProject.projectDir)
+    val javaExtension = project.extensions.findByType<JavaPluginExtension>() // No java plugin applied
+    if (javaExtension != null) {
+        sourceDirectories.from(javaExtension.sourceSets["main"].java.srcDirs)
+        project.configurations.findByName("compileClasspath")?.let { classpath.from(it) }
+
+        val javaToolchainService = project.extensions.findByType<JavaToolchainService>()
+        if (javaToolchainService != null) {
+            classpath.from(javaToolchainService.launcherFor(javaExtension.toolchain).map { launcher ->
+                project.fileTree(launcher.metadata.installationPath.dir("jmods")) {
+                    include("**/*.jmod")
+                }
+            })
+        }
+    }
+}


### PR DESCRIPTION
Add inline error messages like how Gradle did in 9.6+, by parsing line number from the sources Also ignore inner classes if the parent is internal 
Update the workflow to capture ::error instead
Fix some inheritance issues
Delete internal warnings, and don't even bother parsing internal classes.
Fixes some lookup issues (Uses toolchain to lookup dependency classes and parses them).