### PR TITLE
fix: Entity & Block Worldborder

### DIFF
--- a/jmh-benchmarks/src/jmh/java/net/minestom/server/collision/BlockPhysicsBenchmark.java
+++ b/jmh-benchmarks/src/jmh/java/net/minestom/server/collision/BlockPhysicsBenchmark.java
@@ -33,6 +33,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  *     <li>{@link #largeMoveSlow()} - {@code slowPhysics} ray-cast (velocity length &gt; 1)</li>
  *     <li>{@link #fenceCollision()} - multi-box shape + tall-below ({@code shouldCheckLower}) path</li>
  *     <li>{@link #denseCollision()} - collisions on all axes, multiple step-physics iterations</li>
+ *     <li>{@link #walkOnFloorFarBorder()} - {@link #walkOnFloor()} plus a distant border (skip path)</li>
+ *     <li>{@link #walkIntoBorder()} - {@link #walkOnFloor()} into a border wall (sweep engaged)</li>
  *     <li>{@link #simulateOnGround()} - full movement incl. friction lookup + velocity update</li>
  *     <li>{@link #simulateFalling()} - full movement incl. gravity velocity update</li>
  * </ul>
@@ -50,6 +52,8 @@ public class BlockPhysicsBenchmark {
     // Representative player aerodynamics (gravity, horizontal drag, vertical drag)
     private static final Aerodynamics AERO = new Aerodynamics(0.08, 0.91, 0.98);
     private static final WorldBorder BORDER = WorldBorder.DEFAULT_BORDER;
+    // Walls at +-1, so walking +x from x=0.6 crosses the wall at x=1 (entity-relative 0.7).
+    private static final WorldBorder NEAR_BORDER = new WorldBorder(2, 0, 0, 0, 0);
 
     // --- In-memory block getters ---
 
@@ -157,6 +161,22 @@ public class BlockPhysicsBenchmark {
         // multiple iterations of the stepPhysics while-loop.
         return CollisionUtils.handlePhysics(DENSE_GETTER, PLAYER_BB, new Pos(0.5, 64.5, 0.5),
                 new Vec(0.3, -0.3, 0.3), null, false);
+    }
+
+    // --- world border variants: measure the border sweep cost against walkOnFloor ---
+
+    @Benchmark
+    public PhysicsResult walkOnFloorFarBorder() {
+        // The default 60M block border takes the up-front in-bounds skip path.
+        return CollisionUtils.handlePhysics(FLOOR_GETTER, BORDER, PLAYER_BB, new Pos(0.5, 64.0, 0.5),
+                new Vec(0.2, -0.08, 0.15), null, false);
+    }
+
+    @Benchmark
+    public PhysicsResult walkIntoBorder() {
+        // The target crosses the wall at x=1, so the border is swept on every slide pass.
+        return CollisionUtils.handlePhysics(FLOOR_GETTER, NEAR_BORDER, PLAYER_BB, new Pos(0.6, 64.0, 0.5),
+                new Vec(0.2, -0.08, 0.15), null, false);
     }
 
     // --- locking-getter variants: measure block-lookup cost (dedup benefit) ---

--- a/src/main/java/net/minestom/server/collision/BlockCollision.java
+++ b/src/main/java/net/minestom/server/collision/BlockCollision.java
@@ -7,6 +7,7 @@ import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.Player;
 import net.minestom.server.instance.Instance;
+import net.minestom.server.instance.WorldBorder;
 import net.minestom.server.instance.block.Block;
 import org.jetbrains.annotations.Nullable;
 
@@ -26,6 +27,15 @@ final class BlockCollision {
                                        Block.Getter getter,
                                        @Nullable PhysicsResult lastPhysicsResult,
                                        boolean singleCollision) {
+        return handlePhysics(boundingBox, velocity, entityPosition, getter, lastPhysicsResult, singleCollision, null);
+    }
+
+    static PhysicsResult handlePhysics(BoundingBox boundingBox,
+                                       Vec velocity, Pos entityPosition,
+                                       Block.Getter getter,
+                                       @Nullable PhysicsResult lastPhysicsResult,
+                                       boolean singleCollision,
+                                       @Nullable WorldBorder worldBorder) {
         if (velocity.isZero()) {
             return new PhysicsResult(entityPosition, Vec.ZERO, false, false, false, false,
                     velocity, NO_COLLISION_POINTS, NO_COLLISION_SHAPES, NO_COLLISION_SHAPE_POSITIONS, false, Double.MAX_VALUE);
@@ -36,7 +46,7 @@ final class BlockCollision {
             return cachedResult;
         }
         // Expensive AABB computation
-        return stepPhysics(boundingBox, velocity, entityPosition, getter, singleCollision);
+        return stepPhysics(boundingBox, velocity, entityPosition, getter, singleCollision, worldBorder);
     }
 
     @Nullable
@@ -87,7 +97,8 @@ final class BlockCollision {
 
     private static PhysicsResult stepPhysics(BoundingBox boundingBox,
                                              Vec velocity, Pos entityPosition,
-                                             Block.Getter getter, boolean singleCollision) {
+                                             Block.Getter getter, boolean singleCollision,
+                                             @Nullable WorldBorder worldBorder) {
         final SweepResult finalResult = new SweepResult(1 - Vec.EPSILON, 0, 0, 0, null, 0, 0, 0, 0, 0, 0);
 
         // Start as the shared (all-null) arrays; only allocate real ones on the first collision.
@@ -95,15 +106,50 @@ final class BlockCollision {
         @Nullable Shape[] collisionShapes = NO_COLLISION_SHAPES;
         @Nullable BlockVec[] collisionShapePositions = NO_COLLISION_SHAPE_POSITIONS;
 
+        // The world border acts as four vertical walls around the complete bounding box.
+        double borderMinX = 0, borderMaxX = 0, borderMinZ = 0, borderMaxZ = 0;
+        boolean sweepBorder = false;
+        if (worldBorder != null) {
+            final double radius = worldBorder.diameter() / 2;
+            final double wallMinX = Math.floor(worldBorder.centerX() - radius);
+            final double wallMaxX = Math.ceil(worldBorder.centerX() + radius);
+            final double wallMinZ = Math.floor(worldBorder.centerZ() - radius);
+            final double wallMaxZ = Math.ceil(worldBorder.centerZ() + radius);
+            borderMinX = wallMinX - boundingBox.minX();
+            borderMaxX = wallMaxX - boundingBox.maxX();
+            borderMinZ = wallMinZ - boundingBox.minZ();
+            borderMaxZ = wallMaxZ - boundingBox.maxZ();
+            // The border only collides entities inside it, with a margin of the bounding
+            // box size (at least one block). Entities farther outside move freely.
+            final double margin = Math.max(Math.max(boundingBox.width(), boundingBox.depth()), 1);
+            final double targetX = entityPosition.x() + velocity.x();
+            final double targetZ = entityPosition.z() + velocity.z();
+            sweepBorder = (targetX < borderMinX || targetX > borderMaxX || targetZ < borderMinZ || targetZ > borderMaxZ)
+                    && entityPosition.x() >= wallMinX - margin && entityPosition.x() < wallMaxX + margin
+                    && entityPosition.z() >= wallMinZ - margin && entityPosition.z() < wallMaxZ + margin;
+        }
+
         Pos position = entityPosition;
         Vec remaining = velocity;
+        boolean foundX = false;
+        boolean foundY = false;
+        boolean foundZ = false;
         // Each sweep advances along `remaining` until the first hit, zeroes the
         // collided axis, then repeats so the entity slides along the others.
         while (true) {
+            if (sweepBorder) {
+                sweepWorldBorderAxis(position.x(), remaining.x(),
+                        borderMinX, borderMaxX, 0,
+                        position, remaining, finalResult);
+                sweepWorldBorderAxis(position.z(), remaining.z(),
+                        borderMinZ, borderMaxZ, 2,
+                        position, remaining, finalResult);
+            }
             sweepBlocks(boundingBox, remaining, position, getter, finalResult);
-            double dx = finalResult.res * remaining.x();
-            double dy = finalResult.res * remaining.y();
-            double dz = finalResult.res * remaining.z();
+            final double res = finalResult.res;
+            double dx = res * remaining.x();
+            double dy = res * remaining.y();
+            double dz = res * remaining.z();
             if (Math.abs(dx) < Vec.EPSILON) dx = 0;
             if (Math.abs(dy) < Vec.EPSILON) dy = 0;
             if (Math.abs(dz) < Vec.EPSILON) dz = 0;
@@ -116,16 +162,26 @@ final class BlockCollision {
             else if (finalResult.normalZ != 0) axis = 2;
             else break; // no collision this pass
 
-            if (collisionShapes == NO_COLLISION_SHAPES) {
-                collidedPoints = new Vec[3];
-                collisionShapes = new Shape[3];
-                collisionShapePositions = new BlockVec[3];
-            }
-            collisionShapes[axis] = finalResult.collidedShape;
-            collisionShapePositions[axis] = new BlockVec(finalResult.collidedBlockX, finalResult.collidedBlockY, finalResult.collidedBlockZ);
-            collidedPoints[axis] = new Vec(finalResult.collidedPositionX, finalResult.collidedPositionY, finalResult.collidedPositionZ);
+            if (axis == 0) foundX = true;
+            else if (axis == 1) foundY = true;
+            else foundZ = true;
 
-            if (singleCollision || (collisionShapes[0] != null && collisionShapes[1] != null && collisionShapes[2] != null))
+            if (collidedPoints == NO_COLLISION_POINTS) {
+                collidedPoints = new Vec[3];
+            }
+            collidedPoints[axis] = new Vec(finalResult.collidedPositionX, finalResult.collidedPositionY, finalResult.collidedPositionZ);
+            // World border collisions have a point and axis, but no block shape or position.
+            final Shape collidedShape = finalResult.collidedShape;
+            if (collidedShape != null) {
+                if (collisionShapes == NO_COLLISION_SHAPES) {
+                    collisionShapes = new Shape[3];
+                    collisionShapePositions = new BlockVec[3];
+                }
+                collisionShapes[axis] = collidedShape;
+                collisionShapePositions[axis] = new BlockVec(finalResult.collidedBlockX, finalResult.collidedBlockY, finalResult.collidedBlockZ);
+            }
+
+            if (singleCollision || (foundX && foundY && foundZ))
                 break;
 
             remaining = new Vec(
@@ -140,9 +196,6 @@ final class BlockCollision {
             finalResult.res = 1 - Vec.EPSILON;
         }
 
-        final boolean foundX = collisionShapes[0] != null;
-        final boolean foundY = collisionShapes[1] != null;
-        final boolean foundZ = collisionShapes[2] != null;
         final boolean anyCollision = foundX || foundY || foundZ;
         final boolean allCollision = foundX && foundY && foundZ;
         final Vec newDelta;
@@ -158,6 +211,39 @@ final class BlockCollision {
                 foundX, foundY, foundZ,
                 velocity, collidedPoints, collisionShapes, collisionShapePositions,
                 anyCollision, finalResult.res);
+    }
+
+    /**
+     * Sweeps against one pair of world border walls, located entity-relative at {@code minimum}
+     * and {@code maximum}. A wall only stops a box that has not yet crossed it. A box already
+     * extending past a wall keeps moving away from the border freely.
+     */
+    private static void sweepWorldBorderAxis(double position, double velocity,
+                                             double minimum, double maximum, int axis,
+                                             Pos entityPosition, Vec entityVelocity,
+                                             SweepResult finalResult) {
+        final double percentage;
+        if (velocity > 0) {
+            if (position > maximum || position + velocity <= maximum) return;
+            percentage = (maximum - position) / velocity;
+        } else if (velocity < 0) {
+            if (position < minimum || position + velocity >= minimum) return;
+            percentage = (minimum - position) / velocity;
+        } else {
+            return;
+        }
+
+        final double acceptedPercentage = percentage * 0.99999;
+        if (!(acceptedPercentage <= finalResult.res)) return;
+
+        finalResult.res = acceptedPercentage;
+        finalResult.normalX = axis == 0 ? 1 : 0;
+        finalResult.normalY = 0;
+        finalResult.normalZ = axis == 2 ? 1 : 0;
+        finalResult.collidedPositionX = entityPosition.x() + entityVelocity.x() * acceptedPercentage;
+        finalResult.collidedPositionY = entityPosition.y() + entityVelocity.y() * acceptedPercentage;
+        finalResult.collidedPositionZ = entityPosition.z() + entityVelocity.z() * acceptedPercentage;
+        finalResult.collidedShape = null;
     }
 
     /**

--- a/src/main/java/net/minestom/server/collision/CollisionUtils.java
+++ b/src/main/java/net/minestom/server/collision/CollisionUtils.java
@@ -126,6 +126,27 @@ public final class CollisionUtils {
     }
 
     /**
+     * Moves a bounding box with physics applied, colliding with blocks and the world border.
+     * <p>
+     * The world border collides as four vertical walls at the block-aligned border bounds.
+     * A box whose movement target stays inside the walls never collides with them, and a box
+     * already extending past a wall keeps moving away from the border freely.
+     *
+     * @param blockGetter the block getter to check collisions against, ensure block access is synchronized
+     * @param worldBorder the world border to collide with
+     * @return the result of physics simulation
+     */
+    @ApiStatus.Internal
+    public static PhysicsResult handlePhysics(Block.Getter blockGetter, WorldBorder worldBorder,
+                                              BoundingBox boundingBox,
+                                              Pos position, Vec velocity,
+                                              @Nullable PhysicsResult lastPhysicsResult, boolean singleCollision) {
+        return BlockCollision.handlePhysics(boundingBox,
+                velocity, position,
+                blockGetter, lastPhysicsResult, singleCollision, worldBorder);
+    }
+
+    /**
      * Checks whether shape is reachable by the given line of sight
      * (ie there are no blocks colliding with it).
      *
@@ -153,27 +174,6 @@ public final class CollisionUtils {
 
     public static @Nullable Entity canPlaceBlockAt(Instance instance, Point blockPos, Block b) {
         return BlockCollision.canPlaceBlockAt(instance, blockPos, b);
-    }
-
-    /**
-     * Applies world border collision.
-     *
-     * @param worldBorder     the world border
-     * @param currentPosition the current position
-     * @param newPosition     the future target position
-     * @return the position with the world border collision applied (can be {@code newPosition} if not changed)
-     */
-    public static Pos applyWorldBorder(WorldBorder worldBorder, Pos currentPosition, Pos newPosition) {
-        double radius = worldBorder.diameter() / 2;
-        // If there is a collision on a given axis prevent the entity
-        // from moving forward by supplying their previous position's value
-        boolean xCollision = newPosition.x() > worldBorder.centerX() + radius || newPosition.x() < worldBorder.centerX() - radius;
-        boolean zCollision = newPosition.z() > worldBorder.centerZ() + radius || newPosition.z() < worldBorder.centerZ() - radius;
-        if (xCollision || zCollision) {
-            return newPosition.withCoord(xCollision ? currentPosition.x() : newPosition.x(), newPosition.y(),
-                    zCollision ? currentPosition.z() : newPosition.z());
-        }
-        return newPosition;
     }
 
     @ApiStatus.Internal

--- a/src/main/java/net/minestom/server/collision/PhysicsResult.java
+++ b/src/main/java/net/minestom/server/collision/PhysicsResult.java
@@ -8,6 +8,11 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * The result of a physics simulation.
+ * <p>
+ * A world border collision records a collision axis and point without a shape. The
+ * corresponding {@code collisionShapes} and {@code collisionShapePositions} entries stay
+ * null even though the axis flag is set and the {@code collisionPoints} entry is present.
+ *
  * @param newPosition the new position of the entity
  * @param newVelocity the new velocity of the entity
  * @param isOnGround if the entity is on the ground

--- a/src/main/java/net/minestom/server/collision/PhysicsUtils.java
+++ b/src/main/java/net/minestom/server/collision/PhysicsUtils.java
@@ -17,7 +17,7 @@ public final class PhysicsUtils {
      * @param entityPosition the current entity position
      * @param entityVelocityPerTick the current entity velocity in blocks/tick
      * @param entityBoundingBox the current entity bounding box
-     * @param worldBorder the world border to test bounds against
+     * @param worldBorder the world border colliding with the entity, applied only when {@code entityHasPhysics} is true
      * @param blockGetter the block getter to test block collisions against
      * @param aerodynamics the current entity aerodynamics
      * @param entityNoGravity whether the entity has gravity
@@ -31,20 +31,19 @@ public final class PhysicsUtils {
                                                           WorldBorder worldBorder, Block.Getter blockGetter, Aerodynamics aerodynamics, boolean entityNoGravity,
                                                           boolean entityHasPhysics, boolean entityOnGround, boolean entityFlying, @Nullable PhysicsResult previousPhysicsResult) {
         final PhysicsResult physicsResult = entityHasPhysics ?
-                CollisionUtils.handlePhysics(blockGetter, entityBoundingBox, entityPosition, entityVelocityPerTick, previousPhysicsResult, false) :
+                CollisionUtils.handlePhysics(blockGetter, worldBorder, entityBoundingBox, entityPosition, entityVelocityPerTick, previousPhysicsResult, false) :
                 CollisionUtils.blocklessCollision(entityPosition, entityVelocityPerTick);
 
         Pos newPosition = physicsResult.newPosition();
         Vec newVelocity = physicsResult.newVelocity();
 
-        Pos positionWithinBorder = CollisionUtils.applyWorldBorder(worldBorder, entityPosition, newPosition);
-        newVelocity = updateVelocity(positionWithinBorder, newVelocity, blockGetter, aerodynamics, !positionWithinBorder.samePoint(entityPosition), entityFlying, entityOnGround, entityNoGravity);
+        newVelocity = updateVelocity(newPosition, newVelocity, blockGetter, aerodynamics, !newPosition.samePoint(entityPosition), entityFlying, entityOnGround, entityNoGravity);
 
-        if (physicsResult == previousPhysicsResult && newVelocity.samePoint(physicsResult.newVelocity()) && positionWithinBorder.samePoint(physicsResult.newPosition())) {
+        if (physicsResult == previousPhysicsResult && newVelocity.samePoint(physicsResult.newVelocity())) {
             return physicsResult;
         }
 
-        return new PhysicsResult(positionWithinBorder, newVelocity, physicsResult.isOnGround(), physicsResult.collisionX(), physicsResult.collisionY(), physicsResult.collisionZ(),
+        return new PhysicsResult(newPosition, newVelocity, physicsResult.isOnGround(), physicsResult.collisionX(), physicsResult.collisionY(), physicsResult.collisionZ(),
                 physicsResult.originalDelta(), physicsResult.collisionPoints(), physicsResult.collisionShapes(), physicsResult.collisionShapePositions(), physicsResult.hasCollision(), physicsResult.collisionFraction());
     }
 

--- a/src/main/java/net/minestom/server/instance/WorldBorder.java
+++ b/src/main/java/net/minestom/server/instance/WorldBorder.java
@@ -1,6 +1,7 @@
 package net.minestom.server.instance;
 
 import net.minestom.server.ServerFlag;
+import net.minestom.server.collision.BoundingBox;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.network.packet.server.play.InitializeWorldBorderPacket;
@@ -32,10 +33,11 @@ public record WorldBorder(double diameter, double centerX, double centerZ, int w
     public static final WorldBorder DEFAULT_BORDER = new WorldBorder(ServerFlag.WORLD_BORDER_SIZE * 2, 0, 0, 5, 15, ServerFlag.WORLD_BORDER_SIZE);
 
     /**
-     * @throws IllegalArgumentException if {@code diameter} is less than 0
+     * @throws IllegalArgumentException if {@code diameter} is less than 0 or NaN, or if a center coordinate is NaN
      */
     public WorldBorder {
-        Check.argCondition(diameter < 0, "Diameter should be >= 0");
+        Check.argCondition(!(diameter >= 0), "Diameter should be >= 0");
+        Check.argCondition(Double.isNaN(centerX) || Double.isNaN(centerZ), "Center cannot be NaN");
     }
 
     public WorldBorder(double diameter, double centerX, double centerZ, int warningDistance, int warningTime) {
@@ -64,14 +66,38 @@ public record WorldBorder(double diameter, double centerX, double centerZ, int w
 
     /**
      * Used to know if a position is located inside the world border or not.
+     * <p>
+     * The maximum bound is exclusive. A point exactly on the maximum
+     * x or z bound is outside the world border.
      *
      * @param point the point to check
-     * @return true if {@code position} is inside the world border, false otherwise
+     * @return true if {@code point} is inside the world border, false otherwise
      */
     public boolean inBounds(Point point) {
-        double radius = diameter / 2;
-        return point.x() <= centerX + radius && point.x() >= centerX - radius &&
-                point.z() <= centerZ + radius && point.z() >= centerZ - radius;
+        final double radius = diameter / 2;
+        return point.x() >= centerX - radius && point.x() < centerX + radius &&
+                point.z() >= centerZ - radius && point.z() < centerZ + radius;
+    }
+
+    /**
+     * Checks whether a bounding box at the given position is entirely inside this world border.
+     * <p>
+     * The check uses the exact border bounds, with inclusive maximums. Collisions use walls
+     * expanded outward to whole block coordinates, so when the diameter is not a whole number
+     * an entity stopped by the border may rest slightly outside these bounds.
+     *
+     * @param position the position of the bounding box
+     * @param boundingBox the relative bounding box
+     * @return true if the complete bounding box is inside the world border
+     */
+    public boolean inBounds(Point position, BoundingBox boundingBox) {
+        final double radius = diameter / 2;
+        final double minX = centerX - radius;
+        final double maxX = centerX + radius;
+        final double minZ = centerZ - radius;
+        final double maxZ = centerZ + radius;
+        return position.x() + boundingBox.minX() >= minX && position.x() + boundingBox.maxX() <= maxX &&
+                position.z() + boundingBox.minZ() >= minZ && position.z() + boundingBox.maxZ() <= maxZ;
     }
 
     /**
@@ -79,9 +105,12 @@ public record WorldBorder(double diameter, double centerX, double centerZ, int w
      *
      * @param entity the entity to check
      * @return true if {@code entity} is inside the world border, false otherwise
+     * @deprecated Use {@link #inBounds(Point, BoundingBox)} instead. This method now checks
+     * the complete bounding box where it previously checked only the entity position.
      */
+    @Deprecated(forRemoval = true)
     public boolean inBounds(Entity entity) {
-        return inBounds(entity.getPosition());
+        return inBounds(entity.getPosition(), entity.getBoundingBox());
     }
 
     /**

--- a/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
+++ b/src/main/java/net/minestom/server/listener/BlockPlacementListener.java
@@ -29,7 +29,6 @@ import net.minestom.server.network.packet.server.play.AcknowledgeBlockChangePack
 import net.minestom.server.network.packet.server.play.BlockChangePacket;
 import net.minestom.server.utils.chunk.ChunkUtils;
 import net.minestom.server.utils.inventory.PlayerInventoryUtils;
-import net.minestom.server.utils.validate.Check;
 import net.minestom.server.world.DimensionType;
 
 public class BlockPlacementListener {
@@ -50,12 +49,25 @@ public class BlockPlacementListener {
         final Chunk interactedChunk = instance.getChunkAt(blockPosition);
         if (!ChunkUtils.isLoaded(interactedChunk)) {
             // Client tried to place a block in an unloaded chunk; ignore the request but still ack to reset the client prediction
+            refreshUsedHandSlot(player, hand);
             player.sendPacket(new AcknowledgeBlockChangePacket(packet.sequence()));
             return;
         }
 
         final ItemStack usedItem = player.getItemInHand(hand);
         final Block interactedBlock = instance.getBlock(blockPosition);
+
+        // Any use of a block outside the world border is rejected before interaction handling.
+        // The resulting placement position is intentionally not checked as placing outward across
+        // the border by clicking a block inside of it is allowed.
+        if (!instance.getWorldBorder().inBounds(blockPosition)) {
+            final Point relative = blockPosition.relative(blockFace);
+            if (ChunkUtils.isLoaded(instance.getChunkAt(relative))) {
+                player.sendPacket(new BlockChangePacket(relative, instance.getBlock(relative)));
+            }
+            rollback(player, hand, blockPosition, interactedBlock, packet.sequence());
+            return;
+        }
 
         final Point cursorPosition = new Vec(packet.cursorPositionX(), packet.cursorPositionY(), packet.cursorPositionZ());
 
@@ -73,6 +85,7 @@ public class BlockPlacementListener {
         if (blockUse) {
             // If the usage was blocked then the world is already up-to-date (from the prior handlers),
             // So ack the change with the current world state.
+            refreshUsedHandSlot(player, hand);
             player.sendPacket(new AcknowledgeBlockChangePacket(packet.sequence()));
             return;
         }
@@ -103,11 +116,20 @@ public class BlockPlacementListener {
         //todo it feels like it should be possible to have better replacement rules than this, feels pretty scuffed.
         Point placementPosition = blockPosition;
         var interactedPlacementRule = BLOCK_MANAGER.getBlockPlacementRule(interactedBlock);
-        if (!interactedBlock.air() && (interactedPlacementRule == null || !interactedPlacementRule.isSelfReplaceable(
-                new BlockPlacementRule.Replacement(interactedBlock, blockFace, cursorPosition, false, useMaterial)))) {
-            // If the block is not replaceable, try to place next to it.
-            placementPosition = blockPosition.relative(blockFace);
+        final boolean placeAdjacent = !interactedBlock.air() && (interactedPlacementRule == null || !interactedPlacementRule.isSelfReplaceable(
+                new BlockPlacementRule.Replacement(interactedBlock, blockFace, cursorPosition, false, useMaterial)));
+        // If the block is not replaceable, try to place next to it.
+        if (placeAdjacent) placementPosition = blockPosition.relative(blockFace);
 
+        final Chunk chunk = instance.getChunkAt(placementPosition);
+        if (!ChunkUtils.isLoaded(chunk)) {
+            // Placement into an unloaded chunk, reachable by placing against a block at the edge of loaded terrain.
+            refreshUsedHandSlot(player, hand);
+            player.sendPacket(new AcknowledgeBlockChangePacket(packet.sequence()));
+            return;
+        }
+
+        if (placeAdjacent) {
             var placementBlock = instance.getBlock(placementPosition);
             var placementRule = BLOCK_MANAGER.getBlockPlacementRule(placementBlock);
             if (!placementBlock.replaceable() && !(placementRule != null && placementRule.isSelfReplaceable(
@@ -124,11 +146,6 @@ public class BlockPlacementListener {
             return;
         }
 
-        // Ensure that the final placement position is inside the world border.
-        if (!instance.getWorldBorder().inBounds(placementPosition)) {
-            canPlaceBlock = false;
-        }
-
         if (!canPlaceBlock) {
             // Keep the client in sync with a targeted block change (plus a held-slot refresh) instead of a chunk resend,
             // which leaves the client desynced after rapid invalid block placements.
@@ -136,9 +153,6 @@ public class BlockPlacementListener {
             return;
         }
 
-        final Chunk chunk = instance.getChunkAt(placementPosition);
-        Check.stateCondition(!ChunkUtils.isLoaded(chunk),
-                "A player tried to place a block in the border of a loaded chunk {0}", placementPosition);
         if (chunk.isReadOnly()) {
             rollback(player, hand, placementPosition, instance.getBlock(placementPosition), packet.sequence());
             return;
@@ -182,17 +196,21 @@ public class BlockPlacementListener {
             player.setItemInHand(hand, newUsedItem);
         } else {
             // Prevent invisible item on client: it predicted a decrement that didn't happen, so refresh just that slot.
-            final int slot = hand == PlayerHand.OFF ? PlayerInventoryUtils.OFFHAND_SLOT : player.getHeldSlot();
-            player.getInventory().sendSlotRefresh(slot, player.getItemInHand(hand));
+            refreshUsedHandSlot(player, hand);
         }
     }
 
     // Corrects a rejected placement with a targeted block change instead of resending the whole chunk, and refreshes
     // only the used hand slot so the client's predicted item count stays in sync without a full inventory resend.
     private static void rollback(Player player, PlayerHand hand, Point placementPosition, Block block, int sequence) {
-        final int slot = hand == PlayerHand.OFF ? PlayerInventoryUtils.OFFHAND_SLOT : player.getHeldSlot();
-        player.getInventory().sendSlotRefresh(slot, player.getItemInHand(hand));
+        refreshUsedHandSlot(player, hand);
         player.sendPacket(new BlockChangePacket(placementPosition, block));
         player.sendPacket(new AcknowledgeBlockChangePacket(sequence));
+    }
+
+    // Refreshes only the used hand slot so the client's predicted item count stays in sync without a full inventory resend.
+    private static void refreshUsedHandSlot(Player player, PlayerHand hand) {
+        final int slot = hand == PlayerHand.OFF ? PlayerInventoryUtils.OFFHAND_SLOT : player.getHeldSlot();
+        player.getInventory().sendSlotRefresh(slot, player.getItemInHand(hand));
     }
 }

--- a/src/test/java/net/minestom/server/collision/EntityBlockPhysicsIntegrationTest.java
+++ b/src/test/java/net/minestom/server/collision/EntityBlockPhysicsIntegrationTest.java
@@ -7,6 +7,7 @@ import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.EntityType;
 import net.minestom.server.entity.metadata.cube.SlimeMeta;
+import net.minestom.server.instance.WorldBorder;
 import net.minestom.server.instance.block.Block;
 import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
@@ -17,6 +18,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -1124,6 +1126,171 @@ public class EntityBlockPhysicsIntegrationTest {
         var physicsResult = CollisionUtils.handlePhysics(entity, new Vec(0, -10, 0), null);
 
         assertEquals(blockPosition, physicsResult.collisionShapePositions()[1]);
+    }
+
+    @Test
+    public void worldBorderCollidesWithCompleteBoundingBoxAndSlides(Env env) {
+        var instance = env.createFlatInstance();
+        instance.loadChunk(-1, -1).join();
+        instance.loadChunk(-1, 0).join();
+        instance.loadChunk(0, -1).join();
+        instance.loadChunk(0, 0).join();
+        var boundingBox = new BoundingBox(0.6, 1.8, 0.6);
+        var worldBorder = new WorldBorder(4, 0, 0, 0, 0);
+
+        var result = CollisionUtils.handlePhysics(instance, worldBorder, boundingBox,
+                new Pos(0, 42, 0), new Vec(3, 0, 1), null, false);
+
+        assertEquals(2, result.newPosition().x() + boundingBox.maxX(), Vec.EPSILON * 20);
+        assertEquals(1, result.newPosition().z(), Vec.EPSILON);
+        assertEquals(new Vec(0, 0, 1), result.newVelocity());
+        assertTrue(result.collisionX());
+        assertFalse(result.collisionY());
+        assertFalse(result.collisionZ());
+        assertTrue(result.hasCollision());
+        assertNotSame(BlockCollision.NO_COLLISION_POINTS, result.collisionPoints());
+        assertSame(BlockCollision.NO_COLLISION_SHAPES, result.collisionShapes());
+        assertSame(BlockCollision.NO_COLLISION_SHAPE_POSITIONS, result.collisionShapePositions());
+        assertNotNull(result.collisionPoints()[0]);
+    }
+
+    @Test
+    public void worldBorderUsesEverySideOfAnAsymmetricBoundingBox(Env env) {
+        var instance = env.createFlatInstance();
+        instance.loadChunk(-1, -1).join();
+        instance.loadChunk(-1, 0).join();
+        instance.loadChunk(0, -1).join();
+        instance.loadChunk(0, 0).join();
+        var boundingBox = new BoundingBox(new Vec(-0.2, 0, -0.4), new Vec(0.6, 1, 0.1));
+        var worldBorder = new WorldBorder(4, 0, 0, 0, 0);
+
+        record Case(Vec velocity, double expectedPosition, boolean xAxis) {}
+        for (var testCase : List.of(
+                new Case(new Vec(3, 0, 0), 1.4, true),
+                new Case(new Vec(-3, 0, 0), -1.8, true),
+                new Case(new Vec(0, 0, 3), 1.9, false),
+                new Case(new Vec(0, 0, -3), -1.6, false))) {
+            var result = CollisionUtils.handlePhysics(instance, worldBorder, boundingBox,
+                    new Pos(0, 42, 0), testCase.velocity(), null, false);
+
+            assertEquals(testCase.expectedPosition(),
+                    testCase.xAxis() ? result.newPosition().x() : result.newPosition().z(), Vec.EPSILON * 25);
+            assertEquals(testCase.xAxis(), result.collisionX());
+            assertEquals(!testCase.xAxis(), result.collisionZ());
+            assertTrue(worldBorder.inBounds(result.newPosition(), boundingBox));
+        }
+    }
+
+    @Test
+    public void worldBorderFreesABoxAlreadyPastTheWall(Env env) {
+        var instance = env.createFlatInstance();
+        instance.loadChunk(0, -1).join();
+        instance.loadChunk(0, 0).join();
+        var boundingBox = new BoundingBox(0.6, 1.8, 0.6);
+        var worldBorder = new WorldBorder(4, 0, 0, 0, 0);
+        // The box spans [1.6, 2.2] and already extends past the wall at x=2.
+        var start = new Pos(1.9, 42, 0);
+
+        var inward = CollisionUtils.handlePhysics(instance, worldBorder, boundingBox,
+                start, new Vec(-0.5, 0, 0), null, false);
+        assertEquals(1.4, inward.newPosition().x(), Vec.EPSILON);
+        assertFalse(inward.collisionX());
+
+        var outward = CollisionUtils.handlePhysics(instance, worldBorder, boundingBox,
+                start, new Vec(0.5, 0, 0), null, false);
+        assertEquals(2.4, outward.newPosition().x(), Vec.EPSILON);
+        assertFalse(outward.collisionX());
+    }
+
+    @Test
+    public void worldBorderDoesNotTrapABoxWiderThanTheBorder(Env env) {
+        var instance = env.createFlatInstance();
+        instance.loadChunk(-1, -1).join();
+        instance.loadChunk(-1, 0).join();
+        instance.loadChunk(0, -1).join();
+        instance.loadChunk(0, 0).join();
+        var boundingBox = new BoundingBox(4, 1, 4);
+        var worldBorder = new WorldBorder(2, 0, 0, 0, 0);
+
+        var result = CollisionUtils.handlePhysics(instance, worldBorder, boundingBox,
+                new Pos(0, 42, 0), new Vec(1, 0, 0), null, false);
+
+        assertEquals(1, result.newPosition().x(), Vec.EPSILON * 2);
+        assertFalse(result.hasCollision());
+    }
+
+    @Test
+    public void worldBorderOffCenterUsesBlockAlignedWalls(Env env) {
+        var instance = env.createFlatInstance();
+        instance.loadChunk(0, 0).join();
+        var boundingBox = new BoundingBox(0.6, 1.8, 0.6);
+        // Exact bounds [6.5, 9.5] on both axes with block aligned walls at 6 and 10.
+        var worldBorder = new WorldBorder(3, 8, 8, 0, 0);
+
+        var result = CollisionUtils.handlePhysics(instance, worldBorder, boundingBox,
+                new Pos(8.5, 42, 8), new Vec(3, 0, 0), null, false);
+
+        assertEquals(10, result.newPosition().x() + boundingBox.maxX(), Vec.EPSILON * 20);
+        assertTrue(result.collisionX());
+    }
+
+    @Test
+    public void simulateMovementWithoutPhysicsIgnoresWorldBorder(Env env) {
+        var instance = env.createFlatInstance();
+        instance.loadChunk(0, 0).join();
+        var boundingBox = new BoundingBox(0.6, 1.8, 0.6);
+        var worldBorder = new WorldBorder(4, 0, 0, 0, 0);
+        var aerodynamics = new Aerodynamics(0, 1, 1);
+
+        var result = PhysicsUtils.simulateMovement(new Pos(1.5, 42, 0.5), new Vec(2, 0, 0), boundingBox,
+                worldBorder, instance, aerodynamics, true, false, false, false, null);
+
+        assertEquals(3.5, result.newPosition().x(), Vec.EPSILON);
+        assertFalse(result.hasCollision());
+    }
+
+    @Test
+    public void worldBorderIgnoresEntitiesFarOutside(Env env) {
+        var instance = env.createFlatInstance();
+        instance.loadChunk(0, -1).join();
+        instance.loadChunk(0, 0).join();
+        var boundingBox = new BoundingBox(0.6, 1.8, 0.6);
+        var worldBorder = new WorldBorder(4, 0, 0, 0, 0);
+        // Walls at +-2 with a one block margin, so the border stops colliding beyond x=3.
+        var start = new Pos(3.5, 42, 0);
+
+        var outward = CollisionUtils.handlePhysics(instance, worldBorder, boundingBox,
+                start, new Vec(0.5, 0, 0), null, false);
+        assertEquals(4, outward.newPosition().x(), Vec.EPSILON);
+        assertFalse(outward.collisionX());
+
+        var inward = CollisionUtils.handlePhysics(instance, worldBorder, boundingBox,
+                start, new Vec(-0.5, 0, 0), null, false);
+        assertEquals(3, inward.newPosition().x(), Vec.EPSILON);
+        assertFalse(inward.collisionX());
+    }
+
+    @Test
+    public void worldBorderCornerCollidesOnBothAxes(Env env) {
+        var instance = env.createFlatInstance();
+        instance.loadChunk(-1, -1).join();
+        instance.loadChunk(-1, 0).join();
+        instance.loadChunk(0, -1).join();
+        instance.loadChunk(0, 0).join();
+        var boundingBox = new BoundingBox(0.6, 1.8, 0.6);
+        var worldBorder = new WorldBorder(4, 0, 0, 0, 0);
+
+        // Moving diagonally into a corner must hit one wall, slide, then hit the other.
+        var result = CollisionUtils.handlePhysics(instance, worldBorder, boundingBox,
+                new Pos(0, 42, 0), new Vec(3, 0, 3), null, false);
+
+        assertEquals(2, result.newPosition().x() + boundingBox.maxX(), Vec.EPSILON * 20);
+        assertEquals(2, result.newPosition().z() + boundingBox.maxZ(), Vec.EPSILON * 20);
+        assertEquals(Vec.ZERO, result.newVelocity());
+        assertTrue(result.collisionX());
+        assertTrue(result.collisionZ());
+        assertFalse(result.collisionY());
+        assertTrue(worldBorder.inBounds(result.newPosition(), boundingBox));
     }
 
     @Test

--- a/src/test/java/net/minestom/server/entity/EntityVelocityIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/EntityVelocityIntegrationTest.java
@@ -199,7 +199,7 @@ public class EntityVelocityIntegrationTest {
         loadChunks(instance);
 
         var entity = new Entity(EntityTypes.ZOMBIE);
-        var point = new Pos(1.9, 40, 0.2);
+        var point = new Pos(1.5, 40, 0.2);
         instance.setWorldBorder(new WorldBorder(4, 0, 0, 0, 0));
         instance.setBlock(new Vec(1, 39, 0), Block.ICE);
         instance.setBlock(new Vec(1, 39, 1), Block.SOUL_SAND);
@@ -219,11 +219,12 @@ public class EntityVelocityIntegrationTest {
         double expectedDrag = newFriction * horizontalAirResistance;
         double expectedOldDrag = oldFriction * horizontalAirResistance;
 
-        assertEquals(point.x(), entity.getPosition().x(), Vec.EPSILON);
+        assertEquals(2, entity.getPosition().x() + entity.getBoundingBox().maxX(), Vec.EPSILON * 20);
+        assertTrue(instance.getWorldBorder().inBounds(entity.getPosition(), entity.getBoundingBox()));
         assertTrue(entity.getPosition().z() > point.z());
-        assertEquals(initialVelocity.x() * expectedDrag, entity.getVelocity().x(), Vec.EPSILON);
+        assertEquals(0, entity.getVelocity().x(), Vec.EPSILON);
         assertEquals(initialVelocity.z() * expectedDrag, entity.getVelocity().z(), Vec.EPSILON);
-        assertNotEquals(initialVelocity.x() * expectedOldDrag, entity.getVelocity().x(), Vec.EPSILON);
+        assertNotEquals(initialVelocity.z() * expectedOldDrag, entity.getVelocity().z(), Vec.EPSILON);
     }
 
     private static void testMovement(Env env, Entity entity, Vec... sample) {

--- a/src/test/java/net/minestom/server/entity/player/PlayerBlockPlacementIntegrationTest.java
+++ b/src/test/java/net/minestom/server/entity/player/PlayerBlockPlacementIntegrationTest.java
@@ -4,6 +4,9 @@ import net.minestom.server.component.DataComponents;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.GameMode;
 import net.minestom.server.entity.PlayerHand;
+import net.minestom.server.event.EventFilter;
+import net.minestom.server.event.player.PlayerBlockInteractEvent;
+import net.minestom.server.instance.WorldBorder;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockFace;
 import net.minestom.server.instance.block.BlockKeys;
@@ -13,9 +16,12 @@ import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
 import net.minestom.server.item.component.BlockPredicates;
 import net.minestom.server.network.packet.client.play.ClientPlayerBlockPlacementPacket;
+import net.minestom.server.network.packet.server.play.AcknowledgeBlockChangePacket;
+import net.minestom.server.network.packet.server.play.BlockChangePacket;
 import net.minestom.server.registry.RegistryTag;
 import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -23,6 +29,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnvTest
 public class PlayerBlockPlacementIntegrationTest {
@@ -49,6 +56,75 @@ public class PlayerBlockPlacementIntegrationTest {
 
         var placedBlock = instance.getBlock(1, 41, 0);
         assertEquals("minecraft:white_wool", placedBlock.name());
+    }
+
+    @Test
+    public void placeAgainstBlockOutsideWorldBorderIsDenied(Env env) {
+        var instance = env.createFlatInstance();
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0, 42, 0));
+        // The border spans [-1.5, 1.5), so the clicked block at x=2 is outside it.
+        instance.setWorldBorder(new WorldBorder(3, 0, 0, 0, 0));
+        instance.setBlock(2, 41, 0, Block.STONE);
+        player.setItemInMainHand(ItemStack.of(Material.WHITE_WOOL));
+
+        var interactions = env.trackEvent(PlayerBlockInteractEvent.class, EventFilter.PLAYER, player);
+        var blockChanges = connection.trackIncoming(BlockChangePacket.class);
+        var acks = connection.trackIncoming(AcknowledgeBlockChangePacket.class);
+        var packet = new ClientPlayerBlockPlacementPacket(
+                PlayerHand.MAIN, new Pos(2, 41, 0), BlockFace.WEST,
+                1f, 1f, 1f,
+                false, false, 0);
+        player.addPacketToQueue(packet);
+        player.interpretPacketQueue();
+
+        assertTrue(instance.getBlock(1, 41, 0).air());
+        // The denial happens before interaction handling and resyncs both predicted positions.
+        interactions.assertCount(0);
+        blockChanges.assertCount(2);
+        acks.assertCount(1);
+    }
+
+    @Test
+    public void placeIntoUnloadedChunkIsIgnored(Env env) {
+        var instance = env.createFlatInstance();
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(8, 42, 8));
+        // Chunk (100, 0) is loaded explicitly, its east neighbor is not.
+        instance.loadChunk(100, 0).join();
+        instance.setBlock(1615, 41, 5, Block.STONE);
+        player.setItemInMainHand(ItemStack.of(Material.WHITE_WOOL));
+
+        var acks = connection.trackIncoming(AcknowledgeBlockChangePacket.class);
+        var packet = new ClientPlayerBlockPlacementPacket(
+                PlayerHand.MAIN, new Pos(1615, 41, 5), BlockFace.EAST,
+                1f, 1f, 1f,
+                false, false, 0);
+        player.addPacketToQueue(packet);
+        player.interpretPacketQueue();
+
+        // The placement lands in the unloaded chunk and is ignored, but the sequence is still acked.
+        acks.assertCount(1);
+    }
+
+    @Test
+    public void placeOutwardAcrossWorldBorderIsAllowed(Env env) {
+        var instance = env.createFlatInstance();
+        var connection = env.createConnection();
+        var player = connection.connect(instance, new Pos(0, 42, 0));
+        // The border spans [-1.5, 1.5), so the clicked block at x=1 is inside it and the placement at x=2 is not.
+        instance.setWorldBorder(new WorldBorder(3, 0, 0, 0, 0));
+        instance.setBlock(1, 41, 0, Block.STONE);
+        player.setItemInMainHand(ItemStack.of(Material.WHITE_WOOL));
+
+        var packet = new ClientPlayerBlockPlacementPacket(
+                PlayerHand.MAIN, new Pos(1, 41, 0), BlockFace.EAST,
+                1f, 1f, 1f,
+                false, false, 0);
+        player.addPacketToQueue(packet);
+        player.interpretPacketQueue();
+
+        assertEquals("minecraft:white_wool", instance.getBlock(2, 41, 0).name());
     }
 
     private static Stream<Arguments> placeBlockFromAdventureModeParams() {

--- a/src/test/java/net/minestom/server/instance/WorldBorderIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/WorldBorderIntegrationTest.java
@@ -1,11 +1,17 @@
 package net.minestom.server.instance;
 
+import net.minestom.server.coordinate.Pos;
+import net.minestom.server.coordinate.Vec;
+import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.EntityType;
 import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnvTest
 public class WorldBorderIntegrationTest {
@@ -56,5 +62,30 @@ public class WorldBorderIntegrationTest {
         WorldBorder border = instance.getWorldBorder();
         assertThrows(IllegalStateException.class, () -> instance.setWorldBorder(border, -1));
         assertThrows(IllegalArgumentException.class, () -> border.withDiameter(-1));
+        assertThrows(IllegalArgumentException.class, () -> border.withDiameter(Double.NaN));
+        assertThrows(IllegalArgumentException.class, () -> border.withCenter(Double.NaN, 0));
+        assertThrows(IllegalArgumentException.class, () -> border.withCenter(0, Double.NaN));
+    }
+
+    @Test
+    public void pointInBoundsExcludesMaximumBound() {
+        WorldBorder border = new WorldBorder(4, 0, 0, 0, 0);
+        assertTrue(border.inBounds(new Vec(-2, 0, -2)));
+        assertTrue(border.inBounds(new Vec(1.999, 0, 1.999)));
+        assertFalse(border.inBounds(new Vec(2, 0, 0)));
+        assertFalse(border.inBounds(new Vec(0, 0, 2)));
+    }
+
+    @Test
+    public void entityBoundsIncludeBoundingBox(Env env) {
+        Instance instance = env.createFlatInstance();
+        WorldBorder border = new WorldBorder(4, 0, 0, 0, 0);
+        Entity entity = new Entity(EntityType.ZOMBIE);
+        double maximumEntityX = 2 - entity.getBoundingBox().maxX();
+        entity.setInstance(instance, new Pos(maximumEntityX, 42, 0)).join();
+
+        assertTrue(border.inBounds(entity.getPosition(), entity.getBoundingBox()));
+        entity.refreshPosition(new Pos(maximumEntityX + Vec.EPSILON, 42, 0));
+        assertFalse(border.inBounds(entity.getPosition(), entity.getBoundingBox()));
     }
 }


### PR DESCRIPTION
## Proposed changes

Entites hitbox is now accounted for borders, also optimizes some allocations around collison

Fix block placement behavior around world borders.

Fixes #3326

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

WorldBorder#inBounds(Entity) is now deprecated as we remove the dependency for the class.