### PR TITLE
fix: parse negative coordinates in block collision shapes

### DIFF
--- a/src/main/java/net/minestom/server/collision/ShapeImpl.java
+++ b/src/main/java/net/minestom/server/collision/ShapeImpl.java
@@ -13,7 +13,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public record ShapeImpl(ShapeData shapeData, OcclusionData occlusionData) implements Shape {
-    private static final Pattern PATTERN = Pattern.compile("\\d.\\d+", Pattern.MULTILINE);
+    private static final Pattern PATTERN = Pattern.compile("-?\\d+\\.\\d+");
 
     record ShapeData(List<BoundingBox> boundingBoxes,
                      Point relativeStart, Point relativeEnd,

--- a/src/test/java/net/minestom/server/collision/TestShape.java
+++ b/src/test/java/net/minestom/server/collision/TestShape.java
@@ -1,7 +1,9 @@
 package net.minestom.server.collision;
 
+import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockFace;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -31,5 +33,14 @@ public class TestShape {
     @MethodSource("isFullFaceCases")
     void isFullFace(Block block, BlockFace face, boolean isFullFace) {
         assertEquals(block.collisionShape().isFaceFull(face), isFullFace);
+    }
+
+    @Test
+    void negativeCoordinates() {
+        // Pitcher crop's registry collision shape is [AABB[0.3125, -0.0625, 0.3125] -> [0.6875, 0.1875, 0.6875]],
+        // the sign of the negative Y coordinate must survive parsing
+        Shape shape = Block.PITCHER_CROP.collisionShape();
+        assertEquals(new Vec(0.3125, -0.0625, 0.3125), shape.relativeStart());
+        assertEquals(new Vec(0.6875, 0.1875, 0.6875), shape.relativeEnd());
     }
 }


### PR DESCRIPTION
## Proposed changes

Fixes bug where the negative y and etc wouldn't parse correctly in ShapeImpl AABB

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments