### PR TITLE
feat: Add more bulk primitive network types

### DIFF
--- a/jmh-benchmarks/src/jmh/java/net/minestom/server/network/NetworkBufferRawArrayBenchmark.java
+++ b/jmh-benchmarks/src/jmh/java/net/minestom/server/network/NetworkBufferRawArrayBenchmark.java
@@ -1,0 +1,265 @@
+package net.minestom.server.network;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 8, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class NetworkBufferRawArrayBenchmark {
+
+    @Param({"16", "1024"})
+    public int count;
+
+    private NetworkBuffer writeBuffer, readBuffer;
+
+    private byte[] bytes;
+    private short[] shorts;
+    private int[] ints;
+    private long[] longs;
+    private float[] floats;
+    private double[] doubles;
+
+    private NetworkBuffer.Type<byte[]> bytesType;
+    private NetworkBuffer.Type<short[]> shortsType;
+    private NetworkBuffer.Type<int[]> intsType;
+    private NetworkBuffer.Type<long[]> longsType;
+    private NetworkBuffer.Type<float[]> floatsType;
+    private NetworkBuffer.Type<double[]> doublesType;
+
+    @Setup
+    public void setup() {
+        bytes = new byte[count];
+        shorts = new short[count];
+        ints = new int[count];
+        longs = new long[count];
+        floats = new float[count];
+        doubles = new double[count];
+        for (int i = 0; i < count; i++) {
+            bytes[i] = (byte) i;
+            shorts[i] = (short) i;
+            ints[i] = i;
+            longs[i] = i;
+            floats[i] = i;
+            doubles[i] = i;
+        }
+
+        bytesType = NetworkBuffer.FixedRawBytes(count);
+        shortsType = NetworkBuffer.FixedRawShorts(count);
+        intsType = NetworkBuffer.FixedRawInts(count);
+        longsType = NetworkBuffer.FixedRawLongs(count);
+        floatsType = NetworkBuffer.FixedRawFloats(count);
+        doublesType = NetworkBuffer.FixedRawDoubles(count);
+
+        final long capacity = (long) count * Double.BYTES;
+        writeBuffer = NetworkBuffer.staticBuffer(capacity);
+        readBuffer = NetworkBuffer.staticBuffer(capacity);
+        readBuffer.write(NetworkBuffer.RAW_DOUBLES, doubles);
+    }
+
+    @Benchmark
+    public NetworkBuffer writeBytes() {
+        final NetworkBuffer buffer = this.writeBuffer;
+        buffer.writeIndex(0);
+        buffer.write(NetworkBuffer.RAW_BYTES, bytes);
+        return buffer;
+    }
+
+    @Benchmark
+    public NetworkBuffer writeBytesLoop() {
+        final NetworkBuffer buffer = this.writeBuffer;
+        buffer.writeIndex(0);
+        for (byte value : bytes) buffer.write(NetworkBuffer.BYTE, value);
+        return buffer;
+    }
+
+    @Benchmark
+    public NetworkBuffer writeShorts() {
+        final NetworkBuffer buffer = this.writeBuffer;
+        buffer.writeIndex(0);
+        buffer.write(NetworkBuffer.RAW_SHORTS, shorts);
+        return buffer;
+    }
+
+    @Benchmark
+    public NetworkBuffer writeShortsLoop() {
+        final NetworkBuffer buffer = this.writeBuffer;
+        buffer.writeIndex(0);
+        for (short value : shorts) buffer.write(NetworkBuffer.SHORT, value);
+        return buffer;
+    }
+
+    @Benchmark
+    public NetworkBuffer writeInts() {
+        final NetworkBuffer buffer = this.writeBuffer;
+        buffer.writeIndex(0);
+        buffer.write(NetworkBuffer.RAW_INTS, ints);
+        return buffer;
+    }
+
+    @Benchmark
+    public NetworkBuffer writeIntsLoop() {
+        final NetworkBuffer buffer = this.writeBuffer;
+        buffer.writeIndex(0);
+        for (int value : ints) buffer.write(NetworkBuffer.INT, value);
+        return buffer;
+    }
+
+    @Benchmark
+    public NetworkBuffer writeLongs() {
+        final NetworkBuffer buffer = this.writeBuffer;
+        buffer.writeIndex(0);
+        buffer.write(NetworkBuffer.RAW_LONGS, longs);
+        return buffer;
+    }
+
+    @Benchmark
+    public NetworkBuffer writeLongsLoop() {
+        final NetworkBuffer buffer = this.writeBuffer;
+        buffer.writeIndex(0);
+        for (long value : longs) buffer.write(NetworkBuffer.LONG, value);
+        return buffer;
+    }
+
+    @Benchmark
+    public NetworkBuffer writeFloats() {
+        final NetworkBuffer buffer = this.writeBuffer;
+        buffer.writeIndex(0);
+        buffer.write(NetworkBuffer.RAW_FLOATS, floats);
+        return buffer;
+    }
+
+    @Benchmark
+    public NetworkBuffer writeFloatsLoop() {
+        final NetworkBuffer buffer = this.writeBuffer;
+        buffer.writeIndex(0);
+        for (float value : floats) buffer.write(NetworkBuffer.FLOAT, value);
+        return buffer;
+    }
+
+    @Benchmark
+    public NetworkBuffer writeDoubles() {
+        final NetworkBuffer buffer = this.writeBuffer;
+        buffer.writeIndex(0);
+        buffer.write(NetworkBuffer.RAW_DOUBLES, doubles);
+        return buffer;
+    }
+
+    @Benchmark
+    public NetworkBuffer writeDoublesLoop() {
+        final NetworkBuffer buffer = this.writeBuffer;
+        buffer.writeIndex(0);
+        for (double value : doubles) buffer.write(NetworkBuffer.DOUBLE, value);
+        return buffer;
+    }
+
+    @Benchmark
+    public byte[] readBytes() {
+        final NetworkBuffer buffer = this.readBuffer;
+        buffer.readIndex(0);
+        return buffer.read(bytesType);
+    }
+
+    @Benchmark
+    public byte[] readBytesLoop() {
+        final NetworkBuffer buffer = this.readBuffer;
+        buffer.readIndex(0);
+        final byte[] values = new byte[count];
+        for (int i = 0; i < values.length; i++) values[i] = buffer.read(NetworkBuffer.BYTE);
+        return values;
+    }
+
+    @Benchmark
+    public short[] readShorts() {
+        final NetworkBuffer buffer = this.readBuffer;
+        buffer.readIndex(0);
+        return buffer.read(shortsType);
+    }
+
+    @Benchmark
+    public short[] readShortsLoop() {
+        final NetworkBuffer buffer = this.readBuffer;
+        buffer.readIndex(0);
+        final short[] values = new short[count];
+        for (int i = 0; i < values.length; i++) values[i] = buffer.read(NetworkBuffer.SHORT);
+        return values;
+    }
+
+    @Benchmark
+    public int[] readInts() {
+        final NetworkBuffer buffer = this.readBuffer;
+        buffer.readIndex(0);
+        return buffer.read(intsType);
+    }
+
+    @Benchmark
+    public int[] readIntsLoop() {
+        final NetworkBuffer buffer = this.readBuffer;
+        buffer.readIndex(0);
+        final int[] values = new int[count];
+        for (int i = 0; i < values.length; i++) values[i] = buffer.read(NetworkBuffer.INT);
+        return values;
+    }
+
+    @Benchmark
+    public long[] readLongs() {
+        final NetworkBuffer buffer = this.readBuffer;
+        buffer.readIndex(0);
+        return buffer.read(longsType);
+    }
+
+    @Benchmark
+    public long[] readLongsLoop() {
+        final NetworkBuffer buffer = this.readBuffer;
+        buffer.readIndex(0);
+        final long[] values = new long[count];
+        for (int i = 0; i < values.length; i++) values[i] = buffer.read(NetworkBuffer.LONG);
+        return values;
+    }
+
+    @Benchmark
+    public float[] readFloats() {
+        final NetworkBuffer buffer = this.readBuffer;
+        buffer.readIndex(0);
+        return buffer.read(floatsType);
+    }
+
+    @Benchmark
+    public float[] readFloatsLoop() {
+        final NetworkBuffer buffer = this.readBuffer;
+        buffer.readIndex(0);
+        final float[] values = new float[count];
+        for (int i = 0; i < values.length; i++) values[i] = buffer.read(NetworkBuffer.FLOAT);
+        return values;
+    }
+
+    @Benchmark
+    public double[] readDoubles() {
+        final NetworkBuffer buffer = this.readBuffer;
+        buffer.readIndex(0);
+        return buffer.read(doublesType);
+    }
+
+    @Benchmark
+    public double[] readDoublesLoop() {
+        final NetworkBuffer buffer = this.readBuffer;
+        buffer.readIndex(0);
+        final double[] values = new double[count];
+        for (int i = 0; i < values.length; i++) values[i] = buffer.read(NetworkBuffer.DOUBLE);
+        return values;
+    }
+}

