### PR TITLE
fix: Replace replaceable blocks in place when clicked

### DIFF
--- a/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
+++ b/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
@@ -104,7 +104,10 @@ public class BlockPlacementListener {
         //todo it feels like it should be possible to have better replacement rules than this, feels pretty scuffed.
         Point placementPosition = blockPosition;
         var interactedPlacementRule = BLOCK_MANAGER.getBlockPlacementRule(interactedBlock);
-        if (!interactedBlock.isAir() && (interactedPlacementRule == null || !interactedPlacementRule.isSelfReplaceable(
+        // A replaceable clicked block (grass, snow layers, water) is replaced in place, like vanilla and the
+        // client's own prediction; the same check the neighbor position already gets below.
+        if (!interactedBlock.isAir() && !interactedBlock.registry().isReplaceable()
+                && (interactedPlacementRule == null || !interactedPlacementRule.isSelfReplaceable(
                 new BlockPlacementRule.Replacement(interactedBlock, blockFace, cursorPosition, false, useMaterial)))) {
             // If the block is not replaceable, try to place next to it.
             placementPosition = blockPosition.relative(blockFace);

--- a/src/test/java/net/minestom/server/entity/player/PlayerBlockPlacementIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerBlockPlacementIntegrationTest.java
@@ -3,6 +3,7 @@ package net.minestom.server.entity.player;
 import net.minestom.server.component.DataComponents;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.GameMode;
+import net.minestom.server.entity.Player;
 import net.minestom.server.entity.PlayerHand;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockFace;
@@ -15,6 +16,7 @@ import net.minestom.server.network.packet.client.play.ClientPlayerBlockPlacement
 import net.minestom.server.registry.RegistryTag;
 import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -22,6 +24,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnvTest
 public class PlayerBlockPlacementIntegrationTest {
@@ -48,6 +51,32 @@ public class PlayerBlockPlacementIntegrationTest {
 
         var placedBlock = instance.getBlock(1, 41, 0);
         assertEquals("minecraft:white_wool", placedBlock.name());
+    }
+
+    @Test
+    public void placeAgainstReplaceableBlock(Env env) {
+        var instance = env.createFlatInstance();
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0, 42, 0));
+        player.setItemInMainHand(ItemStack.of(Material.WHITE_WOOL, 64));
+
+        // clicking a replaceable block places IN PLACE, like vanilla and the client's prediction
+        instance.setBlock(2, 41, 0, Block.SHORT_GRASS);
+        placeAgainst(player, new Pos(2, 41, 0), BlockFace.WEST);
+        assertEquals(Block.WHITE_WOOL, instance.getBlock(2, 41, 0), "the replaceable block is replaced in place");
+        assertTrue(instance.getBlock(1, 41, 0).isAir(), "nothing lands on the clicked face's neighbor");
+
+        // a non-replaceable clicked block still places against the face
+        placeAgainst(player, new Pos(2, 41, 0), BlockFace.WEST);
+        assertEquals(Block.WHITE_WOOL, instance.getBlock(1, 41, 0));
+    }
+
+    private static void placeAgainst(Player player, Pos clicked, BlockFace face) {
+        player.addPacketToQueue(new ClientPlayerBlockPlacementPacket(
+                PlayerHand.MAIN, clicked, face,
+                1f, 1f, 1f,
+                false, false, 0));
+        player.interpretPacketQueue();
     }
 
     private static Stream<Arguments> placeBlockFromAdventureModeParams() {


### PR DESCRIPTION
## Proposed changes

Clicking a replaceable block (grass, snow layers, water) places the new block into its cell in vanilla, and modern clients predict that locally. The listener only honored self-replaceable placement rules for the clicked block and bumped everything else to the neighbor face, desyncing the prediction: the block visibly jumps one cell toward the player, or fails when that neighbor is occupied. The neighbor position already gets the `isReplaceable` check; the clicked position now gets the same one.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Easy to reproduce: place a block against tall grass and watch it land one cell toward you after the client predicted it in place. The test covers the in-place replacement and that non-replaceable blocks still place against the face.