### PR TITLE
Fix Palette#compare between single-value and indirect palettes

### DIFF
--- a/src/main/java/net/minestom/server/instance/palette/PaletteImpl.java
+++ b/src/main/java/net/minestom/server/instance/palette/PaletteImpl.java
@@ -533,9 +533,13 @@ final class PaletteImpl implements Palette {
         final PaletteImpl palette = (PaletteImpl) p;
         final int dimension = this.dimension();
         if (palette.dimension() != dimension) return false;
-        if (palette.count != this.count) return false;
-        if (palette.count == 0) return true;
-        if (palette.bitsPerEntry == 0 && this.bitsPerEntry == 0) return true;
+        // `count` stores the palette value when bitsPerEntry == 0, and the non-air entry count
+        // otherwise, so it is only comparable between palettes using the same storage format
+        if (bitsPerEntry == 0 && palette.bitsPerEntry == 0) return count == palette.count;
+        if (bitsPerEntry > 0 && palette.bitsPerEntry > 0) {
+            if (palette.count != count) return false;
+            if (palette.count == 0) return true;
+        }
         final long[] thisValues = this.values;
         final long[] thatValues = palette.values;
         final int thisBpe = this.bitsPerEntry;

--- a/src/test/java/net/minestom/server/instance/palette/PaletteCompareTest.java
+++ b/src/test/java/net/minestom/server/instance/palette/PaletteCompareTest.java
@@ -1,0 +1,89 @@
+package net.minestom.server.instance.palette;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PaletteCompareTest {
+
+    @Test
+    public void singleValueAgainstEqualIndirect() {
+        Palette indirect = Palette.biomes(1);
+        for (int x = 0; x < 4; x++)
+            for (int y = 0; y < 4; y++)
+                for (int z = 0; z < 4; z++)
+                    indirect.set(x, y, z, 1);
+        Palette single = Palette.biomes();
+        single.fill(1);
+
+        assertTrue(single.compare(indirect));
+        assertTrue(indirect.compare(single));
+    }
+
+    @Test
+    public void singleValueAgainstDifferentIndirect() {
+        Palette indirect = Palette.biomes(1);
+        for (int x = 0; x < 4; x++)
+            for (int y = 0; y < 4; y++)
+                for (int z = 0; z < 4; z++)
+                    indirect.set(x, y, z, 2);
+        Palette single = Palette.biomes();
+        single.fill(1);
+
+        assertFalse(single.compare(indirect));
+        assertFalse(indirect.compare(single));
+    }
+
+    @Test
+    public void partiallyFilledSingleValue() {
+        Palette partial = Palette.biomes(1);
+        for (int x = 0; x < 4; x++)
+            for (int y = 0; y < 4; y++)
+                for (int z = 0; z < 2; z++)
+                    partial.set(x, y, z, 1);
+        Palette single = Palette.biomes();
+        single.fill(1);
+
+        assertFalse(single.compare(partial));
+        assertFalse(partial.compare(single));
+    }
+
+    @Test
+    public void singleValueZeroAgainstEmptyIndirect() {
+        Palette empty = Palette.biomes(1);
+        Palette single = Palette.biomes();
+        single.fill(0);
+
+        assertTrue(single.compare(empty));
+        assertTrue(empty.compare(single));
+    }
+
+    @Test
+    public void twoSingleValues() {
+        Palette stone = Palette.biomes();
+        stone.fill(1);
+        Palette dirt = Palette.biomes();
+        dirt.fill(2);
+        Palette alsoStone = Palette.biomes();
+        alsoStone.fill(1);
+
+        assertTrue(stone.compare(alsoStone));
+        assertFalse(stone.compare(dirt));
+    }
+
+    @Test
+    public void singleValueAgainstDirect() {
+        // Value above maxBitsPerEntry forces direct (non-paletted) storage
+        Palette direct = Palette.blocks(15);
+        for (int x = 0; x < 16; x++)
+            for (int y = 0; y < 16; y++)
+                for (int z = 0; z < 16; z++)
+                    direct.set(x, y, z, 20000);
+        Palette single = Palette.blocks();
+        single.fill(20000);
+
+        assertTrue(single.compare(direct));
+        assertTrue(direct.compare(single));
+    }
+}


### PR DESCRIPTION
## Proposed changes

Fixes #3334.

`Palette#compare` rejected a single-value palette compared against an indirect palette with identical content. The `count` field in `PaletteImpl` is dual-purpose: it stores the palette value itself when `bitsPerEntry == 0`, and the non-air entry count otherwise. The early `count` equality check therefore compared a stored value (e.g. `1`) against an entry count (e.g. `64`) and returned false before the per-entry loop could run.

The fix only compares `count` between palettes using the same storage format, and falls through to the per-entry loop for mixed formats, where using `count` as the single value is already correct.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Added `PaletteCompareTest` covering the reproducer from the issue (both directions), differing values, partially filled palettes, single value `0` vs an empty indirect palette, two single-value palettes, and single value vs direct storage. All existing palette tests and the root test suite pass.