### PR TITLE
fix(ci): Concurrency canceling jobs

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -7,10 +7,6 @@ on:
 permissions:
   contents: write
 
-concurrency:
-  group: build-main-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build:
     name: JVM Check
@@ -84,6 +80,8 @@ jobs:
     name: Publish Snapshot
     needs: [ build, javadoc, native-test ]
     runs-on: ubuntu-latest
+    concurrency:
+      group: publish-${{ github.ref }}
     steps:
       - name: Generate Bot Token
         if: needs.native-test.outputs.metadata-updated == 'true'

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -9,10 +9,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: build-pr-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   build:
     name: JVM Check
@@ -135,6 +131,8 @@ jobs:
       needs.native-test.result == 'success' &&
       (needs.binary-compatibility.result == 'success' || needs.binary-compatibility.result == 'skipped')
     runs-on: ubuntu-latest
+    concurrency:
+      group: publish-pr-${{ github.head_ref }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    concurrency:
+      group: publish-${{ github.ref }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7


### PR DESCRIPTION
## Proposed changes

We only need the concurrency check for when we are publishing, so we can avoid canceling for most pull requests. There is likely an improvement possible with release but avoiding the race but since the commit sha is saved is more difficult.