### PR TITLE
Unlink shared instances when unregistering

### DIFF
--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -598,6 +598,10 @@ public class InstanceContainer extends Instance {
         this.sharedInstances.add(sharedInstance);
     }
 
+    void removeSharedInstance(SharedInstance sharedInstance) {
+        this.sharedInstances.remove(sharedInstance);
+    }
+
     /**
      * Copies all the chunks of this instance and create a new instance container with all of them.
      * <p>

--- a/src/main/java/net/minestom/server/instance/InstanceManager.java
+++ b/src/main/java/net/minestom/server/instance/InstanceManager.java
@@ -123,6 +123,9 @@ public final class InstanceManager {
                 var dispatcher = MinecraftServer.process().dispatcher();
                 instance.getChunks().forEach(dispatcher::deletePartition);
             }
+            if (instance instanceof SharedInstance sharedInstance) {
+                sharedInstance.getInstanceContainer().removeSharedInstance(sharedInstance);
+            }
             // Unregister
             instance.setRegistered(false);
             this.instances.remove(instance);

--- a/src/test/java/net/minestom/server/instance/InstanceUnregisterIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/InstanceUnregisterIntegrationTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.lang.ref.WeakReference;
+import java.util.List;
 import java.util.UUID;
 
 import static net.minestom.testing.TestUtils.waitUntilCleared;
@@ -32,14 +33,28 @@ public class InstanceUnregisterIntegrationTest {
         env.tick();
 
         var acquired = player.acquirable().lock();
-        player.setInstance(instanceManager.createSharedInstance(instance)).join();
+        var shared2 = instanceManager.createSharedInstance(instance);
+        player.setInstance(shared2).join();
         acquired.unlock();
         listener.followup();
         env.tick();
 
         instanceManager.unregisterInstance(shared1);
+        Assertions.assertEquals(List.of(shared2), instance.getSharedInstances());
         listener.followup();
         env.tick();
+    }
+
+    @Test
+    public void sharedInstanceGC(Env env) {
+        var instanceManager = env.process().instance();
+        var instance = instanceManager.createInstanceContainer();
+        var shared = instanceManager.createSharedInstance(instance);
+        var ref = new WeakReference<>(shared);
+        instanceManager.unregisterInstance(shared);
+
+        shared = null;
+        waitUntilCleared(ref);
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

Fixes #3250.

Unregistering a `SharedInstance` now removes it from its parent `InstanceContainer`, allowing it to be garbage collected instead of remaining strongly referenced.

The regression coverage verifies that unregistering one shared instance preserves its siblings and that the unregistered instance can be collected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Validated with the focused `InstanceUnregisterIntegrationTest` suite and the Java compilation, test compilation, and forbidden-import checks.
