### PR TITLE
Fix boss bar bugs

### DIFF
--- a/src/main/java/net/minestom/server/adventure/bossbar/BossBarManager.java
+++ b/src/main/java/net/minestom/server/adventure/bossbar/BossBarManager.java
@@ -47,7 +47,7 @@ public class BossBarManager {
         BossBarHolder holder = this.getOrCreateHandler(bar);
         if (holder.addViewer(player)) {
             player.sendPacket(holder.createAddPacket());
-            this.playerBars.computeIfAbsent(player.getUuid(), _ -> new HashSet<>()).add(holder);
+            this.addPlayer(player, holder);
         }
     }
 
@@ -76,6 +76,10 @@ public class BossBarManager {
         BossBarHolder holder = this.getOrCreateHandler(bar);
         List<? extends Player> addedPlayers = players.stream().filter(holder::addViewer).toList();
         if (!addedPlayers.isEmpty()) {
+            for (Player player : addedPlayers) {
+                this.addPlayer(player, holder);
+            }
+
             PacketSendingUtils.sendGroupedPacket(addedPlayers, holder.createAddPacket());
         }
     }
@@ -91,6 +95,10 @@ public class BossBarManager {
         if (holder != null) {
             List<? extends Player> removedPlayers = players.stream().filter(holder::removeViewer).toList();
             if (!removedPlayers.isEmpty()) {
+                for (Player player : removedPlayers) {
+                    this.removePlayer(player, holder);
+                }
+
                 PacketSendingUtils.sendGroupedPacket(removedPlayers, holder.createRemovePacket());
             }
         }
@@ -104,6 +112,7 @@ public class BossBarManager {
     public void destroyBossBar(BossBar bossBar) {
         BossBarHolder holder = this.bars.remove(bossBar);
         if (holder != null) {
+            bossBar.removeListener(this.listener);
             PacketSendingUtils.sendGroupedPacket(holder.players, holder.createRemovePacket());
             for (Player player : holder.players) {
                 this.removePlayer(player, holder);
@@ -165,13 +174,21 @@ public class BossBarManager {
         });
     }
 
-    private void removePlayer(Player player, BossBarHolder holder) {
-        Set<BossBarHolder> holders = this.playerBars.get(player.getUuid());
-        if (holders != null) {
-            holders.remove(holder);
-            if (holders.isEmpty()) {
-                this.playerBars.remove(player.getUuid());
+    private void addPlayer(Player player, BossBarHolder holder) {
+        this.playerBars.compute(player.getUuid(), (_, holders) -> {
+            if (holders == null) {
+                holders = ConcurrentHashMap.newKeySet();
             }
-        }
+
+            holders.add(holder);
+            return holders;
+        });
+    }
+
+    private void removePlayer(Player player, BossBarHolder holder) {
+        this.playerBars.computeIfPresent(player.getUuid(), (_, holders) -> {
+            holders.remove(holder);
+            return holders.isEmpty() ? null : holders;
+        });
     }
 }


### PR DESCRIPTION
- populate player map in `addBossBar` (path used in PacketGroupingAudience)
- unregister listener when destroyed