### PR TITLE
Match vanilla username regex

### DIFF
--- a/src/main/java/net/minestom/server/listener/preplay/LoginListener.java
+++ b/src/main/java/net/minestom/server/listener/preplay/LoginListener.java
@@ -22,6 +22,7 @@ import net.minestom.server.network.player.PlayerConnection;
 import net.minestom.server.network.player.PlayerSocketConnection;
 import net.minestom.server.network.plugin.LoginPlugin;
 import net.minestom.server.network.plugin.LoginPluginMessageProcessor;
+import net.minestom.server.utils.StringUtils;
 import net.minestom.server.utils.mojang.MojangUtils;
 
 import javax.crypto.SecretKey;
@@ -45,13 +46,18 @@ public final class LoginListener {
 
     private static final Component ALREADY_CONNECTED = Component.text("You are already on this server", NamedTextColor.RED);
     private static final Component ERROR_DURING_LOGIN = Component.text("Error during login!", NamedTextColor.RED);
-    private static final Component ERROR_MALFORMED_USERNAME = Component.text("Error malformed username", NamedTextColor.RED);
+    private static final Component ERROR_MALFORMED_USERNAME = Component.text("Malformed username!", NamedTextColor.RED);
     private static final Component ENCRYPTION_FAILED = Component.text("Encryption failed!", NamedTextColor.RED);
     private static final Component ERROR_MOJANG_RESPONSE = Component.text("Failed to contact Mojang's Session Servers (Are they down?)", NamedTextColor.RED);
 
     public static final Component INVALID_PROXY_RESPONSE = Component.text("Invalid proxy response!", NamedTextColor.RED);
 
     public static void loginStartListener(ClientLoginStartPacket packet, PlayerConnection connection) {
+        if (!StringUtils.isValidUsername(packet.username())) {
+            connection.kick(ERROR_MALFORMED_USERNAME);
+            return;
+        }
+
         final Auth auth = MinecraftServer.process().auth();
         final boolean isSocketConnection = connection instanceof PlayerSocketConnection;
         // Proxy support (only for socket clients) and cache the login username

--- a/src/main/java/net/minestom/server/network/packet/client/login/ClientLoginStartPacket.java
+++ b/src/main/java/net/minestom/server/network/packet/client/login/ClientLoginStartPacket.java
@@ -15,9 +15,4 @@ public record ClientLoginStartPacket(String username,
             STRING, ClientLoginStartPacket::username,
             UUID, ClientLoginStartPacket::profileId,
             ClientLoginStartPacket::new);
-
-    public ClientLoginStartPacket {
-        if (username.length() > 16)
-            throw new IllegalArgumentException("Username is not allowed to be longer than 16 characters");
-    }
 }

--- a/src/main/java/net/minestom/server/utils/StringUtils.java
+++ b/src/main/java/net/minestom/server/utils/StringUtils.java
@@ -7,6 +7,28 @@ public class StringUtils {
     public static final String SPACE = " ";
     public static final char SPACE_CHAR = ' ';
 
+    /**
+     * Checks whether a username is valid. (between 1 and 16 characters, printable ASCII)
+     *
+     * @param name The username to check
+     * @return true if the username is valid
+     */
+    public static boolean isValidUsername(final String name) {
+        if (name.isEmpty() || name.length() > 16) {
+            return false;
+        }
+
+        for (int index = 0; index < name.length(); index++) {
+            char character = name.charAt(index);
+
+            if (character <= 32 || character >= 127) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     public static int countMatches(final CharSequence str, final char ch) {
         if (str.isEmpty()) {
             return 0;

--- a/src/main/java/net/minestom/server/utils/mojang/MojangUtils.java
+++ b/src/main/java/net/minestom/server/utils/mojang/MojangUtils.java
@@ -28,7 +28,7 @@ public final class MojangUtils {
     private static final String BASE_AUTH_URL = ServerFlag.AUTH_URL.concat("?username=%s&serverId=%s");
     private static final String PREVENT_PROXY_CONNECTIONS_AUTH_URL = BASE_AUTH_URL.concat("&ip=%s");
 
-    private static final Pattern USERNAME_PATTERN = Pattern.compile("[a-zA-Z0-9_]{3,16}");
+    private static final Pattern USERNAME_PATTERN = Pattern.compile("[\\x21-\\x7E]{1,16}");
 
     /**
      * Gets a player's UUID from their username
@@ -41,7 +41,7 @@ public final class MojangUtils {
     public static UUID getUUID(String username) throws IOException {
         // Thanks stackoverflow: https://stackoverflow.com/a/19399768/13247146
         return UUID.fromString(
-                formatUUID(retrieve(String.format(FROM_USERNAME_URL, validateUsername(username))).get("id").getAsString())
+                formatUUID(retrieve(String.format(FROM_USERNAME_URL, encode(validateUsername(username)))).get("id").getAsString())
         );
     }
 
@@ -97,9 +97,9 @@ public final class MojangUtils {
      */
     @Blocking
     public static @Nullable JsonObject fromUsername(String username) {
-        if (!USERNAME_PATTERN.matcher(username).matches()) return null;
+        if (!isValidUsername(username)) return null;
         try {
-            return retrieve(String.format(FROM_USERNAME_URL, username));
+            return retrieve(String.format(FROM_USERNAME_URL, encode(username)));
         } catch (IOException _) {
             return null;
         }
@@ -137,10 +137,14 @@ public final class MojangUtils {
     }
 
     private static String validateUsername(String username) throws IOException {
-        if (!USERNAME_PATTERN.matcher(username).matches()) {
+        if (!isValidUsername(username)) {
             throw new IOException("Invalid username: " + username);
         }
         return username;
+    }
+
+    static boolean isValidUsername(String username) {
+        return USERNAME_PATTERN.matcher(username).matches();
     }
 
     /**

--- a/src/main/java/net/minestom/server/utils/mojang/MojangUtils.java
+++ b/src/main/java/net/minestom/server/utils/mojang/MojangUtils.java
@@ -3,6 +3,7 @@ package net.minestom.server.utils.mojang;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import net.minestom.server.ServerFlag;
+import net.minestom.server.utils.StringUtils;
 import net.minestom.server.utils.url.URLUtils;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Blocking;
@@ -15,7 +16,6 @@ import java.net.SocketAddress;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
-import java.util.regex.Pattern;
 
 /**
  * Utils class using mojang API.
@@ -27,8 +27,6 @@ public final class MojangUtils {
     // Auth
     private static final String BASE_AUTH_URL = ServerFlag.AUTH_URL.concat("?username=%s&serverId=%s");
     private static final String PREVENT_PROXY_CONNECTIONS_AUTH_URL = BASE_AUTH_URL.concat("&ip=%s");
-
-    private static final Pattern USERNAME_PATTERN = Pattern.compile("[\\x21-\\x7E]{1,16}");
 
     /**
      * Gets a player's UUID from their username
@@ -97,7 +95,7 @@ public final class MojangUtils {
      */
     @Blocking
     public static @Nullable JsonObject fromUsername(String username) {
-        if (!isValidUsername(username)) return null;
+        if (!StringUtils.isValidUsername(username)) return null;
         try {
             return retrieve(String.format(FROM_USERNAME_URL, encode(username)));
         } catch (IOException _) {
@@ -137,14 +135,10 @@ public final class MojangUtils {
     }
 
     private static String validateUsername(String username) throws IOException {
-        if (!isValidUsername(username)) {
+        if (!StringUtils.isValidUsername(username)) {
             throw new IOException("Invalid username: " + username);
         }
         return username;
-    }
-
-    static boolean isValidUsername(String username) {
-        return USERNAME_PATTERN.matcher(username).matches();
     }
 
     /**

--- a/src/test/java/net/minestom/server/utils/StringUtilsTest.java
+++ b/src/test/java/net/minestom/server/utils/StringUtilsTest.java
@@ -1,0 +1,39 @@
+package net.minestom.server.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class StringUtilsTest {
+    @Test
+    public void validUsernames() {
+        assertTrue(StringUtils.isValidUsername("Notch"));
+        assertTrue(StringUtils.isValidUsername("jeb_"));
+        assertTrue(StringUtils.isValidUsername("abcdefghijklmnop"));
+    }
+
+    @Test
+    public void invalidUsernames() {
+        assertFalse(StringUtils.isValidUsername("Notch with spaces"));
+        assertFalse(StringUtils.isValidUsername("Notch\u007F"));
+        assertFalse(StringUtils.isValidUsername("Notch\n"));
+        assertFalse(StringUtils.isValidUsername("水跃鱼"));
+    }
+
+    @Test
+    public void emptyUsername() {
+        assertFalse(StringUtils.isValidUsername(""));
+    }
+
+    @Test
+    public void veryShortUsernames() {
+        assertTrue(StringUtils.isValidUsername("a"));
+        assertTrue(StringUtils.isValidUsername("ab"));
+    }
+
+    @Test
+    public void veryLongUsernames() {
+        assertFalse(StringUtils.isValidUsername("abcdefghijklmnopq"));
+    }
+}

--- a/src/test/java/net/minestom/server/utils/TestMojangUtils.java
+++ b/src/test/java/net/minestom/server/utils/TestMojangUtils.java
@@ -77,6 +77,6 @@ public class TestMojangUtils {
     @Disabled
     @Test
     public void testGetInvalidNameThrows() {
-        assertThrows(IOException.class, () -> MojangUtils.getUUID("a")); // Too short
+        assertThrows(IOException.class, () -> MojangUtils.getUUID(""));
     }
 }


### PR DESCRIPTION
Fold all username validation into a single function, add kick for invalid usernames instead of just an exception thrown, and change the regex to match vanilla "1-16 printable ASCII characters" pattern