--- a/src/main/java/net/minestom/server/instance/palette/Palette.java
+++ b/src/main/java/net/minestom/server/instance/palette/Palette.java
@@ -10,7 +10,8 @@ import org.jetbrains.annotations.Nullable;
 import java.util.function.IntUnaryOperator;
 
 import static net.minestom.server.network.NetworkBuffer.BYTE;
-import static net.minestom.server.network.NetworkBuffer.LONG;
+import static net.minestom.server.network.NetworkBuffer.FixedRawLongs;
+import static net.minestom.server.network.NetworkBuffer.RAW_LONGS;
 import static net.minestom.server.network.NetworkBuffer.VAR_INT;
 import static net.minestom.server.network.NetworkBuffer.VAR_INT_ARRAY;
 
@@ -249,7 +250,7 @@ public sealed interface Palette permits PaletteImpl {
                     if (value.hasPalette()) {
                         buffer.write(VAR_INT.list(), value.paletteToValueList);
                     }
-                    for (long l : value.values) buffer.write(LONG, l);
+                    buffer.write(RAW_LONGS, value.values);
                 }
             }
 
@@ -278,8 +279,7 @@ public sealed interface Palette permits PaletteImpl {
                         result.valueToPaletteMap.put(palette[i], i);
                     }
                 }
-                final long[] data = new long[Palettes.arrayLength(dimension, bitsPerEntry)];
-                for (int i = 0; i < data.length; i++) data[i] = buffer.read(LONG);
+                final long[] data = buffer.read(FixedRawLongs(Palettes.arrayLength(dimension, bitsPerEntry)));
                 result.values = data;
                 if (palette != null) Palettes.validateIndices(bitsPerEntry, dimension, data, palette.length);
                 result.recount();

--- a/src/main/java/net/minestom/server/network/NetworkBuffer.java
+++ b/src/main/java/net/minestom/server/network/NetworkBuffer.java
@@ -14,6 +14,7 @@ import net.minestom.server.utils.Direction;
 import net.minestom.server.utils.Either;
 import net.minestom.server.utils.Unit;
 import net.minestom.server.utils.crypto.KeyUtils;
