### PR TITLE
fix: match vanilla's neighbor update order

### DIFF
--- a/src/main/java/net/minestom/server/instance/InstanceContainer.java
+++ b/src/main/java/net/minestom/server/instance/InstanceContainer.java
@@ -73,8 +73,9 @@ public class InstanceContainer extends Instance {
 
     private static final NoopChunkLoaderImpl DEFAULT_LOADER = NoopChunkLoaderImpl.INSTANCE;
 
+    // vanilla's NeighborUpdater.UPDATE_ORDER
     private static final BlockFace[] BLOCK_UPDATE_FACES = new BlockFace[]{
-            BlockFace.WEST, BlockFace.EAST, BlockFace.NORTH, BlockFace.SOUTH, BlockFace.BOTTOM, BlockFace.TOP
+            BlockFace.WEST, BlockFace.EAST, BlockFace.BOTTOM, BlockFace.TOP, BlockFace.NORTH, BlockFace.SOUTH
     };
 
     // the shared instances assigned to this instance

--- a/src/test/java/net/minestom/server/instance/InstanceBlockIntegrationTest.java
+++ b/src/test/java/net/minestom/server/instance/InstanceBlockIntegrationTest.java
@@ -1,5 +1,6 @@
 package net.minestom.server.instance;
 
+import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.SuspiciousGravelBlockHandler;
@@ -10,6 +11,8 @@ import net.minestom.testing.EnvTest;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -77,6 +80,37 @@ public class InstanceBlockIntegrationTest {
         // Different block type
         instance.setBlock(point, Block.GRASS_BLOCK.withTag(tag, 8));
         assertEquals(8, instance.getBlock(point).getTag(tag));
+    }
+
+    @Test
+    public void neighborUpdateOrderMatchesVanilla(Env env) {
+        List<Point> updated = new ArrayList<>();
+        env.process().block().registerBlockPlacementRule(new BlockPlacementRule(Block.CACTUS) {
+            @Override
+            public @Nullable Block blockPlace(PlacementState placementState) {
+                return placementState.block();
+            }
+
+            @Override
+            public Block blockUpdate(UpdateState updateState) {
+                updated.add(updateState.blockPosition());
+                return updateState.currentBlock();
+            }
+        });
+        var instance = env.createFlatInstance();
+        instance.loadChunk(0, 0).join();
+        var center = new Vec(8, 50, 8);
+        for (var face : new Vec[]{new Vec(7, 50, 8), new Vec(9, 50, 8), new Vec(8, 49, 8),
+                new Vec(8, 51, 8), new Vec(8, 50, 7), new Vec(8, 50, 9)}) {
+            instance.setBlock(face, Block.CACTUS);
+        }
+        updated.clear();
+
+        instance.setBlock(center, Block.STONE);
+
+        // NeighborUpdater.UPDATE_ORDER
+        assertEquals(List.of(new Vec(7, 50, 8), new Vec(9, 50, 8), new Vec(8, 49, 8),
+                new Vec(8, 51, 8), new Vec(8, 50, 7), new Vec(8, 50, 9)), updated);
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

Match vanilla block update order: notifies neighbors west, east, down, up, north, south (NeighborUpdater.UPDATE_ORDER, unchanged since 1.8). The block update faces ran north/south before the vertical pair, which alters the "winner" whenever two neighbors react to the same change.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)