### PR TITLE
feat: Per-entity block placement rule

### DIFF
--- a/src/main/java/net/minestom/server/collision/BlockCollision.java
+++ b/src/main/java/net/minestom/server/collision/BlockCollision.java
@@ -38,9 +38,10 @@ final class BlockCollision {
         return stepPhysics(boundingBox, velocity, entityPosition, getter, singleCollision);
     }
 
-    static Entity canPlaceBlockAt(Instance instance, Point blockPos, Block b) {
+    static Entity canPlaceBlockAt(Instance instance, Point blockPos, Block b, @Nullable Player placer) {
         for (Entity entity : instance.getNearbyEntities(blockPos, 3)) {
-            if (!entity.preventBlockPlacement())
+            final boolean prevents = placer != null ? entity.preventBlockPlacement(placer) : entity.preventBlockPlacement();
+            if (!prevents)
                 continue;
 
             final boolean intersects;

--- a/src/main/java/net/minestom/server/collision/CollisionUtils.java
+++ b/src/main/java/net/minestom/server/collision/CollisionUtils.java
@@ -4,6 +4,7 @@ import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.Player;
 import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.WorldBorder;
@@ -152,7 +153,15 @@ public final class CollisionUtils {
     }
 
     public static Entity canPlaceBlockAt(Instance instance, Point blockPos, Block b) {
-        return BlockCollision.canPlaceBlockAt(instance, blockPos, b);
+        return BlockCollision.canPlaceBlockAt(instance, blockPos, b, null);
+    }
+
+    /**
+     * {@link #canPlaceBlockAt(Instance, Point, Block)} consulting each entity's
+     * {@link Entity#preventBlockPlacement(Player) placement rule} with {@code placer}.
+     */
+    public static Entity canPlaceBlockAt(Instance instance, Point blockPos, Block b, Player placer) {
+        return BlockCollision.canPlaceBlockAt(instance, blockPos, b, placer);
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -135,6 +135,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     protected boolean hasPhysics = true;
     protected boolean collidesWithEntities = true;
     protected boolean preventBlockPlacement = true;
+    private volatile @Nullable Predicate<? super Player> placementRule;
 
     private Aerodynamics aerodynamics;
     protected int gravityTickCount; // Number of tick where gravity tick was applied
@@ -1901,6 +1902,26 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         // Can be overridden to allow for custom behaviour
         if (entityMeta instanceof ArmorStandMeta armorStandMeta && armorStandMeta.isMarker()) return false;
         return preventBlockPlacement;
+    }
+
+    /**
+     * Gets whether this entity prevents {@code placer} from placing a block it collides with: the
+     * {@link #updatePlacementRule(Predicate) placement rule} when one is set, {@link #preventBlockPlacement()} otherwise.
+     */
+    public boolean preventBlockPlacement(Player placer) {
+        final Predicate<? super Player> rule = placementRule;
+        return rule != null ? rule.test(placer) : preventBlockPlacement();
+    }
+
+    /**
+     * Changes which players this entity blocks placements for; {@code null} restores
+     * {@link #preventBlockPlacement()} for everyone.
+     * <p>
+     * Lets an entity hidden from some players (vanish, {@link #updateViewableRule(Predicate) viewable rules},
+     * virtual worlds) opt out of physically obstructing the players it does not exist for.
+     */
+    public void updatePlacementRule(@Nullable Predicate<? super Player> predicate) {
+        this.placementRule = predicate;
     }
 
     protected void updateCollisions() {

--- a/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
+++ b/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
@@ -148,7 +148,7 @@ public class BlockPlacementListener {
         final ItemBlockState blockState = usedItem.get(DataComponents.BLOCK_STATE, ItemBlockState.EMPTY);
         final Block placedBlock = blockState.apply(useMaterial.block());
 
-        Entity collisionEntity = CollisionUtils.canPlaceBlockAt(instance, placementPosition, placedBlock);
+        Entity collisionEntity = CollisionUtils.canPlaceBlockAt(instance, placementPosition, placedBlock, player);
         if (collisionEntity != null) {
             // If a player is trying to place a block on themselves, the client sends a block change but does not set
             // the block on its own client, so it only needs an acknowledgement.

--- a/src/test/java/net/minestom/server/collision/PlacementCollisionIntegrationTest.java
+++ b/src/test/java/net/minestom/server/collision/PlacementCollisionIntegrationTest.java
@@ -17,27 +17,27 @@ public class PlacementCollisionIntegrationTest {
     @Test
     public void empty(Env env) {
         var instance = env.createFlatInstance();
-        assertNull(BlockCollision.canPlaceBlockAt(instance, new Vec(0, 40, 0), Block.STONE));
+        assertNull(BlockCollision.canPlaceBlockAt(instance, new Vec(0, 40, 0), Block.STONE, null));
     }
 
     @Test
     public void entityBlock(Env env) {
         var instance = env.createFlatInstance();
         new Entity(EntityType.ZOMBIE).setInstance(instance, new Pos(0, 40, 0)).join();
-        assertNotNull(BlockCollision.canPlaceBlockAt(instance, new Vec(0, 40, 0), Block.STONE));
+        assertNotNull(BlockCollision.canPlaceBlockAt(instance, new Vec(0, 40, 0), Block.STONE, null));
     }
 
     @Test
     public void slab(Env env) {
         var instance = env.createFlatInstance();
         new Entity(EntityType.ZOMBIE).setInstance(instance, new Pos(0, 40.75, 0)).join();
-        assertNull(BlockCollision.canPlaceBlockAt(instance, new Vec(0, 40, 0), Block.STONE_SLAB));
+        assertNull(BlockCollision.canPlaceBlockAt(instance, new Vec(0, 40, 0), Block.STONE_SLAB, null));
     }
 
     @Test
     public void belowPlayer(Env env) {
         var instance = env.createFlatInstance();
         env.createPlayer(instance, new Pos(5.7, -8, 6.389));
-        assertNull(BlockCollision.canPlaceBlockAt(instance, new Vec(5, -9, 6), Block.STONE));
+        assertNull(BlockCollision.canPlaceBlockAt(instance, new Vec(5, -9, 6), Block.STONE, null));
     }
 }

--- a/src/test/java/net/minestom/server/entity/player/PlayerBlockPlacementIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerBlockPlacementIntegrationTest.java
@@ -2,7 +2,10 @@ package net.minestom.server.entity.player;
 
 import net.minestom.server.component.DataComponents;
 import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.EntityType;
 import net.minestom.server.entity.GameMode;
+import net.minestom.server.entity.Player;
 import net.minestom.server.entity.PlayerHand;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockFace;
@@ -10,11 +13,13 @@ import net.minestom.server.instance.block.predicate.BlockPredicate;
 import net.minestom.server.instance.block.predicate.PropertiesPredicate;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
+import net.minestom.server.entity.metadata.other.ArmorStandMeta;
 import net.minestom.server.item.component.BlockPredicates;
 import net.minestom.server.network.packet.client.play.ClientPlayerBlockPlacementPacket;
 import net.minestom.server.registry.RegistryTag;
 import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -22,6 +27,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnvTest
 public class PlayerBlockPlacementIntegrationTest {
@@ -48,6 +54,52 @@ public class PlayerBlockPlacementIntegrationTest {
 
         var placedBlock = instance.getBlock(1, 41, 0);
         assertEquals("minecraft:white_wool", placedBlock.name());
+    }
+
+    @Test
+    public void placementRule(Env env) {
+        var instance = env.createFlatInstance();
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0, 42, 0));
+        player.setItemInMainHand(ItemStack.of(Material.WHITE_WOOL, 64));
+        instance.setBlock(2, 41, 0, Block.STONE);
+
+        var blocker = new Entity(EntityType.ZOMBIE);
+        blocker.setInstance(instance, new Pos(1.5, 41, 0.5)).join();
+
+        placeAgainstStone(player);
+        assertTrue(instance.getBlock(1, 41, 0).isAir(), "a colliding entity blocks placement by default");
+
+        blocker.updatePlacementRule(p -> false);
+        placeAgainstStone(player);
+        assertEquals(Block.WHITE_WOOL, instance.getBlock(1, 41, 0), "an exempting rule lets the placement through");
+
+        instance.setBlock(1, 41, 0, Block.AIR);
+        blocker.updatePlacementRule(null);
+        placeAgainstStone(player);
+        assertTrue(instance.getBlock(1, 41, 0).isAir(), "clearing the rule restores the default");
+
+        // the rule outranks the type default in the other direction too: a marker armor stand never blocks...
+        blocker.remove();
+        var marker = new Entity(EntityType.ARMOR_STAND);
+        ((ArmorStandMeta) marker.getEntityMeta()).setMarker(true);
+        marker.setInstance(instance, new Pos(1.5, 41, 0.5)).join();
+        placeAgainstStone(player);
+        assertEquals(Block.WHITE_WOOL, instance.getBlock(1, 41, 0));
+
+        // ...unless its rule says otherwise
+        instance.setBlock(1, 41, 0, Block.AIR);
+        marker.updatePlacementRule(p -> true);
+        placeAgainstStone(player);
+        assertTrue(instance.getBlock(1, 41, 0).isAir(), "a blocking rule outranks the type default");
+    }
+
+    private static void placeAgainstStone(Player player) {
+        player.addPacketToQueue(new ClientPlayerBlockPlacementPacket(
+                PlayerHand.MAIN, new Pos(2, 41, 0), BlockFace.WEST,
+                1f, 1f, 1f,
+                false, false, 0));
+        player.interpretPacketQueue();
     }
 
     private static Stream<Arguments> placeBlockFromAdventureModeParams() {


### PR DESCRIPTION
## Proposed changes

`preventBlockPlacement` is a placer-blind boolean, so an entity some players cannot see (vanish, viewable rules, virtual worlds) still physically blocks their placements — leaking its position and reverting client-predicted blocks. Adds an optional per-entity rule consulted with the placer, mirroring `updateViewableRule`:

```java
entity.updatePlacementRule(placer -> ...); // null = the boolean, unchanged
## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments

The rule outranks the type default in both directions (tested with a marker armor stand). The old `CollisionUtils.canPlaceBlockAt` overload keeps its exact behavior.