### PR TITLE
fix: encode PROVIDES_BANNER_PATTERNS as a holder set

### DIFF
--- a/src/main/java/net/minestom/server/component/DataComponents.java
+++ b/src/main/java/net/minestom/server/component/DataComponents.java
@@ -102,7 +102,7 @@ public class DataComponents {
     public static final DataComponent<Holder<TrimMaterial>> PROVIDES_TRIM_MATERIAL = register("provides_trim_material", Holder.networkType(Registries::trimMaterial, TrimMaterial.REGISTRY_NETWORK_TYPE), Holder.codec(Registries::trimMaterial, TrimMaterial.REGISTRY_CODEC));
     public static final DataComponent<Integer> OMINOUS_BOTTLE_AMPLIFIER = register("ominous_bottle_amplifier", NetworkBuffer.VAR_INT, Codec.INT);
     public static final DataComponent<RegistryKey<JukeboxSong>> JUKEBOX_PLAYABLE = register("jukebox_playable", JukeboxSong.JUKEBOX_PLAYABLE_NETWORK_TYPE, JukeboxSong.CODEC);
-    public static final DataComponent<TagKey<BannerPattern>> PROVIDES_BANNER_PATTERNS = register("provides_banner_patterns", TagKey.networkType(Registries::bannerPattern), TagKey.hashCodec(Registries::bannerPattern));
+    public static final DataComponent<RegistryTag<BannerPattern>> PROVIDES_BANNER_PATTERNS = register("provides_banner_patterns", RegistryTag.networkType(Registries::bannerPattern), RegistryTag.codec(Registries::bannerPattern));
     public static final DataComponent<List<String>> RECIPES = register("recipes", NetworkBuffer.STRING.list(Short.MAX_VALUE), Codec.STRING.list(Short.MAX_VALUE), List::copyOf);
     public static final DataComponent<LodestoneTracker> LODESTONE_TRACKER = register("lodestone_tracker", LodestoneTracker.NETWORK_TYPE, LodestoneTracker.CODEC);
     public static final DataComponent<FireworkExplosion> FIREWORK_EXPLOSION = register("firework_explosion", FireworkExplosion.NETWORK_TYPE, FireworkExplosion.CODEC);

--- a/src/main/java/net/minestom/server/registry/TagKey.java
+++ b/src/main/java/net/minestom/server/registry/TagKey.java
@@ -12,6 +12,16 @@ public sealed interface TagKey<T> extends Keyed permits TagKeyImpl {
         return new RegistryCodecs.TagKeyImpl<>(selector, false);
     }
 
+    /**
+     * Creates a codec encoding the tag key in the hashed {@code #namespace:value} form.
+     *
+     * @param selector selects the owning registry
+     * @param <T>      the registry entry type
+     * @return the hashed tag key codec
+     * @deprecated no longer used by any component; vanilla encodes tag valued components as holder
+     * sets, see {@link RegistryTag#codec(Registries.Selector)}
+     */
+    @Deprecated(forRemoval = true)
     static <T> Codec<TagKey<T>> hashCodec(Registries.Selector<T> selector) {
         return new RegistryCodecs.TagKeyImpl<>(selector, true);
     }


### PR DESCRIPTION
## Proposed changes

Vanilla defines PROVIDES_BANNER_PATTERNS as a homogenous HolderSet.

Deprecates old method

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Ported work is why it had the big doc comment.