### PR TITLE
Allow advancement tabs to be unregistered

### DIFF
--- a/src/main/java/net/minestom/server/Viewable.java
+++ b/src/main/java/net/minestom/server/Viewable.java
@@ -7,7 +7,6 @@ import net.minestom.server.network.packet.server.SendablePacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.utils.PacketSendingUtils;
 import org.jetbrains.annotations.Unmodifiable;
-import org.jetbrains.annotations.UnmodifiableView;
 
 import java.util.Collection;
 import java.util.List;
@@ -35,25 +34,11 @@ public interface Viewable {
     boolean removeViewer(Player player);
 
     /**
-     * Removes all viewers
-     *
-     * @return all players that were removed
-     */
-    @Unmodifiable
-    default Set<? extends Player> clearViewers() {
-        final Set<? extends Player> copy = Set.copyOf(getViewers());
-        for (final Player player : copy) {
-            this.removeViewer(player);
-        }
-        return copy;
-    }
-
-    /**
      * Gets all the viewers of this viewable element.
      *
      * @return A Set containing all the element's viewers
      */
-    @UnmodifiableView
+    @Unmodifiable
     Set<? extends Player> getViewers();
 
     /**

--- a/src/main/java/net/minestom/server/Viewable.java
+++ b/src/main/java/net/minestom/server/Viewable.java
@@ -7,6 +7,7 @@ import net.minestom.server.network.packet.server.SendablePacket;
 import net.minestom.server.network.packet.server.ServerPacket;
 import net.minestom.server.utils.PacketSendingUtils;
 import org.jetbrains.annotations.Unmodifiable;
+import org.jetbrains.annotations.UnmodifiableView;
 
 import java.util.Collection;
 import java.util.List;
@@ -34,11 +35,25 @@ public interface Viewable {
     boolean removeViewer(Player player);
 
     /**
+     * Removes all viewers
+     *
+     * @return all players that were removed
+     */
+    @Unmodifiable
+    default Set<? extends Player> clearViewers() {
+        final Set<? extends Player> copy = Set.copyOf(getViewers());
+        for (final Player player : copy) {
+            this.removeViewer(player);
+        }
+        return copy;
+    }
+
+    /**
      * Gets all the viewers of this viewable element.
      *
      * @return A Set containing all the element's viewers
      */
-    @Unmodifiable
+    @UnmodifiableView
     Set<? extends Player> getViewers();
 
     /**

--- a/src/main/java/net/minestom/server/advancements/AdvancementManager.java
+++ b/src/main/java/net/minestom/server/advancements/AdvancementManager.java
@@ -67,7 +67,7 @@ public class AdvancementManager {
         if (advancementTab == null) {
             return null;
         }
-        advancementTab.removeViewers();
+        advancementTab.removeAllViewers();
         return advancementTab;
     }
 }

--- a/src/main/java/net/minestom/server/advancements/AdvancementManager.java
+++ b/src/main/java/net/minestom/server/advancements/AdvancementManager.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * Used to manage all the registered {@link AdvancementTab}.
  * <p>
  * Use {@link #createTab(String, AdvancementRoot)} to create a tab with the appropriate {@link AdvancementRoot}.
+ * Use {@link #removeTab(String)} to remove an advancement tab with the appropriate root identifier
  */
 public class AdvancementManager {
 
@@ -54,22 +55,19 @@ public class AdvancementManager {
     }
 
     /**
-     * See {@link Map#remove(Object)}
+     * Removes an advancement tab stored by this {@link AdvancementManager}
      *
      * @param rootIdentifier key whose mapping is to be removed from the map
-     * @param removeViewers whether the current viewers of the advancement tab should be ignored. This
-     *                      is only used if the return value of this method is not null.
      * @return the previous advancement tab associated with {@code rootIdentifier}, or {@code null}
-     * if there was .no tab associated with {@code rootIdentifier}
+     * if there was no tab associated with {@code rootIdentifier}
      */
     @Nullable
-    public AdvancementTab removeTab(String rootIdentifier, boolean removeViewers) {
+    public AdvancementTab removeTab(String rootIdentifier) {
         final AdvancementTab advancementTab = advancementTabMap.remove(rootIdentifier);
-        if (advancementTab == null || !removeViewers) {
-            return advancementTab;
+        if (advancementTab == null) {
+            return null;
         }
-        advancementTab.clearViewers();
+        advancementTab.removeViewers();
         return advancementTab;
     }
-
 }

--- a/src/main/java/net/minestom/server/advancements/AdvancementManager.java
+++ b/src/main/java/net/minestom/server/advancements/AdvancementManager.java
@@ -1,7 +1,5 @@
 package net.minestom.server.advancements;
 
-import net.kyori.adventure.audience.Audience;
-import net.minestom.server.entity.Player;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.Nullable;
 
@@ -70,9 +68,7 @@ public class AdvancementManager {
         if (advancementTab == null || !removeViewers) {
             return advancementTab;
         }
-        for (final Player viewer : advancementTab.getViewers()) {
-            advancementTab.removeViewer(viewer);
-        }
+        advancementTab.clearViewers();
         return advancementTab;
     }
 

--- a/src/main/java/net/minestom/server/advancements/AdvancementManager.java
+++ b/src/main/java/net/minestom/server/advancements/AdvancementManager.java
@@ -1,5 +1,7 @@
 package net.minestom.server.advancements;
 
+import net.kyori.adventure.audience.Audience;
+import net.minestom.server.entity.Player;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.Nullable;
 
@@ -51,6 +53,27 @@ public class AdvancementManager {
      */
     public Collection<AdvancementTab> getTabs() {
         return advancementTabMap.values();
+    }
+
+    /**
+     * See {@link Map#remove(Object)}
+     *
+     * @param rootIdentifier key whose mapping is to be removed from the map
+     * @param removeViewers whether the current viewers of the advancement tab should be ignored. This
+     *                      is only used if the return value of this method is not null.
+     * @return the previous advancement tab associated with {@code rootIdentifier}, or {@code null}
+     * if there was .no tab associated with {@code rootIdentifier}
+     */
+    @Nullable
+    public AdvancementTab removeTab(String rootIdentifier, boolean removeViewers) {
+        final AdvancementTab advancementTab = advancementTabMap.remove(rootIdentifier);
+        if (advancementTab == null || !removeViewers) {
+            return advancementTab;
+        }
+        for (final Player viewer : advancementTab.getViewers()) {
+            advancementTab.removeViewer(viewer);
+        }
+        return advancementTab;
     }
 
 }

--- a/src/main/java/net/minestom/server/advancements/AdvancementTab.java
+++ b/src/main/java/net/minestom/server/advancements/AdvancementTab.java
@@ -5,8 +5,10 @@ import net.minestom.server.entity.Player;
 import net.minestom.server.network.packet.server.play.AdvancementsPacket;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -139,8 +141,9 @@ public class AdvancementTab implements Viewable {
     }
 
     @Override
+    @Unmodifiable
     public Set<? extends Player> getViewers() {
-        return viewers;
+        return Collections.unmodifiableSet(viewers);
     }
 
     /**

--- a/src/main/java/net/minestom/server/advancements/AdvancementTab.java
+++ b/src/main/java/net/minestom/server/advancements/AdvancementTab.java
@@ -146,6 +146,17 @@ public class AdvancementTab implements Viewable {
         return Collections.unmodifiableSet(viewers);
     }
 
+    protected void removeAllViewers() {
+        viewers.removeIf(player -> {
+            if (player.isRemoved()) {
+                return true;
+            }
+            player.sendPacket(removePacket);
+            removePlayer(player);
+            return true;
+        });
+    }
+
     /**
      * Adds the tab to the player set.
      *

--- a/src/test/java/net/minestom/server/advancements/AdvancementIntegrationTest.java
+++ b/src/test/java/net/minestom/server/advancements/AdvancementIntegrationTest.java
@@ -10,6 +10,7 @@ import net.minestom.testing.EnvTest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -135,26 +136,23 @@ public class AdvancementIntegrationTest {
         tab3.addViewer(player2);
 
         assertEquals(2, tab1.getViewers().size());
-        final AdvancementTab tab1Removed = env.process().advancement().removeTab(tab1.getRoot().getIdentifier(), true);
+        final AdvancementTab tab1Removed = env.process().advancement().removeTab(tab1.getRoot().getIdentifier());
         assertNotNull(tab1Removed);
+        assertFalse(tab1Removed.isViewer(player1));
+        assertFalse(tab1Removed.isViewer(player2));
         assertEquals(0, tab1Removed.getViewers().size());
-        assertEquals(0, tab1Removed.getViewers().size());
-        assertNull(env.process().advancement().removeTab(tab1.getRoot().getIdentifier(), true));
-        assertNull(env.process().advancement().removeTab(tab1.getRoot().getIdentifier(), false));
+        assertNull(env.process().advancement().removeTab(tab1.getRoot().getIdentifier()));
 
-        final AdvancementTab tab2Removed = env.process().advancement().removeTab(tab2.getRoot().getIdentifier(), false);
+        final AdvancementTab tab2Removed = env.process().advancement().removeTab(tab2.getRoot().getIdentifier());
         assertNotNull(tab2Removed);
-        assertEquals(2, tab2Removed.getViewers().size());
-        assertTrue(tab2Removed.isViewer(player1));
-        assertTrue(tab2Removed.isViewer(player2));
-        assertNull(env.process().advancement().removeTab(tab2.getRoot().getIdentifier(), true));
-        assertNull(env.process().advancement().removeTab(tab2.getRoot().getIdentifier(), false));
+        assertEquals(0, tab2Removed.getViewers().size());
+        assertFalse(tab2Removed.isViewer(player1));
+        assertFalse(tab2Removed.isViewer(player2));
+        assertNull(env.process().advancement().removeTab(tab2.getRoot().getIdentifier()));
 
-        final AdvancementTab tab3Removed = env.process().advancement().removeTab(tab3.getRoot().getIdentifier(), false);
+        final AdvancementTab tab3Removed = env.process().advancement().removeTab(tab3.getRoot().getIdentifier());
         assertNotNull(tab3Removed);
-        assertEquals(1, tab3Removed.getViewers().size());
-        assertTrue(tab3Removed.isViewer(player2));
-        assertNull(env.process().advancement().removeTab(tab3.getRoot().getIdentifier(), true));
-        assertNull(env.process().advancement().removeTab(tab3.getRoot().getIdentifier(), false));
+        assertEquals(0, tab3Removed.getViewers().size());
+        assertFalse(tab3Removed.isViewer(player2));
     }
 }

--- a/src/test/java/net/minestom/server/advancements/AdvancementIntegrationTest.java
+++ b/src/test/java/net/minestom/server/advancements/AdvancementIntegrationTest.java
@@ -2,6 +2,8 @@ package net.minestom.server.advancements;
 
 import net.kyori.adventure.text.Component;
 import net.minestom.server.coordinate.Pos;
+import net.minestom.server.entity.Player;
+import net.minestom.server.instance.Instance;
 import net.minestom.server.item.Material;
 import net.minestom.testing.Env;
 import net.minestom.testing.EnvTest;
@@ -82,5 +84,77 @@ public class AdvancementIntegrationTest {
         assertEquals(0, tab1.getViewers().size());
         assertEquals(0, tab2.getViewers().size());
         assertNull(AdvancementTab.getTabs(player));
+    }
+
+    @Test
+    public void unregisterAdvancementTab(Env env) {
+        final Instance instance = env.createFlatInstance();
+        final Player player1 = env.createPlayer(instance, new Pos(0, 42, 0));
+        final Player player2 = env.createPlayer(instance, new Pos(0, 42, 0));
+
+        final AdvancementRoot root1 = new AdvancementRoot(
+                Component.text("title"),
+                Component.text("description"),
+                Material.DIAMOND,
+                FrameType.TASK,
+                0,
+                0,
+                "minecraft:textures/block/stone.png"
+        );
+
+        final AdvancementRoot root2 = new AdvancementRoot(
+                Component.text("title2"),
+                Component.text("description"),
+                Material.DIAMOND,
+                FrameType.TASK,
+                0,
+                0,
+                "minecraft:textures/block/stone.png"
+        );
+
+        final AdvancementRoot root3 = new AdvancementRoot(
+                Component.text("title3"),
+                Component.text("description"),
+                Material.DIAMOND,
+                FrameType.TASK,
+                0,
+                0,
+                "minecraft:textures/block/stone.png"
+        );
+
+        final AdvancementTab tab1 = env.process().advancement().createTab("minestom:minestom_tab1", root1);
+        final AdvancementTab tab2 = env.process().advancement().createTab("minestom:minestom_tab2", root2);
+        final AdvancementTab tab3 = env.process().advancement().createTab("minestom:minestom_tab3", root3);
+
+        tab1.addViewer(player1);
+        tab1.addViewer(player2);
+
+        tab2.addViewer(player1);
+        tab2.addViewer(player2);
+
+        tab3.addViewer(player2);
+
+        assertEquals(2, tab1.getViewers().size());
+        final AdvancementTab tab1Removed = env.process().advancement().removeTab(tab1.getRoot().getIdentifier(), true);
+        assertNotNull(tab1Removed);
+        assertEquals(0, tab1Removed.getViewers().size());
+        assertEquals(0, tab1Removed.getViewers().size());
+        assertNull(env.process().advancement().removeTab(tab1.getRoot().getIdentifier(), true));
+        assertNull(env.process().advancement().removeTab(tab1.getRoot().getIdentifier(), false));
+
+        final AdvancementTab tab2Removed = env.process().advancement().removeTab(tab2.getRoot().getIdentifier(), false);
+        assertNotNull(tab2Removed);
+        assertEquals(2, tab2Removed.getViewers().size());
+        assertTrue(tab2Removed.isViewer(player1));
+        assertTrue(tab2Removed.isViewer(player2));
+        assertNull(env.process().advancement().removeTab(tab2.getRoot().getIdentifier(), true));
+        assertNull(env.process().advancement().removeTab(tab2.getRoot().getIdentifier(), false));
+
+        final AdvancementTab tab3Removed = env.process().advancement().removeTab(tab3.getRoot().getIdentifier(), false);
+        assertNotNull(tab3Removed);
+        assertEquals(1, tab3Removed.getViewers().size());
+        assertTrue(tab3Removed.isViewer(player2));
+        assertNull(env.process().advancement().removeTab(tab3.getRoot().getIdentifier(), true));
+        assertNull(env.process().advancement().removeTab(tab3.getRoot().getIdentifier(), false));
     }
 }


### PR DESCRIPTION
## Proposed changes

This allows advancement roots to be unregistered. Currently, the advancement tabs are there forever once they are created. This allows old advancements to be cleaned up and not stuck in memory.

I also changed the annotation on the `Viewable#getViewers` method from `@Unmodifiable` to `@UnmodifiableView` to make it more accurate. The current `AdvancementTab#getViewers` just directly returns the backing viewers set, so I also changed it to return an unmodifiable view.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)