### PR TITLE
feat: Extract a public LightEngine for lighting arbitrary worlds

### DIFF
--- a/src/main/java/net/minestom/server/instance/LightingChunk.java
+++ b/src/main/java/net/minestom/server/instance/LightingChunk.java
@@ -1,29 +1,23 @@
 package net.minestom.server.instance;
 
-import net.kyori.adventure.key.Key;
-import net.minestom.server.MinecraftServer;
 import net.minestom.server.ServerFlag;
-import net.minestom.server.collision.Shape;
 import net.minestom.server.coordinate.CoordConversion;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.instance.block.BlockHandler;
 import net.minestom.server.instance.heightmap.Heightmap;
 import net.minestom.server.instance.light.Light;
+import net.minestom.server.instance.light.LightEngine;
 import net.minestom.server.instance.palette.Palette;
 import net.minestom.server.network.packet.server.CachedPacket;
 import net.minestom.server.network.packet.server.play.data.LightData;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 
 import static net.minestom.server.instance.light.LightCompute.EMPTY_CONTENT;
 
@@ -34,8 +28,6 @@ import static net.minestom.server.instance.light.LightCompute.EMPTY_CONTENT;
  * <p>
  */
 public class LightingChunk extends DynamicChunk {
-
-    private static final ExecutorService pool = Executors.newWorkStealingPool();
 
     private volatile @Nullable OcclusionData occlusionData;
     final CachedPacket partialLightCache = new CachedPacket(this::createLightPacket);
@@ -49,42 +41,6 @@ public class LightingChunk extends DynamicChunk {
     private final int resendDelay = ServerFlag.SEND_LIGHT_AFTER_BLOCK_PLACEMENT_DELAY;
 
     private boolean doneInit = false;
-
-    enum LightType {
-        SKY,
-        BLOCK
-    }
-
-    private enum QueueType {
-        INTERNAL,
-        EXTERNAL
-    }
-
-    private static final Set<Key> DIFFUSE_SKY_LIGHT = Set.of(
-            Block.COBWEB.key(),
-            Block.ICE.key(),
-            Block.HONEY_BLOCK.key(),
-            Block.SLIME_BLOCK.key(),
-            Block.WATER.key(),
-            Block.ACACIA_LEAVES.key(),
-            Block.AZALEA_LEAVES.key(),
-            Block.BIRCH_LEAVES.key(),
-            Block.DARK_OAK_LEAVES.key(),
-            Block.FLOWERING_AZALEA_LEAVES.key(),
-            Block.JUNGLE_LEAVES.key(),
-            Block.CHERRY_LEAVES.key(),
-            Block.OAK_LEAVES.key(),
-            Block.SPRUCE_LEAVES.key(),
-            Block.SPAWNER.key(),
-            Block.BEACON.key(),
-            Block.END_GATEWAY.key(),
-            Block.CHORUS_PLANT.key(),
-            Block.CHORUS_FLOWER.key(),
-            Block.FROSTED_ICE.key(),
-            Block.SEAGRASS.key(),
-            Block.TALL_SEAGRASS.key(),
-            Block.LAVA.key()
-    );
 
     public void invalidate() {
         this.partialLightCache.invalidate();
@@ -102,14 +58,7 @@ public class LightingChunk extends DynamicChunk {
     }
 
     private boolean checkSkyOcclusion(Block block) {
-        if (block == Block.AIR) return false;
-        if (DIFFUSE_SKY_LIGHT.contains(block.key())) return true;
-
-        Shape shape = block.registry().occlusionShape();
-        boolean occludesTop = Block.AIR.registry().occlusionShape().isOccluded(shape, BlockFace.TOP);
-        boolean occludesBottom = Block.AIR.registry().occlusionShape().isOccluded(shape, BlockFace.BOTTOM);
-
-        return occludesBottom || occludesTop;
+        return LightEngine.checkSkyOcclusion(block);
     }
 
     public void setFreezeInvalidation(boolean freezeInvalidation) {
@@ -291,14 +240,14 @@ public class LightingChunk extends DynamicChunk {
                 boolean wasUpdatedSky = false;
 
                 if (section.blockLight().requiresUpdate()) {
-                    relightSection(instance, this.chunkX, index + minSection, chunkZ, LightType.BLOCK);
+                    relightSection(instance, this.chunkX, index + minSection, chunkZ, LightEngine.Type.BLOCK);
                     wasUpdatedBlock = true;
                 } else if (requiredFullChunk || section.blockLight().requiresSend()) {
                     wasUpdatedBlock = true;
                 }
 
                 if (section.skyLight().requiresUpdate()) {
-                    relightSection(instance, this.chunkX, index + minSection, chunkZ, LightType.SKY);
+                    relightSection(instance, this.chunkX, index + minSection, chunkZ, LightEngine.Type.SKY);
                     wasUpdatedSky = true;
                 } else if (requiredFullChunk || section.skyLight().requiresSend()) {
                     wasUpdatedSky = true;
@@ -358,84 +307,55 @@ public class LightingChunk extends DynamicChunk {
         }
     }
 
-    private static Set<Chunk> flushQueue(Instance instance, Set<Point> queue, LightType type, QueueType queueType) {
-        Set<Light> sections = ConcurrentHashMap.newKeySet();
-        Set<Point> newQueue = ConcurrentHashMap.newKeySet();
+    private static Set<Chunk> flushQueue(Instance instance, Set<Point> queue, LightEngine.Type type) {
+        Set<Chunk> chunks = new HashSet<>();
+        for (Point section : LightEngine.relight(new InstanceView(instance), queue, type)) {
+            Chunk chunk = instance.getChunk(section.blockX(), section.blockZ());
+            if (chunk != null) chunks.add(chunk);
+        }
+        return chunks;
+    }
 
-        Set<Chunk> responseChunks = ConcurrentHashMap.newKeySet();
-        List<CompletableFuture<Void>> tasks = new ArrayList<>();
-
-        Light.LightLookup lightLookup = (x, y, z) -> {
-            Chunk chunk = instance.getChunk(x, z);
-            if (chunk == null) return null;
+    /** {@link LightEngine.WorldView} over an instance's loaded {@link LightingChunk}s. */
+    private record InstanceView(Instance instance) implements LightEngine.WorldView {
+        @Override
+        public Light light(LightEngine.Type type, int chunkX, int sectionY, int chunkZ) {
+            Chunk chunk = instance.getChunk(chunkX, chunkZ);
             if (!(chunk instanceof LightingChunk lighting)) return null;
-            if (y - lighting.getMinSection() < 0 || y - lighting.getMaxSection() >= 0) return null;
-            final Section section = lighting.getSection(y);
-            return switch (type) {
-                case BLOCK -> section.blockLight();
-                case SKY -> section.skyLight();
-            };
-        };
-
-        Light.PaletteLookup paletteLookup = (x, y, z) -> {
-            Chunk chunk = instance.getChunk(x, z);
-            if (chunk == null) return null;
-            if (!(chunk instanceof LightingChunk lighting)) return null;
-            if (y - lighting.getMinSection() < 0 || y - lighting.getMaxSection() >= 0) return null;
-            return chunk.getSection(y).blockPalette();
-        };
-
-        for (Point point : queue) {
-            Chunk chunk = instance.getChunk(point.blockX(), point.blockZ());
-            if (!(chunk instanceof LightingChunk lightingChunk)) continue;
-
-            Section section = chunk.getSection(point.blockY());
-            responseChunks.add(chunk);
-
-            Light light = switch (type) {
-                case BLOCK -> section.blockLight();
-                case SKY -> section.skyLight();
-            };
-
-            final Palette blockPalette = section.blockPalette();
-            CompletableFuture<Void> task = CompletableFuture.runAsync(() -> {
-                try {
-                    final Set<Point> toAdd;
-                    lightingChunk.lockReadLock();
-                    try {
-                        toAdd = switch (queueType) {
-                            case INTERNAL -> light.calculateInternal(blockPalette,
-                                    chunk.getChunkX(), point.blockY(), chunk.getChunkZ(),
-                                    lightingChunk.getOcclusionMap(), chunk.instance.getCachedDimensionType().maxY(),
-                                    lightLookup);
-                            case EXTERNAL -> light.calculateExternal(blockPalette,
-                                    Light.getNeighbors(chunk, point.blockY()),
-                                    lightLookup, paletteLookup);
-                        };
-                    } finally {
-                        lightingChunk.unlockReadLock();
-                    }
-
-                    sections.add(light);
-
-                    light.flip();
-                    newQueue.addAll(toAdd);
-                } catch (Exception e) {
-                    MinecraftServer.getExceptionManager().handleException(e);
-                }
-            }, pool);
-
-            tasks.add(task);
+            if (sectionY < lighting.getMinSection() || sectionY >= lighting.getMaxSection()) return null;
+            Section section = lighting.getSection(sectionY);
+            return type == LightEngine.Type.BLOCK ? section.blockLight() : section.skyLight();
         }
 
-        tasks.forEach(CompletableFuture::join);
-
-        if (!newQueue.isEmpty()) {
-            var newResponse = flushQueue(instance, newQueue, type, QueueType.EXTERNAL);
-            responseChunks.addAll(newResponse);
+        @Override
+        public Palette palette(int chunkX, int sectionY, int chunkZ) {
+            Chunk chunk = instance.getChunk(chunkX, chunkZ);
+            if (chunk == null) return null;
+            if (sectionY < chunk.getMinSection() || sectionY >= chunk.getMaxSection()) return null;
+            return chunk.getSection(sectionY).blockPalette();
         }
 
-        return responseChunks;
+        @Override
+        public int[] occlusionMap(int chunkX, int chunkZ) {
+            return instance.getChunk(chunkX, chunkZ) instanceof LightingChunk lighting ? lighting.getOcclusionMap() : null;
+        }
+
+        @Override
+        public int maxY() {
+            return instance.getCachedDimensionType().maxY();
+        }
+
+        @Override
+        public <T> T locked(int chunkX, int chunkZ, Supplier<T> op) {
+            Chunk chunk = instance.getChunk(chunkX, chunkZ);
+            if (chunk == null) return op.get();
+            chunk.lockReadLock();
+            try {
+                return op.get();
+            } finally {
+                chunk.unlockReadLock();
+            }
+        }
     }
 
     /**
@@ -466,16 +386,16 @@ public class LightingChunk extends DynamicChunk {
             // Expand the sections to include nearby sections
             var blockSections = new HashSet<Point>();
             for (Point point : sections) {
-                blockSections.addAll(getNearbyRequired(instance, point, LightType.BLOCK));
+                blockSections.addAll(getNearbyRequired(instance, point, LightEngine.Type.BLOCK));
             }
 
             var skySections = new HashSet<Point>();
             for (Point point : sections) {
-                skySections.addAll(getNearbyRequired(instance, point, LightType.SKY));
+                skySections.addAll(getNearbyRequired(instance, point, LightEngine.Type.SKY));
             }
 
-            relight(instance, blockSections, LightType.BLOCK);
-            relight(instance, skySections, LightType.SKY);
+            relight(instance, blockSections, LightEngine.Type.BLOCK);
+            relight(instance, skySections, LightEngine.Type.SKY);
 
             var chunksToRelight = new HashSet<Chunk>();
             for (Point point : blockSections) {
@@ -490,7 +410,7 @@ public class LightingChunk extends DynamicChunk {
         }
     }
 
-    private static Set<Point> getNearbyRequired(Instance instance, Point point, LightType type) {
+    private static Set<Point> getNearbyRequired(Instance instance, Point point, LightEngine.Type type) {
         Set<Point> collected = new HashSet<>();
         collected.add(point);
 
@@ -520,12 +440,12 @@ public class LightingChunk extends DynamicChunk {
                 for (int y = point.blockY() - 1; y <= point.blockY() + 1; y++) {
                     Point sectionPosition = new Vec(x, y, z);
                     int sectionHeight = instance.getCachedDimensionType().minY() + 16 * y;
-                    if ((sectionHeight + 16) > highestRegionPoint && type == LightType.SKY) continue;
+                    if ((sectionHeight + 16) > highestRegionPoint && type == LightEngine.Type.SKY) continue;
 
                     if (sectionPosition.blockY() < chunkCheck.getMaxSection() && sectionPosition.blockY() >= chunkCheck.getMinSection()) {
                         Section s = chunkCheck.getSection(sectionPosition.blockY());
-                        if (type == LightType.BLOCK && !s.blockLight().requiresUpdate()) continue;
-                        if (type == LightType.SKY && !s.skyLight().requiresUpdate()) continue;
+                        if (type == LightEngine.Type.BLOCK && !s.blockLight().requiresUpdate()) continue;
+                        if (type == LightEngine.Type.SKY && !s.skyLight().requiresUpdate()) continue;
 
                         collected.add(sectionPosition);
                     }
@@ -536,7 +456,7 @@ public class LightingChunk extends DynamicChunk {
         return collected;
     }
 
-    private static Set<Point> collectRequiredNearby(Instance instance, Point point, LightType type) {
+    private static Set<Point> collectRequiredNearby(Instance instance, Point point, LightEngine.Type type) {
         final Set<Point> found = new HashSet<>();
         final ArrayDeque<Point> toCheck = new ArrayDeque<>();
 
@@ -558,12 +478,12 @@ public class LightingChunk extends DynamicChunk {
     }
 
     static Set<Chunk> relightSection(Instance instance, int chunkX, int sectionY, int chunkZ) {
-        var res = new HashSet<>(relightSection(instance, chunkX, sectionY, chunkZ, LightType.BLOCK));
-        res.addAll(relightSection(instance, chunkX, sectionY, chunkZ, LightType.SKY));
+        var res = new HashSet<>(relightSection(instance, chunkX, sectionY, chunkZ, LightEngine.Type.BLOCK));
+        res.addAll(relightSection(instance, chunkX, sectionY, chunkZ, LightEngine.Type.SKY));
         return res;
     }
 
-    private static Set<Chunk> relightSection(Instance instance, int chunkX, int sectionY, int chunkZ, LightType type) {
+    private static Set<Chunk> relightSection(Instance instance, int chunkX, int sectionY, int chunkZ, LightEngine.Type type) {
         Chunk c = instance.getChunk(chunkX, chunkZ);
         if (c == null) return Set.of();
         if (!(c instanceof LightingChunk)) return Set.of();
@@ -574,8 +494,8 @@ public class LightingChunk extends DynamicChunk {
         }
     }
 
-    private static Set<Chunk> relight(Instance instance, Set<Point> queue, LightType type) {
-        return flushQueue(instance, queue, type, QueueType.INTERNAL);
+    private static Set<Chunk> relight(Instance instance, Set<Point> queue, LightEngine.Type type) {
+        return flushQueue(instance, queue, type);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/instance/LightingChunk.java
+++ b/src/main/java/net/minestom/server/instance/LightingChunk.java
@@ -1,17 +1,14 @@
 package net.minestom.server.instance;
 
-import net.kyori.adventure.key.Key;
-import net.minestom.server.MinecraftServer;
 import net.minestom.server.ServerFlag;
-import net.minestom.server.collision.Shape;
 import net.minestom.server.coordinate.CoordConversion;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.instance.block.BlockHandler;
 import net.minestom.server.instance.heightmap.Heightmap;
 import net.minestom.server.instance.light.Light;
+import net.minestom.server.instance.light.LightEngine;
 import net.minestom.server.instance.palette.Palette;
 import net.minestom.server.network.packet.server.CachedPacket;
 import net.minestom.server.network.packet.server.play.data.LightData;
@@ -24,12 +21,9 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 
 import static net.minestom.server.instance.light.LightCompute.EMPTY_CONTENT;
 
@@ -40,8 +34,6 @@ import static net.minestom.server.instance.light.LightCompute.EMPTY_CONTENT;
  * <p>
  */
 public class LightingChunk extends DynamicChunk {
-
-    private static final ExecutorService pool = Executors.newWorkStealingPool();
 
     private volatile @Nullable OcclusionData occlusionData;
     @SuppressWarnings("this-escape") // deliberate self registration during construction
@@ -56,42 +48,6 @@ public class LightingChunk extends DynamicChunk {
     private static final int resendDelay = ServerFlag.SEND_LIGHT_AFTER_BLOCK_PLACEMENT_DELAY;
 
     private boolean doneInit = false;
-
-    enum LightType {
-        SKY,
-        BLOCK
-    }
-
-    private enum QueueType {
-        INTERNAL,
-        EXTERNAL
-    }
-
-    private static final Set<Key> DIFFUSE_SKY_LIGHT = Set.of(
-            Block.COBWEB.key(),
-            Block.ICE.key(),
-            Block.HONEY_BLOCK.key(),
-            Block.SLIME_BLOCK.key(),
-            Block.WATER.key(),
-            Block.ACACIA_LEAVES.key(),
-            Block.AZALEA_LEAVES.key(),
-            Block.BIRCH_LEAVES.key(),
-            Block.DARK_OAK_LEAVES.key(),
-            Block.FLOWERING_AZALEA_LEAVES.key(),
-            Block.JUNGLE_LEAVES.key(),
-            Block.CHERRY_LEAVES.key(),
-            Block.OAK_LEAVES.key(),
-            Block.SPRUCE_LEAVES.key(),
-            Block.SPAWNER.key(),
-            Block.BEACON.key(),
-            Block.END_GATEWAY.key(),
-            Block.CHORUS_PLANT.key(),
-            Block.CHORUS_FLOWER.key(),
-            Block.FROSTED_ICE.key(),
-            Block.SEAGRASS.key(),
-            Block.TALL_SEAGRASS.key(),
-            Block.LAVA.key()
-    );
 
     @Override
     public void invalidate() {
@@ -110,14 +66,7 @@ public class LightingChunk extends DynamicChunk {
     }
 
     private static boolean checkSkyOcclusion(Block block) {
-        if (block == Block.AIR) return false;
-        if (DIFFUSE_SKY_LIGHT.contains(block.key())) return true;
-
-        Shape shape = block.occlusionShape();
-        boolean occludesTop = Block.AIR.occlusionShape().isOccluded(shape, BlockFace.TOP);
-        boolean occludesBottom = Block.AIR.occlusionShape().isOccluded(shape, BlockFace.BOTTOM);
-
-        return occludesBottom || occludesTop;
+        return LightEngine.checkSkyOcclusion(block);
     }
 
     public void setFreezeInvalidation(boolean freezeInvalidation) {
@@ -299,14 +248,14 @@ public class LightingChunk extends DynamicChunk {
                 boolean wasUpdatedSky = false;
 
                 if (section.blockLight().requiresUpdate()) {
-                    relightSection(instance, this.chunkX, index + minSection, chunkZ, LightType.BLOCK);
+                    relightSection(instance, this.chunkX, index + minSection, chunkZ, LightEngine.Type.BLOCK);
                     wasUpdatedBlock = true;
                 } else if (requiredFullChunk || section.blockLight().requiresSend()) {
                     wasUpdatedBlock = true;
                 }
 
                 if (section.skyLight().requiresUpdate()) {
-                    relightSection(instance, this.chunkX, index + minSection, chunkZ, LightType.SKY);
+                    relightSection(instance, this.chunkX, index + minSection, chunkZ, LightEngine.Type.SKY);
                     wasUpdatedSky = true;
                 } else if (requiredFullChunk || section.skyLight().requiresSend()) {
                     wasUpdatedSky = true;
@@ -366,84 +315,55 @@ public class LightingChunk extends DynamicChunk {
         }
     }
 
-    private static Set<Chunk> flushQueue(Instance instance, Set<Point> queue, LightType type, QueueType queueType) {
-        Set<Light> sections = ConcurrentHashMap.newKeySet();
-        Set<Point> newQueue = ConcurrentHashMap.newKeySet();
+    private static Set<Chunk> flushQueue(Instance instance, Set<Point> queue, LightEngine.Type type) {
+        Set<Chunk> chunks = new HashSet<>();
+        for (Point section : LightEngine.relight(new InstanceView(instance), queue, type)) {
+            Chunk chunk = instance.getChunk(section.blockX(), section.blockZ());
+            if (chunk != null) chunks.add(chunk);
+        }
+        return chunks;
+    }
 
-        Set<Chunk> responseChunks = ConcurrentHashMap.newKeySet();
-        List<CompletableFuture<Void>> tasks = new ArrayList<>();
-
-        Light.LightLookup lightLookup = (x, y, z) -> {
-            Chunk chunk = instance.getChunk(x, z);
-            if (chunk == null) return null;
+    /** {@link LightEngine.WorldView} over an instance's loaded {@link LightingChunk}s. */
+    private record InstanceView(Instance instance) implements LightEngine.WorldView {
+        @Override
+        public Light light(LightEngine.Type type, int chunkX, int sectionY, int chunkZ) {
+            Chunk chunk = instance.getChunk(chunkX, chunkZ);
             if (!(chunk instanceof LightingChunk lighting)) return null;
-            if (y - lighting.getMinSection() < 0 || y - lighting.getMaxSection() >= 0) return null;
-            final Section section = lighting.getSection(y);
-            return switch (type) {
-                case BLOCK -> section.blockLight();
-                case SKY -> section.skyLight();
-            };
-        };
-
-        Light.PaletteLookup paletteLookup = (x, y, z) -> {
-            Chunk chunk = instance.getChunk(x, z);
-            if (chunk == null) return null;
-            if (!(chunk instanceof LightingChunk lighting)) return null;
-            if (y - lighting.getMinSection() < 0 || y - lighting.getMaxSection() >= 0) return null;
-            return chunk.getSection(y).blockPalette();
-        };
-
-        for (Point point : queue) {
-            Chunk chunk = instance.getChunk(point.blockX(), point.blockZ());
-            if (!(chunk instanceof LightingChunk lightingChunk)) continue;
-
-            Section section = chunk.getSection(point.blockY());
-            responseChunks.add(chunk);
-
-            Light light = switch (type) {
-                case BLOCK -> section.blockLight();
-                case SKY -> section.skyLight();
-            };
-
-            final Palette blockPalette = section.blockPalette();
-            CompletableFuture<Void> task = CompletableFuture.runAsync(() -> {
-                try {
-                    final Set<Point> toAdd;
-                    lightingChunk.lockReadLock();
-                    try {
-                        toAdd = switch (queueType) {
-                            case INTERNAL -> light.calculateInternal(blockPalette,
-                                    chunk.getChunkX(), point.blockY(), chunk.getChunkZ(),
-                                    lightingChunk.getOcclusionMap(), chunk.instance.getCachedDimensionType().maxY(),
-                                    lightLookup);
-                            case EXTERNAL -> light.calculateExternal(blockPalette,
-                                    Light.getNeighbors(chunk, point.blockY()),
-                                    lightLookup, paletteLookup);
-                        };
-                    } finally {
-                        lightingChunk.unlockReadLock();
-                    }
-
-                    sections.add(light);
-
-                    light.flip();
-                    newQueue.addAll(toAdd);
-                } catch (Exception e) {
-                    MinecraftServer.getExceptionManager().handleException(e);
-                }
-            }, pool);
-
-            tasks.add(task);
+            if (sectionY < lighting.getMinSection() || sectionY >= lighting.getMaxSection()) return null;
+            Section section = lighting.getSection(sectionY);
+            return type == LightEngine.Type.BLOCK ? section.blockLight() : section.skyLight();
         }
 
-        tasks.forEach(CompletableFuture::join);
-
-        if (!newQueue.isEmpty()) {
-            var newResponse = flushQueue(instance, newQueue, type, QueueType.EXTERNAL);
-            responseChunks.addAll(newResponse);
+        @Override
+        public Palette palette(int chunkX, int sectionY, int chunkZ) {
+            Chunk chunk = instance.getChunk(chunkX, chunkZ);
+            if (chunk == null) return null;
+            if (sectionY < chunk.getMinSection() || sectionY >= chunk.getMaxSection()) return null;
+            return chunk.getSection(sectionY).blockPalette();
         }
 
-        return responseChunks;
+        @Override
+        public int[] occlusionMap(int chunkX, int chunkZ) {
+            return instance.getChunk(chunkX, chunkZ) instanceof LightingChunk lighting ? lighting.getOcclusionMap() : null;
+        }
+
+        @Override
+        public int maxY() {
+            return instance.getCachedDimensionType().maxY();
+        }
+
+        @Override
+        public <T> T locked(int chunkX, int chunkZ, Supplier<T> op) {
+            Chunk chunk = instance.getChunk(chunkX, chunkZ);
+            if (chunk == null) return op.get();
+            chunk.lockReadLock();
+            try {
+                return op.get();
+            } finally {
+                chunk.unlockReadLock();
+            }
+        }
     }
 
     /**
@@ -474,16 +394,16 @@ public class LightingChunk extends DynamicChunk {
             // Expand the sections to include nearby sections
             var blockSections = new HashSet<Point>();
             for (Point point : sections) {
-                blockSections.addAll(getNearbyRequired(instance, point, LightType.BLOCK));
+                blockSections.addAll(getNearbyRequired(instance, point, LightEngine.Type.BLOCK));
             }
 
             var skySections = new HashSet<Point>();
             for (Point point : sections) {
-                skySections.addAll(getNearbyRequired(instance, point, LightType.SKY));
+                skySections.addAll(getNearbyRequired(instance, point, LightEngine.Type.SKY));
             }
 
-            relight(instance, blockSections, LightType.BLOCK);
-            relight(instance, skySections, LightType.SKY);
+            relight(instance, blockSections, LightEngine.Type.BLOCK);
+            relight(instance, skySections, LightEngine.Type.SKY);
 
             var chunksToRelight = new HashSet<Chunk>();
             for (Point point : blockSections) {
@@ -498,7 +418,7 @@ public class LightingChunk extends DynamicChunk {
         }
     }
 
-    private static Set<Point> getNearbyRequired(Instance instance, Point point, LightType type) {
+    private static Set<Point> getNearbyRequired(Instance instance, Point point, LightEngine.Type type) {
         Set<Point> collected = new HashSet<>();
         collected.add(point);
 
@@ -528,12 +448,12 @@ public class LightingChunk extends DynamicChunk {
                 for (int y = point.blockY() - 1; y <= point.blockY() + 1; y++) {
                     Point sectionPosition = new Vec(x, y, z);
                     int sectionHeight = instance.getCachedDimensionType().minY() + 16 * y;
-                    if ((sectionHeight + 16) > highestRegionPoint && type == LightType.SKY) continue;
+                    if ((sectionHeight + 16) > highestRegionPoint && type == LightEngine.Type.SKY) continue;
 
                     if (sectionPosition.blockY() < chunkCheck.getMaxSection() && sectionPosition.blockY() >= chunkCheck.getMinSection()) {
                         Section s = chunkCheck.getSection(sectionPosition.blockY());
-                        if (type == LightType.BLOCK && !s.blockLight().requiresUpdate()) continue;
-                        if (type == LightType.SKY && !s.skyLight().requiresUpdate()) continue;
+                        if (type == LightEngine.Type.BLOCK && !s.blockLight().requiresUpdate()) continue;
+                        if (type == LightEngine.Type.SKY && !s.skyLight().requiresUpdate()) continue;
 
                         collected.add(sectionPosition);
                     }
@@ -544,7 +464,7 @@ public class LightingChunk extends DynamicChunk {
         return collected;
     }
 
-    private static Set<Point> collectRequiredNearby(Instance instance, Point point, LightType type) {
+    private static Set<Point> collectRequiredNearby(Instance instance, Point point, LightEngine.Type type) {
         final Set<Point> found = new HashSet<>();
         final ArrayDeque<Point> toCheck = new ArrayDeque<>();
 
@@ -566,12 +486,12 @@ public class LightingChunk extends DynamicChunk {
     }
 
     static Set<Chunk> relightSection(Instance instance, int chunkX, int sectionY, int chunkZ) {
-        var res = new HashSet<>(relightSection(instance, chunkX, sectionY, chunkZ, LightType.BLOCK));
-        res.addAll(relightSection(instance, chunkX, sectionY, chunkZ, LightType.SKY));
+        var res = new HashSet<>(relightSection(instance, chunkX, sectionY, chunkZ, LightEngine.Type.BLOCK));
+        res.addAll(relightSection(instance, chunkX, sectionY, chunkZ, LightEngine.Type.SKY));
         return res;
     }
 
-    private static Set<Chunk> relightSection(Instance instance, int chunkX, int sectionY, int chunkZ, LightType type) {
+    private static Set<Chunk> relightSection(Instance instance, int chunkX, int sectionY, int chunkZ, LightEngine.Type type) {
         Chunk c = instance.getChunk(chunkX, chunkZ);
         if (c == null) return Set.of();
         if (!(c instanceof LightingChunk)) return Set.of();
@@ -582,8 +502,8 @@ public class LightingChunk extends DynamicChunk {
         }
     }
 
-    private static Set<Chunk> relight(Instance instance, Set<Point> queue, LightType type) {
-        return flushQueue(instance, queue, type, QueueType.INTERNAL);
+    private static Set<Chunk> relight(Instance instance, Set<Point> queue, LightEngine.Type type) {
+        return flushQueue(instance, queue, type);
     }
 
     @Override

--- a/src/main/java/net/minestom/server/instance/light/LightEngine.java
+++ b/src/main/java/net/minestom/server/instance/light/LightEngine.java
@@ -1,0 +1,178 @@
+package net.minestom.server.instance.light;
+
+import net.kyori.adventure.key.Key;
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.collision.Shape;
+import net.minestom.server.coordinate.BlockVec;
+import net.minestom.server.coordinate.Point;
+import net.minestom.server.instance.block.Block;
+import net.minestom.server.instance.block.BlockFace;
+import net.minestom.server.instance.palette.Palette;
+import net.minestom.server.utils.Direction;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
+
+/**
+ * Computes light over an arbitrary section-addressable world.
+ * <p>
+ * {@link net.minestom.server.instance.LightingChunk} drives this engine for instances. Other worlds (virtual or
+ * packet-based worlds, world diffs, schematic previews) implement {@link WorldView} and get the same propagation
+ * without materializing chunks.
+ * <p>
+ * {@link #relight(WorldView, Set, Type)} recomputes the given sections, then propagates outward wave by wave until
+ * no section border changes. Each wave's sections are computed in parallel.
+ */
+public final class LightEngine {
+
+    private static final ExecutorService POOL = Executors.newWorkStealingPool();
+    private static final Direction[] DIRECTIONS = Direction.values();
+
+    /** Blocks that occlude sky light despite a non-occluding collision shape. */
+    private static final Set<Key> DIFFUSE_SKY_LIGHT = Set.of(
+            Block.COBWEB.key(), Block.ICE.key(), Block.HONEY_BLOCK.key(), Block.SLIME_BLOCK.key(),
+            Block.WATER.key(), Block.ACACIA_LEAVES.key(), Block.AZALEA_LEAVES.key(), Block.BIRCH_LEAVES.key(),
+            Block.DARK_OAK_LEAVES.key(), Block.FLOWERING_AZALEA_LEAVES.key(), Block.JUNGLE_LEAVES.key(),
+            Block.CHERRY_LEAVES.key(), Block.OAK_LEAVES.key(), Block.SPRUCE_LEAVES.key(), Block.SPAWNER.key(),
+            Block.BEACON.key(), Block.END_GATEWAY.key(), Block.CHORUS_PLANT.key(), Block.CHORUS_FLOWER.key(),
+            Block.FROSTED_ICE.key(), Block.SEAGRASS.key(), Block.TALL_SEAGRASS.key(), Block.LAVA.key());
+
+    private LightEngine() {
+    }
+
+    public enum Type {
+        BLOCK,
+        SKY
+    }
+
+    /**
+     * A section-addressable world for the engine to light. Sections are addressed by chunk coordinates plus an
+     * absolute section Y. Return {@code null} for sections that do not exist (unloaded, out of range).
+     */
+    public interface WorldView {
+        /**
+         * The {@link Light} state of a section, or {@code null}.
+         * <p>
+         * The engine mutates lights of sections it {@link #recomputes(int, int, int) recomputes}; other sections
+         * are only read for border seeds.
+         */
+        @Nullable Light light(Type type, int chunkX, int sectionY, int chunkZ);
+
+        /**
+         * The block palette of a section, or {@code null}.
+         */
+        @Nullable Palette palette(int chunkX, int sectionY, int chunkZ);
+
+        /**
+         * The sky-occlusion heightmap of a column, or {@code null}. Each entry is one above the highest
+         * {@link #checkSkyOcclusion(Block) sky-occluding} block of that column, indexed {@code z << 4 | x}.
+         */
+        int @Nullable [] occlusionMap(int chunkX, int chunkZ);
+
+        /**
+         * The world's maximum Y (exclusive).
+         */
+        int maxY();
+
+        /**
+         * Whether the engine may recompute this section's light. Border changes never propagate past a
+         * non-recomputing section. Defaults to every section with a light.
+         */
+        default boolean recomputes(int chunkX, int sectionY, int chunkZ) {
+            return light(Type.BLOCK, chunkX, sectionY, chunkZ) != null;
+        }
+
+        /**
+         * Runs {@code op} under the column's read lock, if the world has one.
+         */
+        default <T> T locked(int chunkX, int chunkZ, Supplier<T> op) {
+            return op.get();
+        }
+    }
+
+    /**
+     * Recomputes {@code sections} and every section their border changes reach, until stable.
+     * <p>
+     * Queue the whole dirty neighborhood - a changed section plus its adjacent sections: an internal pass resets
+     * its neighbors' propagation, exactly like instance relights collect their surroundings.
+     *
+     * @return every section that recomputed; their {@link Light#array()} contents are fresh
+     */
+    public static Set<Point> relight(WorldView view, Set<Point> sections, Type type) {
+        Set<Point> touched = new HashSet<>();
+        Set<Point> queue = Set.copyOf(sections);
+        boolean internal = true;
+        while (!queue.isEmpty()) {
+            // normalized: callers may queue any Point implementation
+            for (Point point : queue) touched.add(new BlockVec(point.blockX(), point.blockY(), point.blockZ()));
+            queue = wave(view, queue, type, internal);
+            internal = false;
+        }
+        return touched;
+    }
+
+    private static Set<Point> wave(WorldView view, Set<Point> queue, Type type, boolean internal) {
+        Set<Point> newQueue = ConcurrentHashMap.newKeySet();
+        List<CompletableFuture<Void>> tasks = new ArrayList<>();
+        Light.LightLookup lightLookup = (x, y, z) -> view.light(type, x, y, z);
+        Light.PaletteLookup paletteLookup = view::palette;
+        for (Point point : queue) {
+            final int x = point.blockX(), y = point.blockY(), z = point.blockZ();
+            Light light = view.light(type, x, y, z);
+            Palette palette = view.palette(x, y, z);
+            if (light == null || palette == null) continue;
+            tasks.add(CompletableFuture.runAsync(() -> {
+                try {
+                    Set<Point> toAdd = view.locked(x, z, () -> {
+                        if (!internal) {
+                            return light.calculateExternal(palette, neighbors(view, x, y, z), lightLookup, paletteLookup);
+                        }
+                        int[] occlusion = view.occlusionMap(x, z); // under the lock: implementations may compute it lazily
+                        if (occlusion == null && type == Type.SKY) return Set.<Point>of();
+                        return light.calculateInternal(palette, x, y, z, occlusion, view.maxY(), lightLookup);
+                    });
+                    light.flip();
+                    for (Point neighbor : toAdd) {
+                        if (view.recomputes(neighbor.blockX(), neighbor.blockY(), neighbor.blockZ())) {
+                            newQueue.add(neighbor);
+                        }
+                    }
+                } catch (Exception e) {
+                    MinecraftServer.getExceptionManager().handleException(e);
+                }
+            }, POOL));
+        }
+        tasks.forEach(CompletableFuture::join);
+        return newQueue;
+    }
+
+    private static Point[] neighbors(WorldView view, int chunkX, int sectionY, int chunkZ) {
+        Point[] links = new Point[DIRECTIONS.length];
+        for (Direction direction : DIRECTIONS) {
+            final int x = chunkX + direction.normalX();
+            final int y = sectionY + direction.normalY();
+            final int z = chunkZ + direction.normalZ();
+            if (view.palette(x, y, z) == null) continue;
+            links[direction.ordinal()] = new BlockVec(x, y, z);
+        }
+        return links;
+    }
+
+    /** Whether {@code block} occludes sky light - the test behind a {@link WorldView#occlusionMap} column walk. */
+    public static boolean checkSkyOcclusion(Block block) {
+        if (block == Block.AIR) return false;
+        if (DIFFUSE_SKY_LIGHT.contains(block.key())) return true;
+        Shape shape = block.registry().occlusionShape();
+        boolean occludesTop = Block.AIR.registry().occlusionShape().isOccluded(shape, BlockFace.TOP);
+        boolean occludesBottom = Block.AIR.registry().occlusionShape().isOccluded(shape, BlockFace.BOTTOM);
+        return occludesBottom || occludesTop;
+    }
+}

--- a/src/main/java/net/minestom/server/instance/light/LightEngine.java
+++ b/src/main/java/net/minestom/server/instance/light/LightEngine.java
@@ -1,0 +1,178 @@
+package net.minestom.server.instance.light;
+
+import net.kyori.adventure.key.Key;
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.collision.Shape;
+import net.minestom.server.coordinate.BlockVec;
+import net.minestom.server.coordinate.Point;
+import net.minestom.server.instance.block.Block;
+import net.minestom.server.instance.block.BlockFace;
+import net.minestom.server.instance.palette.Palette;
+import net.minestom.server.utils.Direction;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
+
+/**
+ * Computes light over an arbitrary section-addressable world.
+ * <p>
+ * {@link net.minestom.server.instance.LightingChunk} drives this engine for instances. Other worlds (virtual or
+ * packet-based worlds, world diffs, schematic previews) implement {@link WorldView} and get the same propagation
+ * without materializing chunks.
+ * <p>
+ * {@link #relight(WorldView, Set, Type)} recomputes the given sections, then propagates outward wave by wave until
+ * no section border changes. Each wave's sections are computed in parallel.
+ */
+public final class LightEngine {
+
+    private static final ExecutorService POOL = Executors.newWorkStealingPool();
+    private static final Direction[] DIRECTIONS = Direction.values();
+
+    /** Blocks that occlude sky light despite a non-occluding collision shape. */
+    private static final Set<Key> DIFFUSE_SKY_LIGHT = Set.of(
+            Block.COBWEB.key(), Block.ICE.key(), Block.HONEY_BLOCK.key(), Block.SLIME_BLOCK.key(),
+            Block.WATER.key(), Block.ACACIA_LEAVES.key(), Block.AZALEA_LEAVES.key(), Block.BIRCH_LEAVES.key(),
+            Block.DARK_OAK_LEAVES.key(), Block.FLOWERING_AZALEA_LEAVES.key(), Block.JUNGLE_LEAVES.key(),
+            Block.CHERRY_LEAVES.key(), Block.OAK_LEAVES.key(), Block.SPRUCE_LEAVES.key(), Block.SPAWNER.key(),
+            Block.BEACON.key(), Block.END_GATEWAY.key(), Block.CHORUS_PLANT.key(), Block.CHORUS_FLOWER.key(),
+            Block.FROSTED_ICE.key(), Block.SEAGRASS.key(), Block.TALL_SEAGRASS.key(), Block.LAVA.key());
+
+    private LightEngine() {
+    }
+
+    public enum Type {
+        BLOCK,
+        SKY
+    }
+
+    /**
+     * A section-addressable world for the engine to light. Sections are addressed by chunk coordinates plus an
+     * absolute section Y. Return {@code null} for sections that do not exist (unloaded, out of range).
+     */
+    public interface WorldView {
+        /**
+         * The {@link Light} state of a section, or {@code null}.
+         * <p>
+         * The engine mutates lights of sections it {@link #recomputes(int, int, int) recomputes}; other sections
+         * are only read for border seeds.
+         */
+        @Nullable Light light(Type type, int chunkX, int sectionY, int chunkZ);
+
+        /**
+         * The block palette of a section, or {@code null}.
+         */
+        @Nullable Palette palette(int chunkX, int sectionY, int chunkZ);
+
+        /**
+         * The sky-occlusion heightmap of a column, or {@code null}. Each entry is one above the highest
+         * {@link #checkSkyOcclusion(Block) sky-occluding} block of that column, indexed {@code z << 4 | x}.
+         */
+        int @Nullable [] occlusionMap(int chunkX, int chunkZ);
+
+        /**
+         * The world's maximum Y (exclusive).
+         */
+        int maxY();
+
+        /**
+         * Whether the engine may recompute this section's light. Border changes never propagate past a
+         * non-recomputing section. Defaults to every section with a light.
+         */
+        default boolean recomputes(int chunkX, int sectionY, int chunkZ) {
+            return light(Type.BLOCK, chunkX, sectionY, chunkZ) != null;
+        }
+
+        /**
+         * Runs {@code op} under the column's read lock, if the world has one.
+         */
+        default <T> T locked(int chunkX, int chunkZ, Supplier<T> op) {
+            return op.get();
+        }
+    }
+
+    /**
+     * Recomputes {@code sections} and every section their border changes reach, until stable.
+     * <p>
+     * Queue the whole dirty neighborhood - a changed section plus its adjacent sections: an internal pass resets
+     * its neighbors' propagation, exactly like instance relights collect their surroundings.
+     *
+     * @return every section that recomputed; their {@link Light#array()} contents are fresh
+     */
+    public static Set<Point> relight(WorldView view, Set<Point> sections, Type type) {
+        Set<Point> touched = new HashSet<>();
+        Set<Point> queue = Set.copyOf(sections);
+        boolean internal = true;
+        while (!queue.isEmpty()) {
+            // normalized: callers may queue any Point implementation
+            for (Point point : queue) touched.add(new BlockVec(point.blockX(), point.blockY(), point.blockZ()));
+            queue = wave(view, queue, type, internal);
+            internal = false;
+        }
+        return touched;
+    }
+
+    private static Set<Point> wave(WorldView view, Set<Point> queue, Type type, boolean internal) {
+        Set<Point> newQueue = ConcurrentHashMap.newKeySet();
+        List<CompletableFuture<Void>> tasks = new ArrayList<>();
+        Light.LightLookup lightLookup = (x, y, z) -> view.light(type, x, y, z);
+        Light.PaletteLookup paletteLookup = view::palette;
+        for (Point point : queue) {
+            final int x = point.blockX(), y = point.blockY(), z = point.blockZ();
+            Light light = view.light(type, x, y, z);
+            Palette palette = view.palette(x, y, z);
+            if (light == null || palette == null) continue;
+            tasks.add(CompletableFuture.runAsync(() -> {
+                try {
+                    Set<Point> toAdd = view.locked(x, z, () -> {
+                        if (!internal) {
+                            return light.calculateExternal(palette, neighbors(view, x, y, z), lightLookup, paletteLookup);
+                        }
+                        int[] occlusion = view.occlusionMap(x, z); // under the lock: implementations may compute it lazily
+                        if (occlusion == null && type == Type.SKY) return Set.<Point>of();
+                        return light.calculateInternal(palette, x, y, z, occlusion, view.maxY(), lightLookup);
+                    });
+                    light.flip();
+                    for (Point neighbor : toAdd) {
+                        if (view.recomputes(neighbor.blockX(), neighbor.blockY(), neighbor.blockZ())) {
+                            newQueue.add(neighbor);
+                        }
+                    }
+                } catch (Exception e) {
+                    MinecraftServer.getExceptionManager().handleException(e);
+                }
+            }, POOL));
+        }
+        tasks.forEach(CompletableFuture::join);
+        return newQueue;
+    }
+
+    private static Point[] neighbors(WorldView view, int chunkX, int sectionY, int chunkZ) {
+        Point[] links = new Point[DIRECTIONS.length];
+        for (Direction direction : DIRECTIONS) {
+            final int x = chunkX + direction.normalX();
+            final int y = sectionY + direction.normalY();
+            final int z = chunkZ + direction.normalZ();
+            if (view.palette(x, y, z) == null) continue;
+            links[direction.ordinal()] = new BlockVec(x, y, z);
+        }
+        return links;
+    }
+
+    /** Whether {@code block} occludes sky light - the test behind a {@link WorldView#occlusionMap} column walk. */
+    public static boolean checkSkyOcclusion(Block block) {
+        if (block == Block.AIR) return false;
+        if (DIFFUSE_SKY_LIGHT.contains(block.key())) return true;
+        Shape shape = block.occlusionShape();
+        boolean occludesTop = Block.AIR.occlusionShape().isOccluded(shape, BlockFace.TOP);
+        boolean occludesBottom = Block.AIR.occlusionShape().isOccluded(shape, BlockFace.BOTTOM);
+        return occludesBottom || occludesTop;
+    }
+}

--- a/src/test/java/net/minestom/server/instance/light/LightEngineTest.java
+++ b/src/test/java/net/minestom/server/instance/light/LightEngineTest.java
@@ -1,0 +1,129 @@
+package net.minestom.server.instance.light;
+
+import net.minestom.server.coordinate.BlockVec;
+import net.minestom.server.coordinate.Vec;
+import net.minestom.server.instance.block.Block;
+import net.minestom.server.instance.palette.Palette;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LightEngineTest {
+
+    /**
+     * A minimal in-memory world: sections in a map, no chunks or instances involved - the {@link LightEngine.WorldView}
+     * contract a virtual world implements.
+     */
+    private static class VirtualWorld implements LightEngine.WorldView {
+        final Map<Vec, Palette> palettes = new HashMap<>();
+        final Map<Vec, Light> blockLights = new HashMap<>();
+        final Map<Vec, Light> skyLights = new HashMap<>();
+        final int[] openColumn = new int[16 * 16]; // all zero: nothing occludes the sky
+
+        Palette section(int chunkX, int sectionY, int chunkZ) {
+            var key = new Vec(chunkX, sectionY, chunkZ);
+            blockLights.computeIfAbsent(key, k -> Light.block());
+            skyLights.computeIfAbsent(key, k -> Light.sky());
+            return palettes.computeIfAbsent(key, k -> Palette.blocks());
+        }
+
+        @Override
+        public @Nullable Light light(LightEngine.Type type, int chunkX, int sectionY, int chunkZ) {
+            var key = new Vec(chunkX, sectionY, chunkZ);
+            return type == LightEngine.Type.BLOCK ? blockLights.get(key) : skyLights.get(key);
+        }
+
+        @Override
+        public @Nullable Palette palette(int chunkX, int sectionY, int chunkZ) {
+            return palettes.get(new Vec(chunkX, sectionY, chunkZ));
+        }
+
+        @Override
+        public int @Nullable [] occlusionMap(int chunkX, int chunkZ) {
+            return openColumn;
+        }
+
+        @Override
+        public int maxY() {
+            return 64;
+        }
+    }
+
+    @Test
+    public void borderBrighteningQueuesUnlistedSections() {
+        var world = new VirtualWorld();
+        // corner glowstone: light entering the east neighbor lands on its south border and must queue the
+        // diagonal section, which the initial queue never listed (direct neighbors are the caller's job,
+        // like LightingChunk#invalidateNeighborsSection - a single emitter cannot out-travel a section)
+        world.section(0, 0, 0).set(15, 8, 15, Block.GLOWSTONE.stateId());
+        world.section(1, 0, 0);
+        world.section(1, 0, 1);
+
+        var touched = LightEngine.relight(world, Set.of(new Vec(0, 0, 0), new Vec(1, 0, 0)), LightEngine.Type.BLOCK);
+        assertTrue(touched.contains(new BlockVec(1, 0, 1)), "the brightened border queues the diagonal section");
+        // an internal pass nulls its neighbors' propagation, so a relight always queues the whole dirty
+        // neighborhood (what collectRequiredNearby collects for instances) - then the diagonal exposes its level
+        LightEngine.relight(world, Set.of(new Vec(0, 0, 0), new Vec(1, 0, 0), new Vec(1, 0, 1)), LightEngine.Type.BLOCK);
+        assertEquals(13, world.light(LightEngine.Type.BLOCK, 1, 0, 1).getLevel(0, 8, 0));
+    }
+
+    @Test
+    public void lightCrossesSectionBorders() {
+        var world = new VirtualWorld();
+        world.section(0, 0, 0).set(15, 8, 8, Block.GLOWSTONE.stateId());
+        world.section(1, 0, 0);
+
+        LightEngine.relight(world, Set.of(new Vec(0, 0, 0), new Vec(1, 0, 0)), LightEngine.Type.BLOCK);
+        var source = world.light(LightEngine.Type.BLOCK, 0, 0, 0);
+        var neighbor = world.light(LightEngine.Type.BLOCK, 1, 0, 0);
+        assertEquals(15, source.getLevel(15, 8, 8));
+        assertEquals(14, neighbor.getLevel(0, 8, 8), "light continues across the section border");
+        assertEquals(13, neighbor.getLevel(1, 8, 8));
+    }
+
+    @Test
+    public void recomputesGateContainsTheWave() {
+        // the same corner setup as above, but the diagonal section opts out of recomputing
+        var world = new VirtualWorld() {
+            @Override
+            public boolean recomputes(int chunkX, int sectionY, int chunkZ) {
+                return chunkZ == 0;
+            }
+        };
+        world.section(0, 0, 0).set(15, 8, 15, Block.GLOWSTONE.stateId());
+        world.section(1, 0, 0);
+        world.section(1, 0, 1);
+
+        var touched = LightEngine.relight(world, Set.of(new Vec(0, 0, 0), new Vec(1, 0, 0)), LightEngine.Type.BLOCK);
+        assertTrue(touched.contains(new BlockVec(1, 0, 0)));
+        assertFalse(touched.contains(new BlockVec(1, 0, 1)), "a non-recomputing section stops the wave");
+        assertEquals(0, world.light(LightEngine.Type.BLOCK, 1, 0, 1).getLevel(0, 8, 0));
+    }
+
+    @Test
+    public void skyLightFloodsAnOpenColumn() {
+        var world = new VirtualWorld();
+        world.section(0, 0, 0);
+
+        LightEngine.relight(world, Set.of(new Vec(0, 0, 0)), LightEngine.Type.SKY);
+        var sky = world.light(LightEngine.Type.SKY, 0, 0, 0);
+        assertEquals(15, sky.getLevel(0, 0, 0));
+        assertEquals(15, sky.getLevel(8, 15, 8));
+    }
+
+    @Test
+    public void occlusionMatchesTheDiffuseSet() {
+        assertTrue(LightEngine.checkSkyOcclusion(Block.STONE));
+        assertTrue(LightEngine.checkSkyOcclusion(Block.WATER), "diffuse blocks occlude despite their shape");
+        assertTrue(LightEngine.checkSkyOcclusion(Block.OAK_LEAVES));
+        assertFalse(LightEngine.checkSkyOcclusion(Block.AIR));
+        assertFalse(LightEngine.checkSkyOcclusion(Block.OAK_FENCE));
+    }
+}

--- a/src/test/java/net/minestom/server/instance/light/LightEngineTest.java
+++ b/src/test/java/net/minestom/server/instance/light/LightEngineTest.java
@@ -1,0 +1,129 @@
+package net.minestom.server.instance.light;
+
+import net.minestom.server.coordinate.BlockVec;
+import net.minestom.server.coordinate.Vec;
+import net.minestom.server.instance.block.Block;
+import net.minestom.server.instance.palette.Palette;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LightEngineTest {
+
+    /**
+     * A minimal in-memory world: sections in a map, no chunks or instances involved - the {@link LightEngine.WorldView}
+     * contract a virtual world implements.
+     */
+    private static class VirtualWorld implements LightEngine.WorldView {
+        final Map<Vec, Palette> palettes = new HashMap<>();
+        final Map<Vec, Light> blockLights = new HashMap<>();
+        final Map<Vec, Light> skyLights = new HashMap<>();
+        final int[] openColumn = new int[16 * 16]; // all zero: nothing occludes the sky
+
+        Palette section(int chunkX, int sectionY, int chunkZ) {
+            var key = new Vec(chunkX, sectionY, chunkZ);
+            blockLights.computeIfAbsent(key, _ -> Light.block());
+            skyLights.computeIfAbsent(key, _ -> Light.sky());
+            return palettes.computeIfAbsent(key, _ -> Palette.blocks());
+        }
+
+        @Override
+        public @Nullable Light light(LightEngine.Type type, int chunkX, int sectionY, int chunkZ) {
+            var key = new Vec(chunkX, sectionY, chunkZ);
+            return type == LightEngine.Type.BLOCK ? blockLights.get(key) : skyLights.get(key);
+        }
+
+        @Override
+        public @Nullable Palette palette(int chunkX, int sectionY, int chunkZ) {
+            return palettes.get(new Vec(chunkX, sectionY, chunkZ));
+        }
+
+        @Override
+        public int @Nullable [] occlusionMap(int chunkX, int chunkZ) {
+            return openColumn;
+        }
+
+        @Override
+        public int maxY() {
+            return 64;
+        }
+    }
+
+    @Test
+    public void borderBrighteningQueuesUnlistedSections() {
+        var world = new VirtualWorld();
+        // corner glowstone: light entering the east neighbor lands on its south border and must queue the
+        // diagonal section, which the initial queue never listed (direct neighbors are the caller's job,
+        // like LightingChunk#invalidateNeighborsSection - a single emitter cannot out-travel a section)
+        world.section(0, 0, 0).set(15, 8, 15, Block.GLOWSTONE.stateId());
+        world.section(1, 0, 0);
+        world.section(1, 0, 1);
+
+        var touched = LightEngine.relight(world, Set.of(new Vec(0, 0, 0), new Vec(1, 0, 0)), LightEngine.Type.BLOCK);
+        assertTrue(touched.contains(new BlockVec(1, 0, 1)), "the brightened border queues the diagonal section");
+        // an internal pass nulls its neighbors' propagation, so a relight always queues the whole dirty
+        // neighborhood (what collectRequiredNearby collects for instances) - then the diagonal exposes its level
+        LightEngine.relight(world, Set.of(new Vec(0, 0, 0), new Vec(1, 0, 0), new Vec(1, 0, 1)), LightEngine.Type.BLOCK);
+        assertEquals(13, world.light(LightEngine.Type.BLOCK, 1, 0, 1).getLevel(0, 8, 0));
+    }
+
+    @Test
+    public void lightCrossesSectionBorders() {
+        var world = new VirtualWorld();
+        world.section(0, 0, 0).set(15, 8, 8, Block.GLOWSTONE.stateId());
+        world.section(1, 0, 0);
+
+        LightEngine.relight(world, Set.of(new Vec(0, 0, 0), new Vec(1, 0, 0)), LightEngine.Type.BLOCK);
+        var source = world.light(LightEngine.Type.BLOCK, 0, 0, 0);
+        var neighbor = world.light(LightEngine.Type.BLOCK, 1, 0, 0);
+        assertEquals(15, source.getLevel(15, 8, 8));
+        assertEquals(14, neighbor.getLevel(0, 8, 8), "light continues across the section border");
+        assertEquals(13, neighbor.getLevel(1, 8, 8));
+    }
+
+    @Test
+    public void recomputesGateContainsTheWave() {
+        // the same corner setup as above, but the diagonal section opts out of recomputing
+        var world = new VirtualWorld() {
+            @Override
+            public boolean recomputes(int chunkX, int sectionY, int chunkZ) {
+                return chunkZ == 0;
+            }
+        };
+        world.section(0, 0, 0).set(15, 8, 15, Block.GLOWSTONE.stateId());
+        world.section(1, 0, 0);
+        world.section(1, 0, 1);
+
+        var touched = LightEngine.relight(world, Set.of(new Vec(0, 0, 0), new Vec(1, 0, 0)), LightEngine.Type.BLOCK);
+        assertTrue(touched.contains(new BlockVec(1, 0, 0)));
+        assertFalse(touched.contains(new BlockVec(1, 0, 1)), "a non-recomputing section stops the wave");
+        assertEquals(0, world.light(LightEngine.Type.BLOCK, 1, 0, 1).getLevel(0, 8, 0));
+    }
+
+    @Test
+    public void skyLightFloodsAnOpenColumn() {
+        var world = new VirtualWorld();
+        world.section(0, 0, 0);
+
+        LightEngine.relight(world, Set.of(new Vec(0, 0, 0)), LightEngine.Type.SKY);
+        var sky = world.light(LightEngine.Type.SKY, 0, 0, 0);
+        assertEquals(15, sky.getLevel(0, 0, 0));
+        assertEquals(15, sky.getLevel(8, 15, 8));
+    }
+
+    @Test
+    public void occlusionMatchesTheDiffuseSet() {
+        assertTrue(LightEngine.checkSkyOcclusion(Block.STONE));
+        assertTrue(LightEngine.checkSkyOcclusion(Block.WATER), "diffuse blocks occlude despite their shape");
+        assertTrue(LightEngine.checkSkyOcclusion(Block.OAK_LEAVES));
+        assertFalse(LightEngine.checkSkyOcclusion(Block.AIR));
+        assertFalse(LightEngine.checkSkyOcclusion(Block.OAK_FENCE));
+    }
+}


### PR DESCRIPTION
## Proposed changes

Pulls the relight logic out of `LightingChunk` into a public `LightEngine` that runs over a `WorldView` interface (light/palette/occlusion lookups). This allows lighting worlds that are not instances (packet worlds, schematic previews, etc) without cloning chunks into a scratch instance just to call `LightingChunk.relight`.

`LightingChunk` delegates to the engine internally. No public API changes, only private/package-private members moved. Existing light tests pass unchanged.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

The new test runs the engine on a map-backed `WorldView` with no instance at all.

Exposing `Light.calculateInternal`/`calculateExternal` directly was considered instead, but every caller would need to reimplement the wave loop. The relight thread pool moved from `LightingChunk` to `LightEngine`, otherwise identical.