### PR TITLE
Match vanilla/Paper registry tag ordering

### DIFF
--- a/src/main/java/net/minestom/server/instance/Section.java
+++ b/src/main/java/net/minestom/server/instance/Section.java
@@ -1,20 +1,44 @@
 package net.minestom.server.instance;
 
+import net.minestom.server.MinecraftServer;
 import net.minestom.server.instance.light.Light;
 import net.minestom.server.instance.palette.Palette;
+import net.minestom.server.registry.DynamicRegistry;
+import net.minestom.server.world.biome.Biome;
 
 public record Section(Palette blockPalette, Palette biomePalette, Light skyLight, Light blockLight) {
+    // Biome ids are no longer guaranteed to place plains at 0 (biomes are now sent in vanilla
+    // alphabetical order, see Biome#createDefaultRegistry), so the default "empty" biome is resolved
+    // from the registry once it is available and cached. Falls back to 0 during early init / tests.
+    private static volatile int cachedDefaultBiomeId = -1;
+
     public Section(Palette blockPalette, Palette biomePalette) {
         this(blockPalette, biomePalette, Light.sky(), Light.block());
     }
 
     public Section() {
         this(Palette.blocks(), Palette.biomes());
+        this.biomePalette.fill(defaultBiomeId());
     }
 
     public void clear() {
         this.blockPalette.fill(0);
-        this.biomePalette.fill(0);
+        this.biomePalette.fill(defaultBiomeId());
+    }
+
+    private static int defaultBiomeId() {
+        int cached = cachedDefaultBiomeId;
+        if (cached >= 0) return cached;
+        try {
+            final DynamicRegistry<Biome> registry = MinecraftServer.getBiomeRegistry();
+            if (registry == null) return 0;
+            final int id = registry.getId(Biome.PLAINS);
+            if (id < 0) return 0;
+            cachedDefaultBiomeId = id;
+            return id;
+        } catch (Exception ignored) {
+            return 0; // registry not ready yet; retry on next call
+        }
     }
 
     public void invalidate() {

--- a/src/main/java/net/minestom/server/registry/DynamicRegistry.java
+++ b/src/main/java/net/minestom/server/registry/DynamicRegistry.java
@@ -56,7 +56,8 @@ public sealed interface DynamicRegistry<T> extends Registry<T> permits DynamicRe
      */
     @ApiStatus.Internal
     static <T> DynamicRegistry<T> create(RegistryKey<Registry<T>> key, Codec<T> codec) {
-        return create(key, codec, null, null, null);
+        // Default to vanilla (alphabetical by id) ordering so network ids match a vanilla/Paper server.
+        return create(key, codec, null, Comparator.naturalOrder(), null);
     }
 
     /**
@@ -66,7 +67,8 @@ public sealed interface DynamicRegistry<T> extends Registry<T> permits DynamicRe
      */
     @ApiStatus.Internal
     static <T> DynamicRegistry<T> create(RegistryKey<Registry<T>> key, Codec<T> codec, @Nullable Registries registries) {
-        return create(key, codec, registries, null, null);
+        // Default to vanilla (alphabetical by id) ordering so network ids match a vanilla/Paper server.
+        return create(key, codec, registries, Comparator.naturalOrder(), null);
     }
 
     /**
@@ -88,7 +90,8 @@ public sealed interface DynamicRegistry<T> extends Registry<T> permits DynamicRe
     ) {
         final DynamicRegistryImpl<T> registry = new DynamicRegistryImpl<>(key.key(), codec);
         final Registries effectiveRegistries = loadingRegistries.apply(registries, registry);
-        registry.loadStaticJsonRegistry(effectiveRegistries, null, codec);
+        // Default to vanilla (alphabetical by id) ordering so network ids match a vanilla/Paper server.
+        registry.loadStaticJsonRegistry(effectiveRegistries, Comparator.naturalOrder(), codec);
         return registry.compact();
     }
 

--- a/src/main/java/net/minestom/server/world/DimensionType.java
+++ b/src/main/java/net/minestom/server/world/DimensionType.java
@@ -12,6 +12,8 @@ import net.minestom.server.world.timeline.Timeline;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 
+import java.util.Comparator;
+
 /**
  * <a href="https://minecraft.wiki/w/Dimension_type">Dimension type</a>
  */
@@ -69,7 +71,10 @@ public sealed interface DimensionType extends DimensionTypes permits DimensionTy
      */
     @ApiStatus.Internal
     static DynamicRegistry<DimensionType> createDefaultRegistry(Registries registries) {
-        return DynamicRegistry.create(BuiltinRegistries.DIMENSION_TYPE, REGISTRY_CODEC, registries);
+        // Emit entries in vanilla (alphabetical by id) order so the network ids assigned to dimension
+        // types match a vanilla/Paper server.
+        return DynamicRegistry.create(BuiltinRegistries.DIMENSION_TYPE, REGISTRY_CODEC, registries,
+                Comparator.naturalOrder(), null);
     }
 
     boolean hasFixedTime();

--- a/src/main/java/net/minestom/server/world/biome/Biome.java
+++ b/src/main/java/net/minestom/server/world/biome/Biome.java
@@ -11,6 +11,8 @@ import net.minestom.server.world.attribute.EnvironmentAttributeMap;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 
+import java.util.Comparator;
+
 public sealed interface Biome extends Biomes permits BiomeImpl {
     Codec<Biome> REGISTRY_CODEC = StructCodec.struct(
             "has_precipitation", Codec.BOOLEAN, Biome::hasPrecipitation,
@@ -52,9 +54,12 @@ public sealed interface Biome extends Biomes permits BiomeImpl {
     static DynamicRegistry<Biome> createDefaultRegistry() {
         return DynamicRegistry.create(
                 BuiltinRegistries.WORLDGEN_BIOME, NETWORK_CODEC, null,
-                // We force plains to be first because it allows convenient palette initialization.
-                // Maybe worth switching to fetching plains in the palette in the future to avoid this.
-                (a, b) -> a.equals("minecraft:plains") ? -1 : b.equals("minecraft:plains") ? 1 : 0,
+                // Emit entries in vanilla (alphabetical by id) order so the network ids assigned to
+                // biomes match a vanilla/Paper server.
+                //
+                // Note: this no longer forces plains to id 0, so the empty-section biome default is
+                // resolved dynamically instead - see Section#defaultBiomeId.
+                Comparator.naturalOrder(),
                 REGISTRY_CODEC
         );
     }


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

This is a bugfix/correctness PR.

We're working on a feature that skips the reconfiguring screen when switching between backend servers through Velocity. This is only possible when the registries match exactly between backend servers, otherwise very weird behavior will occur (biomes mismatch, overworld looks like end, all blocks are different, etc. etc.). See https://github.com/GemstoneGG/Velocity-CTD/pull/1004.

Paper/vanilla uses a stable registry tag order; it sorts them alphabetically. This means that skipping the reconfig screen between Paper backends (that are on the same (Minecraft) version) is possible, but unfortunately, because Minestom sorts the registry tags differently, it currently isn't possible to skip the reconfig screen when transfering from a Minestom backend to a Paper backend or vice versa.

This PR aligns Minestom's tag ordering with that of Paper, making it possible to skip the reconfig screen through a PR like the referenced PR (vanilla Velocity also has a open, terminally-unmerged PR open for this reconfig-skipping behavior, this PR would of course make Minestom compatible with that one as well).

Happy to add tests covering this if needed, but as this is a simple change (changing previously untested behavior), I haven't implemented them just yet.