### PR TITLE
Change sprinting speed modifier from 0.3D to 0.3F

### DIFF
--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -49,7 +49,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class LivingEntity extends Entity implements EquipmentHandler {
 
-    private static final AttributeModifier SPRINTING_SPEED_MODIFIER = new AttributeModifier(Key.key("sprinting"), 0.3, AttributeOperation.ADD_MULTIPLIED_TOTAL);
+    private static final AttributeModifier SPRINTING_SPEED_MODIFIER = new AttributeModifier(Key.key("sprinting"), 0.3F, AttributeOperation.ADD_MULTIPLIED_TOTAL);
 
     /**
      * IDs of modifiers that are protected from removal by methods like {@link AttributeInstance#clearModifiers()}.


### PR DESCRIPTION
Vanilla minecraft uses 0.3F as it's sprinting speed modifier. Minestom currently uses 0.3, which causes sprinting to be ever so slightly slower on Minestom servers compared to vanilla and additionally makes the exact movement dependent on latency.

## Proposed changes

Changing the double SPRINTING_SPEED_MODIFIER field from 0.3 to 0.3F. This is the value that both vanilla servers and clients use and without this change the server will overwrite the modifier on the client, making the exact movement of players very slightly dependent on latency (Even though the discrepancies are typically only around the order of ~1e-8).

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)