### PR TITLE
Fix chunks disappearing when switching instances

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -708,8 +708,25 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
                              boolean firstSpawn, boolean dimensionChange, boolean updateChunks) {
         if (!firstSpawn && !dimensionChange) {
             // Player instance changed, clear current viewable collections
-            if (updateChunks)
-                ChunkRange.chunksInRange(spawnPosition, this.effectiveViewDistance(), chunkRemover);
+            if (updateChunks) {
+                final int viewDist = this.effectiveViewDistance();
+                ChunkRange.chunksInRange(
+                        (int) this.chunksLoadedByClient.x(), (int) this.chunksLoadedByClient.z(), viewDist,
+                        (x, z) -> {
+                            boolean inNewView = Math.abs(x - spawnPosition.chunkX()) <= viewDist
+                                    && Math.abs(z - spawnPosition.chunkZ()) <= viewDist;
+                            if (!inNewView) {
+                                // Only send UnloadChunkPacket for chunks no longer in the new view.
+                                // This alleviates a 26.2 client bug where, if it processes an UnloadChunkPacket
+                                // and a ChunkDataPacket for the same chunk in the same frame, the chunk disappears.
+                                // https://bugs.mojang.com/browse/MC/issues/MC-310041
+                                // TODO(26.3): Revert this change; the client bug is fixed in 26.3-snapshot5
+                                sendPacket(new UnloadChunkPacket(x, z));
+                            }
+                            EventDispatcher.call(new PlayerChunkUnloadEvent(this, x, z));
+                        }
+                );
+            }
         }
 
         if (dimensionChange) sendDimension(instance.getDimensionType(), instance.getDimensionName());

--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -636,7 +636,7 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
 
         // Ensure that surrounding chunks are loaded
         List<CompletableFuture<Chunk>> futures = new ArrayList<>();
-        ChunkRange.chunksInRange(spawnPosition, this.effectiveViewDistance(), (chunkX, chunkZ) -> {
+        ChunkRange.chunksInRange(spawnPosition, effectiveViewDistance(instance), (chunkX, chunkZ) -> {
             final CompletableFuture<Chunk> future = instance.loadOptionalChunk(chunkX, chunkZ);
             if (!future.isDone()) futures.add(future);
         });
@@ -709,12 +709,15 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
         if (!firstSpawn && !dimensionChange) {
             // Player instance changed, clear current viewable collections
             if (updateChunks) {
-                final int viewDist = this.effectiveViewDistance();
+                final int oldViewDistance = effectiveViewDistance();
+                final int newViewDistance = effectiveViewDistance(instance);
+                final int newChunkX = spawnPosition.chunkX();
+                final int newChunkZ = spawnPosition.chunkZ();
                 ChunkRange.chunksInRange(
-                        (int) this.chunksLoadedByClient.x(), (int) this.chunksLoadedByClient.z(), viewDist,
+                        (int) this.chunksLoadedByClient.x(), (int) this.chunksLoadedByClient.z(), oldViewDistance,
                         (x, z) -> {
-                            boolean inNewView = Math.abs(x - spawnPosition.chunkX()) <= viewDist
-                                    && Math.abs(z - spawnPosition.chunkZ()) <= viewDist;
+                            boolean inNewView = Math.abs(x - newChunkX) <= newViewDistance
+                                    && Math.abs(z - newChunkZ) <= newViewDistance;
                             if (!inNewView) {
                                 // Only send UnloadChunkPacket for chunks no longer in the new view.
                                 // This alleviates a 26.2 client bug where, if it processes an UnloadChunkPacket
@@ -2473,7 +2476,10 @@ public class Player extends LivingEntity implements CommandSender, HoverEventSou
      * @return The effective chunk view distance range of the client
      */
     public int effectiveViewDistance() {
-        Instance instance = this.instance;
+        return effectiveViewDistance(instance);
+    }
+
+    private int effectiveViewDistance(@Nullable Instance instance) {
         int maxViewDistance = instance != null ? instance.viewDistance() : ServerFlag.CHUNK_VIEW_DISTANCE;
         return Math.min(settings.viewDistance(), maxViewDistance) + 1;
     }

--- a/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerMovementIntegrationTest.java
@@ -2,6 +2,7 @@ package net.minestom.server.entity.player;
 
 import net.minestom.server.ServerFlag;
 import net.minestom.server.coordinate.ChunkRange;
+import net.minestom.server.coordinate.CoordConversion;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.MainHand;
@@ -28,6 +29,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -337,6 +339,48 @@ public class PlayerMovementIntegrationTest {
     }
 
     @Test
+    public void testInstanceSwitchSameViewDoesNotUnloadOverlappingChunks(Env env) {
+        assertInstanceSwitchChunkUnloads(env, 8, new Pos(0, 42, 0), 8, new Pos(0, 42, 0));
+    }
+
+    @Test
+    public void testInstanceSwitchShrinkingViewUnloadsOldRing(Env env) {
+        assertInstanceSwitchChunkUnloads(env, 8, new Pos(0, 42, 0), 3, new Pos(0, 42, 0));
+    }
+
+    @Test
+    public void testInstanceSwitchExpandingViewDoesNotUnloadDestinationChunks(Env env) {
+        assertInstanceSwitchChunkUnloads(env, 3, new Pos(0, 42, 0), 8, new Pos(80, 42, 0));
+    }
+
+    private static void assertInstanceSwitchChunkUnloads(Env env, int oldInstanceViewDistance, Pos oldPosition, int newInstanceViewDistance, Pos newPosition) {
+        final Instance oldInstance = env.createFlatInstance();
+        oldInstance.viewDistance(oldInstanceViewDistance);
+        final Instance newInstance = env.createFlatInstance();
+        newInstance.viewDistance(newInstanceViewDistance);
+
+        final TestConnection connection = env.createConnection();
+        final Player player = connection.connect(oldInstance, oldPosition);
+        final int oldViewDistance = player.effectiveViewDistance();
+        final int newViewDistance = Math.min(ClientSettings.DEFAULT.viewDistance(), newInstanceViewDistance) + 1;
+
+        final Set<Long> expectedUnloads = new HashSet<>();
+        ChunkRange.chunksInRange(oldPosition.chunkX(), oldPosition.chunkZ(), oldViewDistance, (chunkX, chunkZ) -> {
+            if (!isChunkInView(chunkX, chunkZ, newPosition, newViewDistance)) {
+                expectedUnloads.add(CoordConversion.chunkIndex(chunkX, chunkZ));
+            }
+        });
+
+        final Collector<UnloadChunkPacket> removed = connection.trackIncoming(UnloadChunkPacket.class);
+        player.setInstance(newInstance, newPosition).join();
+
+        assertEquals(newViewDistance, player.effectiveViewDistance());
+        removed.assertCount(expectedUnloads.size());
+        final Set<Long> actualUnloads = removed.collect().stream().map(packet -> CoordConversion.chunkIndex(packet.chunkX(), packet.chunkZ())).collect(Collectors.toSet());
+        assertEquals(expectedUnloads, actualUnloads);
+    }
+
+    @Test
     public void testCancelledMove(Env env) {
         var instance = env.createFlatInstance();
         var connection = env.createConnection();
@@ -356,5 +400,10 @@ public class PlayerMovementIntegrationTest {
             // Must reset velocity or the player will keep moving and create a loop of teleport cancel teleport.
             assertEquals(Vec.ZERO, packet.delta());
         });
+    }
+
+    private static boolean isChunkInView(int chunkX, int chunkZ, Pos viewCenter, int viewDistance) {
+        return Math.abs(chunkX - viewCenter.chunkX()) <= viewDistance
+                && Math.abs(chunkZ - viewCenter.chunkZ()) <= viewDistance;
     }
 }


### PR DESCRIPTION
## Proposed changes

Fixes #3307

Starting in 26.2, Minestom's fast instance switching (changing instances without a loading screen) started to make chunks invisible if the old and new player positions were close to each other. This seems to be due to a Minecraft client bug ([MC-310041](https://bugs.mojang.com/browse/MC/issues/MC-310041)) where processing a chunk unload packet and a chunk data packet in the same frame caused the chunk to become invisible until it was unloaded and reloaded. This client issue is fixed in 26.3 snapshot 5, but 26.3 won't be released for a while, so I think it's worth implementing a workaround in the meantime.

This PR fixes the issue by skipping sending the `ChunkUnloadPacket` for chunks that will be within the client's render distance from their new spawn position.

This does mean that some of the old chunks are visible for a split second after joining the new instance. If we wanted to avoid that, we'd probably have to wait a tick in between sending all the `ChunkUnloadPacket`s and sending the new chunk data. However, I think the bug is related to frame rate, so if the client ever took more than one tick to render a frame, the chunks still may become invisible.

I intend for this PR to be reverted when 26.3 is released.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)