+import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
@@ -55,6 +56,11 @@ public sealed interface NetworkBuffer permits NetworkBufferImpl {
     Type<Integer> VAR_INT_3 = new NetworkBufferTypeImpl.VarInt3Type();
     Type<Long> VAR_LONG = new NetworkBufferTypeImpl.VarLongType();
     Type<byte[]> RAW_BYTES = new NetworkBufferTypeImpl.RawBytesType(-1);
+    Type<short[]> RAW_SHORTS = new NetworkBufferTypeImpl.RawShortsType(-1);
+    Type<int[]> RAW_INTS = new NetworkBufferTypeImpl.RawIntsType(-1);
+    Type<long[]> RAW_LONGS = new NetworkBufferTypeImpl.RawLongsType(-1);
+    Type<float[]> RAW_FLOATS = new NetworkBufferTypeImpl.RawFloatsType(-1);
+    Type<double[]> RAW_DOUBLES = new NetworkBufferTypeImpl.RawDoublesType(-1);
     Type<String> STRING = new NetworkBufferTypeImpl.StringType();
     Type<Key> KEY = STRING.transform(Key::key, Key::asString);
     Type<String> STRING_TERMINATED = new NetworkBufferTypeImpl.StringTerminatedType();
@@ -102,12 +108,81 @@ public sealed interface NetworkBuffer permits NetworkBufferImpl {
         return new NetworkBufferTypeImpl.EnumSetType<>(enumClass, values);
     }
 
+    /**
+     * Creates a type for a bit set of exactly {@code length} bits, stored in {@code (length + 7) / 8} bytes.
+     *
+     * @param length the bit count, which must not be negative
+     * @return the fixed length bit set type
+     */
     static Type<BitSet> FixedBitSet(int length) {
+        Check.argCondition(length < 0, "Length cannot be negative: {0}", length);
         return new NetworkBufferTypeImpl.FixedBitSetType(length);
     }
 
+    /**
+     * Creates a type for exactly {@code length} bytes, unlike {@link #RAW_BYTES} which reads every byte left in the buffer.
+     *
+     * @param length the element count, which must not be negative
+     * @return the fixed length byte type
+     */
     static Type<byte[]> FixedRawBytes(int length) {
+        Check.argCondition(length < 0, "Length cannot be negative: {0}", length);
         return new NetworkBufferTypeImpl.RawBytesType(length);
+    }
+
+    /**
+     * Creates a type for exactly {@code length} shorts, unlike {@link #RAW_SHORTS} which reads every short left in the buffer.
+     *
+     * @param length the element count, which must not be negative
+     * @return the fixed length short type
+     */
+    static Type<short[]> FixedRawShorts(int length) {
+        Check.argCondition(length < 0, "Length cannot be negative: {0}", length);
+        return new NetworkBufferTypeImpl.RawShortsType(length);
+    }
+
+    /**
+     * Creates a type for exactly {@code length} ints, unlike {@link #RAW_INTS} which reads every int left in the buffer.
+     *
+     * @param length the element count, which must not be negative
+     * @return the fixed length int type
+     */
+    static Type<int[]> FixedRawInts(int length) {
+        Check.argCondition(length < 0, "Length cannot be negative: {0}", length);
+        return new NetworkBufferTypeImpl.RawIntsType(length);
+    }
+
+    /**
+     * Creates a type for exactly {@code length} longs, unlike {@link #RAW_LONGS} which reads every long left in the buffer.
+     *
+     * @param length the element count, which must not be negative
+     * @return the fixed length long type
+     */
+    static Type<long[]> FixedRawLongs(int length) {
+        Check.argCondition(length < 0, "Length cannot be negative: {0}", length);
+        return new NetworkBufferTypeImpl.RawLongsType(length);
+    }
+
+    /**
+     * Creates a type for exactly {@code length} floats, unlike {@link #RAW_FLOATS} which reads every float left in the buffer.
+     *
+     * @param length the element count, which must not be negative
+     * @return the fixed length float type
+     */
+    static Type<float[]> FixedRawFloats(int length) {
+        Check.argCondition(length < 0, "Length cannot be negative: {0}", length);
+        return new NetworkBufferTypeImpl.RawFloatsType(length);
+    }
+
+    /**
+     * Creates a type for exactly {@code length} doubles, unlike {@link #RAW_DOUBLES} which reads every double left in the buffer.
+     *
+     * @param length the element count, which must not be negative
+     * @return the fixed length double type
+     */
+    static Type<double[]> FixedRawDoubles(int length) {
+        Check.argCondition(length < 0, "Length cannot be negative: {0}", length);
+        return new NetworkBufferTypeImpl.RawDoublesType(length);
     }
 
     static <T> Type<T> Lazy(Supplier<Type<T>> supplier) {

--- a/src/main/java/net/minestom/server/network/NetworkBuffer.java
+++ b/src/main/java/net/minestom/server/network/NetworkBuffer.java
@@ -88,7 +88,7 @@ public sealed interface NetworkBuffer permits NetworkBufferImpl {
     Type<Point> VECTOR3I = new NetworkBufferTypeImpl.Vector3IType();
     Type<Point> VECTOR3B = new NetworkBufferTypeImpl.Vector3BType();
     Type<Vec> LP_VECTOR3 = new NetworkBufferTypeImpl.LpVector3Type();
-    Type<float[]> QUATERNION = new NetworkBufferTypeImpl.QuaternionType();
+    Type<float[]> QUATERNION = FixedRawFloats(4);
 
     Type<@Nullable Component> OPT_CHAT = COMPONENT.optional();
     Type<@Nullable Point> OPT_BLOCK_POSITION = BLOCK_POSITION.optional();

--- a/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferImpl.java
@@ -424,6 +424,18 @@ final class NetworkBufferImpl implements NetworkBuffer {
         return segment.get(SHORT_LAYOUT, index);
     }
 
+    void _putShorts(long index, short[] value) {
+        final MemorySegment segment = this.segment;
+        if (isDummy(segment)) return;
+        MemorySegment.copy(value, 0, segment, SHORT_LAYOUT, index, value.length);
+    }
+
+    void _getShorts(long index, short[] value) {
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
+        MemorySegment.copy(segment, SHORT_LAYOUT, index, value, 0, value.length);
+    }
+
     void _putInt(long index, int value) {
         final MemorySegment segment = this.segment;
         if (isDummy(segment)) return;
@@ -434,6 +446,18 @@ final class NetworkBufferImpl implements NetworkBuffer {
         final MemorySegment segment = this.segment;
         assertDummy(segment);
         return segment.get(INT_LAYOUT, index);
+    }
+
+    void _putInts(long index, int[] value) {
+        final MemorySegment segment = this.segment;
+        if (isDummy(segment)) return;
+        MemorySegment.copy(value, 0, segment, INT_LAYOUT, index, value.length);
+    }
+
+    void _getInts(long index, int[] value) {
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
+        MemorySegment.copy(segment, INT_LAYOUT, index, value, 0, value.length);
     }
 
     void _putLong(long index, long value) {
@@ -448,6 +472,18 @@ final class NetworkBufferImpl implements NetworkBuffer {
         return segment.get(LONG_LAYOUT, index);
     }
 
+    void _putLongs(long index, long[] value) {
+        final MemorySegment segment = this.segment;
+        if (isDummy(segment)) return;
+        MemorySegment.copy(value, 0, segment, LONG_LAYOUT, index, value.length);
+    }
+
+    void _getLongs(long index, long[] value) {
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
+        MemorySegment.copy(segment, LONG_LAYOUT, index, value, 0, value.length);
+    }
+
     void _putFloat(long index, float value) {
         final MemorySegment segment = this.segment;
         if (isDummy(segment)) return;
@@ -460,6 +496,18 @@ final class NetworkBufferImpl implements NetworkBuffer {
         return segment.get(FLOAT_LAYOUT, index);
     }
 
+    void _putFloats(long index, float[] value) {
+        final MemorySegment segment = this.segment;
+        if (isDummy(segment)) return;
+        MemorySegment.copy(value, 0, segment, FLOAT_LAYOUT, index, value.length);
+    }
+
+    void _getFloats(long index, float[] value) {
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
+        MemorySegment.copy(segment, FLOAT_LAYOUT, index, value, 0, value.length);
+    }
+
     void _putDouble(long index, double value) {
         final MemorySegment segment = this.segment;
         if (isDummy(segment)) return;
@@ -470,6 +518,18 @@ final class NetworkBufferImpl implements NetworkBuffer {
         final MemorySegment segment = this.segment;
         assertDummy(segment);
         return segment.get(DOUBLE_LAYOUT, index);
+    }
+
+    void _putDoubles(long index, double[] value) {
+        final MemorySegment segment = this.segment;
+        if (isDummy(segment)) return;
+        MemorySegment.copy(value, 0, segment, DOUBLE_LAYOUT, index, value.length);
+    }
+
+    void _getDoubles(long index, double[] value) {
+        final MemorySegment segment = this.segment;
+        assertDummy(segment);
+        MemorySegment.copy(segment, DOUBLE_LAYOUT, index, value, 0, value.length);
     }
 
     static NetworkBuffer wrap(MemorySegment segment, long readIndex, long writeIndex, @Nullable Registries registries) {

--- a/src/main/java/net/minestom/server/network/NetworkBufferTypeImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferTypeImpl.java
@@ -44,10 +44,12 @@ import static net.minestom.server.network.NetworkBuffer.DOUBLE;
 import static net.minestom.server.network.NetworkBuffer.FLOAT;
 import static net.minestom.server.network.NetworkBuffer.FixedBitSet;
 import static net.minestom.server.network.NetworkBuffer.FixedRawBytes;
+import static net.minestom.server.network.NetworkBuffer.FixedRawLongs;
 import static net.minestom.server.network.NetworkBuffer.INT;
 import static net.minestom.server.network.NetworkBuffer.LONG;
 import static net.minestom.server.network.NetworkBuffer.NBT;
 import static net.minestom.server.network.NetworkBuffer.RAW_BYTES;
+import static net.minestom.server.network.NetworkBuffer.RAW_LONGS;
 import static net.minestom.server.network.NetworkBuffer.SHORT;
 import static net.minestom.server.network.NetworkBuffer.STRING;
 import static net.minestom.server.network.NetworkBuffer.UNSIGNED_BYTE;
@@ -650,9 +652,6 @@ interface NetworkBufferTypeImpl<T> extends NetworkBuffer.Type<T> {
         @Override
         public byte[] read(NetworkBuffer buffer) {
             final int length = buffer.read(VAR_INT);
-            if (length == 0) return new byte[0];
-            final long remaining = buffer.readableBytes();
-            Check.argCondition(length > remaining, "String is too long (length: {0}, readable: {1})", length, remaining);
             return buffer.read(FixedRawBytes(length));
         }
     }
@@ -661,15 +660,13 @@ interface NetworkBufferTypeImpl<T> extends NetworkBuffer.Type<T> {
         @Override
         public void write(NetworkBuffer buffer, long[] value) {
             buffer.write(VAR_INT, value.length);
-            for (long l : value) buffer.write(LONG, l);
+            buffer.write(RAW_LONGS, value);
         }
 
         @Override
         public long[] read(NetworkBuffer buffer) {
             final int length = buffer.read(VAR_INT);
-            final long[] longs = new long[length];
-            for (int i = 0; i < length; i++) longs[i] = buffer.read(LONG);
-            return longs;
+            return buffer.read(FixedRawLongs(length));
         }
     }
 
@@ -836,25 +833,6 @@ interface NetworkBufferTypeImpl<T> extends NetworkBuffer.Type<T> {
 
         private static double unpack(long value) {
             return Math.min((double) (value & DATA_BITS_MASK), MAX_QUANTIZED_VALUE) * 2.0 / MAX_QUANTIZED_VALUE - 1.0;
-        }
-    }
-
-    record QuaternionType() implements NetworkBufferTypeImpl<float[]> {
-        @Override
-        public void write(NetworkBuffer buffer, float[] value) {
-            buffer.write(FLOAT, value[0]);
-            buffer.write(FLOAT, value[1]);
-            buffer.write(FLOAT, value[2]);
-            buffer.write(FLOAT, value[3]);
-        }
-
-        @Override
-        public float[] read(NetworkBuffer buffer) {
-            final float x = buffer.read(FLOAT);
-            final float y = buffer.read(FLOAT);
-            final float z = buffer.read(FLOAT);
-            final float w = buffer.read(FLOAT);
-            return new float[]{x, y, z, w};
         }
     }
 

--- a/src/main/java/net/minestom/server/network/NetworkBufferTypeImpl.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferTypeImpl.java
@@ -356,19 +356,150 @@ interface NetworkBufferTypeImpl<T> extends NetworkBuffer.Type<T> {
 
         @Override
         public byte[] read(NetworkBuffer buffer) {
-            long length = this.length;
-            if (length == -1) {
-                length = buffer.readableBytes();
-            }
-            if (length == 0) return new byte[0];
-            assert length > 0 : "Invalid remaining: " + length;
-            if (length > buffer.readableBytes())
-                throw new IndexOutOfBoundsException("Buffer needs " + length + " bytes to read found" + buffer.readableBytes());
-            final int arrayLength = Math.toIntExact(length);
-            final byte[] bytes = new byte[arrayLength];
+            final long readable = buffer.readableBytes();
+            final int count = length != -1 ? length : Math.toIntExact(readable);
+            assert count >= 0 : "Invalid count: " + count;
+            if (count > readable) // count == byteLength
+                throw new IndexOutOfBoundsException("Buffer needs " + count + " bytes to read, found " + readable);
+            final byte[] bytes = new byte[count];
             impl(buffer)._getBytes(buffer.readIndex(), bytes);
-            buffer.advanceRead(arrayLength);
+            buffer.advanceRead(count);
             return bytes;
+        }
+    }
+
+    record RawShortsType(int length) implements NetworkBufferTypeImpl<short[]> {
+        @Override
+        public void write(NetworkBuffer buffer, short[] value) {
+            if (length != -1 && value.length != length) {
+                throw new IllegalArgumentException("Invalid length: " + value.length + " != " + length);
+            }
+            final long byteLength = (long) value.length * Short.BYTES;
+            buffer.ensureWritable(byteLength);
+            impl(buffer)._putShorts(buffer.writeIndex(), value);
+            buffer.advanceWrite(byteLength);
+        }
+
+        @Override
+        public short[] read(NetworkBuffer buffer) {
+            final long readable = buffer.readableBytes();
+            final int count = length != -1 ? length : Math.toIntExact(readable / Short.BYTES);
+            assert count >= 0 : "Invalid count: " + count;
+            final long byteLength = (long) count * Short.BYTES;
+            if (byteLength > readable)
+                throw new IndexOutOfBoundsException("Buffer needs " + byteLength + " bytes to read, found " + readable);
+            final short[] values = new short[count];
+            impl(buffer)._getShorts(buffer.readIndex(), values);
+            buffer.advanceRead(byteLength);
+            return values;
+        }
+    }
+
+    record RawIntsType(int length) implements NetworkBufferTypeImpl<int[]> {
+        @Override
+        public void write(NetworkBuffer buffer, int[] value) {
+            if (length != -1 && value.length != length) {
+                throw new IllegalArgumentException("Invalid length: " + value.length + " != " + length);
+            }
+            final long byteLength = (long) value.length * Integer.BYTES;
+            buffer.ensureWritable(byteLength);
+            impl(buffer)._putInts(buffer.writeIndex(), value);
+            buffer.advanceWrite(byteLength);
+        }
+
+        @Override
+        public int[] read(NetworkBuffer buffer) {
+            final long readable = buffer.readableBytes();
+            final int count = length != -1 ? length : Math.toIntExact(readable / Integer.BYTES);
+            assert count >= 0 : "Invalid count: " + count;
+            final long byteLength = (long) count * Integer.BYTES;
+            if (byteLength > readable)
+                throw new IndexOutOfBoundsException("Buffer needs " + byteLength + " bytes to read, found " + readable);
+            final int[] values = new int[count];
+            impl(buffer)._getInts(buffer.readIndex(), values);
+            buffer.advanceRead(byteLength);
+            return values;
+        }
+    }
+
+    record RawLongsType(int length) implements NetworkBufferTypeImpl<long[]> {
+        @Override
+        public void write(NetworkBuffer buffer, long[] value) {
+            if (length != -1 && value.length != length) {
+                throw new IllegalArgumentException("Invalid length: " + value.length + " != " + length);
+            }
+            final long byteLength = (long) value.length * Long.BYTES;
+            buffer.ensureWritable(byteLength);
+            impl(buffer)._putLongs(buffer.writeIndex(), value);
+            buffer.advanceWrite(byteLength);
+        }
+
+        @Override
+        public long[] read(NetworkBuffer buffer) {
+            final long readable = buffer.readableBytes();
+            final int count = length != -1 ? length : Math.toIntExact(readable / Long.BYTES);
+            assert count >= 0 : "Invalid count: " + count;
+            final long byteLength = (long) count * Long.BYTES;
+            if (byteLength > readable)
+                throw new IndexOutOfBoundsException("Buffer needs " + byteLength + " bytes to read, found " + readable);
+            final long[] values = new long[count];
+            impl(buffer)._getLongs(buffer.readIndex(), values);
+            buffer.advanceRead(byteLength);
+            return values;
+        }
+    }
+
+    record RawFloatsType(int length) implements NetworkBufferTypeImpl<float[]> {
+        @Override
+        public void write(NetworkBuffer buffer, float[] value) {
+            if (length != -1 && value.length != length) {
+                throw new IllegalArgumentException("Invalid length: " + value.length + " != " + length);
+            }
+            final long byteLength = (long) value.length * Float.BYTES;
+            buffer.ensureWritable(byteLength);
+            impl(buffer)._putFloats(buffer.writeIndex(), value);
+            buffer.advanceWrite(byteLength);
+        }
+
+        @Override
+        public float[] read(NetworkBuffer buffer) {
+            final long readable = buffer.readableBytes();
+            final int count = length != -1 ? length : Math.toIntExact(readable / Float.BYTES);
+            assert count >= 0 : "Invalid count: " + count;
+            final long byteLength = (long) count * Float.BYTES;
+            if (byteLength > readable)
+                throw new IndexOutOfBoundsException("Buffer needs " + byteLength + " bytes to read, found " + readable);
+            final float[] values = new float[count];
+            impl(buffer)._getFloats(buffer.readIndex(), values);
+            buffer.advanceRead(byteLength);
+            return values;
+        }
+    }
+
+    record RawDoublesType(int length) implements NetworkBufferTypeImpl<double[]> {
+        @Override
+        public void write(NetworkBuffer buffer, double[] value) {
+            if (length != -1 && value.length != length) {
+                throw new IllegalArgumentException("Invalid length: " + value.length + " != " + length);
+            }
+            final long byteLength = (long) value.length * Double.BYTES;
+            buffer.ensureWritable(byteLength);
+            impl(buffer)._putDoubles(buffer.writeIndex(), value);
+            buffer.advanceWrite(byteLength);
+        }
+
+        @Override
+        public double[] read(NetworkBuffer buffer) {
+            final long readable = buffer.readableBytes();
+            final int count = length != -1 ? length : Math.toIntExact(readable / Double.BYTES);
+            assert count >= 0 : "Invalid count: " + count;
+            final long byteLength = (long) count * Double.BYTES;
+            if (byteLength > readable)
+                throw new IndexOutOfBoundsException("Buffer needs " + byteLength + " bytes to read, found " + readable);
+            final double[] values = new double[count];
+            impl(buffer)._getDoubles(buffer.readIndex(), values);
+            buffer.advanceRead(byteLength);
+            return values;
         }
     }
 

--- a/src/test/java/net/minestom/server/network/NetworkBufferRawArrayTest.java
+++ b/src/test/java/net/minestom/server/network/NetworkBufferRawArrayTest.java
@@ -1,0 +1,234 @@
+package net.minestom.server.network;
+
+import org.junit.jupiter.api.Test;
+
+import static net.minestom.server.network.NetworkBuffer.INT;
+import static net.minestom.server.network.NetworkBuffer.RAW_BYTES;
+import static net.minestom.server.network.NetworkBuffer.RAW_DOUBLES;
+import static net.minestom.server.network.NetworkBuffer.RAW_FLOATS;
+import static net.minestom.server.network.NetworkBuffer.RAW_INTS;
+import static net.minestom.server.network.NetworkBuffer.RAW_LONGS;
+import static net.minestom.server.network.NetworkBuffer.RAW_SHORTS;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class NetworkBufferRawArrayTest {
+
+    @Test
+    public void bytes() {
+        var values = new byte[]{0x00, 0x7F, (byte) 0x80, (byte) 0xFF};
+
+        var buffer = NetworkBuffer.staticBuffer(4);
+        buffer.write(RAW_BYTES, values);
+        assertEquals(values.length, buffer.writeIndex());
+        assertArrayEquals(values, written(buffer));
+        assertEquals(values.length, RAW_BYTES.sizeOf(values));
+
+        assertArrayEquals(values, buffer.read(RAW_BYTES));
+        assertEquals(values.length, buffer.readIndex());
+    }
+
+    @Test
+    public void shorts() {
+        var values = new short[]{0, (short) 0x7FFF, (short) 0x8000, -1};
+        var expected = new byte[]{0x00, 0x00, 0x7F, (byte) 0xFF, (byte) 0x80, 0x00, (byte) 0xFF, (byte) 0xFF};
+
+        var buffer = NetworkBuffer.staticBuffer(8);
+        buffer.write(RAW_SHORTS, values);
+        assertEquals(expected.length, buffer.writeIndex());
+        assertArrayEquals(expected, written(buffer));
+        assertEquals(expected.length, RAW_SHORTS.sizeOf(values));
+
+        assertArrayEquals(values, buffer.read(RAW_SHORTS));
+        assertEquals(expected.length, buffer.readIndex());
+    }
+
+    @Test
+    public void ints() {
+        var values = new int[]{0, Integer.MAX_VALUE, Integer.MIN_VALUE, -1};
+        var expected = new byte[]{
+                0x00, 0x00, 0x00, 0x00,
+                0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+                (byte) 0x80, 0x00, 0x00, 0x00,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF};
+
+        var buffer = NetworkBuffer.staticBuffer(16);
+        buffer.write(RAW_INTS, values);
+        assertEquals(expected.length, buffer.writeIndex());
+        assertArrayEquals(expected, written(buffer));
+        assertEquals(expected.length, RAW_INTS.sizeOf(values));
+
+        assertArrayEquals(values, buffer.read(RAW_INTS));
+        assertEquals(expected.length, buffer.readIndex());
+    }
+
+    @Test
+    public void longs() {
+        var values = new long[]{0L, Long.MAX_VALUE, Long.MIN_VALUE};
+        var expected = new byte[]{
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+                (byte) 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+        var buffer = NetworkBuffer.staticBuffer(24);
+        buffer.write(RAW_LONGS, values);
+        assertEquals(expected.length, buffer.writeIndex());
+        assertArrayEquals(expected, written(buffer));
+        assertEquals(expected.length, RAW_LONGS.sizeOf(values));
+
+        assertArrayEquals(values, buffer.read(RAW_LONGS));
+        assertEquals(expected.length, buffer.readIndex());
+    }
+
+    @Test
+    public void floats() {
+        var values = new float[]{1f, -2f, 0f, Float.NaN};
+        var expected = new byte[]{
+                0x3F, (byte) 0x80, 0x00, 0x00,
+                (byte) 0xC0, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00,
+                0x7F, (byte) 0xC0, 0x00, 0x00};
+
+        var buffer = NetworkBuffer.staticBuffer(16);
+        buffer.write(RAW_FLOATS, values);
+        assertEquals(expected.length, buffer.writeIndex());
+        assertArrayEquals(expected, written(buffer));
+        assertEquals(expected.length, RAW_FLOATS.sizeOf(values));
+
+        assertArrayEquals(values, buffer.read(RAW_FLOATS));
+        assertEquals(expected.length, buffer.readIndex());
+    }
+
+    @Test
+    public void doubles() {
+        var values = new double[]{1d, -2d, 0d, Double.NaN};
+        var expected = new byte[]{
+                0x3F, (byte) 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                (byte) 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x7F, (byte) 0xF8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+        var buffer = NetworkBuffer.staticBuffer(32);
+        buffer.write(RAW_DOUBLES, values);
+        assertEquals(expected.length, buffer.writeIndex());
+        assertArrayEquals(expected, written(buffer));
+        assertEquals(expected.length, RAW_DOUBLES.sizeOf(values));
+
+        assertArrayEquals(values, buffer.read(RAW_DOUBLES));
+        assertEquals(expected.length, buffer.readIndex());
+    }
+
+    @Test
+    public void empty() {
+        var buffer = NetworkBuffer.staticBuffer(0);
+        buffer.write(RAW_BYTES, new byte[0]);
+        buffer.write(RAW_SHORTS, new short[0]);
+        buffer.write(RAW_INTS, new int[0]);
+        buffer.write(RAW_LONGS, new long[0]);
+        buffer.write(RAW_FLOATS, new float[0]);
+        buffer.write(RAW_DOUBLES, new double[0]);
+        assertEquals(0, buffer.writeIndex());
+
+        assertArrayEquals(new byte[0], buffer.read(RAW_BYTES));
+        assertArrayEquals(new short[0], buffer.read(RAW_SHORTS));
+        assertArrayEquals(new int[0], buffer.read(RAW_INTS));
+        assertArrayEquals(new long[0], buffer.read(RAW_LONGS));
+        assertArrayEquals(new float[0], buffer.read(RAW_FLOATS));
+        assertArrayEquals(new double[0], buffer.read(RAW_DOUBLES));
+        assertEquals(0, buffer.readIndex());
+    }
+
+    @Test
+    public void resize() {
+        var buffer = NetworkBuffer.resizableBuffer(0);
+        buffer.write(RAW_BYTES, new byte[]{1});
+        buffer.write(RAW_SHORTS, new short[]{2});
+        buffer.write(RAW_INTS, new int[]{3});
+        buffer.write(RAW_LONGS, new long[]{4L});
+        buffer.write(RAW_FLOATS, new float[]{5f});
+        buffer.write(RAW_DOUBLES, new double[]{6d});
+        assertEquals(27, buffer.writeIndex());
+
+        assertArrayEquals(new byte[]{1}, buffer.read(NetworkBuffer.FixedRawBytes(1)));
+        assertArrayEquals(new short[]{2}, buffer.read(NetworkBuffer.FixedRawShorts(1)));
+        assertArrayEquals(new int[]{3}, buffer.read(NetworkBuffer.FixedRawInts(1)));
+        assertArrayEquals(new long[]{4L}, buffer.read(NetworkBuffer.FixedRawLongs(1)));
+        assertArrayEquals(new float[]{5f}, buffer.read(NetworkBuffer.FixedRawFloats(1)));
+        assertArrayEquals(new double[]{6d}, buffer.read(NetworkBuffer.FixedRawDoubles(1)));
+        assertEquals(0, buffer.readableBytes());
+    }
+
+    @Test
+    public void unalignedRemainder() {
+        var buffer = NetworkBuffer.staticBuffer(20);
+        buffer.write(INT, 7);
+        buffer.write(RAW_LONGS, new long[]{1L, 2L});
+
+        assertEquals(7, buffer.read(INT));
+        assertArrayEquals(new long[]{1L, 2L}, buffer.read(RAW_LONGS));
+        assertEquals(0, buffer.readableBytes());
+    }
+
+    @Test
+    public void trailingPartialElement() {
+        var buffer = NetworkBuffer.wrap(new byte[]{0x00, 0x01, 0x00, 0x02, 0x03}, 0, 5);
+
+        assertArrayEquals(new short[]{1, 2}, buffer.read(RAW_SHORTS));
+        assertEquals(4, buffer.readIndex());
+        assertEquals(1, buffer.readableBytes());
+    }
+
+    @Test
+    public void fixedLength() {
+        var buffer = NetworkBuffer.staticBuffer(14);
+        buffer.write(NetworkBuffer.FixedRawBytes(2), new byte[]{1, 2});
+        buffer.write(NetworkBuffer.FixedRawInts(2), new int[]{1, 2});
+        buffer.write(INT, 3);
+
+        assertArrayEquals(new byte[]{1, 2}, buffer.read(NetworkBuffer.FixedRawBytes(2)));
+        assertArrayEquals(new int[]{1, 2}, buffer.read(NetworkBuffer.FixedRawInts(2)));
+        assertEquals(3, buffer.read(INT));
+    }
+
+    @Test
+    public void fixedLengthWriteMismatch() {
+        var buffer = NetworkBuffer.staticBuffer(0);
+        assertThrows(IllegalArgumentException.class, () -> buffer.write(NetworkBuffer.FixedRawBytes(2), new byte[]{1}));
+        assertThrows(IllegalArgumentException.class, () -> buffer.write(NetworkBuffer.FixedRawShorts(2), new short[]{1}));
+        assertThrows(IllegalArgumentException.class, () -> buffer.write(NetworkBuffer.FixedRawInts(2), new int[]{1, 2, 3}));
+        assertThrows(IllegalArgumentException.class, () -> buffer.write(NetworkBuffer.FixedRawLongs(1), new long[0]));
+        assertThrows(IllegalArgumentException.class, () -> buffer.write(NetworkBuffer.FixedRawFloats(1), new float[]{1f, 2f}));
+        assertThrows(IllegalArgumentException.class, () -> buffer.write(NetworkBuffer.FixedRawDoubles(3), new double[]{1d}));
+        assertEquals(0, buffer.writeIndex());
+    }
+
+    @Test
+    public void fixedLengthReadUnderflow() {
+        var buffer = NetworkBuffer.wrap(new byte[]{0x01, 0x02, 0x03}, 0, 3);
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.read(NetworkBuffer.FixedRawBytes(4)));
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.read(NetworkBuffer.FixedRawShorts(2)));
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.read(NetworkBuffer.FixedRawInts(1)));
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.read(NetworkBuffer.FixedRawLongs(1)));
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.read(NetworkBuffer.FixedRawFloats(1)));
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.read(NetworkBuffer.FixedRawDoubles(1)));
+        assertEquals(0, buffer.readIndex());
+    }
+
+    @Test
+    public void fixedLengthNegative() {
+        assertThrows(IllegalArgumentException.class, () -> NetworkBuffer.FixedRawBytes(-1));
+        assertThrows(IllegalArgumentException.class, () -> NetworkBuffer.FixedRawShorts(-1));
+        assertThrows(IllegalArgumentException.class, () -> NetworkBuffer.FixedRawInts(-1));
+        assertThrows(IllegalArgumentException.class, () -> NetworkBuffer.FixedRawLongs(-1));
+        assertThrows(IllegalArgumentException.class, () -> NetworkBuffer.FixedRawFloats(-1));
+        assertThrows(IllegalArgumentException.class, () -> NetworkBuffer.FixedRawDoubles(-1));
+        assertThrows(IllegalArgumentException.class, () -> NetworkBuffer.FixedBitSet(-1));
+    }
+
+    private static byte[] written(NetworkBuffer buffer) {
+        final byte[] bytes = new byte[Math.toIntExact(buffer.writeIndex())];
+        buffer.copyTo(0, bytes, 0, bytes.length);
+        return bytes;
+    }
+}

--- a/src/test/java/net/minestom/server/network/NetworkBufferRegistriesTest.java
+++ b/src/test/java/net/minestom/server/network/NetworkBufferRegistriesTest.java
@@ -806,7 +806,7 @@ public class NetworkBufferRegistriesTest {
         buffer.write(VAR_INT, Integer.MAX_VALUE); // String length
         buffer.write(RAW_BYTES, "Hello".getBytes(StandardCharsets.UTF_8)); // String data
 
-        assertThrows(IllegalArgumentException.class, () -> buffer.read(STRING)); // oom
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.read(STRING)); // oom
     }
 
     @Test
@@ -815,7 +815,7 @@ public class NetworkBufferRegistriesTest {
         buffer.write(UNSIGNED_SHORT, 65535); // String length
         buffer.write(RAW_BYTES, "Hello".getBytes(StandardCharsets.UTF_8)); // String data
 
-        assertThrows(IllegalArgumentException.class, () -> buffer.read(STRING)); // oom
+        assertThrows(IndexOutOfBoundsException.class, () -> buffer.read(STRING)); // oom
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

Add RAW_SHORTS, RAW_INTS, RAW_LONGS, RAW_FLOATS and RAW_DOUBLES alongside RAW_BYTES, each backed by a bulk MemorySegment copy rather than a loop. A length of -1 consumes every whole element left in the buffer, and the FixedRaw variants read and write an exact element count.

FixedRawBytes and FixedBitSet now reject a negative length. Usages have been updated as well.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Will be used in a future PR

Benchmarks
``` (branch)
NetworkBufferRawArrayBenchmark.readBytes              16  avgt   30    5.325 ±  0.125  ns/op
NetworkBufferRawArrayBenchmark.readBytes            1024  avgt   30   38.261 ±  0.586  ns/op
NetworkBufferRawArrayBenchmark.readBytesLoop          16  avgt   30   12.420 ±  0.070  ns/op
NetworkBufferRawArrayBenchmark.readBytesLoop        1024  avgt   30  428.892 ±  1.314  ns/op
NetworkBufferRawArrayBenchmark.readDoubles            16  avgt   30   16.468 ±  0.115  ns/op
NetworkBufferRawArrayBenchmark.readDoubles          1024  avgt   30  453.992 ±  3.760  ns/op
NetworkBufferRawArrayBenchmark.readDoublesLoop        16  avgt   30   11.729 ±  0.051  ns/op
NetworkBufferRawArrayBenchmark.readDoublesLoop      1024  avgt   30  624.066 ±  3.306  ns/op
NetworkBufferRawArrayBenchmark.readFloats             16  avgt   30   15.965 ±  0.370  ns/op
NetworkBufferRawArrayBenchmark.readFloats           1024  avgt   30  323.117 ±  4.370  ns/op
NetworkBufferRawArrayBenchmark.readFloatsLoop         16  avgt   30   11.409 ±  0.068  ns/op
NetworkBufferRawArrayBenchmark.readFloatsLoop       1024  avgt   30  508.976 ±  6.265  ns/op
NetworkBufferRawArrayBenchmark.readInts               16  avgt   30   15.491 ±  0.138  ns/op
NetworkBufferRawArrayBenchmark.readInts             1024  avgt   30  312.774 ±  3.146  ns/op
NetworkBufferRawArrayBenchmark.readIntsLoop           16  avgt   30   11.408 ±  0.103  ns/op
NetworkBufferRawArrayBenchmark.readIntsLoop         1024  avgt   30  536.491 ± 31.951  ns/op
NetworkBufferRawArrayBenchmark.readLongs              16  avgt   30   19.513 ±  2.581  ns/op
NetworkBufferRawArrayBenchmark.readLongs            1024  avgt   30  462.148 ± 15.749  ns/op
NetworkBufferRawArrayBenchmark.readLongsLoop          16  avgt   30   11.684 ±  0.066  ns/op
NetworkBufferRawArrayBenchmark.readLongsLoop        1024  avgt   30  621.032 ±  2.308  ns/op
NetworkBufferRawArrayBenchmark.readShorts             16  avgt   30   15.220 ±  2.190  ns/op
NetworkBufferRawArrayBenchmark.readShorts           1024  avgt   30   99.406 ±  6.923  ns/op
NetworkBufferRawArrayBenchmark.readShortsLoop         16  avgt   30   18.377 ±  6.980  ns/op
NetworkBufferRawArrayBenchmark.readShortsLoop       1024  avgt   30  565.907 ± 26.730  ns/op
NetworkBufferRawArrayBenchmark.writeBytes             16  avgt   30    3.826 ±  0.161  ns/op
NetworkBufferRawArrayBenchmark.writeBytes           1024  avgt   30   11.497 ±  0.815  ns/op
NetworkBufferRawArrayBenchmark.writeBytesLoop         16  avgt   30   13.055 ±  0.191  ns/op
NetworkBufferRawArrayBenchmark.writeBytesLoop       1024  avgt   30  607.626 ± 10.141  ns/op
NetworkBufferRawArrayBenchmark.writeDoubles           16  avgt   30   15.934 ±  3.357  ns/op
NetworkBufferRawArrayBenchmark.writeDoubles         1024  avgt   30  283.054 ± 79.704  ns/op
NetworkBufferRawArrayBenchmark.writeDoublesLoop       16  avgt   30   12.242 ±  0.352  ns/op
NetworkBufferRawArrayBenchmark.writeDoublesLoop     1024  avgt   30  576.930 ±  6.464  ns/op
NetworkBufferRawArrayBenchmark.writeFloats            16  avgt   30   13.050 ±  0.296  ns/op
NetworkBufferRawArrayBenchmark.writeFloats          1024  avgt   30  220.834 ±  1.004  ns/op
NetworkBufferRawArrayBenchmark.writeFloatsLoop        16  avgt   30   12.059 ±  0.018  ns/op
NetworkBufferRawArrayBenchmark.writeFloatsLoop      1024  avgt   30  577.773 ±  7.285  ns/op
NetworkBufferRawArrayBenchmark.writeInts              16  avgt   30   12.729 ±  0.021  ns/op
NetworkBufferRawArrayBenchmark.writeInts            1024  avgt   30  223.219 ±  1.474  ns/op
NetworkBufferRawArrayBenchmark.writeIntsLoop          16  avgt   30   12.176 ±  0.044  ns/op
NetworkBufferRawArrayBenchmark.writeIntsLoop        1024  avgt   30  575.118 ±  0.477  ns/op
NetworkBufferRawArrayBenchmark.writeLongs             16  avgt   30   12.933 ±  0.051  ns/op
NetworkBufferRawArrayBenchmark.writeLongs           1024  avgt   30  221.582 ±  0.885  ns/op
NetworkBufferRawArrayBenchmark.writeLongsLoop         16  avgt   30   12.100 ±  0.028  ns/op
NetworkBufferRawArrayBenchmark.writeLongsLoop       1024  avgt   30  574.136 ±  0.506  ns/op
NetworkBufferRawArrayBenchmark.writeShorts            16  avgt   30   10.575 ±  0.036  ns/op
NetworkBufferRawArrayBenchmark.writeShorts          1024  avgt   30   48.762 ±  0.301  ns/op
NetworkBufferRawArrayBenchmark.writeShortsLoop        16  avgt   30   13.098 ±  0.028  ns/op
NetworkBufferRawArrayBenchmark.writeShortsLoop      1024  avgt   30  627.808 ±  1.394  ns/op
```
Showing ~13x improvement on writing shorts at 1024 entries and some regressions at smaller counts which is fine for now. Using 25.0.3 Graal with JVMCI for benchmarks here, which may be misleading on regressions compared to hotspot