### PR TITLE
Set profile prior to login success

### DIFF
--- a/src/main/java/net/minestom/server/listener/preplay/LoginListener.java
+++ b/src/main/java/net/minestom/server/listener/preplay/LoginListener.java
@@ -233,10 +233,7 @@ public final class LoginListener {
     private static void enterConfig(PlayerConnection connection, GameProfile gameProfile) {
         Thread.startVirtualThread(() -> {
             try {
-                var newGameProfile = MinecraftServer.getConnectionManager().transitionLoginToConfig(connection, gameProfile);
-                if (connection instanceof PlayerSocketConnection socketConnection) {
-                    socketConnection.UNSAFE_setProfile(newGameProfile);
-                }
+                MinecraftServer.getConnectionManager().transitionLoginToConfig(connection, gameProfile);
             } catch (Throwable t) {
                 MinecraftServer.getExceptionManager().handleException(t);
             }

--- a/src/main/java/net/minestom/server/network/ConnectionManager.java
+++ b/src/main/java/net/minestom/server/network/ConnectionManager.java
@@ -209,6 +209,10 @@ public final class ConnectionManager {
             connection.kick(LoginListener.INVALID_PROXY_RESPONSE);
             throw new RuntimeException("Error getting replies for login plugin messages", t);
         }
+        // Publish the final profile before the client could possibly respond
+        if (connection instanceof PlayerSocketConnection socketConnection) {
+            socketConnection.UNSAFE_setProfile(gameProfile);
+        }
         // Send login success packet (and switch to configuration phase)
         connection.sendPacket(new LoginSuccessPacket(gameProfile, new UUID(0L, 0L)));
         return gameProfile;

--- a/src/main/java/net/minestom/server/network/player/PlayerSocketConnection.java
+++ b/src/main/java/net/minestom/server/network/player/PlayerSocketConnection.java
@@ -79,7 +79,7 @@ public class PlayerSocketConnection extends PlayerConnection {
 
     // Data from client packets
     private @Nullable String loginUsername;
-    private @Nullable GameProfile gameProfile;
+    private volatile @Nullable GameProfile gameProfile;
     private @Nullable String serverAddress;
     private int serverPort;
     private int protocolVersion;

--- a/src/test/java/net/minestom/server/network/ConnectionManagerIntegrationTest.java
+++ b/src/test/java/net/minestom/server/network/ConnectionManagerIntegrationTest.java
@@ -3,20 +3,25 @@ package net.minestom.server.network;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.Player;
 import net.minestom.server.instance.Instance;
+import net.minestom.server.network.packet.server.SendablePacket;
+import net.minestom.server.network.packet.server.login.LoginSuccessPacket;
 import net.minestom.server.network.player.GameProfile;
+import net.minestom.server.network.player.PlayerSocketConnection;
 import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.channels.SocketChannel;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 @EnvTest
 public class ConnectionManagerIntegrationTest {
-
 
     private GameProfile[] profiles;
 
@@ -41,6 +46,49 @@ public class ConnectionManagerIntegrationTest {
         assertEquals(minestomPlayer, connectionManager.findOnlinePlayer("Mine"));
         assertEquals(notchPlayer, connectionManager.findOnlinePlayer("No"));
         assertNull(connectionManager.findOnlinePlayer("leo"));
+    }
+
+    @Test
+    public void profileIsPublishedBeforeLoginSuccess(Env env) throws IOException {
+        final GameProfile profile = profiles[0];
+
+        try (SocketChannel channel = SocketChannel.open()) {
+            final var connection = new ProfileCapturingConnection(channel);
+            connection.setClientState(ConnectionState.LOGIN);
+
+            final CompletableFuture<GameProfile> future = new CompletableFuture<>();
+            Thread.startVirtualThread(() -> {
+                try {
+                    future.complete(env.process().connection().transitionLoginToConfig(connection, profiles[0]));
+                } catch (Throwable throwable) {
+                    future.completeExceptionally(throwable);
+                }
+            });
+            final GameProfile result = future.join();
+
+            assertSame(profile, result);
+            assertSame(profile, connection.profileWhenLoginSuccessSent.join());
+            assertSame(profile, connection.gameProfile());
+        }
+    }
+
+    private static final class ProfileCapturingConnection extends PlayerSocketConnection {
+        private final CompletableFuture<GameProfile> profileWhenLoginSuccessSent = new CompletableFuture<>();
+
+        private ProfileCapturingConnection(SocketChannel channel) {
+            super(channel, new InetSocketAddress("localhost", 25565),
+                    Thread.currentThread(), Thread.currentThread());
+        }
+
+        @Override
+        public void sendPacket(SendablePacket packet) {
+            if (packet instanceof LoginSuccessPacket) {
+                // Model the socket reader handling an immediate acknowledgement before the login
+                // thread resumes from sendPacket.
+                Thread.startVirtualThread(() -> profileWhenLoginSuccessSent.complete(gameProfile()));
+                profileWhenLoginSuccessSent.join();
+            }
+        }
     }
 
 }


### PR DESCRIPTION
## Proposed changes

Fixes a race in login where the game profile may end up null in config state due to an immediate login ack from the client (or more likely a proxy).

It's been observed a few times on hollow cube but I havent been able to reproduce it myself.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
