### PR TITLE
Entity external ticking

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -53,6 +53,7 @@ import net.minestom.server.tag.TagHandler;
 import net.minestom.server.tag.Taggable;
 import net.minestom.server.thread.Acquirable;
 import net.minestom.server.thread.AcquirableSource;
+import net.minestom.server.thread.TickOwner;
 import net.minestom.server.thread.TickThread;
 import net.minestom.server.timer.Schedulable;
 import net.minestom.server.timer.Scheduler;
@@ -175,6 +176,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     private boolean isActive; // False if entity has only been instanced without being added somewhere
     protected boolean removed;
     private volatile boolean externallyTicked;
+    private volatile @Nullable TickOwner tickOwner;
 
     private final List<Entity> passengers = new CopyOnWriteArrayList<>();
 
@@ -629,8 +631,12 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     public void tick(long time) {
         if (instance == null || isRemoved() || !ChunkUtils.isLoaded(currentChunk))
             return;
-        // Dispatcher eviction is a queued signal: a tick thread may still call in until it drains
-        if (externallyTicked && Thread.currentThread() instanceof TickThread) return;
+        // Dispatcher eviction is a queued signal: a tick thread may still call in until it drains.
+        // With a registered owner, only the owner's thread may tick.
+        if (externallyTicked) {
+            final TickOwner owner = this.tickOwner;
+            if (owner != null ? !owner.isCurrentThread() : Thread.currentThread() instanceof TickThread) return;
+        }
 
         // scheduled tasks
         this.scheduler.processTick();
@@ -872,7 +878,8 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
      * An externally ticked entity is not registered with the tick dispatcher (chunk crossings included), and
      * {@link #tick(long)} calls from server tick threads are ignored; the external system is expected to call
      * {@link #tick(long)} itself. Viewers and tracking are unaffected. {@link Acquirable} APIs assume
-     * dispatcher ownership and are not valid on externally ticked entities.
+     * dispatcher ownership and are not valid on externally ticked entities, unless an owner is registered
+     * with {@link #setExternallyTicked(TickOwner)}.
      *
      * @param externallyTicked true to let an external system tick this entity, false to hand it back to the server
      */
@@ -882,9 +889,36 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         final Chunk chunk = currentChunk;
         if (externallyTicked) {
             MinecraftServer.process().dispatcher().removeElement(this);
-        } else if (chunk != null && !isRemoved()) {
-            MinecraftServer.process().dispatcher().updateElement(this, chunk);
+        } else {
+            this.tickOwner = null;
+            acquirable().assignOwner(null);
+            if (chunk != null && !isRemoved()) {
+                MinecraftServer.process().dispatcher().updateElement(this, chunk);
+            }
         }
+    }
+
+    /**
+     * Changes this entity to be ticked by {@code owner} instead of the server.
+     * <p>
+     * Same as {@link #setExternallyTicked(boolean)}, except that only the owner's thread may call
+     * {@link #tick(long)} and {@link Acquirable} APIs stay valid by locking {@link TickOwner#lock()}.
+     *
+     * @param owner the external system ticking this entity
+     */
+    public void setExternallyTicked(TickOwner owner) {
+        this.tickOwner = owner;
+        acquirable().assignOwner(owner);
+        setExternallyTicked(true);
+    }
+
+    /**
+     * Gets the registered external tick owner, or null.
+     *
+     * @see #setExternallyTicked(TickOwner)
+     */
+    public @Nullable TickOwner getTickOwner() {
+        return tickOwner;
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -53,6 +53,7 @@ import net.minestom.server.tag.TagHandler;
 import net.minestom.server.tag.Taggable;
 import net.minestom.server.thread.Acquirable;
 import net.minestom.server.thread.AcquirableSource;
+import net.minestom.server.thread.TickThread;
 import net.minestom.server.timer.Schedulable;
 import net.minestom.server.timer.Scheduler;
 import net.minestom.server.timer.TaskSchedule;
@@ -173,6 +174,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     private final UUID uuid;
     private boolean isActive; // False if entity has only been instanced without being added somewhere
     protected boolean removed;
+    private volatile boolean externallyTicked;
 
     private final List<Entity> passengers = new CopyOnWriteArrayList<>();
 
@@ -627,6 +629,8 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     public void tick(long time) {
         if (instance == null || isRemoved() || !ChunkUtils.isLoaded(currentChunk))
             return;
+        // Dispatcher eviction is a queued signal: a tick thread may still call in until it drains
+        if (externallyTicked && Thread.currentThread() instanceof TickThread) return;
 
         // scheduled tasks
         this.scheduler.processTick();
@@ -850,7 +854,37 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     @ApiStatus.Internal
     protected void refreshCurrentChunk(Chunk currentChunk) {
         this.currentChunk = currentChunk;
-        MinecraftServer.process().dispatcher().updateElement(this, currentChunk);
+        if (!externallyTicked) MinecraftServer.process().dispatcher().updateElement(this, currentChunk);
+    }
+
+    /**
+     * Gets whether this entity is ticked by an external system instead of the server.
+     *
+     * @see #setExternallyTicked(boolean)
+     */
+    public boolean isExternallyTicked() {
+        return externallyTicked;
+    }
+
+    /**
+     * Changes whether this entity is ticked by the server.
+     * <p>
+     * An externally ticked entity is not registered with the tick dispatcher (chunk crossings included), and
+     * {@link #tick(long)} calls from server tick threads are ignored; the external system is expected to call
+     * {@link #tick(long)} itself. Viewers and tracking are unaffected. {@link Acquirable} APIs assume
+     * dispatcher ownership and are not valid on externally ticked entities.
+     *
+     * @param externallyTicked true to let an external system tick this entity, false to hand it back to the server
+     */
+    public void setExternallyTicked(boolean externallyTicked) {
+        if (this.externallyTicked == externallyTicked) return;
+        this.externallyTicked = externallyTicked;
+        final Chunk chunk = currentChunk;
+        if (externallyTicked) {
+            MinecraftServer.process().dispatcher().removeElement(this);
+        } else if (chunk != null && !isRemoved()) {
+            MinecraftServer.process().dispatcher().updateElement(this, chunk);
+        }
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -80,6 +80,7 @@ import net.minestom.server.tag.TagHandler;
 import net.minestom.server.tag.Taggable;
 import net.minestom.server.thread.Acquirable;
 import net.minestom.server.thread.AcquirableSource;
+import net.minestom.server.thread.TickOwner;
 import net.minestom.server.thread.TickThread;
 import net.minestom.server.timer.Schedulable;
 import net.minestom.server.timer.Scheduler;
@@ -214,6 +215,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     private boolean isActive; // False if entity has only been instanced without being added somewhere
     protected boolean removed;
     private volatile boolean externallyTicked;
+    private volatile @Nullable TickOwner tickOwner;
 
     private final List<Entity> passengers = new CopyOnWriteArrayList<>();
 
@@ -669,8 +671,12 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     public void tick(long time) {
         if (instance == null || isRemoved() || !ChunkUtils.isLoaded(currentChunk))
             return;
-        // Dispatcher eviction is a queued signal: a tick thread may still call in until it drains
-        if (externallyTicked && Thread.currentThread() instanceof TickThread) return;
+        // Dispatcher eviction is a queued signal: a tick thread may still call in until it drains.
+        // With a registered owner, only the owner's thread may tick.
+        if (externallyTicked) {
+            final TickOwner owner = this.tickOwner;
+            if (owner != null ? !owner.isCurrentThread() : Thread.currentThread() instanceof TickThread) return;
+        }
 
         // scheduled tasks
         this.scheduler.processTick();
@@ -913,7 +919,8 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
      * An externally ticked entity is not registered with the tick dispatcher (chunk crossings included), and
      * {@link #tick(long)} calls from server tick threads are ignored; the external system is expected to call
      * {@link #tick(long)} itself. Viewers and tracking are unaffected. {@link Acquirable} APIs assume
-     * dispatcher ownership and are not valid on externally ticked entities.
+     * dispatcher ownership and are not valid on externally ticked entities, unless an owner is registered
+     * with {@link #setExternallyTicked(TickOwner)}.
      *
      * @param externallyTicked true to let an external system tick this entity, false to hand it back to the server
      */
@@ -923,9 +930,36 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         final Chunk chunk = currentChunk;
         if (externallyTicked) {
             MinecraftServer.process().dispatcher().removeElement(this);
-        } else if (chunk != null && !isRemoved()) {
-            MinecraftServer.process().dispatcher().updateElement(this, chunk);
+        } else {
+            this.tickOwner = null;
+            acquirable().assignOwner(null);
+            if (chunk != null && !isRemoved()) {
+                MinecraftServer.process().dispatcher().updateElement(this, chunk);
+            }
         }
+    }
+
+    /**
+     * Changes this entity to be ticked by {@code owner} instead of the server.
+     * <p>
+     * Same as {@link #setExternallyTicked(boolean)}, except that only the owner's thread may call
+     * {@link #tick(long)} and {@link Acquirable} APIs stay valid by locking {@link TickOwner#lock()}.
+     *
+     * @param owner the external system ticking this entity
+     */
+    public void setExternallyTicked(TickOwner owner) {
+        this.tickOwner = owner;
+        acquirable().assignOwner(owner);
+        setExternallyTicked(true);
+    }
+
+    /**
+     * Gets the registered external tick owner, or null.
+     *
+     * @see #setExternallyTicked(TickOwner)
+     */
+    public @Nullable TickOwner getTickOwner() {
+        return tickOwner;
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -80,6 +80,7 @@ import net.minestom.server.tag.TagHandler;
 import net.minestom.server.tag.Taggable;
 import net.minestom.server.thread.Acquirable;
 import net.minestom.server.thread.AcquirableSource;
+import net.minestom.server.thread.TickThread;
 import net.minestom.server.timer.Schedulable;
 import net.minestom.server.timer.Scheduler;
 import net.minestom.server.timer.TaskSchedule;
@@ -212,6 +213,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     private final UUID uuid;
     private boolean isActive; // False if entity has only been instanced without being added somewhere
     protected boolean removed;
+    private volatile boolean externallyTicked;
 
     private final List<Entity> passengers = new CopyOnWriteArrayList<>();
 
@@ -667,6 +669,8 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     public void tick(long time) {
         if (instance == null || isRemoved() || !ChunkUtils.isLoaded(currentChunk))
             return;
+        // Dispatcher eviction is a queued signal: a tick thread may still call in until it drains
+        if (externallyTicked && Thread.currentThread() instanceof TickThread) return;
 
         // scheduled tasks
         this.scheduler.processTick();
@@ -891,7 +895,37 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     @ApiStatus.Internal
     protected void refreshCurrentChunk(Chunk currentChunk) {
         this.currentChunk = currentChunk;
-        MinecraftServer.process().dispatcher().updateElement(this, currentChunk);
+        if (!externallyTicked) MinecraftServer.process().dispatcher().updateElement(this, currentChunk);
+    }
+
+    /**
+     * Gets whether this entity is ticked by an external system instead of the server.
+     *
+     * @see #setExternallyTicked(boolean)
+     */
+    public boolean isExternallyTicked() {
+        return externallyTicked;
+    }
+
+    /**
+     * Changes whether this entity is ticked by the server.
+     * <p>
+     * An externally ticked entity is not registered with the tick dispatcher (chunk crossings included), and
+     * {@link #tick(long)} calls from server tick threads are ignored; the external system is expected to call
+     * {@link #tick(long)} itself. Viewers and tracking are unaffected. {@link Acquirable} APIs assume
+     * dispatcher ownership and are not valid on externally ticked entities.
+     *
+     * @param externallyTicked true to let an external system tick this entity, false to hand it back to the server
+     */
+    public void setExternallyTicked(boolean externallyTicked) {
+        if (this.externallyTicked == externallyTicked) return;
+        this.externallyTicked = externallyTicked;
+        final Chunk chunk = currentChunk;
+        if (externallyTicked) {
+            MinecraftServer.process().dispatcher().removeElement(this);
+        } else if (chunk != null && !isRemoved()) {
+            MinecraftServer.process().dispatcher().updateElement(this, chunk);
+        }
     }
 
     /**

--- a/src/main/java/net/minestom/server/thread/Acquirable.java
+++ b/src/main/java/net/minestom/server/thread/Acquirable.java
@@ -2,6 +2,7 @@ package net.minestom.server.thread;
 
 import net.minestom.server.entity.Entity;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
 
 import java.util.Optional;
@@ -175,4 +176,11 @@ public sealed interface Acquirable<T> permits AcquirableImpl {
      * @throws AcquirableOwnershipException if the current thread does not own the acquirable element
      */
     void assertOwnership();
+
+    /**
+     * Routes acquisition through an external {@link TickOwner} instead of the assigned {@link TickThread};
+     * {@code null} restores dispatcher routing.
+     */
+    @ApiStatus.Internal
+    void assignOwner(@Nullable TickOwner owner);
 }

--- a/src/main/java/net/minestom/server/thread/AcquirableImpl.java
+++ b/src/main/java/net/minestom/server/thread/AcquirableImpl.java
@@ -21,6 +21,7 @@ final class AcquirableImpl<T> implements Acquirable<T> {
     private final T value;
     private final Thread initThread = Thread.currentThread();
     private volatile @Nullable TickThread assignedThread;
+    private volatile @Nullable TickOwner tickOwner;
 
     public AcquirableImpl(T value) {
         this.value = value;
@@ -28,6 +29,8 @@ final class AcquirableImpl<T> implements Acquirable<T> {
 
     @Override
     public Acquired<T> lock() {
+        final TickOwner owner = this.tickOwner;
+        if (owner != null) return new AcquiredImpl<>(unwrap(), enter(owner));
         final TickThread assignedThread = this.assignedThread;
         if (assignedThread == null) {
             assertInitThread();
@@ -40,12 +43,16 @@ final class AcquirableImpl<T> implements Acquirable<T> {
 
     @Override
     public boolean isLocal() {
+        final TickOwner owner = this.tickOwner;
+        if (owner != null) return owner.isCurrentThread();
         final TickThread assignedThread = this.assignedThread;
         return Thread.currentThread() == Objects.requireNonNullElse(assignedThread, initThread);
     }
 
     @Override
     public boolean isOwned() {
+        final TickOwner owner = this.tickOwner;
+        if (owner != null) return isOwnedImpl(owner);
         final TickThread assignedThread = this.assignedThread;
         if (assignedThread == null) return Thread.currentThread() == initThread;
         return AcquirableImpl.isOwnedImpl(assignedThread);
@@ -53,6 +60,16 @@ final class AcquirableImpl<T> implements Acquirable<T> {
 
     @Override
     public void sync(Consumer<T> consumer) {
+        final TickOwner owner = this.tickOwner;
+        if (owner != null) {
+            ReentrantLock lock = enter(owner);
+            try {
+                consumer.accept(unwrap());
+            } finally {
+                leave(lock);
+            }
+            return;
+        }
         final TickThread assignedThread = this.assignedThread;
         if (assignedThread == null) {
             assertInitThread();
@@ -74,16 +91,16 @@ final class AcquirableImpl<T> implements Acquirable<T> {
             consumer.accept(unwrap());
             return true;
         }
-        TickThread assignedThread = this.assignedThread;
-        if (assignedThread != null) {
-            ReentrantLock lock = assignedThread.lock();
-            if (lock.tryLock()) {
-                try {
-                    consumer.accept(unwrap());
-                    return true;
-                } finally {
-                    lock.unlock();
-                }
+        final TickOwner owner = this.tickOwner;
+        final TickThread assignedThread = this.assignedThread;
+        final ReentrantLock lock = owner != null ? owner.lock()
+                : assignedThread != null ? assignedThread.lock() : null;
+        if (lock != null && lock.tryLock()) {
+            try {
+                consumer.accept(unwrap());
+                return true;
+            } finally {
+                lock.unlock();
             }
         }
         return false;
@@ -104,12 +121,18 @@ final class AcquirableImpl<T> implements Acquirable<T> {
     }
 
     @Override
+    public void assignOwner(@Nullable TickOwner owner) {
+        this.tickOwner = owner;
+    }
+
+    @Override
     public void assertOwnership() {
         if (!ASSERTIONS_ENABLED && !ServerFlag.ACQUIRABLE_STRICT) return;
         if (isOwned()) return;
+        TickOwner owner = this.tickOwner;
         TickThread assignedThread = this.assignedThread;
         Thread initThread = this.initThread;
-        if (assignedThread == null && Thread.currentThread() == initThread) return;
+        if (owner == null && assignedThread == null && Thread.currentThread() == initThread) return;
         throw new AcquirableOwnershipException(initThread, assignedThread, unwrap().toString());
     }
 
@@ -123,8 +146,22 @@ final class AcquirableImpl<T> implements Acquirable<T> {
         return elementThread.lock().isHeldByCurrentThread();
     }
 
+    static boolean isOwnedImpl(TickOwner owner) {
+        if (owner.isCurrentThread()) return true;
+        return owner.lock().isHeldByCurrentThread();
+    }
+
     static @Nullable ReentrantLock enter(TickThread elementThread) {
         if (isOwnedImpl(elementThread)) return null; // Nothing to lock, already owned by the current thread.
+        return enterLock(elementThread.lock());
+    }
+
+    static @Nullable ReentrantLock enter(TickOwner owner) {
+        if (isOwnedImpl(owner)) return null;
+        return enterLock(owner.lock());
+    }
+
+    private static ReentrantLock enterLock(ReentrantLock targetLock) {
         final long time = System.nanoTime();
         // Enter the target thread
         if (Thread.currentThread() instanceof TickThread tickThread && tickThread.lock().isHeldByCurrentThread()) {
@@ -135,7 +172,6 @@ final class AcquirableImpl<T> implements Acquirable<T> {
         } else {
             GLOBAL_LOCK.lock();
         }
-        final ReentrantLock targetLock = elementThread.lock();
         targetLock.lock();
         WAIT_COUNTER_NANO.addAndGet(System.nanoTime() - time);
         return targetLock;

--- a/src/main/java/net/minestom/server/thread/TickOwner.java
+++ b/src/main/java/net/minestom/server/thread/TickOwner.java
@@ -1,0 +1,25 @@
+package net.minestom.server.thread;
+
+import net.minestom.server.entity.Entity;
+
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Tick loop of an external system owning entities, registered through
+ * {@link Entity#setExternallyTicked(TickOwner)} so that {@link Acquirable} stays valid on them.
+ * <p>
+ * Acquisition locks {@link #lock()} the same way it locks a {@link TickThread}'s: the owner's loop
+ * must hold it while ticking its elements, and must not hold it while acquiring foreign elements.
+ */
+public interface TickOwner {
+
+    /**
+     * Gets the lock held by the owner's loop while it ticks its elements.
+     */
+    ReentrantLock lock();
+
+    /**
+     * Gets whether the calling thread is the owner's tick thread.
+     */
+    boolean isCurrentThread();
+}

--- a/src/test/java/net/minestom/server/entity/EntityExternalTickIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/EntityExternalTickIntegrationTest.java
@@ -1,0 +1,87 @@
+package net.minestom.server.entity;
+
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.thread.TickThread;
+import net.minestom.testing.Env;
+import net.minestom.testing.EnvTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@EnvTest
+public class EntityExternalTickIntegrationTest {
+
+    @Test
+    public void tickOwnership(Env env) {
+        var instance = env.createFlatInstance();
+        var entity = new TickCounter();
+        entity.setInstance(instance, new Pos(0, 42, 0)).join();
+
+        env.tick();
+        assertEquals(1, entity.ticks, "Server-ticked by default");
+
+        entity.setExternallyTicked(true);
+        env.tick();
+        env.tick();
+        assertEquals(1, entity.ticks, "The server must not tick an externally ticked entity");
+
+        entity.tick(System.currentTimeMillis());
+        assertEquals(2, entity.ticks, "The external system ticks it directly");
+
+        entity.setExternallyTicked(false);
+        env.tick();
+        assertEquals(3, entity.ticks, "Server ticking resumes");
+    }
+
+    @Test
+    public void chunkCrossing(Env env) {
+        var instance = env.createFlatInstance();
+        instance.loadChunk(4, 0).join();
+        var entity = new TickCounter();
+        entity.setInstance(instance, new Pos(0, 42, 0)).join();
+        entity.setExternallyTicked(true);
+
+        // A chunk crossing re-registers a regular entity with the dispatcher
+        entity.teleport(new Pos(64, 42, 0)).join();
+        env.tick();
+        env.tick();
+        assertEquals(0, entity.ticks, "A chunk crossing must not hand the entity back to the server");
+    }
+
+    @Test
+    public void evictionWindow(Env env) throws Exception {
+        var instance = env.createFlatInstance();
+        var entity = new TickCounter();
+        entity.setInstance(instance, new Pos(0, 42, 0)).join();
+        entity.setExternallyTicked(true);
+
+        // Eviction is a queued dispatcher signal: until it drains, tick threads may still reach the entity
+        var done = new CompletableFuture<Void>();
+        Thread thread = new TickThread("test-tick-thread") {
+            @Override
+            public void run() {
+                entity.tick(System.currentTimeMillis());
+                done.complete(null);
+            }
+        };
+        thread.start();
+        done.get(5, TimeUnit.SECONDS);
+        assertEquals(0, entity.ticks, "a tick-thread call must be ignored while externally ticked");
+    }
+
+    static final class TickCounter extends Entity {
+        int ticks;
+
+        TickCounter() {
+            super(EntityType.ZOMBIE);
+        }
+
+        @Override
+        public void update(long time) {
+            ticks++;
+        }
+    }
+}

--- a/src/test/java/net/minestom/server/thread/AcquirableTickOwnerIntegrationTest.java
+++ b/src/test/java/net/minestom/server/thread/AcquirableTickOwnerIntegrationTest.java
@@ -1,0 +1,112 @@
+package net.minestom.server.thread;
+
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.EntityType;
+import net.minestom.testing.Env;
+import net.minestom.testing.EnvTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@EnvTest
+public class AcquirableTickOwnerIntegrationTest {
+
+    @Test
+    public void ownerRouting(Env env) throws InterruptedException {
+        var instance = env.createFlatInstance();
+        var owner = new TestOwner();
+        var entity = new Entity(EntityType.ZOMBIE);
+        entity.setInstance(instance, new Pos(0, 42, 0)).join();
+        entity.setExternallyTicked(owner);
+        var acquirable = entity.acquirable();
+
+        assertFalse(acquirable.isLocal());
+        assertFalse(acquirable.isOwned());
+        acquirable.sync(e -> assertTrue(acquirable.isOwned()));
+
+        // On the owner's thread the element is local: sync is free
+        var done = new CountDownLatch(1);
+        Thread.startVirtualThread(() -> {
+            owner.thread = Thread.currentThread();
+            assertTrue(acquirable.isLocal());
+            acquirable.sync(e -> assertTrue(acquirable.isLocal()));
+            done.countDown();
+        });
+        assertTrue(done.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void ownerBlocking(Env env) throws InterruptedException {
+        var instance = env.createFlatInstance();
+        var owner = new TestOwner();
+        var entity = new Entity(EntityType.ZOMBIE);
+        entity.setInstance(instance, new Pos(0, 42, 0)).join();
+        entity.setExternallyTicked(owner);
+
+        // A sync must wait while the owner's loop holds its lock
+        owner.lock.lock();
+        var acquired = new CountDownLatch(1);
+        Thread.startVirtualThread(() -> entity.acquirable().sync(e -> acquired.countDown()));
+        assertFalse(acquired.await(200, TimeUnit.MILLISECONDS), "Sync must block while the owner ticks");
+        owner.lock.unlock();
+        assertTrue(acquired.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void ownerGuard(Env env) {
+        var instance = env.createFlatInstance();
+        var owner = new TestOwner();
+        var ticks = new AtomicInteger();
+        var entity = new Entity(EntityType.ZOMBIE) {
+            @Override
+            public void update(long time) {
+                ticks.incrementAndGet();
+            }
+        };
+        entity.setInstance(instance, new Pos(0, 42, 0)).join();
+        entity.setExternallyTicked(owner);
+
+        entity.tick(System.currentTimeMillis()); // Not the owner's thread: ignored
+        assertEquals(0, ticks.get());
+
+        owner.thread = Thread.currentThread();
+        entity.tick(System.currentTimeMillis());
+        assertEquals(1, ticks.get());
+    }
+
+    @Test
+    public void ownerHandback(Env env) {
+        var instance = env.createFlatInstance();
+        var owner = new TestOwner();
+        var entity = new Entity(EntityType.ZOMBIE);
+        entity.setInstance(instance, new Pos(0, 42, 0)).join();
+        entity.setExternallyTicked(owner);
+        assertSame(owner, entity.getTickOwner());
+
+        entity.setExternallyTicked(false);
+        assertNull(entity.getTickOwner());
+        env.tick(); // Re-registration assigns a tick thread again
+        assertNotNull(entity.acquirable().assignedThread());
+    }
+
+    static final class TestOwner implements TickOwner {
+        final ReentrantLock lock = new ReentrantLock();
+        volatile Thread thread;
+
+        @Override
+        public ReentrantLock lock() {
+            return lock;
+        }
+
+        @Override
+        public boolean isCurrentThread() {
+            return Thread.currentThread() == thread;
+        }
+    }
+}

--- a/src/test/java/net/minestom/server/thread/AcquirableTickOwnerIntegrationTest.java
+++ b/src/test/java/net/minestom/server/thread/AcquirableTickOwnerIntegrationTest.java
@@ -1,0 +1,120 @@
+package net.minestom.server.thread;
+
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.EntityType;
+import net.minestom.testing.Env;
+import net.minestom.testing.EnvTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnvTest
+public class AcquirableTickOwnerIntegrationTest {
+
+    @Test
+    public void ownerRouting(Env env) throws InterruptedException {
+        var instance = env.createFlatInstance();
+        var owner = new TestOwner();
+        var entity = new Entity(EntityType.ZOMBIE);
+        entity.setInstance(instance, new Pos(0, 42, 0)).join();
+        entity.setExternallyTicked(owner);
+        var acquirable = entity.acquirable();
+
+        assertFalse(acquirable.isLocal());
+        assertFalse(acquirable.isOwned());
+        acquirable.sync(_ -> assertTrue(acquirable.isOwned()));
+
+        // On the owner's thread the element is local: sync is free
+        var done = new CountDownLatch(1);
+        Thread.startVirtualThread(() -> {
+            owner.thread = Thread.currentThread();
+            assertTrue(acquirable.isLocal());
+            acquirable.sync(_ -> assertTrue(acquirable.isLocal()));
+            done.countDown();
+        });
+        assertTrue(done.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void ownerBlocking(Env env) throws InterruptedException {
+        var instance = env.createFlatInstance();
+        var owner = new TestOwner();
+        var entity = new Entity(EntityType.ZOMBIE);
+        entity.setInstance(instance, new Pos(0, 42, 0)).join();
+        entity.setExternallyTicked(owner);
+
+        // A sync must wait while the owner's loop holds its lock
+        var acquired = new CountDownLatch(1);
+        owner.lock.lock();
+        try {
+            Thread.startVirtualThread(() -> entity.acquirable().sync(_ -> acquired.countDown()));
+            assertFalse(acquired.await(200, TimeUnit.MILLISECONDS), "Sync must block while the owner ticks");
+        } finally {
+            owner.lock.unlock();
+        }
+        assertTrue(acquired.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void ownerGuard(Env env) {
+        var instance = env.createFlatInstance();
+        var owner = new TestOwner();
+        var ticks = new AtomicInteger();
+        var entity = new Entity(EntityType.ZOMBIE) {
+            @Override
+            public void update(long time) {
+                ticks.incrementAndGet();
+            }
+        };
+        entity.setInstance(instance, new Pos(0, 42, 0)).join();
+        entity.setExternallyTicked(owner);
+
+        entity.tick(System.currentTimeMillis()); // Not the owner's thread: ignored
+        assertEquals(0, ticks.get());
+
+        owner.thread = Thread.currentThread();
+        entity.tick(System.currentTimeMillis());
+        assertEquals(1, ticks.get());
+    }
+
+    @Test
+    public void ownerHandback(Env env) {
+        var instance = env.createFlatInstance();
+        var owner = new TestOwner();
+        var entity = new Entity(EntityType.ZOMBIE);
+        entity.setInstance(instance, new Pos(0, 42, 0)).join();
+        entity.setExternallyTicked(owner);
+        assertSame(owner, entity.getTickOwner());
+
+        entity.setExternallyTicked(false);
+        assertNull(entity.getTickOwner());
+        env.tick(); // Re-registration assigns a tick thread again
+        assertNotNull(entity.acquirable().assignedThread());
+    }
+
+    static final class TestOwner implements TickOwner {
+        final ReentrantLock lock = new ReentrantLock();
+        volatile Thread thread;
+
+        @Override
+        public ReentrantLock lock() {
+            return lock;
+        }
+
+        @Override
+        public boolean isCurrentThread() {
+            return Thread.currentThread() == thread;
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

Adds a supported way for an external system (per-entity container parallel tickers, custom schedulers) to own an entity's tick. Currently this requires overriding the internal `refreshCurrentChunk` in every entity hierarchy and racing the dispatcher's queued eviction signal, which can double-tick an entity for up to a tick after hand-off.

- `Entity#setExternallyTicked(boolean)`: the entity is kept out of the tick dispatcher (chunk crossings included) and `tick()` calls from tick threads are ignored; the external system calls `tick()` itself. Default is off with no behavior unchanged, one volatile read added.
- `Entity#setExternallyTicked(TickOwner)`: registers the owner: only its thread may tick, and `Acquirable` stays valid. `TickOwner` exposes a `ReentrantLock` like `TickThread`. Acquisition goes through the existing `GLOBAL_LOCK` discipline, so `sync`/`lock`/`trySync` are unchanged.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

There is no cancellable pre-tick hook and dispatcher eviction is a queued signal, so a flag plus a `TickThread` guard in `tick()` is the smallest safe seam. `TickOwner` is the interface `TickThread` could itself implement (`lock()` already exists there with the same semantics). Covered by `EntityExternalTickIntegrationTest` and `AcquirableTickOwnerIntegrationTest`, the existing thread-package suite passes unchanged.