### PR TITLE
Refactor CachedPacket synchronization and docs

### DIFF
--- a/src/main/java/net/minestom/server/network/packet/server/CachedPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/CachedPacket.java
@@ -8,69 +8,208 @@ import net.minestom.server.network.packet.PacketWriting;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.lang.ref.SoftReference;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 /**
- * Represents a packet that is only computed when required (either due to memory demand or invalidated data)
- * <p>
- * The cache is stored in a {@link SoftReference} and is invalidated when {@link #invalidate()} is called.
- * <p>
- * Packet supplier must be thread-safe.
+ * Represents a packet whose framed representation is computed lazily and
+ * cached for reuse.
+ *
+ * <p>The cached value is stored in a {@link SoftReference}, allowing it to be
+ * reclaimed in response to memory pressure. The value is recomputed when the
+ * reference has been cleared or when {@link #invalidate()} is called.
+ *
+ * <p>When caching is enabled, cache computation is serialized so that only one
+ * thread invokes the packet supplier and computes a replacement value at a
+ * time. Cache reads and publication use acquire and release memory semantics.
+ *
+ * <p>When caching is disabled, calls to {@link #packet(ConnectionState)} invoke
+ * the packet supplier directly. The supplier must therefore be thread safe if
+ * this object may be accessed concurrently while caching is disabled.
+ *
+ * <p>The supplied packet and its serialized representation must remain valid
+ * for the {@link ConnectionState} used to populate the cache. A
+ * {@code CachedPacket} should not be shared across connection states when the
+ * resulting framed representation differs between those states.
  */
 @ApiStatus.Internal
 public final class CachedPacket implements SendablePacket {
-    private final Supplier<ServerPacket> packetSupplier;
-    private volatile @Nullable SoftReference<FramedPacket> packet;
+    private static final VarHandle PACKET;
 
-    public CachedPacket(Supplier<ServerPacket> packetSupplier) {
-        this.packetSupplier = packetSupplier;
+    static {
+        try {
+            PACKET = MethodHandles.lookup().findVarHandle(CachedPacket.class, "packet", SoftReference.class);
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
     }
 
+    private final Supplier<ServerPacket> packetSupplier;
+
+    // Accessed through PACKET using acquire/release semantics.
+    private @Nullable SoftReference<FramedPacket> packet;
+
+    /**
+     * Creates a cached packet backed by the given packet supplier.
+     *
+     * <p>The supplier is invoked whenever the framed packet must be recomputed.
+     * It may therefore be invoked multiple times over the lifetime of this
+     * object.
+     *
+     * <p>When caching is enabled, supplier invocation is serialized. When
+     * caching is disabled, the supplier may be invoked concurrently and must be
+     * thread safe if this object is accessed by multiple threads.
+     *
+     * @param packetSupplier the packet supplier
+     * @throws NullPointerException if {@code packetSupplier} is {@code null}
+     */
+    public CachedPacket(Supplier<ServerPacket> packetSupplier) {
+        this.packetSupplier = Objects.requireNonNull(packetSupplier, "packetSupplier");
+    }
+
+    /**
+     * Creates a cached packet backed by a constant packet value.
+     *
+     * @param packet the packet to frame and cache
+     * @throws NullPointerException if {@code packet} is {@code null}
+     */
     public CachedPacket(ServerPacket packet) {
+        Objects.requireNonNull(packet, "packet");
         this(() -> packet);
     }
 
+    /**
+     * Invalidates the currently cached packet, if any.
+     *
+     * <p>The next cache access recomputes the packet unless caching is disabled.
+     * This method has no effect when caching is disabled.
+     *
+     * @implSpec This method clears the cached reference using release semantics.
+     * Cache computation is not synchronized with invalidation, so an in progress
+     * computation may publish a value after this method returns.
+     */
     public void invalidate() {
         if (!ServerFlag.CACHED_PACKET) return;
-        this.packet = null;
+        PACKET.setRelease(this, null);
     }
 
+    /**
+     * Returns the packet represented by this cached value.
+     *
+     * <p>When caching is enabled, this method may initialize or reuse the cached
+     * framed packet. Supplier invocation and cache computation are serialized.
+     *
+     * <p>When caching is disabled, the packet supplier is invoked directly and
+     * may be invoked concurrently by multiple callers.
+     *
+     * @param state the connection state used when framing the packet
+     * @return the packet value
+     */
     public ServerPacket packet(ConnectionState state) {
-        FramedPacket cache = updatedCache(state);
+        final FramedPacket cache = updatedCache(state);
         return cache != null ? cache.packet() : packetSupplier.get();
     }
 
+    /**
+     * Returns the cached framed packet body for the given connection state.
+     *
+     * <p>If caching is enabled, this method initializes the cache when necessary.
+     * Cache computation and supplier invocation are serialized.
+     *
+     * <p>If caching is disabled, no framed body is created and {@code null} is
+     * returned.
+     *
+     * @param state the connection state used when framing the packet
+     * @return the framed packet body, or {@code null} when caching is disabled
+     */
     public @Nullable NetworkBuffer body(ConnectionState state) {
-        FramedPacket cache = updatedCache(state);
+        final FramedPacket cache = updatedCache(state);
         return cache != null ? cache.body() : null;
     }
 
+    /**
+     * Returns the current cached value, computing it when absent.
+     *
+     * @param state the connection state used when framing the packet
+     * @return the cached framed packet, or {@code null} when caching is disabled
+     */
     private @Nullable FramedPacket updatedCache(ConnectionState state) {
-        if (!ServerFlag.CACHED_PACKET)
-            return null;
-        SoftReference<FramedPacket> ref = packet;
-        FramedPacket cache;
-        if (ref == null || (cache = ref.get()) == null) {
-            final ServerPacket packet = packetSupplier.get();
-            final NetworkBuffer buffer = PacketWriting.allocateTrimmedPacket(state, packet,
-                    MinecraftServer.getCompressionThreshold());
-            cache = new FramedPacket(packet, buffer);
-            this.packet = new SoftReference<>(cache);
-        }
-        return cache;
+        if (!ServerFlag.CACHED_PACKET) return null;
+
+        final FramedPacket cache = cachedPacket();
+        return cache != null ? cache : computeCache(state);
     }
 
+    /**
+     * Returns an existing cached value or computes and publishes a replacement.
+     *
+     * <p>This method is synchronized so that only one thread invokes the packet
+     * supplier and computes a replacement cache entry at a time. The cache is
+     * checked again after acquiring this object's monitor because another thread
+     * may have populated it while the current thread was waiting.
+     *
+     * <p>Invalidation does not acquire this monitor. An invalidation occurring
+     * during computation may therefore be followed by publication of the
+     * in progress result.
+     *
+     * @param state the connection state used when framing the packet
+     * @return the existing or newly computed framed packet
+     */
+    private synchronized FramedPacket computeCache(ConnectionState state) {
+        final FramedPacket cache = cachedPacket();
+        if (cache != null) return cache;
+
+        final ServerPacket packet = packetSupplier.get();
+        final NetworkBuffer buffer = PacketWriting.allocateTrimmedPacket(state, packet, MinecraftServer.getCompressionThreshold());
+
+        final FramedPacket updated = new FramedPacket(packet, buffer);
+        PACKET.setRelease(this, new SoftReference<>(updated));
+        return updated;
+    }
+
+    /**
+     * Returns the currently referenced cached packet.
+     *
+     * <p>The cached reference is read using acquire semantics.
+     *
+     * @return the cached framed packet, or {@code null} if no cache exists or
+     * the soft reference has been cleared
+     */
+    @SuppressWarnings("unchecked")
+    private @Nullable FramedPacket cachedPacket() {
+        final SoftReference<FramedPacket> ref = (SoftReference<FramedPacket>) PACKET.getAcquire(this);
+        return ref != null ? ref.get() : null;
+    }
+
+    /**
+     * Returns whether a framed packet is currently cached and has not been
+     * reclaimed.
+     *
+     * <p>This result is inherently transient because the underlying soft
+     * reference may be cleared or the cache may be invalidated immediately
+     * after this method returns.
+     *
+     * @return {@code true} if caching is enabled and a cached value is currently
+     * available
+     */
     public boolean isValid() {
-        if (!ServerFlag.CACHED_PACKET) return false;
-        final SoftReference<FramedPacket> ref = packet;
-        return ref != null && ref.get() != null;
+        return ServerFlag.CACHED_PACKET && cachedPacket() != null;
     }
 
+    /**
+     * Returns a string representation containing the currently referenced
+     * cached value.
+     *
+     * <p>Calling this method does not invoke the packet supplier or repopulate
+     * the cache.
+     *
+     * @return a string representation of this cached packet
+     */
     @Override
     public String toString() {
-        final SoftReference<FramedPacket> ref = packet;
-        final FramedPacket cache = ref != null ? ref.get() : null;
-        return String.format("CachedPacket{cache=%s}", cache);
+        return String.format("CachedPacket{cache=%s}", cachedPacket());
     }
 }

--- a/src/main/java/net/minestom/server/network/packet/server/CachedPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/server/CachedPacket.java
@@ -32,6 +32,7 @@ public final class CachedPacket implements SendablePacket {
     }
 
     public void invalidate() {
+        if (!ServerFlag.CACHED_PACKET) return;
         this.packet = null;
     }
 
@@ -61,6 +62,7 @@ public final class CachedPacket implements SendablePacket {
     }
 
     public boolean isValid() {
+        if (!ServerFlag.CACHED_PACKET) return false;
         final SoftReference<FramedPacket> ref = packet;
         return ref != null && ref.get() != null;
     }


### PR DESCRIPTION
## Background

`CachedPacket` currently performs cache reconstruction without serializing concurrent misses. When multiple threads observe an empty or reclaimed cache at the same time, each thread may independently invoke the packet supplier, frame the packet, allocate a buffer, and copy the serialized data. Only one result is ultimately retained, so the remaining work is discarded.

This is particularly expensive for grouped packets, where many connections may request the same cached packet concurrently. For larger packets, a single cache miss can therefore multiply packet serialization, compression, allocation, and copying work across several threads. In the worst case, the cache intended to reduce CPU usage can temporarily increase it during races.

## Proposed changes

This change serializes the cache miss path as hits remain lock free and use acquire/release semantics, while only threads that observe a missing cache enter the synchronized reconstruction path. Ensuring that only one thread performs the expensive reconstruction. Other threads wait for that computation and then reuse the published result.

With virtual threads, waiting on the monitor allows the runtime to suspend the blocked virtual threads and use the carrier threads for other network writes instead of allowing every racing thread to duplicate the same expensive work.

The change also expands the concurrency documentation around cache publication, invalidation, supplier invocation, and the transient nature of `isValid()`.

## Types of changes

What types of changes does your code introduce to this project?
*Put an `x` in the boxes that apply*

* [ ] Bugfix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation Update (if none of the other choices apply)

## Checklist

*Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

* [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have added necessary documentation (if appropriate)

## Further comments

The common cache hit path remains unsynchronized. It performs an acquire read of the cached reference and immediately returns the cached packet when available. Publication uses release semantics so that the completed `FramedPacket` and its buffer are safely visible to lock free readers without requiring full volatile ordering.

Invalidation remains non blocking and is not serialized with an in progress cache computation. As a result, a computation already in progress may publish its result after `invalidate()` returns. This matches the existing weak invalidation behavior and avoids making invalidation wait for potentially expensive packet framing.

The current implementation continues to use a `SoftReference` so that cached packet bodies remain reclaimable under heap pressure. This is useful because `CachedPacket` is a mostly general purpose cache: some instances are global, while many others are associated with chunks and remain reachable until their owning chunk is unloaded.

This representation may be revisited in JDK 29 or later. `FramedPacket` is a possible value object candidate, and directly storing it inside a `SoftReference` may require boxing. A future implementation may instead use an explicit cache holder.