### PR TITLE
fix: MotionBlockingHeightmap use fluid & blocksMotion

### DIFF
--- a/src/main/java/net/minestom/server/instance/heightmap/MotionBlockingHeightmap.java
+++ b/src/main/java/net/minestom/server/instance/heightmap/MotionBlockingHeightmap.java
@@ -10,9 +10,7 @@ public class MotionBlockingHeightmap extends Heightmap {
 
     @Override
     protected boolean checkBlock(Block block) {
-        return (block.solid() && !block.compare(Block.COBWEB) && !block.compare(Block.BAMBOO_SAPLING))
-                || block.liquid()
-                || "true".equals(block.getProperty("waterlogged"));
+        return block.blocksMotion() || block.fluid();
     }
 
     @Override

--- a/src/test/java/net/minestom/server/instance/ChunkHeightmapIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/ChunkHeightmapIntegrationTest.java
@@ -39,6 +39,35 @@ public class ChunkHeightmapIntegrationTest {
     }
 
     @Test
+    public void motionBlockingFluidTest(Env env) {
+        var instance = env.createFlatInstance();
+        instance.loadChunk(0, 0).join();
+        var chunk = instance.getChunk(0, 0);
+        var heightmap = chunk.motionBlockingHeightmap();
+
+        // Inherently waterlogged blocks count even without a "waterlogged" property
+        instance.setBlock(0, 45, 0, Block.KELP);
+        assertEquals(45, heightmap.getHeight(0, 0));
+
+        instance.setBlock(1, 45, 0, Block.SEAGRASS);
+        assertEquals(45, heightmap.getHeight(1, 0));
+
+        // Waterlogged state of a block without collision counts, dry state does not
+        instance.setBlock(2, 45, 0, Block.GLOW_LICHEN.withProperty("waterlogged", "true"));
+        assertEquals(45, heightmap.getHeight(2, 0));
+
+        instance.setBlock(3, 45, 0, Block.GLOW_LICHEN);
+        assertEquals(39, heightmap.getHeight(3, 0));
+
+        // Solid but not motion blocking
+        instance.setBlock(4, 45, 0, Block.COBWEB);
+        assertEquals(39, heightmap.getHeight(4, 0));
+
+        instance.setBlock(5, 45, 0, Block.BAMBOO_SAPLING);
+        assertEquals(39, heightmap.getHeight(5, 0));
+    }
+
+    @Test
     public void heightMapRemoveTest(Env env) {
         var instance = env.createFlatInstance();
         instance.loadChunk(0, 0).join();


### PR DESCRIPTION
## Proposed changes

Should use blocksMotion and fluid instead of guessing with solid & types || liquid + waterlogged property.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments